### PR TITLE
fix(css): resolve empty syntax node pointers

### DIFF
--- a/.changeset/hot-areas-double.md
+++ b/.changeset/hot-areas-double.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10905](https://github.com/biomejs/biome/issues/10905): Biome no longer crashes while analyzing incomplete CSS property values during editing.

--- a/crates/biome_css_semantic/src/semantic_model/db.rs
+++ b/crates/biome_css_semantic/src/semantic_model/db.rs
@@ -163,6 +163,24 @@ mod tests {
     }
 
     #[test]
+    fn incomplete_property_value_does_not_panic() {
+        let mut db = TestDb::new();
+        let file = make_file(&db, ".incomplete {\n  height: 1px\n}\n");
+
+        assert_eq!(rule_count(&db, file), 1);
+
+        let new_parsed = parse_css(
+            ".incomplete {\n  height:\n}\n",
+            CssFileSource::css(),
+            CssParserOptions::default(),
+        )
+        .into();
+        salsa::Setter::to(file.set_parsed(&mut db), new_parsed);
+
+        assert_eq!(rule_count(&db, file), 1);
+    }
+
+    #[test]
     fn declaration_count_change_does_recompute_downstream() {
         let mut db = TestDb::new();
         let file = make_file(&db, "p { color: red; }");

--- a/crates/biome_rowan/src/ast/mod.rs
+++ b/crates/biome_rowan/src/ast/mod.rs
@@ -840,17 +840,24 @@ impl<L: Language> SyntaxNodePtr<L> {
     /// Also returns `None` if `root` is not actually a root (i.e. it has a
     /// parent).
     ///
-    /// The complexity is linear in the depth of the tree and logarithmic in
-    /// tree width. As most trees are shallow, thinking about this as
-    /// `O(log(N))` in the size of the tree is not too wrong!
+    /// For non-empty ranges, the complexity is linear in the depth of the tree
+    /// and logarithmic in tree width. Empty ranges may require a linear scan
+    /// because multiple slots can occupy the same source boundary.
     pub fn try_to_node(&self, root: &SyntaxNode<L>) -> Option<SyntaxNode<L>> {
         if root.parent().is_some() {
             return None;
         }
-        successors(Some(root.clone()), |node| {
+        let node = successors(Some(root.clone()), |node| {
             node.child_or_token_at_range(self.range)?.into_node()
         })
-        .find(|it| it.text_range_with_trivia() == self.range && it.kind() == self.kind)
+        .find(|it| it.text_range_with_trivia() == self.range && it.kind() == self.kind);
+
+        if node.is_some() || !self.range.is_empty() {
+            node
+        } else {
+            root.descendants()
+                .find(|it| it.text_range_with_trivia() == self.range && it.kind() == self.kind)
+        }
     }
 
     /// Casts this to an [`AstPtr`] to the given node type if possible.
@@ -1382,6 +1389,21 @@ mod tests {
             *third.syntax(),
             third_ptr.to_node(list.syntax_list().node())
         );
+    }
+
+    #[test]
+    fn syntax_ptr_roundtrip_nested_empty_node() {
+        let tree = RawSyntaxTreeBuilder::wrap_with_node(RawLanguageKind::ROOT, |builder| {
+            builder.token(RawLanguageKind::LET_TOKEN, "let");
+            builder.start_node(RawLanguageKind::CONDITION);
+            builder.start_node(RawLanguageKind::LITERAL_EXPRESSION);
+            builder.finish_node();
+            builder.finish_node();
+        });
+        let empty = tree.first_child().unwrap().first_child().unwrap();
+        let empty_ptr = SyntaxNodePtr::new(&empty);
+
+        assert_eq!(empty, empty_ptr.to_node(&tree));
     }
 
     #[test]

--- a/crates/biome_rowan/src/ast/mod.rs
+++ b/crates/biome_rowan/src/ast/mod.rs
@@ -855,7 +855,7 @@ impl<L: Language> SyntaxNodePtr<L> {
         if node.is_some() || !self.range.is_empty() {
             node
         } else {
-            root.descendants()
+            root.pruned_descendents(|it| it.text_range_with_trivia().contains_range(self.range))
                 .find(|it| it.text_range_with_trivia() == self.range && it.kind() == self.kind)
         }
     }


### PR DESCRIPTION
> This PR was created with AI assistance (OpenAI Codex).

## Summary

Fixes #10905

Prevents `SyntaxNodePtr` resolution from failing for nested empty-range nodes, avoiding a crash while analyzing incomplete CSS property values during editing.

## Test Plan

- `cargo test`
