### PR TITLE
feat(npm): add Android (Termux) support to the npm distribution

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -18,6 +18,8 @@
       "@biomejs/cli-linux-arm64",
       "@biomejs/cli-linux-x64-musl",
       "@biomejs/cli-linux-arm64-musl",
+      "@biomejs/cli-android-x64",
+      "@biomejs/cli-android-arm64",
       "@biomejs/wasm-web",
       "@biomejs/wasm-bundler",
       "@biomejs/wasm-nodejs"

--- a/.changeset/pretty-webs-hope.md
+++ b/.changeset/pretty-webs-hope.md
@@ -1,5 +1,5 @@
 ---
-"@biomejs/biome": patch
+"@biomejs/biome": minor
 ---
 
-Fixed [#1340](https://github.com/biomejs/biome/issues/1340): `npm install @biomejs/biome` now works on Android (Termux). Added the `@biomejs/cli-android-arm64` and `@biomejs/cli-android-x64` packages, which reuse the static musl binaries.
+Added Android (Termux) support to the npm distribution ([#1340](https://github.com/biomejs/biome/issues/1340)). `npm install @biomejs/biome` now works on Termux through the new `@biomejs/cli-android-arm64` and `@biomejs/cli-android-x64` packages, which reuse the static musl binaries.

--- a/.changeset/pretty-webs-hope.md
+++ b/.changeset/pretty-webs-hope.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#1340](https://github.com/biomejs/biome/issues/1340): `npm install @biomejs/biome` now works on Android (Termux). Added the `@biomejs/cli-android-arm64` and `@biomejs/cli-android-x64` packages, which reuse the static musl binaries.

--- a/packages/@biomejs/biome/bin/biome
+++ b/packages/@biomejs/biome/bin/biome
@@ -34,6 +34,10 @@ const PLATFORMS = {
 		x64: "@biomejs/cli-linux-x64-musl/biome",
 		arm64: "@biomejs/cli-linux-arm64-musl/biome",
 	},
+	android: {
+		x64: "@biomejs/cli-android-x64/biome",
+		arm64: "@biomejs/cli-android-arm64/biome",
+	},
 };
 
 const binPath = env.BIOME_BINARY ||

--- a/packages/@biomejs/biome/package.json
+++ b/packages/@biomejs/biome/package.json
@@ -54,6 +54,8 @@
     "@biomejs/cli-linux-x64": "2.5.10",
     "@biomejs/cli-linux-arm64": "2.5.10",
     "@biomejs/cli-linux-x64-musl": "2.5.10",
-    "@biomejs/cli-linux-arm64-musl": "2.5.10"
+    "@biomejs/cli-linux-arm64-musl": "2.5.10",
+    "@biomejs/cli-android-x64": "2.5.10",
+    "@biomejs/cli-android-arm64": "2.5.10"
   }
 }

--- a/packages/@biomejs/biome/package.json
+++ b/packages/@biomejs/biome/package.json
@@ -53,6 +53,8 @@
     "@biomejs/cli-linux-x64": "2.5.5",
     "@biomejs/cli-linux-arm64": "2.5.5",
     "@biomejs/cli-linux-x64-musl": "2.5.5",
-    "@biomejs/cli-linux-arm64-musl": "2.5.5"
+    "@biomejs/cli-linux-arm64-musl": "2.5.5",
+    "@biomejs/cli-android-x64": "2.5.5",
+    "@biomejs/cli-android-arm64": "2.5.5"
   }
 }

--- a/packages/@biomejs/biome/scripts/generate-packages.mjs
+++ b/packages/@biomejs/biome/scripts/generate-packages.mjs
@@ -14,7 +14,7 @@ function getName(platform, arch, prefix = "cli") {
 	return format(`${prefix}-${platform}`, arch);
 }
 
