### PR TITLE
fix(module_graph): bound nested module inference on the Rust stack

### DIFF
--- a/.changeset/fix-module-inference-stack-overflow.md
+++ b/.changeset/fix-module-inference-stack-overflow.md
@@ -1,0 +1,13 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed a stack overflow in type inference when a project depends on a package
+whose declaration files form a large dependency cycle, such as an SDK whose
+modules all reference each other through barrel files. Inferring one module of
+such a cycle recursed into every other member on the Rust stack and crashed
+workspace worker threads with `fatal runtime error: stack overflow`.
+
+Nested whole-module inference is now bounded. Dependencies beyond the depth
+limit are treated as unavailable, so affected types resolve to `Unknown`
+instead of crashing, mirroring how imports blocked by cycle recovery behave.

--- a/crates/biome_module_graph/src/db/queries/type_inference.rs
+++ b/crates/biome_module_graph/src/db/queries/type_inference.rs
@@ -48,6 +48,7 @@ pub use lookups::{
     infer_local_type, resolve_callable_type,
 };
 pub(crate) use module_types::infer_module_types_bottom_up_for_import_depth;
+pub(in crate::db) use module_types::infer_module_types_nested;
 pub use module_types::{infer_module_types, infer_module_types_bottom_up};
 pub use normalization::normalize_type;
 pub use promises::{

--- a/crates/biome_module_graph/src/db/queries/type_inference/module_types.rs
+++ b/crates/biome_module_graph/src/db/queries/type_inference/module_types.rs
@@ -22,6 +22,43 @@ use crate::{
     JsExport, JsOwnExport, ModuleDb, ResolvedPath, type_inference::TypeInferenceCodeReference,
 };
 use rustc_hash::FxHashSet;
+use std::cell::Cell;
+
+// The bottom-up work list prepares acyclic dependencies before their
+// importers, but modules inside a strongly connected component cannot be
+// prepared ahead of one another. Without a bound, the first inferred member
+// of a large component would pull the entire component onto the Rust stack
+// through recursive `infer_module_types` executions. Each level costs roughly
+// twenty stack frames, so large dependency cycles — such as a package whose
+// modules all import a barrel file that re-exports them — could overflow the
+// stack of a worker thread.
+const MAX_NESTED_MODULE_INFERENCE_DEPTH: usize = 32;
+
+thread_local! {
+    static NESTED_MODULE_INFERENCE_DEPTH: Cell<usize> = const { Cell::new(0) };
+}
+
+struct NestedModuleInferenceGuard;
+
+impl NestedModuleInferenceGuard {
+    fn enter() -> Option<Self> {
+        NESTED_MODULE_INFERENCE_DEPTH.with(|depth| {
+            let current = depth.get();
+            if current >= MAX_NESTED_MODULE_INFERENCE_DEPTH {
+                None
+            } else {
+                depth.set(current + 1);
+                Some(Self)
+            }
+        })
+    }
+}
+
+impl Drop for NestedModuleInferenceGuard {
+    fn drop(&mut self) {
+        NESTED_MODULE_INFERENCE_DEPTH.with(|depth| depth.set(depth.get() - 1));
+    }
+}
 
 // #region COMPLETE MODULE QUERY
 
@@ -73,6 +110,22 @@ pub fn infer_module_types<'db>(
             Some(result)
         },
     )
+}
+
+/// Infers module types as a dependency of an already executing inference.
+///
+/// A cache hit returns without recursion, so prepared dependencies do not
+/// consume the depth budget. Executing an uncached module recurses on the
+/// Rust stack; after 32 nested executions the dependency is treated as
+/// unavailable and the function returns `None`, in addition to the cases
+/// documented on [`infer_module_types`]. Types that depend on such a module
+/// may be `Unknown`, mirroring how imports blocked by cycle recovery behave.
+pub(in crate::db) fn infer_module_types_nested<'db>(
+    db: &'db dyn ModuleDb,
+    module: ModuleInfo,
+) -> Option<&'db InferredModuleTypes<'db>> {
+    let _depth_guard = NestedModuleInferenceGuard::enter()?;
+    infer_module_types(db, module)
 }
 
 // #endregion

--- a/crates/biome_module_graph/src/db/type_inference/lookup.rs
+++ b/crates/biome_module_graph/src/db/type_inference/lookup.rs
@@ -1,5 +1,5 @@
 use super::{InferredModuleTypes, collected_type_result};
