### PR TITLE
fix(core): don't panic from semantic model

### DIFF
--- a/.changeset/hip-bears-retire.md
+++ b/.changeset/hip-bears-retire.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10905](https://github.com/biomejs/biome/issues/10905): Biome no longer crashes when CSS semantic models contain incomplete values. CSS and JavaScript semantic node resolution now handles missing nodes without panicking.

--- a/crates/biome_css_analyze/src/lint/correctness/no_missing_var_function.rs
+++ b/crates/biome_css_analyze/src/lint/correctness/no_missing_var_function.rs
@@ -174,7 +174,8 @@ impl Rule for NoMissingVarFunction {
         if rule
             .declarations()
             .iter()
-            .flat_map(|decl| decl.property(&root).value())
+            .filter_map(|decl| decl.property(&root))
+            .flat_map(|property| property.value())
             .any(|value| value.text() == custom_variable_name.text())
         {
             return Some(node.clone());
@@ -186,7 +187,8 @@ impl Rule for NoMissingVarFunction {
             if parent_rule
                 .declarations()
                 .iter()
-                .flat_map(|decl| decl.property(&root).value())
+                .filter_map(|decl| decl.property(&root))
+                .flat_map(|property| property.value())
                 .any(|value| value.text() == custom_variable_name.text())
             {
                 return Some(node.clone());

--- a/crates/biome_css_analyze/src/lint/nursery/no_duplicate_selectors.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_duplicate_selectors.rs
@@ -146,11 +146,13 @@ impl Rule for NoDuplicateSelectors {
 
                     let is_at_rule = matches!(
                         rule.node(&root),
+                        Some(
                         AnyRuleStart::CssMediaAtRule(_)
                             | AnyRuleStart::CssSupportsAtRule(_)
                             | AnyRuleStart::CssContainerAtRule(_)
                             | AnyRuleStart::CssScopeAtRule(_)
                             | AnyRuleStart::CssStartingStyleAtRule(_)
+                        )
                     );
 
                     if is_at_rule {

--- a/crates/biome_css_analyze/src/lint/style/no_descending_specificity.rs
+++ b/crates/biome_css_analyze/src/lint/style/no_descending_specificity.rs
@@ -143,7 +143,10 @@ fn find_descending_selector(
     }
 
     for selector in rule.selectors() {
-        let Some(casted_selector) = AnyCssSelector::cast(selector.node(root).syntax().clone())
+        let Some(selector_node) = selector.node(root) else {
+            continue;
+        };
+        let Some(casted_selector) = AnyCssSelector::cast(selector_node.syntax().clone())
         else {
             continue;
         };

--- a/crates/biome_css_analyze/src/lint/suspicious/no_duplicate_custom_properties.rs
+++ b/crates/biome_css_analyze/src/lint/suspicious/no_duplicate_custom_properties.rs
@@ -61,7 +61,9 @@ impl Rule for NoDuplicateCustomProperties {
         let mut seen: FxHashMap<TokenText, TextRange> = FxHashMap::default();
 
         for declaration in rule.declarations() {
-            let prop = declaration.property(&root);
+            let Some(prop) = declaration.property(&root) else {
+                continue;
+            };
             let prop_text = prop.value().ok()?;
             let prop_range = prop.range();
 

--- a/crates/biome_css_analyze/src/lint/suspicious/no_duplicate_properties.rs
+++ b/crates/biome_css_analyze/src/lint/suspicious/no_duplicate_properties.rs
@@ -60,7 +60,9 @@ impl Rule for NoDuplicateProperties {
         let mut seen: FxHashMap<TokenText, TextRange> = FxHashMap::default();
 
         for declaration in rule.declarations() {
-            let prop = declaration.property(&root);
+            let Some(prop) = declaration.property(&root) else {
+                continue;
+            };
             let prop_name = prop.value().ok()?;
             let prop_range = prop.range();
 

--- a/crates/biome_css_semantic/src/format_semantic_model.rs
+++ b/crates/biome_css_semantic/src/format_semantic_model.rs
@@ -85,10 +85,9 @@ impl Format<FormatSemanticModelContext> for SemanticModel {
 
         let mut builder = f.join_nodes_with_hardline();
         for selector in &selectors {
-            builder.entry(
-                selector.node(&root).syntax(),
-                &SelectorWithRoot(selector, &root),
-            );
+            if let Some(node) = selector.node(&root) {
+                builder.entry(node.syntax(), &SelectorWithRoot(selector, &root));
+            }
         }
         builder.finish()
     }

--- a/crates/biome_css_semantic/src/semantic_model/builder.rs
+++ b/crates/biome_css_semantic/src/semantic_model/builder.rs
@@ -8,7 +8,6 @@ use super::model::{
     SelectorData, SemanticModel, SemanticModelData, Specificity, selector_tokens,
 };
 use crate::events::SemanticEvent;
-use crate::model::AnyRuleStart;
 
 pub struct SemanticModelBuilder {
     root: AnyCssRoot,
@@ -49,12 +48,11 @@ impl SemanticModelBuilder {
             if let Some(parent_id) = &current_parent_id {
                 let rule = self.all_rules.get(parent_id.index());
                 if let Some(rule) = rule {
-                    let typed_node = rule.node.to_node(self.root.syntax());
                     if matches!(
-                        typed_node,
-                        AnyRuleStart::CssMediaAtRule(_)
-                            | AnyRuleStart::CssScopeAtRule(_)
-                            | AnyRuleStart::CssSupportsAtRule(_)
+                        rule.node.syntax_node_ptr().kind(),
+                        CssSyntaxKind::CSS_MEDIA_AT_RULE
+                            | CssSyntaxKind::CSS_SCOPE_AT_RULE
+                            | CssSyntaxKind::CSS_SUPPORTS_AT_RULE
                     ) {
                         current_parent_id = iterator
                             .next()
@@ -84,12 +82,11 @@ impl SemanticModelBuilder {
             if let Some(parent_id) = &current_parent_id {
                 let rule = self.all_rules.get(parent_id.index());
                 if let Some(rule) = rule {
-                    let typed_node = rule.node.to_node(self.root.syntax());
                     if matches!(
-                        typed_node,
-                        AnyRuleStart::CssMediaAtRule(_)
-                            | AnyRuleStart::CssScopeAtRule(_)
-                            | AnyRuleStart::CssSupportsAtRule(_)
+                        rule.node.syntax_node_ptr().kind(),
+                        CssSyntaxKind::CSS_MEDIA_AT_RULE
+                            | CssSyntaxKind::CSS_SCOPE_AT_RULE
+                            | CssSyntaxKind::CSS_SUPPORTS_AT_RULE
                     ) {
                         current_parent_id = iterator
                             .next()
@@ -137,6 +134,7 @@ impl SemanticModelBuilder {
                 let new_rule = RuleData {
                     id: new_rule_id,
                     node: AstPtr::new(&node),
+                    range: node.text_trimmed_range(),
                     selectors: Vec::new(),
                     declarations: Vec::new(),
                     parent_id,
@@ -155,7 +153,7 @@ impl SemanticModelBuilder {
             }
             SemanticEvent::RuleEnd => {
                 if let Some(completed_rule_id) = self.current_rule_stack.pop() {
-                    let range = self.all_rules[completed_rule_id.index()].range(&self.root);
+                    let range = self.all_rules[completed_rule_id.index()].range;
                     self.range_to_rule_id.insert(range, completed_rule_id);
 
                     if self.current_rule_stack.is_empty() {
@@ -209,6 +207,7 @@ impl SemanticModelBuilder {
                     for resolved in resolved_selectors {
                         current_rule.selectors.push(SelectorData {
                             node: AstPtr::new(&node),
+                            range: node.syntax().text_trimmed_range(),
                             resolved,
                             specificity: combined,
                         });

--- a/crates/biome_css_semantic/src/semantic_model/db.rs
+++ b/crates/biome_css_semantic/src/semantic_model/db.rs
@@ -163,6 +163,28 @@ mod tests {
     }
 
     #[test]
+    fn incomplete_value_does_not_panic_during_recomputation() {
+        let mut db = TestDb::new();
+        let file = make_file(&db, ".incomplete { height: 1px }");
+        assert_eq!(rule_count(&db, file), 1);
+
+        let new_parsed = parse_css(
+            ".incomplete { height: }",
+            CssFileSource::css(),
+            CssParserOptions::default(),
+        )
+        .into();
+        salsa::Setter::to(file.set_parsed(&mut db), new_parsed);
+
+        db.clear_salsa_events();
+        assert_eq!(rule_count(&db, file), 1);
+        let events = db.take_salsa_events();
+
+        assert_function_query_was_run(&db, css_model_from_parsed_source, file, &events);
+        assert_function_query_was_run(&db, rule_count, file, &events);
+    }
+
+    #[test]
     fn declaration_count_change_does_recompute_downstream() {
         let mut db = TestDb::new();
         let file = make_file(&db, "p { color: red; }");

--- a/crates/biome_css_semantic/src/semantic_model/model.rs
+++ b/crates/biome_css_semantic/src/semantic_model/model.rs
@@ -87,7 +87,7 @@ impl SemanticModel {
     }
 
     pub fn is_media_rule(&self, rule: &Rule) -> bool {
-        matches!(rule.node(&self.root()), AnyRuleStart::CssMediaAtRule(_))
+        rule.node.syntax_node_ptr().kind() == CssSyntaxKind::CSS_MEDIA_AT_RULE
     }
 
     fn rule(&self, id: RuleId) -> Option<Rule> {
@@ -157,6 +157,7 @@ impl PartialEq for SemanticModel {
 pub(crate) struct RuleData {
     pub(crate) id: RuleId,
     pub(crate) node: AstPtr<AnyRuleStart>,
+    pub(crate) range: TextRange,
     /// The selectors associated with this rule.
     pub(crate) selectors: Vec<SelectorData>,
     /// The declarations within this rule.
@@ -168,15 +169,6 @@ pub(crate) struct RuleData {
     /// Specificity context of this rule
     /// See https://drafts.csswg.org/selectors-4/#specificity-rules
     pub(crate) specificity: Specificity,
-}
-
-impl RuleData {
-    pub(crate) fn range(&self, css_root: &AnyCssRoot) -> TextRange {
-        self.node
-            .to_node(css_root.syntax())
-            .syntax()
-            .text_trimmed_range()
-    }
 }
 
 /// Represents a CSS rule set, including its selectors, declarations, and nested rules.
@@ -200,6 +192,7 @@ pub struct Rule {
     pub(crate) data: Arc<SemanticModelData>,
     pub(crate) id: RuleId,
     pub(crate) node: AstPtr<AnyRuleStart>,
+    pub(crate) range: TextRange,
     /// The selectors associated with this rule.
     pub(crate) selectors: Vec<Selector>,
     /// The declarations within this rule.
@@ -253,6 +246,7 @@ impl Rule {
             data,
             id: rule.id,
             node: rule.node.clone(),
+            range: rule.range,
             selectors,
             declarations,
             parent_id: rule.parent_id,
@@ -265,15 +259,14 @@ impl Rule {
         self.id
     }
 
-    pub fn node(&self, _css_root: &AnyCssRoot) -> AnyRuleStart {
-        self.node.to_node(self.data.root().syntax())
+    /// Returns the syntax node associated with this rule, or `None` if the stored
+    /// pointer cannot be resolved against the model's syntax tree.
+    pub fn node(&self, _css_root: &AnyCssRoot) -> Option<AnyRuleStart> {
+        self.node.try_to_node(self.data.root().syntax())
     }
 
     pub fn range(&self, _css_root: &AnyCssRoot) -> TextRange {
-        self.node
-            .to_node(self.data.root().syntax())
-            .syntax()
-            .text_trimmed_range()
+        self.range
     }
 
     pub fn selectors(&self) -> &[Selector] {
@@ -527,6 +520,7 @@ impl std::fmt::Display for ResolvedSelector {
 #[derive(Debug, Clone)]
 pub(crate) struct SelectorData {
     pub(crate) node: AstPtr<AnyCssSelectorLike>,
+    pub(crate) range: TextRange,
     /// The resolved selector, accounting for nesting and `&` references.
     /// For top-level selectors this is the token sequence from the source.
     /// For nested selectors each `&` is replaced by the parent token sequence,
@@ -548,6 +542,7 @@ pub(crate) struct SelectorData {
 pub struct Selector {
     pub(crate) data: Arc<SemanticModelData>,
     pub(crate) node: AstPtr<AnyCssSelectorLike>,
+    pub(crate) range: TextRange,
     /// The resolved selector, accounting for nesting and `&` references.
     /// For top-level selectors this is the token sequence from the source.
     /// For nested selectors each `&` is replaced by the parent token sequence,
@@ -561,11 +556,13 @@ impl Selector {
     fn new(data: Arc<SemanticModelData>, rule_id: RuleId, index: usize) -> Self {
         let selector = &data.all_rules[rule_id.index()].selectors[index];
         let node = selector.node.clone();
+        let range = selector.range;
         let resolved = selector.resolved.clone();
         let specificity = selector.specificity;
         Self {
             data,
             node,
+            range,
             resolved,
             specificity,
         }
@@ -579,8 +576,10 @@ impl PartialEq for Selector {
 }
 
 impl Selector {
-    pub fn node(&self, _root: &AnyCssRoot) -> AnyCssSelectorLike {
-        self.node.to_node(self.data.root().syntax())
+    /// Returns the syntax node associated with this selector, or `None` if the
+    /// stored pointer cannot be resolved against the model's syntax tree.
+    pub fn node(&self, _root: &AnyCssRoot) -> Option<AnyCssSelectorLike> {
+        self.node.try_to_node(self.data.root().syntax())
     }
 
     /// Returns the resolved selector, accounting for CSS nesting and `&` references.
@@ -589,10 +588,7 @@ impl Selector {
     }
 
     pub fn range(&self, _root: &AnyCssRoot) -> TextRange {
-        self.node
-            .to_node(self.data.root().syntax())
-            .syntax()
-            .text_trimmed_range()
+        self.range
     }
 
     pub fn specificity(&self) -> Specificity {
@@ -721,12 +717,16 @@ impl CssModelDeclaration {
         }
     }
 
-    pub fn declaration(&self, _root: &AnyCssRoot) -> CssDeclaration {
-        self.declaration.to_node(self.data.root().syntax())
+    /// Returns the syntax node associated with this declaration, or `None` if
+    /// the stored pointer cannot be resolved against the model's syntax tree.
+    pub fn declaration(&self, _root: &AnyCssRoot) -> Option<CssDeclaration> {
+        self.declaration.try_to_node(self.data.root().syntax())
     }
 
-    pub fn property(&self, _root: &AnyCssRoot) -> CssProperty {
-        self.property.to_node(self.data.root().syntax())
+    /// Returns the property associated with this declaration, or `None` if the
+    /// stored pointer cannot be resolved against the model's syntax tree.
+    pub fn property(&self, _root: &AnyCssRoot) -> Option<CssProperty> {
+        self.property.try_to_node(self.data.root().syntax())
     }
 
     pub fn value(&self) -> &CssPropertyInitialValue {
@@ -764,25 +764,65 @@ impl CssPropertyInitialValueKind {
     fn semantic_eq(&self, other: &Self, self_root: &AnyCssRoot, other_root: &AnyCssRoot) -> bool {
         match (self, other) {
             (Self::GenericComponent(a), Self::GenericComponent(b)) => {
-                let a = a.to_node(self_root.syntax());
-                let b = b.to_node(other_root.syntax());
-                semantic_value_tokens(a.syntax()) == semantic_value_tokens(b.syntax())
+                match (
+                    a.try_to_node(self_root.syntax()),
+                    b.try_to_node(other_root.syntax()),
+                ) {
+                    (Some(a), Some(b)) => {
+                        semantic_value_tokens(a.syntax()) == semantic_value_tokens(b.syntax())
+                    }
+                    (None, None) => {
+                        a.syntax_node_ptr().text_range().is_empty()
+                            && b.syntax_node_ptr().text_range().is_empty()
+                    }
+                    _ => false,
+                }
             }
             (Self::CustomProperty(a), Self::CustomProperty(b)) => {
-                let a = a.to_node(self_root.syntax());
-                let b = b.to_node(other_root.syntax());
-                semantic_custom_property_tokens(a.syntax())
-                    == semantic_custom_property_tokens(b.syntax())
+                match (
+                    a.try_to_node(self_root.syntax()),
+                    b.try_to_node(other_root.syntax()),
+                ) {
+                    (Some(a), Some(b)) => {
+                        semantic_custom_property_tokens(a.syntax())
+                            == semantic_custom_property_tokens(b.syntax())
+                    }
+                    (None, None) => {
+                        a.syntax_node_ptr().text_range().is_empty()
+                            && b.syntax_node_ptr().text_range().is_empty()
+                    }
+                    _ => false,
+                }
             }
             (Self::Composes(a), Self::Composes(b)) => {
-                let a = a.to_node(self_root.syntax());
-                let b = b.to_node(other_root.syntax());
-                semantic_value_tokens(a.syntax()) == semantic_value_tokens(b.syntax())
+                match (
+                    a.try_to_node(self_root.syntax()),
+                    b.try_to_node(other_root.syntax()),
+                ) {
+                    (Some(a), Some(b)) => {
+                        semantic_value_tokens(a.syntax()) == semantic_value_tokens(b.syntax())
+                    }
+                    (None, None) => {
+                        a.syntax_node_ptr().text_range().is_empty()
+                            && b.syntax_node_ptr().text_range().is_empty()
+                    }
+                    _ => false,
+                }
             }
             (Self::ScssExpression(a), Self::ScssExpression(b)) => {
-                let a = a.to_node(self_root.syntax());
-                let b = b.to_node(other_root.syntax());
-                semantic_value_tokens(a.syntax()) == semantic_value_tokens(b.syntax())
+                match (
+                    a.try_to_node(self_root.syntax()),
+                    b.try_to_node(other_root.syntax()),
+                ) {
+                    (Some(a), Some(b)) => {
+                        semantic_value_tokens(a.syntax()) == semantic_value_tokens(b.syntax())
+                    }
+                    (None, None) => {
+                        a.syntax_node_ptr().text_range().is_empty()
+                            && b.syntax_node_ptr().text_range().is_empty()
+                    }
+                    _ => false,
+                }
             }
             _ => false,
         }

--- a/crates/biome_css_semantic/src/tests/eq.rs
+++ b/crates/biome_css_semantic/src/tests/eq.rs
@@ -35,6 +35,38 @@ fn comment_change_is_eq() {
 }
 
 #[test]
+fn empty_property_value_is_eq() {
+    assert_eq!(
+        build_model(".incomplete { height: }"),
+        build_model(".incomplete  {  height:  }"),
+    );
+}
+
+#[test]
+fn empty_property_value_is_not_eq_to_non_empty_value() {
+    assert_ne!(
+        build_model(".incomplete { height: }"),
+        build_model(".incomplete { height: 1px }"),
+    );
+}
+
+#[test]
+fn empty_scss_custom_property_value_is_eq() {
+    assert_eq!(
+        build_scss_model("a { --empty:; }"),
+        build_scss_model("a  {  --empty:;  }"),
+    );
+}
+
+#[test]
+fn empty_scss_custom_property_value_is_not_eq_to_non_empty_value() {
+    assert_ne!(
+        build_scss_model("a { --empty:; }"),
+        build_scss_model("a { --empty:value; }"),
+    );
+}
+
+#[test]
 fn selector_change_is_not_eq() {
     assert_ne!(
         build_model("p { color: red; }"),

--- a/crates/biome_js_analyze/src/frameworks/mod.rs
+++ b/crates/biome_js_analyze/src/frameworks/mod.rs
@@ -56,7 +56,8 @@ pub(crate) fn is_framework_api_reference(
 pub(crate) fn is_framework_lib_export(binding: &Binding, package_names: &[&str]) -> bool {
     binding
         .syntax()
-        .ancestors()
+        .into_iter()
+        .flat_map(|syntax| syntax.ancestors())
         .skip(1)
         .find_map(|ancestor| JsImport::cast(ancestor)?.source_text().ok())
         .is_some_and(|source| package_names.contains(&source.text()))
@@ -67,7 +68,7 @@ pub(crate) fn is_named_framework_lib_export(
     name: &str,
     package_names: &[&str],
 ) -> Option<bool> {
-    let ident = JsIdentifierBinding::cast_ref(&binding.syntax())?;
+    let ident = JsIdentifierBinding::cast_ref(&binding.syntax()?)?;
     let import_specifier = ident.parent::<AnyJsNamedImportSpecifier>()?;
     let name_token = match &import_specifier {
         AnyJsNamedImportSpecifier::JsNamedImportSpecifier(named_import) => {

--- a/crates/biome_js_analyze/src/frameworks/playwright.rs
+++ b/crates/biome_js_analyze/src/frameworks/playwright.rs
@@ -399,7 +399,7 @@ pub(crate) fn is_playwright_call_chain_or_resolved(
     if binding.all_writes().next().is_some() {
         return false;
     }
-    let Some(decl) = binding.tree().declaration() else {
+    let Some(decl) = binding.tree().and_then(|tree| tree.declaration()) else {
         return false;
     };
     let decl = decl.parent_binding_pattern_declaration().unwrap_or(decl);

--- a/crates/biome_js_analyze/src/frameworks/vue/vue_component.rs
+++ b/crates/biome_js_analyze/src/frameworks/vue/vue_component.rs
@@ -812,7 +812,8 @@ impl AnyVueSetupDeclaration {
                     && let Some(binding) = model.binding(&ident_ref)
                     && let Some(declarator) = binding
                         .syntax()
-                        .ancestors()
+                        .into_iter()
+                        .flat_map(|syntax| syntax.ancestors())
                         .skip(1)
                         .find_map(|syntax| JsVariableDeclarator::try_cast(syntax).ok())
                     && let Some(decl_initializer) = declarator.initializer()

--- a/crates/biome_js_analyze/src/lint/complexity/no_arguments.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_arguments.rs
@@ -47,7 +47,10 @@ impl Rule for NoArguments {
         let mut found_arguments = vec![];
 
         for unresolved_reference in model.all_unresolved_references() {
-            let name = unresolved_reference.syntax().text_trimmed();
+            let Some(syntax) = unresolved_reference.syntax() else {
+                continue;
+            };
+            let name = syntax.text_trimmed();
             if name == "arguments" {
                 found_arguments.push(unresolved_reference.range());
             }

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_this_alias.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_this_alias.rs
@@ -92,7 +92,7 @@ impl Rule for NoUselessThisAlias {
             .skip(1)
             .find_map(AnyJsControlFlowRoot::cast)?;
         for write in id.all_writes(model) {
-            let assign = JsAssignmentExpression::cast(write.syntax().parent()?)?;
+            let assign = JsAssignmentExpression::cast(write.syntax()?.parent()?)?;
             let assign_right = assign.right().ok()?.omit_parentheses();
             if !JsThisExpression::can_cast(assign_right.syntax().kind()) {
                 return None;
@@ -105,7 +105,7 @@ impl Rule for NoUselessThisAlias {
         }
         for reference in id.all_references(model) {
             let current_this_scope = reference
-                .syntax()
+                .syntax()?
                 .ancestors()
                 .skip(1)
                 .filter(|x| !JsArrowFunctionExpression::can_cast(x.kind()))
@@ -146,13 +146,13 @@ impl Rule for NoUselessThisAlias {
         let this_expr = AnyJsExpression::from(make::js_this_expression(make::token(T![this])));
         for read in id.all_reads(model) {
             let syntax = read.syntax();
-            let syntax = syntax.parent()?;
+            let syntax = syntax?.parent()?;
             let expr = JsIdentifierExpression::cast(syntax)?;
             mutation.replace_node(expr.into(), this_expr.clone());
         }
         for write in id.all_writes(model) {
             let syntax = write.syntax();
-            let syntax = syntax.parent()?;
+            let syntax = syntax?.parent()?;
             let statement = JsExpressionStatement::cast(syntax.parent()?)?;
             mutation.remove_node(statement);
         }

--- a/crates/biome_js_analyze/src/lint/correctness/no_const_assign.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_const_assign.rs
@@ -68,7 +68,7 @@ impl Rule for NoConstAssign {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
         let model = ctx.model();
-        let id_binding = model.binding(node)?.tree();
+        let id_binding = model.binding(node)?.tree()?;
         let decl = id_binding.declaration()?;
         if let AnyJsBindingDeclaration::JsVariableDeclarator(declarator) =
             decl.parent_binding_pattern_declaration().unwrap_or(decl)
@@ -100,7 +100,7 @@ impl Rule for NoConstAssign {
         let node = ctx.query();
         let model = ctx.model();
         let mut mutation = ctx.root().begin();
-        let decl = model.binding(node)?.tree().declaration()?;
+        let decl = model.binding(node)?.tree()?.declaration()?;
         if let AnyJsBindingDeclaration::JsVariableDeclarator(declarator) =
             decl.parent_binding_pattern_declaration().unwrap_or(decl)
         {

--- a/crates/biome_js_analyze/src/lint/correctness/no_invalid_use_before_declaration.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_invalid_use_before_declaration.rs
@@ -105,7 +105,9 @@ impl Rule for NoInvalidUseBeforeDeclaration {
             return Box::default();
         }
         for binding in model.all_bindings() {
-            let id = binding.tree();
+            let Some(id) = binding.tree() else {
+                continue;
+            };
             if matches!(
                 id,
                 AnyJsIdentifierBinding::TsIdentifierBinding(_)
@@ -137,7 +139,9 @@ impl Rule for NoInvalidUseBeforeDeclaration {
                 .find(|ancestor| AnyJsVariableScope::can_cast(ancestor.kind()));
             for reference in binding.all_references() {
                 if reference.range_start() < declaration_end {
-                    let reference_syntax = reference.syntax();
+                    let Some(reference_syntax) = reference.syntax() else {
+                        continue;
+                    };
                     // References that are exports, such as `export { a }` are always valid,
                     // even when they appear before the declaration.
                     // For example:

--- a/crates/biome_js_analyze/src/lint/correctness/no_react_prop_assignments.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_react_prop_assignments.rs
@@ -156,7 +156,7 @@ fn find_param_mutation(
         .take_while(|reference| !reference.is_write())
         .filter_map(|reference| {
             reference
-                .syntax()
+                .syntax()?
                 .ancestors()
                 .find_map(AnyJsStatement::cast)
                 .and_then(|stmt| match stmt {

--- a/crates/biome_js_analyze/src/lint/correctness/no_solid_destructured_props.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_solid_destructured_props.rs
@@ -221,7 +221,7 @@ fn is_binding_used_in_jsx(binding: &AnyJsBinding, model: &SemanticModel) -> Opti
     {
         for reference in binding.all_reads() {
             if reference
-                .syntax()
+                .syntax()?
                 .ancestors()
                 .skip(1)
                 .any(|ancestor| {
@@ -229,7 +229,7 @@ fn is_binding_used_in_jsx(binding: &AnyJsBinding, model: &SemanticModel) -> Opti
                         || JsxExpressionChild::can_cast(ancestor.kind())
                 })
             {
-                return Some(reference.syntax().text_trimmed_range());
+                return Some(reference.syntax()?.text_trimmed_range());
             }
         }
     }

--- a/crates/biome_js_analyze/src/lint/correctness/no_undeclared_variables.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_undeclared_variables.rs
@@ -79,7 +79,7 @@ impl Rule for NoUndeclaredVariables {
         model
             .all_unresolved_references()
             .filter_map(|reference| {
-                let identifier = reference.tree();
+                let identifier = reference.tree()?;
                 let under_as_expression = identifier
                     .parent::<TsReferenceType>()
                     .and_then(|ty| ty.parent::<TsAsExpression>())

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_variables.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_variables.rs
@@ -636,7 +636,9 @@ fn is_namespace_merged_with_used_value(
     let scope = model.scope(&statement_list);
 
     for scope_binding in scope.bindings() {
-        let other = scope_binding.tree();
+        let Some(other) = scope_binding.tree() else {
+            continue;
+        };
         if let Some(is_used) = is_namespace_merge_value_used(model, binding, &other, name) {
             return Some(is_used);
         }
@@ -657,7 +659,7 @@ fn is_value_merged_with_exported_namespace(
 
     // Namespace declarations must follow the value they merge with, so the
     // scope name lookup points directly at the merged namespace when it exists.
-    let namespace = scope.get_binding(name)?.tree();
+    let namespace = scope.get_binding(name)?.tree()?;
     if namespace.syntax().text_trimmed_range() == binding.syntax().text_trimmed_range() {
         return Some(false);
     }
@@ -765,7 +767,7 @@ pub fn is_unused(model: &SemanticModel, binding: &AnyJsIdentifierBinding) -> boo
     let unused_by_refs = binding
         .all_references(model)
         .filter_map(|reference| {
-            let ref_parent = reference.syntax().parent()?;
+            let ref_parent = reference.syntax()?.parent()?;
             if reference.is_write() {
                 // Skip self assignment such as `a += 1` and `a++`.
                 // Ensure that the assignment is not used in an used expression.

--- a/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
@@ -641,9 +641,11 @@ fn capture_needs_to_be_in_the_dependency_list(
                 0,
             ),
             AnyExpressionCandidate::JsReferenceIdentifier(reference_identifier) => {
-                if let Some(binding) = model.binding(reference_identifier) {
+                if let Some(binding) = model.binding(reference_identifier)
+                    && let Some(binding) = binding.tree()
+                {
                     is_stable_binding(
-                        &binding.tree(),
+                        &binding,
                         None,
                         component_function_range,
                         model,
@@ -655,9 +657,11 @@ fn capture_needs_to_be_in_the_dependency_list(
                 }
             }
             AnyExpressionCandidate::JsxReferenceIdentifier(reference_identifier) => {
-                if let Some(binding) = model.binding(reference_identifier) {
+                if let Some(binding) = model.binding(reference_identifier)
+                    && let Some(binding) = binding.tree()
+                {
                     is_stable_binding(
-                        &binding.tree(),
+                        &binding,
                         None,
                         component_function_range,
                         model,
@@ -935,7 +939,9 @@ fn is_stable_expression(
             if let Ok(name) = identifier.name()
                 && let Some(binding) = model.binding(&name)
             {
-                let binding = &binding.tree();
+                let Some(binding) = binding.tree() else {
+                    return true;
+                };
                 let declaration = binding.declaration();
                 let declaration_node = if let Some(
                     AnyJsBindingDeclaration::JsArrowFunctionExpression(arrow_function),
@@ -959,7 +965,7 @@ fn is_stable_expression(
                 }
 
                 is_stable_binding(
-                    binding,
+                    &binding,
                     member,
                     component_function_range,
                     model,
@@ -1108,7 +1114,7 @@ fn is_out_of_function_scope(
 ) -> Option<bool> {
     let identifier_name = identifier.as_js_identifier_expression()?.name().ok()?;
 
-    let declaration = model.binding(&identifier_name)?.tree().declaration()?;
+    let declaration = model.binding(&identifier_name)?.tree()?.declaration()?;
 
     Some(
         model
@@ -1132,7 +1138,7 @@ fn determine_unstable_dependency(
 ) -> Option<UnstableDependencyKind> {
     let identifier_name = dependency.as_js_identifier_expression()?.name().ok()?;
 
-    let declaration = model.binding(&identifier_name)?.tree().declaration()?;
+    let declaration = model.binding(&identifier_name)?.tree()?.declaration()?;
     match declaration {
         AnyJsBindingDeclaration::JsArrowFunctionExpression(_)
         | AnyJsBindingDeclaration::JsFunctionDeclaration(_) => {
@@ -1236,7 +1242,7 @@ fn get_relevant_capture_nodes(
     if let AnyJsExpression::JsIdentifierExpression(identifier) = &closure_expression
         && let Ok(identifier_name) = identifier.name()
         && let Some(binding) = model.binding(&identifier_name)
-        && let AnyJsIdentifierBinding::JsIdentifierBinding(identifier_binding) = binding.tree()
+        && let Some(AnyJsIdentifierBinding::JsIdentifierBinding(identifier_binding)) = binding.tree()
         && let Some(declaration) = identifier_binding.declaration()
     {
         if identifier_binding

--- a/crates/biome_js_analyze/src/lint/correctness/use_hook_at_top_level.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_hook_at_top_level.rs
@@ -568,7 +568,7 @@ impl Rule for UseHookAtTopLevel {
                 {
                     for call in calls_iter {
                         calls.push(CallPath {
-                            call: call.tree(),
+                            call: call.tree()?,
                             path: path.clone(),
                             is_enclosed_in_component_or_hook: enclosed,
                         });

--- a/crates/biome_js_analyze/src/lint/correctness/use_inline_script_id.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_inline_script_id.rs
@@ -113,7 +113,7 @@ impl Rule for UseInlineScriptId {
                                 if let Ok(reference) = ident_expr.name()
                                     && let Some(binding) = semantic_model.binding(&reference)
                                     && let Some(declarator) = binding
-                                        .syntax()
+                                        .syntax()?
                                         .ancestors()
                                         .find_map(JsVariableDeclarator::cast)
                                     && let Some(initializer) = declarator.initializer()

--- a/crates/biome_js_analyze/src/lint/correctness/use_qwik_method_usage.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_qwik_method_usage.rs
@@ -137,7 +137,9 @@ fn is_inside_component_or_hook(call: &JsCallExpression, model: &SemanticModel) -
             && is_from_qwik(&binding)
         {
             // Walk up to find the import specifier
-            let mut current = binding.syntax().clone();
+            let Some(mut current) = binding.syntax() else {
+                return false;
+            };
             while let Some(parent) = current.parent() {
                 // Check if we've reached an import specifier that contains "component$"
                 let text = parent.text_trimmed();
@@ -209,7 +211,8 @@ fn is_from_qwik(binding: &biome_js_semantic::Binding) -> bool {
     const QWIK_IMPORT_NAMES: [&str; 2] = ["@builder.io/qwik", "qwik"];
     binding
         .syntax()
-        .ancestors()
+        .into_iter()
+        .flat_map(|syntax| syntax.ancestors())
         .find_map(|ancestor| JsImport::cast(ancestor)?.source_text().ok())
         .is_some_and(|source| {
             let source_text = source.text();

--- a/crates/biome_js_analyze/src/lint/nursery/no_loop_func.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_loop_func.rs
@@ -377,7 +377,7 @@ fn is_safe_capture(loop_node: &AnyLoopStatement, capture: &Capture, model: &Sema
 /// Returns the variable declaration that created a binding, when the binding comes from a
 /// declaration the rule knows how to classify.
 fn binding_declaration(binding: &Binding) -> Option<AnyJsVariableDeclaration> {
-    let declaration = binding.tree().declaration()?;
+    let declaration = binding.tree()?.declaration()?;
     let declaration = declaration
         .parent_binding_pattern_declaration()
         .unwrap_or(declaration);
@@ -405,7 +405,7 @@ fn is_constant_binding(binding: &Binding) -> bool {
 fn capture_name(capture: &Capture) -> Option<TokenText> {
     capture
         .binding()
-        .tree()
+        .tree()?
         .name_token()
         .ok()
         .map(|token| token.token_text_trimmed())

--- a/crates/biome_js_analyze/src/lint/nursery/no_svelte_unnecessary_state_wrap.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_svelte_unnecessary_state_wrap.rs
@@ -197,7 +197,7 @@ impl Rule for NoSvelteUnnecessaryStateWrap {
         if is_builtin {
             let binding = model.binding(&class_ref)?;
             let imported_from = binding
-                .syntax()
+                .syntax()?
                 .ancestors()
                 .skip(1)
                 .find_map(JsImport::cast)

--- a/crates/biome_js_analyze/src/lint/nursery/no_undeclared_classes.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_undeclared_classes.rs
@@ -466,7 +466,7 @@ fn collect_class_names_from_expression(
         AnyJsExpression::JsIdentifierExpression(ident_expr) => {
             let name = ident_expr.name().ok()?;
             let binding = model.binding(&name)?;
-            let decl = binding.tree().declaration()?;
+            let decl = binding.tree()?.declaration()?;
             let AnyJsBindingDeclaration::JsVariableDeclarator(declarator) = decl else {
                 return None;
             };

--- a/crates/biome_js_analyze/src/lint/nursery/no_vue_ref_as_operand.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_vue_ref_as_operand.rs
@@ -140,7 +140,7 @@ fn check_expression(expr: &NoVueRefAsOperandQuery, model: &SemanticModel) -> Opt
     match expr {
         NoVueRefAsOperandQuery::JsIdentifierExpression(ident_expr) => {
             let reference = ident_expr.name().ok()?;
-            let binding = model.binding(&reference)?.tree();
+            let binding = model.binding(&reference)?.tree()?;
             let declarator = binding
                 .syntax()
                 .ancestors()
@@ -240,7 +240,7 @@ fn check_expression(expr: &NoVueRefAsOperandQuery, model: &SemanticModel) -> Opt
             None
         }
         NoVueRefAsOperandQuery::JsIdentifierAssignment(ident_assignment) => {
-            let binding = model.binding(ident_assignment)?.tree();
+            let binding = model.binding(ident_assignment)?.tree()?;
             let declarator = binding
                 .syntax()
                 .ancestors()
@@ -378,7 +378,7 @@ fn is_emit_call_in_setup(callee_expr: &AnyJsExpression, model: &SemanticModel) -
                 && ident_name == "emit"
                 && let Some(binding) = model.binding(&reference)
             {
-                is_emit_in_setup_method(&binding.tree())
+                binding.tree().is_some_and(|binding| is_emit_in_setup_method(&binding))
             } else {
                 false
             }
@@ -394,7 +394,7 @@ fn is_emit_call_in_setup(callee_expr: &AnyJsExpression, model: &SemanticModel) -
                 && let Ok(reference) = ident.name()
                 && let Some(binding) = model.binding(&reference)
             {
-                is_emit_in_setup_method(&binding.tree())
+                binding.tree().is_some_and(|binding| is_emit_in_setup_method(&binding))
             } else {
                 false
             }
@@ -419,7 +419,7 @@ fn is_emit_call_by_macro(callee: &AnyJsExpression, model: &SemanticModel) -> boo
     if let Some(ident_expr) = callee.as_js_identifier_expression()
         && let Ok(reference) = ident_expr.name()
         && let Some(binding) = model.binding(&reference)
-        && let Some(parent) = binding.syntax().parent()
+        && let Some(parent) = binding.syntax().and_then(|syntax| syntax.parent())
         && let Some(decl) = parent.cast::<JsVariableDeclarator>()
         && let Some(init) = decl.initializer()
         && let Some(expr) = init.expression().ok()

--- a/crates/biome_js_analyze/src/lint/nursery/use_math_min_max.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_math_min_max.rs
@@ -221,7 +221,7 @@ fn has_shadowed_math(model: &SemanticModel, conditional: &JsConditionalExpressio
     model.scope(conditional.syntax()).ancestors().any(|scope| {
         scope
             .get_binding("Math")
-            .is_some_and(|binding| binding.tree().declaration().is_some())
+            .is_some_and(|binding| binding.tree().is_some_and(|tree| tree.declaration().is_some()))
     })
 }
 
@@ -584,7 +584,7 @@ fn has_unsupported_identifier_operand(
     let identifier = unwrapped.as_js_identifier_expression()?;
     let reference = identifier.name().ok()?;
     let binding = model.binding(&reference)?;
-    let declaration = binding.tree().declaration()?;
+    let declaration = binding.tree()?.declaration()?;
 
     Some(
         match declaration

--- a/crates/biome_js_analyze/src/lint/performance/no_accumulating_spread.rs
+++ b/crates/biome_js_analyze/src/lint/performance/no_accumulating_spread.rs
@@ -133,7 +133,7 @@ impl Rule for NoAccumulatingSpread {
 fn is_known_accumulator(reference: &JsReferenceIdentifier, model: &SemanticModel) -> Option<bool> {
     let parameter = model
         .binding(reference)
-        .and_then(|declaration| declaration.syntax().parent())
+        .and_then(|declaration| declaration.syntax()?.parent())
         .and_then(JsFormalParameter::cast)?;
     let function = parameter
         .parent::<JsParameterList>()

--- a/crates/biome_js_analyze/src/lint/performance/no_dynamic_namespace_import_access.rs
+++ b/crates/biome_js_analyze/src/lint/performance/no_dynamic_namespace_import_access.rs
@@ -113,7 +113,7 @@ fn find_dynamic_namespace_import_accesses(
     let ranges = reads
         .into_iter()
         .filter_map(|read| {
-            let syntax = read.syntax().parent()?.parent()?;
+            let syntax = read.syntax()?.parent()?.parent()?;
             let node = JsComputedMemberExpression::cast(syntax)?;
 
             Some(node.range())

--- a/crates/biome_js_analyze/src/lint/performance/no_jsx_props_bind.rs
+++ b/crates/biome_js_analyze/src/lint/performance/no_jsx_props_bind.rs
@@ -115,7 +115,7 @@ impl Rule for NoJsxPropsBind {
                 let model = ctx.model();
                 let binding: Binding = model.binding(&identifier.name().ok()?)?;
 
-                let declaration = binding.tree().declaration()?;
+                let declaration = binding.tree()?.declaration()?;
 
                 match &declaration {
                     AnyJsBindingDeclaration::JsFunctionDeclaration(_) => {

--- a/crates/biome_js_analyze/src/lint/style/no_parameter_assign.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_parameter_assign.rs
@@ -190,8 +190,10 @@ impl Rule for NoParameterAssign {
             ) {
                 let param_reassignments: Vec<_> = binding
                     .all_writes(model)
-                    .map(|expression| {
-                        ProblemType::ParameterAssignment(expression.syntax().text_trimmed_range())
+                    .filter_map(|expression| {
+                        Some(ProblemType::ParameterAssignment(
+                            expression.syntax()?.text_trimmed_range(),
+                        ))
                     })
                     .collect();
 
@@ -240,7 +242,7 @@ impl Rule for NoParameterAssign {
 
 fn extract_statement_from_reference(reference: &Reference) -> Option<JsExpressionStatement> {
     reference
-        .syntax()
+        .syntax()?
         .ancestors()
         .skip(2) // skip the reference identifier and its expression
         .skip_while(|node| AnyJsAssignmentLike::can_cast(node.kind()))

--- a/crates/biome_js_analyze/src/lint/style/no_process_env.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_process_env.rs
@@ -106,7 +106,8 @@ const PROCESS_MODULE_NAMES: [&str; 2] = ["process", "node:process"];
 fn is_process_module_import(binding: &biome_js_semantic::Binding) -> bool {
     binding
         .syntax()
-        .ancestors()
+        .into_iter()
+        .flat_map(|syntax| syntax.ancestors())
         .find_map(|ancestor| JsImport::cast(ancestor)?.source_text().ok())
         .is_some_and(|source| PROCESS_MODULE_NAMES.contains(&source.text()))
 }
@@ -120,7 +121,7 @@ fn is_env_from_process(binding: &biome_js_semantic::Binding) -> bool {
 /// Whether `binding` refers to the `env` export, e.g. `import { env }` (with an
 /// optional alias) or `const { env } = ...`.
 fn is_env_named_binding(binding: &biome_js_semantic::Binding) -> bool {
-    binding.syntax().ancestors().skip(1).any(|n| {
+    binding.syntax().is_some_and(|syntax| syntax.ancestors().skip(1).any(|n| {
         if let Some(specifier) = AnyJsNamedImportSpecifier::cast(n.clone()) {
             return specifier
                 .imported_name()
@@ -130,7 +131,7 @@ fn is_env_named_binding(binding: &biome_js_semantic::Binding) -> bool {
             .and_then(|property| property.identifier().ok())
             .and_then(|id| id.as_js_identifier_binding()?.name_token().ok())
             .is_some_and(|name| name.text_trimmed() == "env")
-    })
+    }))
 }
 
 /// Whether `binding` originates from the `process`/`node:process` module,
@@ -139,7 +140,8 @@ fn is_env_named_binding(binding: &biome_js_semantic::Binding) -> bool {
 fn is_from_process_module(binding: &biome_js_semantic::Binding) -> bool {
     binding
         .syntax()
-        .ancestors()
+        .into_iter()
+        .flat_map(|syntax| syntax.ancestors())
         .skip(1)
         .find_map(|node| {
             if let Some(import) = JsImport::cast(node.clone()) {

--- a/crates/biome_js_analyze/src/lint/style/no_restricted_globals.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_restricted_globals.rs
@@ -82,7 +82,7 @@ impl Rule for NoRestrictedGlobals {
         unresolved_reference_nodes
             .chain(global_references_nodes)
             .filter_map(|node| {
-                let node = AnyJsIdentifierUsage::unwrap_cast(node);
+                let node = AnyJsIdentifierUsage::cast(node?)?;
                 let (token, binding) = match node {
                     AnyJsIdentifierUsage::JsReferenceIdentifier(node) => {
                         (node.value_token(), node.binding(model))

--- a/crates/biome_js_analyze/src/lint/style/no_shouty_constants.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_shouty_constants.rs
@@ -132,8 +132,9 @@ impl Rule for NoShoutyConstants {
             },
         );
 
-        let node = state.reference.syntax();
-        diag = diag.detail(node.text_trimmed_range(), "Used here.");
+        if let Some(node) = state.reference.syntax() {
+            diag = diag.detail(node.text_trimmed_range(), "Used here.");
+        }
 
         let diag = diag.note(
             markup! {"You should avoid declaring constants with a string that's the same
@@ -154,7 +155,7 @@ impl Rule for NoShoutyConstants {
 
         if let Some(node) = state
             .reference
-            .syntax()
+            .syntax()?
             .parent()?
             .cast::<JsIdentifierExpression>()
         {
@@ -164,7 +165,7 @@ impl Rule for NoShoutyConstants {
             );
         } else if let Some(node) = state
             .reference
-            .syntax()
+            .syntax()?
             .parent()?
             .cast::<JsShorthandPropertyObjectMember>()
         {
@@ -173,7 +174,7 @@ impl Rule for NoShoutyConstants {
                 AnyJsObjectMemberName::JsLiteralMemberName(js_literal_member_name(
                     SyntaxToken::new_detached(
                         JsSyntaxKind::JS_LITERAL_MEMBER_NAME,
-                        JsReferenceIdentifier::cast_ref(&state.reference.syntax())?
+                        JsReferenceIdentifier::cast_ref(&state.reference.syntax()?)?
                             .value_token()
                             .ok()?
                             .text_trimmed(),

--- a/crates/biome_js_analyze/src/lint/style/use_const.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_const.rs
@@ -139,7 +139,7 @@ impl Rule for UseConst {
             let binding_name = binding.name_token().ok()?;
             if let Some(write) = binding.all_writes(ctx.model()).next() {
                 diag = diag.detail(
-                    write.syntax().text_trimmed_range(),
+                    write.syntax()?.text_trimmed_range(),
                     markup! {
                         "'"{ binding_name.text_trimmed() }"' is only assigned here."
                     },
@@ -240,7 +240,7 @@ fn check_binding_can_be_const(
         return None;
     }
     let host = write
-        .syntax()
+        .syntax()?
         .ancestors()
         .find_map(DestructuringHost::cast)?;
     if host.has_member_expr_assignment() || host.has_outer_variables(&write.scope()) {

--- a/crates/biome_js_analyze/src/lint/style/use_export_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_export_type.rs
@@ -560,8 +560,12 @@ fn export_named_fix(
                     if model
                         .global_scope()
                         .bindings()
-                        .filter(|binding| binding.syntax().text_trimmed() == local_name)
-                        .all(|binding| binding.tree().is_type_only())
+                        .filter_map(|binding| {
+                            (binding.syntax()?.text_trimmed() == local_name)
+                                .then(|| binding.tree())
+                                .flatten()
+                        })
+                        .all(|binding| binding.is_type_only())
                         && !references.is_used_as_value(token.token_text_trimmed())
                     {
                         specifiers_requiring_type_marker.push(specifier.into());

--- a/crates/biome_js_analyze/src/lint/style/use_for_of.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_for_of.rs
@@ -184,12 +184,12 @@ fn list_initializer_references(
             }
 
             if let Some(AnyJsObjectMember::JsShorthandPropertyObjectMember(expr)) =
-                AnyJsObjectMember::cast(reference.syntax().parent()?)
+                AnyJsObjectMember::cast(reference.syntax()?.parent()?)
             {
                 return Some(AnyBindingExpression::from(expr));
             }
 
-            AnyBindingExpression::try_from(AnyJsExpression::cast(reference.syntax().parent()?)?)
+            AnyBindingExpression::try_from(AnyJsExpression::cast(reference.syntax()?.parent()?)?)
                 .ok()
         })
         .collect()

--- a/crates/biome_js_analyze/src/lint/style/use_import_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_import_type.rs
@@ -838,7 +838,7 @@ fn is_only_used_as_type(
     let mut all_type_only = true;
     for reference in binding.all_references(model) {
         has_reference = true;
-        if let Some(reference) = AnyJsIdentifierUsage::cast_ref(&reference.syntax())
+        if let Some(reference) = reference.syntax().as_ref().and_then(AnyJsIdentifierUsage::cast_ref)
             && !reference.is_only_type()
         {
             all_type_only = false;

--- a/crates/biome_js_analyze/src/lint/suspicious/no_array_index_key.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_array_index_key.rs
@@ -149,7 +149,7 @@ impl Rule for NoArrayIndexKey {
             // and navigate up to the closest call expression.
             let Some(parameter) = model
                 .binding(&reference)
-                .and_then(|declaration| declaration.syntax().parent())
+                .and_then(|declaration| declaration.syntax()?.parent())
                 .and_then(JsFormalParameter::cast)
             else {
                 continue;

--- a/crates/biome_js_analyze/src/lint/suspicious/no_catch_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_catch_assign.rs
@@ -74,7 +74,7 @@ impl Rule for NoCatchAssign {
                 let mut invalid_assignment = Vec::new();
                 for reference in identifier_binding.all_writes(model) {
                     invalid_assignment.push((
-                        reference.syntax().text_trimmed_range(),
+                        reference.syntax()?.text_trimmed_range(),
                         catch_binding_syntax.text_trimmed_range(),
                     ));
                 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_class_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_class_assign.rs
@@ -111,7 +111,7 @@ impl Rule for NoClassAssign {
         Some(
             RuleDiagnostic::new(
                 rule_category!(),
-                reference.syntax().text_trimmed_range(),
+                reference.syntax()?.text_trimmed_range(),
                 markup! {"'"{class_name}"' is a class."},
             )
             .detail(

--- a/crates/biome_js_analyze/src/lint/suspicious/no_document_cookie.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_document_cookie.rs
@@ -80,7 +80,7 @@ fn is_global_document(expr: &AnyJsExpression, model: &SemanticModel) -> Option<(
     } else {
         // Check binding declaration recursively
         let bind = model.binding(&reference)?;
-        let decl = bind.tree().declaration()?;
+        let decl = bind.tree()?.declaration()?;
         let decl = decl.parent_binding_pattern_declaration().unwrap_or(decl);
         match decl {
             // const foo = document;

--- a/crates/biome_js_analyze/src/lint/suspicious/no_function_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_function_assign.rs
@@ -145,8 +145,9 @@ impl Rule for NoFunctionAssign {
 
         let mut hoisted_quantity = 0;
         for reference in state.all_writes.iter() {
-            let node = reference.syntax();
-            diag = diag.detail(node.text_trimmed_range(), "Reassigned here.");
+            if let Some(node) = reference.syntax() {
+                diag = diag.detail(node.text_trimmed_range(), "Reassigned here.");
+            }
 
             hoisted_quantity += i32::from(reference.is_using_hoisted_declaration());
         }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_global_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_global_assign.rs
@@ -60,9 +60,12 @@ impl Rule for NoGlobalAssign {
         let global_refs = ctx.query().all_unresolved_references();
         let mut result = Vec::new();
         for global_ref in global_refs {
-            let is_write = global_ref.syntax().kind() == JsSyntaxKind::JS_IDENTIFIER_ASSIGNMENT;
+            let Some(syntax) = global_ref.syntax() else {
+                continue;
+            };
+            let is_write = syntax.kind() == JsSyntaxKind::JS_IDENTIFIER_ASSIGNMENT;
             if is_write {
-                let identifier = global_ref.syntax().text_trimmed();
+                let identifier = syntax.text_trimmed();
                 let is_global_var = is_js_global(identifier.into_text().text());
                 if is_global_var {
                     result.push(global_ref.range());

--- a/crates/biome_js_analyze/src/lint/suspicious/no_import_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_import_assign.rs
@@ -98,7 +98,7 @@ impl Rule for NoImportAssign {
                 let model = ctx.model();
                 for reference in ident_binding.all_writes(model) {
                     invalid_assign_list.push((
-                        JsIdentifierAssignment::cast_ref(&reference.syntax())?,
+                        JsIdentifierAssignment::cast_ref(&reference.syntax()?)?,
                         ident_binding.clone(),
                     ));
                 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_label_var.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_label_var.rs
@@ -51,7 +51,7 @@ impl Rule for NoLabelVar {
         // if we find a binding that has its name equal to label name, then we found a  `LabelVar` issue.
         for scope in model.scope(label_statement.syntax()).ancestors() {
             if let Some(binding) = scope.get_binding(name) {
-                return Some((binding.syntax().clone(), label_token));
+                return Some((binding.syntax()?, label_token));
             }
         }
         None

--- a/crates/biome_js_analyze/src/lint/suspicious/no_leaked_render.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_leaked_render.rs
@@ -258,7 +258,7 @@ fn is_inside_jsx_expression(node: &JsSyntaxNode) -> Option<bool> {
 
 fn find_variable(model: &SemanticModel, name: &JsReferenceIdentifier) -> Option<AnyJsExpression> {
     let binding = model.binding(name)?;
-    let declaration = binding.tree().declaration()?;
+    let declaration = binding.tree()?.declaration()?;
     let AnyJsBindingDeclaration::JsVariableDeclarator(declarator) = declaration else {
         return None;
     };

--- a/crates/biome_js_analyze/src/lint/suspicious/no_misplaced_assertion.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_misplaced_assertion.rs
@@ -183,7 +183,7 @@ impl Rule for NoMisplacedAssertion {
             let is_exception = is_exception_for_expect(node)?;
             let binding = model.binding(&assertion_call);
             if let Some(binding) = binding {
-                let ident = JsIdentifierBinding::cast_ref(&binding.syntax())?;
+                let ident = JsIdentifierBinding::cast_ref(&binding.syntax()?)?;
                 let import = ident.syntax().ancestors().find_map(JsImport::cast)?;
                 let source_text = import.source_text().ok()?;
                 if (ASSERTION_FUNCTION_NAMES.contains(&call_text.text()))

--- a/crates/biome_js_analyze/src/lint/suspicious/no_nested_promises.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_nested_promises.rs
@@ -220,7 +220,9 @@ fn references_outer_scope(
             if let Some(binding) = model.binding(&ident) {
                 // Check if the binding is defined outside the nested callback
                 // by checking if the binding's syntax node is NOT a descendant of the nested callback
-                let binding_syntax = binding.syntax();
+                let Some(binding_syntax) = binding.syntax() else {
+                    continue;
+                };
 
                 // If the binding is not inside the nested callback, it's an outer scope reference
                 if !is_descendant_of(&binding_syntax, nested_callback.syntax()) {

--- a/crates/biome_js_analyze/src/lint/suspicious/no_parameters_only_used_in_recursion.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_parameters_only_used_in_recursion.rs
@@ -456,7 +456,7 @@ fn is_reference_in_recursive_call(
     let ref_node = reference.syntax();
 
     // Walk up the tree to find if we're inside a call expression
-    let mut current = ref_node.parent();
+    let mut current = ref_node?.parent();
     while let Some(node) = current {
         // Check if this is a call expression
         if let Some(call_expr) = JsCallExpression::cast_ref(&node) {

--- a/crates/biome_js_analyze/src/lint/suspicious/no_react_forward_ref.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_react_forward_ref.rs
@@ -151,7 +151,7 @@ impl Rule for NoReactForwardRef {
 
         let global_react_import = model
             .all_bindings()
-            .filter_map(|binding| JsIdentifierBinding::cast_ref(&binding.syntax()))
+            .filter_map(|binding| binding.syntax().and_then(JsIdentifierBinding::cast))
             .find(|binding| is_global_react_import(binding, ReactLibrary::React));
 
         let new_function: AnyJsExpression = match function.clone() {

--- a/crates/biome_js_analyze/src/lint/suspicious/no_redeclare.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_redeclare.rs
@@ -125,7 +125,7 @@ impl Rule for NoRedeclare {
 
 fn check_redeclarations_in_single_scope(scope: &Scope, redeclarations: &mut Vec<Redeclaration>) {
     let mut declarations = FxHashMap::<TokenText, (TextRange, AnyJsBindingDeclaration)>::default();
-    if scope.syntax().kind() == JsSyntaxKind::JS_FUNCTION_BODY {
+    if scope.syntax().is_some_and(|syntax| syntax.kind() == JsSyntaxKind::JS_FUNCTION_BODY) {
         // Handle cases where a variable/type redeclares a parameter or type parameter.
         // For example:
         //
@@ -148,7 +148,9 @@ fn check_redeclarations_in_single_scope(scope: &Scope, redeclarations: &mut Vec<
         // ```
         if let Some(function_scope) = scope.parent() {
             for binding in function_scope.bindings() {
-                let id_binding = binding.tree();
+                let Some(id_binding) = binding.tree() else {
+                    continue;
+                };
                 if let Some(decl) = id_binding.declaration() {
                     // Ignore the function itself.
                     if !matches!(decl, AnyJsBindingDeclaration::JsFunctionExpression(_)) {
@@ -165,7 +167,9 @@ fn check_redeclarations_in_single_scope(scope: &Scope, redeclarations: &mut Vec<
         }
     }
     for binding in scope.bindings() {
-        let id_binding = binding.tree();
+        let Some(id_binding) = binding.tree() else {
+            continue;
+        };
 
         // We consider only binding of a declaration
         // This allows to skip function parameters, methods, ...

--- a/crates/biome_js_analyze/src/lint/suspicious/no_shadow.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_shadow.rs
@@ -1,5 +1,5 @@
 use biome_analyze::{
-    QueryMatch, Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule,
+    Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule,
 };
 use biome_console::markup;
 use biome_diagnostics::Severity;
@@ -154,13 +154,13 @@ impl Rule for NoShadow {
         Some(
             RuleDiagnostic::new(
                 rule_category!(),
-                state.binding.tree().range(),
+                state.binding.range(),
                 markup! {
                     "This variable shadows another variable with the same name in the outer scope."
                 },
             )
             .detail(
-                state.shadowed_binding.tree().range(),
+                state.shadowed_binding.range(),
                 markup!(
                     "This is the shadowed variable, which is now inaccessible in the inner scope."
                 ),
@@ -198,7 +198,7 @@ fn check_shadowing(
 
     let name = get_binding_name(&binding)?;
     let binding_hoisted_scope = model
-        .scope_hoisted_to(&binding.syntax())
+        .scope_hoisted_to(&binding.syntax()?)
         .unwrap_or(binding.scope());
 
     for upper in binding_hoisted_scope.ancestors().skip(1) {
@@ -236,17 +236,23 @@ fn evaluate_shadowing(
         return false;
     }
     if is_declaration(binding) && is_declaration(upper_binding) {
+        let Some(binding_syntax) = binding.syntax() else {
+            return false;
+        };
+        let Some(upper_binding_syntax) = upper_binding.syntax() else {
+            return false;
+        };
         let binding_hoisted_scope = model
-            .scope_hoisted_to(&binding.syntax())
+            .scope_hoisted_to(&binding_syntax)
             .unwrap_or(binding.scope());
         let upper_binding_hoisted_scope = model
-            .scope_hoisted_to(&upper_binding.syntax())
+            .scope_hoisted_to(&upper_binding_syntax)
             .unwrap_or(upper_binding.scope());
         if binding_hoisted_scope == upper_binding_hoisted_scope {
             // redeclarations are not shadowing, they get caught by `noRedeclare`
             return false;
         }
-        if upper_binding.syntax().text_range().start() >= binding_hoisted_scope.range().end() {
+        if upper_binding.range().start() >= binding_hoisted_scope.range().end() {
             // the shadowed binding must be declared before the shadowing one
             return false;
         }
@@ -259,7 +265,7 @@ fn evaluate_shadowing(
 }
 
 fn get_binding_name(binding: &Binding) -> Option<TokenText> {
-    let node = binding.syntax();
+    let node = binding.syntax()?;
     if let Some(ident) = node.clone().cast::<JsIdentifierBinding>() {
         let name = ident.name_token().ok()?;
         return Some(name.token_text_trimmed());
@@ -295,7 +301,7 @@ declare_node_union! {
 /// var a = function() { function a() {} };
 /// ```
 fn is_on_initializer(a: &Binding, b: &Binding) -> bool {
-    let b_declarator = b.tree().declaration().and_then(|decl| {
+    let b_declarator = b.tree().and_then(|tree| tree.declaration()).and_then(|decl| {
         let decl = decl.parent_binding_pattern_declaration().unwrap_or(decl);
         match decl {
             AnyJsBindingDeclaration::JsVariableDeclarator(d) => Some(d),
@@ -305,7 +311,7 @@ fn is_on_initializer(a: &Binding, b: &Binding) -> bool {
     if let Some(b_initializer_expression) = b_declarator
         .and_then(|d| d.initializer())
         .and_then(|i| i.expression().ok())
-        && let Some(a_parent) = a.tree().parent::<AnyIdentifiableExpression>()
+        && let Some(a_parent) = a.tree().and_then(|tree| tree.parent::<AnyIdentifiableExpression>())
         && a_parent.syntax() == b_initializer_expression.syntax()
     {
         return true;
@@ -325,7 +331,7 @@ fn is_on_initializer(a: &Binding, b: &Binding) -> bool {
 /// const [e] = arr;
 /// ```
 fn is_declaration(binding: &Binding) -> bool {
-    let Some(decl) = binding.tree().declaration() else {
+    let Some(decl) = binding.tree().and_then(|tree| tree.declaration()) else {
         return false;
     };
     let decl = decl.parent_binding_pattern_declaration().unwrap_or(decl);
@@ -337,7 +343,7 @@ fn is_declaration(binding: &Binding) -> bool {
 }
 
 fn is_type_only_declaration(binding: &Binding) -> bool {
-    let Some(decl) = binding.tree().declaration() else {
+    let Some(decl) = binding.tree().and_then(|tree| tree.declaration()) else {
         return false;
     };
     matches!(
@@ -353,7 +359,8 @@ fn is_type_only_declaration(binding: &Binding) -> bool {
 fn is_inside_type_parameter(binding: &Binding) -> bool {
     binding
         .syntax()
-        .ancestors()
+        .into_iter()
+        .flat_map(|syntax| syntax.ancestors())
         .skip(1)
         .any(|ancestor| ancestor.cast::<TsTypeParameter>().is_some())
 }
@@ -361,7 +368,8 @@ fn is_inside_type_parameter(binding: &Binding) -> bool {
 fn is_inside_type_member(binding: &Binding) -> bool {
     binding
         .syntax()
-        .ancestors()
+        .into_iter()
+        .flat_map(|syntax| syntax.ancestors())
         .skip(1)
         .any(|ancestor| ancestor.cast::<TsPropertySignatureTypeMember>().is_some())
 }
@@ -369,13 +377,14 @@ fn is_inside_type_member(binding: &Binding) -> bool {
 fn is_inside_function_parameters(binding: &Binding) -> bool {
     binding
         .syntax()
-        .ancestors()
+        .into_iter()
+        .flat_map(|syntax| syntax.ancestors())
         .skip(1)
         .any(|ancestor| ancestor.cast::<JsParameterList>().is_some())
 }
 
 fn get_parameter_parent_function(binding: &Binding) -> Option<AnyJsParameterParentFunction> {
-    let id = binding.syntax().cast::<JsIdentifierBinding>()?;
+    let id = binding.syntax()?.cast::<JsIdentifierBinding>()?;
     id.parent::<JsFormalParameter>()
         .and_then(|p| p.parent_function())
         .or_else(|| {

--- a/crates/biome_js_analyze/src/lint/suspicious/no_unsafe_declaration_merging.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_unsafe_declaration_merging.rs
@@ -69,7 +69,7 @@ impl Rule for NoUnsafeDeclarationMerging {
         let scope = model.scope(ts_interface.syntax()).parent()?;
         for binding in scope.bindings() {
             if let Some(AnyJsBindingDeclaration::JsClassDeclaration(class)) =
-                binding.tree().declaration()
+                binding.tree()?.declaration()
             {
                 // This is not unsafe of merging an interface and an ambient class.
                 if !class.is_ambient()

--- a/crates/biome_js_analyze/src/nextjs.rs
+++ b/crates/biome_js_analyze/src/nextjs.rs
@@ -21,7 +21,8 @@ impl NextUtility {
 pub(crate) fn is_next_import(binding: &Binding, lib: NextUtility) -> bool {
     binding
         .syntax()
-        .ancestors()
+        .into_iter()
+        .flat_map(|syntax| syntax.ancestors())
         .find_map(|ancestor| JsImport::cast(ancestor)?.source_text().ok())
         .is_some_and(|source| lib.import_names().contains(&source.text()))
 }

--- a/crates/biome_js_analyze/src/react.rs
+++ b/crates/biome_js_analyze/src/react.rs
@@ -284,13 +284,14 @@ pub(crate) fn jsx_reference_identifier_is_fragment(
 fn is_react_export(binding: &Binding, lib: ReactLibrary) -> bool {
     binding
         .syntax()
-        .ancestors()
+        .into_iter()
+        .flat_map(|syntax| syntax.ancestors())
         .find_map(|ancestor| JsImport::cast(ancestor)?.source_text().ok())
         .is_some_and(|source| lib.import_names().contains(&source.text()))
 }
 
 fn is_named_react_export(binding: &Binding, lib: ReactLibrary, name: &str) -> Option<bool> {
-    let ident = JsIdentifierBinding::cast_ref(&binding.syntax())?;
+    let ident = JsIdentifierBinding::cast_ref(&binding.syntax()?)?;
     let import_specifier = ident.parent::<AnyJsNamedImportSpecifier>()?;
     let name_token = match &import_specifier {
         AnyJsNamedImportSpecifier::JsNamedImportSpecifier(named_import) => {

--- a/crates/biome_js_analyze/src/services/typed.rs
+++ b/crates/biome_js_analyze/src/services/typed.rs
@@ -64,7 +64,7 @@ impl TypedService {
             }
             scope = scope.parent()?;
         };
-        Some(binding.tree().syntax().text_trimmed_range())
+        Some(binding.range())
     }
 
     /// Returns the Salsa-inferred type for an expression.

--- a/crates/biome_js_analyze/src/utils/rename.rs
+++ b/crates/biome_js_analyze/src/utils/rename.rs
@@ -30,13 +30,13 @@ impl RenamableNode for TsIdentifierBinding {
 
 impl RenamableNode for JsReferenceIdentifier {
     fn binding(&self, model: &SemanticModel) -> Option<JsSyntaxNode> {
-        Some(model.binding(self)?.syntax().clone())
+        model.binding(self)?.syntax()
     }
 }
 
 impl RenamableNode for JsIdentifierAssignment {
     fn binding(&self, model: &SemanticModel) -> Option<JsSyntaxNode> {
-        Some(model.binding(self)?.syntax().clone())
+        model.binding(self)?.syntax()
     }
 }
 
@@ -252,7 +252,9 @@ impl RenameSymbolExtensions for BatchMutation<JsLanguage> {
                 return false;
             }
 
-            let reference_syntax = reference.syntax();
+            let Some(reference_syntax) = reference.syntax() else {
+                continue;
+            };
             let Some(id_usage) = AnyJsIdentifierUsage::cast_ref(&reference_syntax) else {
                 continue;
             };

--- a/crates/biome_js_semantic/src/format_semantic_model.rs
+++ b/crates/biome_js_semantic/src/format_semantic_model.rs
@@ -98,7 +98,7 @@ impl Format<FormatSemanticModelContext> for Scope {
         // this is easier to read and maintain.
         children.sort_by_key(|item| match item {
             ScopeOrBinding::Scope(scope) => scope.range().start(),
-            ScopeOrBinding::Binding(binding) => binding.syntax().text_range_with_trivia().start(),
+            ScopeOrBinding::Binding(binding) => binding.range().start(),
         });
 
         let formatted_scope_info = format_with(|f| {
@@ -139,6 +139,9 @@ impl Format<FormatSemanticModelContext> for Scope {
 
 impl Format<FormatSemanticModelContext> for Binding {
     fn fmt(&self, f: &mut Formatter<FormatSemanticModelContext>) -> FormatResult<()> {
+        let Some(syntax) = self.syntax() else {
+            return Ok(());
+        };
         let is_imported = format_with(|f| {
             if self.is_imported() {
                 write!(f, [token("Imported: true"), hard_line_break()])
@@ -156,7 +159,7 @@ impl Format<FormatSemanticModelContext> for Binding {
         });
 
         let formatted_binding_info = format_with(|f| {
-            let range = std::format!("{:?}", self.syntax().text_trimmed_range());
+            let range = std::format!("{:?}", self.range());
 
             write!(
                 f,
@@ -174,7 +177,7 @@ impl Format<FormatSemanticModelContext> for Binding {
                 f,
                 [token("Kind: "), self.declaration_kind(), hard_line_break()]
             )?;
-            let full_text = self.syntax().text_trimmed().into_text();
+            let full_text = syntax.text_trimmed().into_text();
             write!(
                 f,
                 [token("ident: "), text(&full_text, None), hard_line_break()]

--- a/crates/biome_js_semantic/src/semantic_model/binding.rs
+++ b/crates/biome_js_semantic/src/semantic_model/binding.rs
@@ -531,6 +531,11 @@ impl Display for Binding {
 }
 
 impl Binding {
+    /// Returns the range associated with this binding.
+    pub fn range(&self) -> TextRange {
+        self.data.binding(self.id).range
+    }
+
     /// Returns the scope of this binding
     pub fn scope(&self) -> Scope {
         let binding = self.data.binding(self.id);
@@ -545,16 +550,20 @@ impl Binding {
         self.data.binding(self.id).declaration_kind
     }
 
-    /// Returns the syntax node associated with this binding.
-    pub fn syntax(&self) -> JsSyntaxNode {
+    /// Returns the syntax node associated with this binding, or `None` if the
+    /// stored pointer cannot be resolved against the model's syntax tree.
+    pub fn syntax(&self) -> Option<JsSyntaxNode> {
         let binding = self.data.binding(self.id);
-        self.data.binding_node_by_start[&binding.range.start()]
-            .to_node(self.data.to_root().syntax())
+        self.data
+            .binding_node_by_start
+            .get(&binding.range.start())?
+            .try_to_node(self.data.to_root().syntax())
     }
 
-    /// Returns the typed AST node associated with this binding.
-    pub fn tree(&self) -> AnyJsIdentifierBinding {
-        AnyJsIdentifierBinding::unwrap_cast(self.syntax().clone())
+    /// Returns the typed AST node associated with this binding, or `None` if the
+    /// stored pointer cannot be resolved against the model's syntax tree.
+    pub fn tree(&self) -> Option<AnyJsIdentifierBinding> {
+        AnyJsIdentifierBinding::cast(self.syntax()?)
     }
 
     /// Returns an iterator to all references of this binding.
@@ -611,16 +620,18 @@ impl Binding {
             self.data
                 .binding_node_by_start
                 .get(&export_start.start())
-                .map(|ptr| ptr.to_node(self.data.to_root().syntax()))
+                .and_then(|ptr| ptr.try_to_node(self.data.to_root().syntax()))
         })
     }
 
     pub fn is_imported(&self) -> bool {
-        super::is_imported(&self.syntax())
+        self.syntax()
+            .is_some_and(|syntax| super::is_imported(&syntax))
     }
 
     pub fn is_exported(&self) -> bool {
-        self.data.is_exported(self.syntax().text_trimmed_range())
+        self.syntax()
+            .is_some_and(|syntax| self.data.is_exported(syntax.text_trimmed_range()))
     }
 
     /// Returns the JSDoc comment associated with this binding, if any.

--- a/crates/biome_js_semantic/src/semantic_model/closure.rs
+++ b/crates/biome_js_semantic/src/semantic_model/closure.rs
@@ -133,10 +133,17 @@ impl Iterator for AllCapturesIter {
                 let binding = &self.data.binding(binding_id);
                 if !self.closure_range.contains(binding.range.start()) {
                     let reference = &binding.references[reference.index()];
+                    let Some(node) = self
+                        .data
+                        .binding_node_by_start
+                        .get(&reference.range_start)
+                        .and_then(|pointer| pointer.try_to_node(self.data.to_root().syntax()))
+                    else {
+                        continue 'references;
+                    };
                     return Some(Capture {
                         data: self.data.clone(),
-                        node: self.data.binding_node_by_start[&reference.range_start]
-                            .to_node(self.data.to_root().syntax()), // TODO change node to store the range
+                        node,
                         ty: CaptureType::ByReference,
                         binding_id,
                     });

--- a/crates/biome_js_semantic/src/semantic_model/globals.rs
+++ b/crates/biome_js_semantic/src/semantic_model/globals.rs
@@ -20,10 +20,14 @@ pub struct GlobalReference {
 }
 
 impl GlobalReference {
-    pub fn syntax(&self) -> JsSyntaxNode {
+    /// Returns the node of this reference, or `None` if the stored pointer cannot
+    /// be resolved against the model's syntax tree.
+    pub fn syntax(&self) -> Option<JsSyntaxNode> {
         let reference = &self.data.global(self.global_id).references[self.id as usize];
-        self.data.binding_node_by_start[&reference.range_start]
-            .to_node(self.data.to_root().syntax())
+        self.data
+            .binding_node_by_start
+            .get(&reference.range_start)?
+            .try_to_node(self.data.to_root().syntax())
     }
 
     /// Returns if this reference is just reading its binding

--- a/crates/biome_js_semantic/src/semantic_model/import.rs
+++ b/crates/biome_js_semantic/src/semantic_model/import.rs
@@ -72,13 +72,13 @@ impl<T: HasDeclarationAstNode> CanBeImportedExported for T {
     type Result = Option<bool>;
 
     fn is_exported(&self, model: &SemanticModel) -> Self::Result {
-        let range = self.binding(model)?.syntax().text_trimmed_range();
+        let range = self.binding(model)?.syntax()?.text_trimmed_range();
         Some(model.data.is_exported(range))
     }
 
     fn is_imported(&self, model: &SemanticModel) -> Self::Result {
         let binding = self.binding(model)?;
-        let node = binding.syntax();
+        let node = binding.syntax()?;
         Some(is_imported(&node))
     }
 }

--- a/crates/biome_js_semantic/src/semantic_model/reference.rs
+++ b/crates/biome_js_semantic/src/semantic_model/reference.rs
@@ -70,9 +70,13 @@ impl Reference {
         }
     }
 
-    /// Returns the node of this reference
-    pub fn syntax(&self) -> JsSyntaxNode {
-        self.data.binding_node_by_start[&self.range_start()].to_node(self.data.to_root().syntax())
+    /// Returns the node of this reference, or `None` if the stored pointer cannot
+    /// be resolved against the model's syntax tree.
+    pub fn syntax(&self) -> Option<JsSyntaxNode> {
+        self.data
+            .binding_node_by_start
+            .get(&self.range_start())?
+            .try_to_node(self.data.to_root().syntax())
     }
 
     /// Returns the binding of this reference
@@ -106,7 +110,7 @@ impl Reference {
 
     /// Returns this reference as a [FunctionCall] if possible
     pub fn as_call(&self) -> Option<FunctionCall> {
-        let call = self.syntax().ancestors().find(|x| {
+        let call = self.syntax()?.ancestors().find(|x| {
             !matches!(
                 x.kind(),
                 JsSyntaxKind::JS_REFERENCE_IDENTIFIER | JsSyntaxKind::JS_IDENTIFIER_EXPRESSION
@@ -136,24 +140,26 @@ impl FunctionCall {
         self.data.reference(self.id).range_start
     }
 
-    /// Returns the node of this reference
-    pub fn syntax(&self) -> JsSyntaxNode {
-        self.data.binding_node_by_start[&self.range_start()].to_node(self.data.to_root().syntax())
+    /// Returns the node of this reference, or `None` if the stored pointer cannot
+    /// be resolved against the model's syntax tree.
+    pub fn syntax(&self) -> Option<JsSyntaxNode> {
+        self.data
+            .binding_node_by_start
+            .get(&self.range_start())?
+            .try_to_node(self.data.to_root().syntax())
     }
 
-    /// Returns the typed AST node of this reference
-    pub fn tree(&self) -> JsCallExpression {
-        let node = self.syntax();
+    /// Returns the typed AST node of this reference, or `None` if its syntax node
+    /// cannot be resolved against the model's syntax tree.
+    pub fn tree(&self) -> Option<JsCallExpression> {
+        let node = self.syntax()?;
         let call = node.ancestors().find(|x| {
             !matches!(
                 x.kind(),
                 JsSyntaxKind::JS_REFERENCE_IDENTIFIER | JsSyntaxKind::JS_IDENTIFIER_EXPRESSION
             )
         });
-        debug_assert!(matches!(&call,
-            Some(call) if call.kind() == JsSyntaxKind::JS_CALL_EXPRESSION
-        ));
-        JsCallExpression::unwrap_cast(call.unwrap())
+        JsCallExpression::cast(call?)
     }
 }
 
@@ -187,14 +193,20 @@ pub struct UnresolvedReference {
 }
 
 impl UnresolvedReference {
-    pub fn syntax(&self) -> JsSyntaxNode {
+    /// Returns the node of this reference, or `None` if the stored pointer cannot
+    /// be resolved against the model's syntax tree.
+    pub fn syntax(&self) -> Option<JsSyntaxNode> {
         let reference = &self.data.unresolved_reference(self.id);
-        self.data.binding_node_by_start[&reference.range.start()]
-            .to_node(self.data.to_root().syntax())
+        self.data
+            .binding_node_by_start
+            .get(&reference.range.start())?
+            .try_to_node(self.data.to_root().syntax())
     }
 
-    pub fn tree(&self) -> AnyJsIdentifierUsage {
-        AnyJsIdentifierUsage::unwrap_cast(self.syntax().clone())
+    /// Returns the typed AST node of this reference, or `None` if its syntax node
+    /// cannot be resolved against the model's syntax tree.
+    pub fn tree(&self) -> Option<AnyJsIdentifierUsage> {
+        AnyJsIdentifierUsage::cast(self.syntax()?)
     }
 
     pub fn range(&self) -> TextRange {

--- a/crates/biome_js_semantic/src/semantic_model/scope.rs
+++ b/crates/biome_js_semantic/src/semantic_model/scope.rs
@@ -166,8 +166,13 @@ impl Scope {
         self.data.scopes[self.id.index()].range
     }
 
-    pub fn syntax(&self) -> JsSyntaxNode {
-        self.data.scope_node_by_range[&self.range()].to_node(self.data.to_root().syntax())
+    /// Returns the node associated with this scope, or `None` if the stored
+    /// pointer cannot be resolved against the model's syntax tree.
+    pub fn syntax(&self) -> Option<JsSyntaxNode> {
+        self.data
+            .scope_node_by_range
+            .get(&self.range())?
+            .try_to_node(self.data.to_root().syntax())
     }
 
     /// Return the [Closure] associated with this scope if

--- a/crates/biome_js_semantic/src/tests/db.rs
+++ b/crates/biome_js_semantic/src/tests/db.rs
@@ -4,12 +4,16 @@
 //! we care re-use the same semantic model, if the information that belong to the semantic model didn't change
 
 use crate::db::semantic_model_from_source;
-use crate::{SemanticModel, semantic_model};
+use crate::{
+    SemanticEventExtractor, SemanticModel, SemanticModelBuilder, SemanticModelOptions,
+    semantic_model,
+};
 use biome_db::ParsedSource;
 use biome_db::testing::{Events, assert_function_query_was_not_run, assert_function_query_was_run};
 use biome_js_parser::parse;
 use biome_js_syntax::AnyJsRoot;
 use biome_languages::{DocumentFileSource, JsFileSource, LanguageDb};
+use biome_rowan::AstNode;
 use camino::{Utf8Path, Utf8PathBuf};
 use salsa::Storage;
 
@@ -17,6 +21,123 @@ fn build_model(source: &str) -> SemanticModel {
     let parsed = parse(source, JsFileSource::js_module(), Default::default());
     let parsed: AnyJsRoot = parsed.tree();
     semantic_model(&parsed, Default::default())
+}
+
+fn assert_pointers_resolve(source: &str, source_type: JsFileSource) {
+    let parsed = parse(source, source_type, Default::default());
+    let root: AnyJsRoot = parsed.tree();
+    let model = semantic_model(&root, SemanticModelOptions::from(&source_type));
+    let syntax = root.syntax();
+
+    for pointer in model.data.binding_node_by_start.values() {
+        assert!(
+            pointer.try_to_node(syntax).is_some(),
+            "unresolved binding pointer for {source:?}: {pointer:?}"
+        );
+    }
+    for pointer in model.data.scope_node_by_range.values() {
+        assert!(
+            pointer.try_to_node(syntax).is_some(),
+            "unresolved scope pointer for {source:?}: {pointer:?}"
+        );
+    }
+    for scope in model.scopes() {
+        assert!(scope.syntax().is_some(), "unresolved scope for {source:?}");
+    }
+    for binding in model.all_bindings() {
+        assert!(
+            binding.syntax().is_some(),
+            "unresolved binding for {source:?}"
+        );
+        assert!(
+            binding.tree().is_some(),
+            "unresolved binding tree for {source:?}"
+        );
+        for reference in binding.all_references() {
+            assert!(
+                reference.syntax().is_some(),
+                "unresolved reference for {source:?}"
+            );
+        }
+    }
+    for reference in model.all_global_references() {
+        assert!(
+            reference.syntax().is_some(),
+            "unresolved global reference for {source:?}"
+        );
+    }
+    for reference in model.all_unresolved_references() {
+        assert!(
+            reference.syntax().is_some(),
+            "unresolved reference for {source:?}"
+        );
+    }
+}
+
+#[test]
+fn pointers_resolve_for_partial_sources() {
+    let cases = [
+        (
+            "export function example(value) { const result = value + external; return result; }",
+            JsFileSource::js_module(),
+        ),
+        (
+            "interface Example<T> { value: T } const element = <Component value={external} />;",
+            JsFileSource::tsx(),
+        ),
+    ];
+
+    for (source, source_type) in cases {
+        for end in source
+            .char_indices()
+            .map(|(index, _)| index)
+            .chain(std::iter::once(source.len()))
+        {
+            assert_pointers_resolve(&source[..end], source_type);
+        }
+    }
+}
+
+#[test]
+fn accessors_return_none_for_foreign_nodes() {
+    let model_root: AnyJsRoot = parse("", JsFileSource::js_module(), Default::default()).tree();
+    let foreign_root: AnyJsRoot = parse(
+        "let value = external;",
+        JsFileSource::js_module(),
+        Default::default(),
+    )
+    .tree();
+    let mut extractor = SemanticEventExtractor::default();
+    let mut builder = SemanticModelBuilder::new(model_root);
+
+    for event in foreign_root.syntax().preorder() {
+        match event {
+            biome_js_syntax::WalkEvent::Enter(node) => {
+                builder.push_node(&node);
+                extractor.enter(&node);
+            }
+            biome_js_syntax::WalkEvent::Leave(node) => extractor.leave(&node),
+        }
+    }
+    while let Some(event) = extractor.pop() {
+        builder.push_event(event);
+    }
+
+    let model = builder.build();
+    let binding = model.all_bindings().next().unwrap();
+    assert!(binding.syntax().is_none());
+    assert!(binding.tree().is_none());
+    assert!(
+        binding
+            .all_references()
+            .all(|reference| reference.syntax().is_none())
+    );
+    assert!(model.scopes().all(|scope| scope.syntax().is_none()));
+    assert!(
+        model
+            .all_unresolved_references()
+            .all(|reference| reference.syntax().is_none())
+    );
 }
 
 #[test]

--- a/crates/biome_module_graph/benches/type_inference.rs
+++ b/crates/biome_module_graph/benches/type_inference.rs
@@ -457,14 +457,13 @@ fn binding_range_by_name(db: &dyn ModuleDb, module: ModuleInfo, name: &str) -> T
     info.semantic_model
         .all_bindings()
         .find(|binding| {
-            binding
-                .tree()
-                .name_token()
-                .is_ok_and(|token| token.text_trimmed() == name)
+            binding.tree().is_some_and(|tree| {
+                tree.name_token()
+                    .is_ok_and(|token| token.text_trimmed() == name)
+            })
         })
         .unwrap_or_else(|| panic!("{name} binding must exist"))
-        .syntax()
-        .text_trimmed_range()
+        .range()
 }
 
 fn overload_binding_range_by_name(
@@ -480,13 +479,13 @@ fn overload_binding_range_by_name(
     info.semantic_model
         .all_bindings()
         .filter(|binding| {
-            binding
-                .tree()
-                .name_token()
-                .is_ok_and(|token| token.text_trimmed() == name)
+            binding.tree().is_some_and(|tree| {
+                tree.name_token()
+                    .is_ok_and(|token| token.text_trimmed() == name)
+            })
         })
         .find_map(|binding| {
-            let range = binding.syntax().text_trimmed_range();
+            let range = binding.range();
             let ty = inferred
                 .binding_type_data
                 .get(&range)

--- a/crates/biome_module_graph/src/db/type_inference/promise_classification.rs
+++ b/crates/biome_module_graph/src/db/type_inference/promise_classification.rs
@@ -306,9 +306,7 @@ fn classify_expression(
                                     projection: state.projection,
                                 };
                             }
-                            let Some(reference) = js_info
-                                .raw_binding_types
-                                .get(&binding.syntax().text_trimmed_range())
+                            let Some(reference) = js_info.raw_binding_types.get(&binding.range())
                             else {
                                 return Indeterminate;
                             };

--- a/crates/biome_module_graph/src/db/type_inference/qualifiers.rs
+++ b/crates/biome_module_graph/src/db/type_inference/qualifiers.rs
@@ -43,10 +43,8 @@ impl<'db> ResolutionCtx<'db, '_> {
                 .and_then(|reference| reference.get_binding_id_for_qualifier(qualifier))
                 .and_then(|id| self.js_info.semantic_model.binding_by_id(id));
             if let Some(binding) = binding {
-                let TypeReference::Resolved(resolved_id) = self
-                    .js_info
-                    .raw_binding_types
-                    .get(&binding.syntax().text_trimmed_range())?
+                let TypeReference::Resolved(resolved_id) =
+                    self.js_info.raw_binding_types.get(&binding.range())?
                 else {
                     return None;
                 };
@@ -109,7 +107,7 @@ impl<'db> ResolutionCtx<'db, '_> {
                 } else {
                     self.js_info
                         .raw_binding_types
-                        .get(&binding.syntax().text_trimmed_range())
+                        .get(&binding.range())
                         .cloned()
                         .map_or(InferredTypeData::Unknown, |reference| {
                             self.resolve(&reference)

--- a/crates/biome_module_graph/src/js_module_info.rs
+++ b/crates/biome_module_graph/src/js_module_info.rs
@@ -185,7 +185,7 @@ impl JsModuleInfo {
                     return None;
                 }
 
-                Some(binding.syntax().text_trimmed().into_text())
+                Some(binding.syntax()?.text_trimmed().into_text())
             })
     }
 
@@ -385,7 +385,7 @@ impl JsModuleInfoInner {
             // Check if this scope has a binding with the given name
             if let Some(binding) = scope.get_binding(name) {
                 // Return the binding's range for type data lookup
-                return Some(binding.syntax().text_trimmed_range());
+                return Some(binding.range());
             }
 
             // Move to parent scope

--- a/crates/biome_module_graph/src/js_module_info/binding.rs
+++ b/crates/biome_module_graph/src/js_module_info/binding.rs
@@ -27,8 +27,7 @@ impl std::fmt::Debug for JsBinding {
         let name = self
             .semantic_binding
             .tree()
-            .name_token()
-            .ok()
+            .and_then(|binding| binding.name_token().ok())
             .map(|t| t.text_trimmed().to_string());
         f.debug_struct("JsBinding").field("name", &name).finish()
     }
@@ -60,8 +59,7 @@ impl JsBinding {
     pub fn name(&self) -> Text {
         self.semantic_binding
             .tree()
-            .name_token()
-            .ok()
+            .and_then(|binding| binding.name_token().ok())
             .map(|t| t.token_text_trimmed().into())
             .unwrap_or_default()
     }
@@ -80,7 +78,7 @@ impl JsBinding {
     /// a default unknown type when no augmentation data exists.
     pub fn ty(&self) -> TypeReference {
         // Look up type augmentation data by binding range
-        let binding_range = self.semantic_binding.syntax().text_trimmed_range();
+        let binding_range = self.semantic_binding.range();
         self.data
             .binding_type_data
             .get(&binding_range)

--- a/crates/biome_module_graph/src/js_module_info/collector.rs
+++ b/crates/biome_module_graph/src/js_module_info/collector.rs
@@ -115,13 +115,15 @@ impl JsModuleInfoCollector {
         let mut bindings = Vec::new();
 
         for binding in semantic_model.all_bindings() {
-            let name = binding
-                .tree()
+            let Some(tree) = binding.tree() else {
+                continue;
+            };
+            let name = tree
                 .name_token()
                 .ok()
                 .map(|t| t.token_text_trimmed().into())
                 .unwrap_or_default();
-            let range = binding.syntax().text_trimmed_range();
+            let range = binding.range();
 
             bindings.push(JsBindingData {
                 name,
@@ -439,7 +441,7 @@ impl JsModuleInfoCollector {
             let binding = &self.bindings[index];
             if let Some(node) = semantic_model
                 .as_binding_by_range(binding.range)
-                .map(|b| b.syntax().clone())
+                .and_then(|binding| binding.syntax())
             {
                 let scope_id = semantic_model.scope_for_range(binding.range).id();
                 let ty = self.infer_type(&node, binding.clone(), scope_id, semantic_model);
@@ -587,7 +589,9 @@ impl JsModuleInfoCollector {
         union_collector.add(ty.clone());
         let mut saw_widening_reference = false;
         for reference in references {
-            let node = reference.syntax();
+            let Some(node) = reference.syntax() else {
+                continue;
+            };
             let reference_scope = reference.scope().id();
 
             // We don't want to widen types inside the same scope

--- a/crates/biome_module_graph/src/js_module_info/module_resolver.rs
+++ b/crates/biome_module_graph/src/js_module_info/module_resolver.rs
@@ -526,9 +526,9 @@ fn resolve_binding_as_import(
         .semantic_model
         .scope_from_id(ScopeId::GLOBAL)
         .bindings()
-        .find(|b| b.syntax().text_trimmed_range() == binding_range)?;
+        .find(|binding| binding.range() == binding_range)?;
 
-    let name = binding.syntax().text_trimmed().into_text();
+    let name = binding.syntax()?.text_trimmed().into_text();
 
     // Check if this binding is an import
     if !module.is_binding_imported(name.text(), ScopeId::GLOBAL) {

--- a/crates/biome_module_graph/tests/snap/mod.rs
+++ b/crates/biome_module_graph/tests/snap/mod.rs
@@ -152,8 +152,8 @@ impl<'a> ModuleGraphSnapshot<'a> {
                                     let binding_name = data
                                         .semantic_model
                                         .all_bindings()
-                                        .find(|b| b.syntax().text_trimmed_range() == binding_range)
-                                        .and_then(|b| b.tree().name_token().ok())
+                                        .find(|binding| binding.range() == binding_range)
+                                        .and_then(|binding| binding.tree()?.name_token().ok())
                                         .map_or_else(|| "<unknown>".to_string(), |b| b.to_string());
 
                                     content.push_str(&format!(

--- a/crates/biome_module_graph/tests/spec_tests_v2.rs
+++ b/crates/biome_module_graph/tests/spec_tests_v2.rs
@@ -556,15 +556,15 @@ fn inferred_binding_ty_by_name<'db>(
         return None;
     };
     let binding = info.semantic_model.all_bindings().find(|binding| {
-        binding
-            .tree()
-            .name_token()
-            .is_ok_and(|token| token.text_trimmed() == name)
+        binding.tree().is_some_and(|tree| {
+            tree.name_token()
+                .is_ok_and(|token| token.text_trimmed() == name)
+        })
     })?;
 
     inferred
         .binding_type_data
-        .get(&binding.syntax().text_trimmed_range())
+        .get(&binding.range())
         .map(|data| data.ty)
 }
 
@@ -674,15 +674,15 @@ fn inferred_overload_ty_by_name<'db>(
     info.semantic_model
         .all_bindings()
         .filter(|binding| {
-            binding
-                .tree()
-                .name_token()
-                .is_ok_and(|token| token.text_trimmed() == name)
+            binding.tree().is_some_and(|tree| {
+                tree.name_token()
+                    .is_ok_and(|token| token.text_trimmed() == name)
+            })
         })
         .filter_map(|binding| {
             inferred
                 .binding_type_data
-                .get(&binding.syntax().text_trimmed_range())
+                .get(&binding.range())
                 .map(|data| inferred.resolve_type(db, data.ty))
         })
         .find(|ty| {
@@ -747,7 +747,7 @@ fn write_inferred_type_rows<'db>(
         let binding_name = info
             .semantic_model
             .as_binding_by_range(*range)
-            .and_then(|binding| binding.tree().name_token().ok())
+            .and_then(|binding| binding.tree()?.name_token().ok())
             .map_or_else(
                 || "<unknown>".to_string(),
                 |token| token.text_trimmed().to_string(),
@@ -923,14 +923,13 @@ fn binding_range_by_name(db: &dyn ModuleDb, module: ModuleInfo, name: &str) -> T
         .semantic_model
         .all_bindings()
         .find(|binding| {
-            binding
-                .tree()
-                .name_token()
-                .is_ok_and(|token| token.text_trimmed() == name)
+            binding.tree().is_some_and(|tree| {
+                tree.name_token()
+                    .is_ok_and(|token| token.text_trimmed() == name)
+            })
         })
         .unwrap_or_else(|| panic!("{name} binding must exist"))
-        .syntax()
-        .text_trimmed_range()
+        .range()
 }
 
 #[test]

--- a/crates/biome_service/src/file_handlers/css/go_to.rs
+++ b/crates/biome_service/src/file_handlers/css/go_to.rs
@@ -45,7 +45,9 @@ pub(crate) fn resolve_definition(params: ResolveDefinitionParams) -> Option<GoTo
         let semantic_model = css_semantic_model(&params.workspace_db, &params.parsed_source);
         for rule in semantic_model.rules() {
             for selector in rule.selectors() {
-                let node = selector.node(&semantic_model.root());
+                let Some(node) = selector.node(&semantic_model.root()) else {
+                    continue;
+                };
                 for class_sel in node
                     .syntax()
                     .descendants()

--- a/crates/biome_service/src/file_handlers/javascript/go_to.rs
+++ b/crates/biome_service/src/file_handlers/javascript/go_to.rs
@@ -47,9 +47,9 @@ pub(crate) fn resolve_binding(params: ResolveBindingParams) -> Option<Definition
         if let Some(reference) = JsReferenceIdentifier::cast_ref(&ancestor)
             && let Some(binding) = semantic_model.binding(&reference)
         {
-            let binding_syntax = binding.syntax();
+            let binding_syntax = binding.syntax()?;
             if let Some(specifier) = is_under_import_clause(&binding_syntax) {
-                let name = binding.syntax().text_trimmed().to_string();
+                let name = binding_syntax.text_trimmed().to_string();
                 return Some(DefinitionReference::Import {
                     local_name: name,
                     specifier: specifier.to_string(),
@@ -59,14 +59,14 @@ pub(crate) fn resolve_binding(params: ResolveBindingParams) -> Option<Definition
                 return Some(result);
             }
             return Some(DefinitionReference::Local {
-                range: binding.syntax().text_trimmed_range(),
+                range: binding_syntax.text_trimmed_range(),
             });
         }
 
         if let Some(reference) = JsxReferenceIdentifier::cast_ref(&ancestor)
             && let Some(binding) = semantic_model.binding(&reference)
         {
-            let binding_syntax = binding.syntax();
+            let binding_syntax = binding.syntax()?;
             if let Some(specifier) = is_under_import_clause(&binding_syntax) {
                 let name = binding_syntax.text_trimmed().to_string();
                 return Some(DefinitionReference::Import {


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/10905

The issue was caused by the semantic model, which used `to_node`. The function panics if the root node contains a broken CST. 

This PR changes the callers to use `try_to_node` instead. The changes are spread out, unfortunately.

Implemented with a coding agent.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added new tests


<!-- What demonstrates that your implementation is correct? -->

## Docs

N/A

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
