### PR TITLE
fix(format/yaml): move overflowing multiline flow scalars below their key

### DIFF
--- a/crates/biome_yaml_formatter/src/yaml/auxiliary/block_map_implicit_entry.rs
+++ b/crates/biome_yaml_formatter/src/yaml/auxiliary/block_map_implicit_entry.rs
@@ -4,6 +4,7 @@ use crate::prelude::*;
 use crate::utils::needs_space_before_colon;
 use biome_formatter::format_args;
 use biome_formatter::write;
+use biome_rowan::Direction;
 use biome_yaml_syntax::{
     AnyYamlBlockNode, YamlBlockMapImplicitEntry, YamlBlockMapImplicitEntryFields,
 };
@@ -159,7 +160,38 @@ impl Format<YamlFormatContext> for FormatEntryValue<'_> {
             // key: word
             //   word
             // ```
-            write!(f, [space(), indent(&value.format())])
+            //
+            // When the key and the scalar's first line together don't fit
+            // within the line width, the whole scalar moves below the key
+            // instead:
+            //
+            // ```yaml
+            // key:
+            //   word that would have overflowed the line
+            //   word
+            // ```
+            //
+            // Only a scalar that is already multiline moves; a single-line
+            // scalar stays on the key's line no matter how long. The break
+            // is inside the scalar's own token: the properties and the
+            // content of the value are joined onto one line, so the breaks
+            // in the trivia between them don't reach the output
+            let is_multiline = value
+                .syntax()
+                .descendants_tokens(Direction::Next)
+                .any(|token| token.text_trimmed().contains(['\n', '\r']));
+            if is_multiline {
+                let value = value.format().memoized();
+                write!(
+                    f,
+                    [best_fitting![
+                        format_args![space(), indent(&value)],
+                        format_args![indent(&format_args![hard_line_break(), value])],
+                    ]]
+                )
+            } else {
+                write!(f, [space(), indent(&value.format())])
+            }
         } else {
             write!(f, [space(), value.format()])
         }

--- a/crates/biome_yaml_formatter/tests/specs/yaml/scalar/multiline_overflow.yaml
+++ b/crates/biome_yaml_formatter/tests/specs/yaml/scalar/multiline_overflow.yaml
@@ -1,0 +1,24 @@
+short_multiline_stays: a multiline scalar whose first line fits
+  stays on the key's line
+single_line_stays: a single line scalar stays on the key's line even when it is far too long to fit
+overflowing_multiline_breaks: a multiline scalar whose first line does not fit within the line width
+  moves below the key as a whole
+quoted: "a multiline quoted scalar whose first line does not fit within the line width
+  also moves below the key"
+own_line_property: &anchor
+  a single line scalar joined onto the key's line with its property stays there
+own_line_property_multiline: &anchor2
+  a multiline scalar whose first line does not fit within the line width
+  moves below the key
+exact_fit:
+  deeply:
+    - name: first line is exactly eighty columns wide, so the scalar stays put
+      description: Filter Transactions by the last 4 digits of the bank account.
+        The bank account last 4 are the last 4 digits of the masked account number.
+paths:
+  /transfers:
+    get:
+      parameters:
+        - name: one level deeper, the same first line overflows and moves down
+          description: Filter Transactions by the last 4 digits of the bank account.
+            The bank account last 4 are the last 4 digits of the masked account number.

--- a/crates/biome_yaml_formatter/tests/specs/yaml/scalar/multiline_overflow.yaml.snap
+++ b/crates/biome_yaml_formatter/tests/specs/yaml/scalar/multiline_overflow.yaml.snap
@@ -1,0 +1,76 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: yaml/scalar/multiline_overflow.yaml
+---
+
+# Input
+
+```yaml
+short_multiline_stays: a multiline scalar whose first line fits
+  stays on the key's line
+single_line_stays: a single line scalar stays on the key's line even when it is far too long to fit
+overflowing_multiline_breaks: a multiline scalar whose first line does not fit within the line width
+  moves below the key as a whole
+quoted: "a multiline quoted scalar whose first line does not fit within the line width
+  also moves below the key"
+own_line_property: &anchor
+  a single line scalar joined onto the key's line with its property stays there
+own_line_property_multiline: &anchor2
+  a multiline scalar whose first line does not fit within the line width
+  moves below the key
+exact_fit:
+  deeply:
+    - name: first line is exactly eighty columns wide, so the scalar stays put
+      description: Filter Transactions by the last 4 digits of the bank account.
+        The bank account last 4 are the last 4 digits of the masked account number.
+paths:
+  /transfers:
+    get:
+      parameters:
+        - name: one level deeper, the same first line overflows and moves down
+          description: Filter Transactions by the last 4 digits of the bank account.
+            The bank account last 4 are the last 4 digits of the masked account number.
+
+```
+
+
+# Formatted
+
+```yaml
+short_multiline_stays: a multiline scalar whose first line fits
+  stays on the key's line
+single_line_stays: a single line scalar stays on the key's line even when it is far too long to fit
+overflowing_multiline_breaks:
+  a multiline scalar whose first line does not fit within the line width
+  moves below the key as a whole
+quoted:
+  "a multiline quoted scalar whose first line does not fit within the line width
+  also moves below the key"
+own_line_property: &anchor a single line scalar joined onto the key's line with its property stays there
+own_line_property_multiline:
+  &anchor2 a multiline scalar whose first line does not fit within the line width
+  moves below the key
+exact_fit:
+  deeply:
+    - name: first line is exactly eighty columns wide, so the scalar stays put
+      description: Filter Transactions by the last 4 digits of the bank account.
+        The bank account last 4 are the last 4 digits of the masked account number.
+paths:
+  /transfers:
+    get:
+      parameters:
+        - name: one level deeper, the same first line overflows and moves down
+          description:
+            Filter Transactions by the last 4 digits of the bank account.
+            The bank account last 4 are the last 4 digits of the masked account number.
+
+```
+
+# Lines exceeding max width of 80 characters
+```
+    3: single_line_stays: a single line scalar stays on the key's line even when it is far too long to fit
+   10: own_line_property: &anchor a single line scalar joined onto the key's line with its property stays there
+   12:   &anchor2 a multiline scalar whose first line does not fit within the line width
+   18:         The bank account last 4 are the last 4 digits of the masked account number.
+   26:             The bank account last 4 are the last 4 digits of the masked account number.
+```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Before, a value always started after the key:

```yaml
  description: A long first line that exceeds the configured width
    followed by another line
```

The fix gives multiline scalars two layouts:

```yaml
  description: A short first line
    followed by another line
```

  or, when the first line would overflow:

```yaml
  description:
    A long first line that exceeds the configured width
    followed by another line
```

Found this while manually stress testing with some huge yaml files.

implemented by fable 5/opus 5
<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
added tests

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