-function copyBinaryToNativePackage(platform, arch) {
+function copyBinaryToNativePackage(platform, arch, binaryPlatform = platform) {
 	const os = platform.split("-")[0];
 	const buildName = getName(platform, arch);
 	const packageRoot = resolve(PACKAGES_ROOT, buildName);
@@ -52,7 +52,7 @@ function copyBinaryToNativePackage(platform, arch) {
 	const ext = os === "win32" ? ".exe" : "";
 	const binarySource = resolve(
 		REPO_ROOT,
-		`${getName(platform, arch, "biome")}${ext}`,
+		`${getName(binaryPlatform, arch, "biome")}${ext}`,
 	);
 	const binaryTarget = resolve(packageRoot, `biome${ext}`);
 
@@ -136,6 +136,12 @@ for (const platform of PLATFORMS) {
 	for (const arch of ARCHITECTURES) {
 		copyBinaryToNativePackage(platform, arch);
 	}
+}
+
+// The Android (Termux) packages have no dedicated build; they reuse the
+// static musl binaries, which run unmodified on Android.
+for (const arch of ARCHITECTURES) {
+	copyBinaryToNativePackage("android-%s", arch, "linux-%s-musl");
 }
 
 for (const jsPackage of JS_PACKAGES) {

--- a/packages/@biomejs/cli-android-arm64/package.json
+++ b/packages/@biomejs/cli-android-arm64/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@biomejs/cli-android-arm64",
+  "version": "2.5.10",
+  "license": "MIT OR Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/biomejs/biome.git",
+    "directory": "packages/@biomejs/biome/cli-android-arm64"
+  },
+  "engines": {
+    "node": ">=14.21.3"
+  },
+  "homepage": "https://biomejs.dev",
+  "os": [
+    "android"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "publishConfig": {
+    "provenance": true
+  }
+}

--- a/packages/@biomejs/cli-android-arm64/package.json
+++ b/packages/@biomejs/cli-android-arm64/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@biomejs/cli-android-arm64",
+  "version": "2.5.5",
+  "license": "MIT OR Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/biomejs/biome.git",
+    "directory": "packages/@biomejs/biome/cli-android-arm64"
+  },
+  "engines": {
+    "node": ">=14.21.3"
+  },
+  "homepage": "https://biomejs.dev",
+  "os": [
+    "android"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "publishConfig": {
+    "provenance": true
+  }
+}

--- a/packages/@biomejs/cli-android-x64/package.json
+++ b/packages/@biomejs/cli-android-x64/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@biomejs/cli-android-x64",
+  "version": "2.5.10",
+  "license": "MIT OR Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/biomejs/biome.git",
+    "directory": "packages/@biomejs/biome/cli-android-x64"
+  },
+  "engines": {
+    "node": ">=14.21.3"
+  },
+  "homepage": "https://biomejs.dev",
+  "os": [
+    "android"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "publishConfig": {
+    "provenance": true
+  }
+}

--- a/packages/@biomejs/cli-android-x64/package.json
+++ b/packages/@biomejs/cli-android-x64/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@biomejs/cli-android-x64",
+  "version": "2.5.5",
+  "license": "MIT OR Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/biomejs/biome.git",
+    "directory": "packages/@biomejs/biome/cli-android-x64"
+  },
+  "engines": {
+    "node": ">=14.21.3"
+  },
+  "homepage": "https://biomejs.dev",
+  "os": [
+    "android"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "publishConfig": {
+    "provenance": true
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,12 @@ importers:
 
   packages/@biomejs/biome:
     optionalDependencies:
+      '@biomejs/cli-android-arm64':
+        specifier: 2.5.5
+        version: link:../cli-android-arm64
+      '@biomejs/cli-android-x64':
+        specifier: 2.5.5
+        version: link:../cli-android-x64
       '@biomejs/cli-darwin-arm64':
         specifier: 2.5.5
         version: link:../cli-darwin-arm64
@@ -99,6 +105,10 @@ importers:
       '@biomejs/cli-win32-x64':
         specifier: 2.5.5
         version: link:../cli-win32-x64
+
+  packages/@biomejs/cli-android-arm64: {}
+
+  packages/@biomejs/cli-android-x64: {}
 
   packages/@biomejs/cli-darwin-arm64: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,12 @@ importers:
 
   packages/@biomejs/biome:
     optionalDependencies:
+      '@biomejs/cli-android-arm64':
+        specifier: 2.5.10
+        version: link:../cli-android-arm64
+      '@biomejs/cli-android-x64':
+        specifier: 2.5.10
+        version: link:../cli-android-x64
       '@biomejs/cli-darwin-arm64':
         specifier: 2.5.10
         version: link:../cli-darwin-arm64
@@ -99,6 +105,10 @@ importers:
       '@biomejs/cli-win32-x64':
         specifier: 2.5.10
         version: link:../cli-win32-x64
+
+  packages/@biomejs/cli-android-arm64: {}
+
+  packages/@biomejs/cli-android-x64: {}
 
   packages/@biomejs/cli-darwin-arm64: {}
 

--- a/scripts/update-manifests.mjs
+++ b/scripts/update-manifests.mjs
@@ -22,6 +22,12 @@ for (const platform of PLATFORMS) {
 	}
 }
 
+// The Android (Termux) packages have no dedicated build; they reuse the
+// static musl binaries, which run unmodified on Android.
+for (const arch of ARCHITECTURES) {
+	updateOptionalDependencies("android-%s", arch, "linux-%s-musl");
+}
+
 for (const target of WASM_TARGETS) {
 	updateWasmPackage(target);
 }
@@ -30,7 +36,7 @@ function getName(platform, arch, prefix = "cli") {
 	return format(`${prefix}-${platform}`, arch);
 }
 
-function updateOptionalDependencies(platform, arch) {
+function updateOptionalDependencies(platform, arch, binaryPlatform = platform) {
 	const os = platform.split("-")[0];
 	const buildName = getName(platform, arch);
 	const packageRoot = resolve(PACKAGES_ROOT, buildName);
@@ -71,7 +77,7 @@ function updateOptionalDependencies(platform, arch) {
 	const ext = os === "win32" ? ".exe" : "";
 	const binarySource = resolve(
 		REPO_ROOT,
-		`${getName(platform, arch, "biome")}${ext}`,
+		`${getName(binaryPlatform, arch, "biome")}${ext}`,
 	);
 	const binaryTarget = resolve(packageRoot, `biome${ext}`);
 


### PR DESCRIPTION
## Summary

Fixes #1340, discussed in #11100.

I need Biome on my Android device.

The static musl binaries already run unmodified on Android (Termux). Only the npm distribution is broken: `process.platform` is `"android"` there, so npm installs none of the `@biomejs/cli-*` optional dependencies and the `bin/biome` wrapper exits with an unsupported platform error.

This adds two packages, `@biomejs/cli-android-arm64` and `@biomejs/cli-android-x64`, which reuse the musl binaries.

## Test Plan

Tested manually on an aarch64 Termux device: packed both packages with the real musl binary, installed the tarballs, then ran `biome format --write` and `biome --version` through the npm wrapper. Also ran `generate-packages.mjs` locally to check the generated android manifests.

## Docs

N/A

Disclosure: this PR was written primarily by Claude Code. I reviewed the changes and ran the tests on my own device.