-use crate::db::queries::{LocalTypeInput, infer_local_type, infer_module_types};
+use crate::db::queries::{LocalTypeInput, infer_local_type, infer_module_types_nested};
 use crate::{ModuleDb, module_for_key};
 use biome_js_type_info::interned_types::{
     Literal as InferredLiteral, LocalTypeHandle, ReturnType as InferredReturnType,
@@ -121,7 +121,8 @@ impl<'db> InferredModuleTypes<'db> {
         }
 
         let module = module_for_key(db, module_key)?;
-        infer_module_types(db, module).and_then(|types| types.types.get(type_id.index()).copied())
+        infer_module_types_nested(db, module)
+            .and_then(|types| types.types.get(type_id.index()).copied())
     }
 
     pub(in crate::db::type_inference) fn find_member_type_iterative(

--- a/crates/biome_module_graph/src/db/type_inference/resolver.rs
+++ b/crates/biome_module_graph/src/db/type_inference/resolver.rs
@@ -1,5 +1,5 @@
 use super::{BindingTypeData, InferredModuleTypes, globals::global_type};
-use crate::db::queries::{LocalTypeInput, infer_local_type, infer_module_types};
+use crate::db::queries::{LocalTypeInput, infer_local_type, infer_module_types_nested};
 use crate::module_graph::ModuleInfo;
 use crate::{JsModuleInfo, ModuleDb, module_for_key};
 use biome_js_type_info::{
@@ -108,18 +108,19 @@ impl<'db, 'a> ResolutionCtx<'db, 'a> {
     ///
     /// The tracked query records the imported result as a dependency of the
     /// current inference. Returns `None` for unsupported modules, disabled type
-    /// inference, or an import cycle.
+    /// inference, an import cycle, or when the nested inference depth limit is
+    /// reached.
     pub(in crate::db::type_inference) fn infer_imported_module(
         &self,
         module: ModuleInfo,
     ) -> Option<&'db InferredModuleTypes<'db>> {
         match self.import_resolution {
-            ImportResolution::OnDemand => infer_module_types(self.db, module),
+            ImportResolution::OnDemand => infer_module_types_nested(self.db, module),
             ImportResolution::CycleFallback(blocked) => {
                 if blocked.contains(&module) {
                     None
                 } else {
-                    infer_module_types(self.db, module)
+                    infer_module_types_nested(self.db, module)
                 }
             }
         }

--- a/crates/biome_module_graph/tests/spec_tests_v2/cycles.test.rs
+++ b/crates/biome_module_graph/tests/spec_tests_v2/cycles.test.rs
@@ -234,6 +234,62 @@ fn test_infer_module_types_bounds_mutual_namespace_reexports() {
 }
 
 #[test]
+fn test_infer_module_types_bounds_stack_depth_across_a_large_component() {
+    // Models an SDK whose declaration files form one large dependency cycle:
+    // every module declares a branded type plus a constructor function whose
+    // return type refers to the next module in the cycle. On-demand import
+    // resolution switches to the iterative fallback after 128 nested
+    // resolutions, but the fallback itself used to execute one nested
+    // `infer_module_types` per remaining cycle member on the Rust stack, so
+    // components larger than the remaining stack overflowed it. The thread's
+    // explicit stack size keeps the previous overflow deterministic.
+    const COMPONENT_SIZE: usize = 300;
+
+    let fs = MemoryFileSystem::default();
+    let mut paths = Vec::with_capacity(COMPONENT_SIZE + 1);
+    for index in 0..COMPONENT_SIZE {
+        let next = (index + 1) % COMPONENT_SIZE;
+        let path = format!("/src/id{index}.ts");
+        fs.insert(
+            path.clone().into(),
+            format!(
+                r#"
+                    import type {{ Id{next} }} from "./id{next}.ts";
+                    export type Id{index} = string & {{ Id{index}: void }};
+                    export declare function Id{index}(value: string): Id{next} | Id{index};
+                "#
+            ),
+        );
+        paths.push(path);
+    }
+    fs.insert(
+        "/src/main.ts".into(),
+        r#"
+            import { Id0 } from "./id0.ts";
+            export const value = Id0("id");
+        "#,
+    );
+    paths.push("/src/main.ts".to_string());
+
+    std::thread::Builder::new()
+        .stack_size(4 * 1024 * 1024)
+        .spawn(move || {
+            let path_refs = paths.iter().map(String::as_str).collect::<Vec<_>>();
+            let db = build_js_test_module_db(&fs, &path_refs, true);
+            let main_module = db
+                .module_for_path(Utf8Path::new("/src/main.ts"))
+                .expect("main module must exist");
+            let inferred =
+                infer_module_types_bottom_up(&db, main_module).expect("types must be inferred");
+            inferred_binding_ty_by_name(&db, main_module, inferred, "value")
+                .expect("value binding type must be inferred");
+        })
+        .expect("worker thread must spawn")
+        .join()
+        .expect("inference must complete without overflowing the stack");
+}
+
+#[test]
 fn test_binding_query_preserves_acyclic_data_next_to_an_import_cycle() {
     let fs = MemoryFileSystem::default();
     fs.insert(


### PR DESCRIPTION
## Summary

Since 2.5.6, running `biome check` on a project that depends on a package whose declaration files form a large dependency cycle crashes with:

```
thread 'biome::workspace_worker_N' (…) has overflowed its stack
fatal runtime error: stack overflow, aborting
```

A real-world trigger is the `candidhealth` npm package (and SDKs with a similar layout): every generated module declares a branded type plus a constructor function whose return type points back through the package barrel (`export type EncounterId = string & {…}; export declare function EncounterId(value: string): CandidApi.EncounterId;`), and the barrel star-re-exports every module, so the whole package is one strongly connected component of ~2,800 modules. A two-line file is enough to crash the whole check:

```ts
import { CandidApi } from "candidhealth";
const f = (id: string) => CandidApi.EncounterId(id);
```

The root cause: on-demand import resolution correctly switches to the iterative bottom-up fallback after 128 nested resolutions (`MAX_ON_DEMAND_IMPORT_DEPTH`), but while the fallback is active, `resolve_import_symbol` short-circuits into `infer_imported_module`, which re-enters the `infer_module_types` salsa query with **no depth bound**. The bottom-up work list can only prepare *acyclic* dependencies, so inside a strongly connected component each uncached member executes nested on the Rust stack (~19 frames per module, observed under lldb), until the worker thread's stack is exhausted. The salsa cycle recovery does not prevent this because each nested execution has a distinct query key, and `inference_scc` caps its dependency walk at 1,024 steps, so blocking is incomplete for components larger than that.

This PR bounds nested whole-module inference with a shared, unwind-safe depth guard (`infer_module_types_nested`, limit 32) at the two call sites that re-enter `infer_module_types` from an executing query (`ResolutionCtx::infer_imported_module` and `ScopedResolver::type_for_local_handle` in `lookup.rs`). Cache hits do not consume the budget, so prepared acyclic chains are unaffected. Dependencies beyond the limit are treated as unavailable and resolve to `Unknown`, mirroring how imports blocked by cycle recovery already behave.

Possibly related to the reports in #10411 (same crash signature with type-aware rules on large projects).

Note: even with the crash fixed, checking a project that imports `candidhealth` takes ~2.5 minutes on an M-series MacBook (it completed in ~8 s on 2.5.5, which did not descend into this inference path). That looks like a separate performance issue in how namespaces of large cyclic packages are resolved; I kept this PR focused on the crash and can file the perf issue separately.

## Test Plan

- Added `test_infer_module_types_bounds_stack_depth_across_a_large_component` to `spec_tests_v2/cycles.test.rs`: a 300-module cyclic chain of branded-type declarations, run on a thread with an explicit 4 MiB stack. Without the fix the test aborts with SIGABRT (stack overflow); with the fix it passes in under a second.
- `cargo test -p biome_module_graph` (252 tests) and `cargo test -p biome_js_analyze` (3,030 tests) pass.
- Verified the release binary no longer crashes on the real-world reproducer (monorepo depending on `candidhealth@1.28.0` with the `ultracite` preset) and on the two-line minimal case above.

## Docs

No user-facing API change; changeset included.

---

*Disclosure: this PR was authored with AI assistance (Cursor). The root-cause analysis (lldb backtraces, bisection of the reproducer) and all testing were performed against real builds as described above, and I reviewed the changes.*