### PR TITLE
fix(noLeakedRender): only report undefined ternary alternates

### DIFF
--- a/.changeset/khaki-doodles-lose.md
+++ b/.changeset/khaki-doodles-lose.md
@@ -1,0 +1,11 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10514](https://github.com/biomejs/biome/issues/10514): [`noLeakedRender`](https://biomejs.dev/linter/rules/no-leaked-render/) no longer reports ternary expressions whose alternate is a variable. Only `undefined` alternates are reported now, so the following code is valid:
+
+```jsx
+<div>{isMobile ? null : decorations}</div>
+```
+
+The logical AND cases reported in the same issue are unchanged, since determining whether the left-hand side can be `0` or `""` requires type information the rule does not have.

--- a/crates/biome_js_analyze/src/lint/suspicious/no_leaked_render.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_leaked_render.rs
@@ -187,11 +187,14 @@ impl Rule for NoLeakedRender {
                 Some(())
             }
             NoLeakedRenderQuery::JsConditionalExpression(expr) => {
-                let alternate = expr.alternate().ok()?;
-                let is_alternate_identifier =
-                    matches!(alternate, AnyJsExpression::JsIdentifierExpression(_));
-                let is_jsx_element_alt = matches!(alternate, AnyJsExpression::JsxTagExpression(_));
-                if !is_alternate_identifier || is_jsx_element_alt {
+                let alternate = expr.alternate().ok()?.omit_parentheses();
+                // `undefined` is the only identifier alternate treated as a leak.
+                // Any other identifier resolves to a value this rule cannot
+                // inspect, so assuming it renders is a guess, not a finding.
+                let AnyJsExpression::JsIdentifierExpression(ident) = alternate else {
+                    return None;
+                };
+                if !ident.name().ok()?.is_undefined() {
                     return None;
                 }
 

--- a/crates/biome_js_analyze/tests/specs/suspicious/noLeakedRender/issue10514.invalid.jsx
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noLeakedRender/issue10514.invalid.jsx
@@ -1,0 +1,8 @@
+/* should generate diagnostics */
+const Component1 = ({ userId }) => {
+	return <div>{userId ? 1 : undefined}</div>;
+};
+
+const Component2 = ({ userId }) => {
+	return <div>{userId ? 1 : (undefined)}</div>;
+};

--- a/crates/biome_js_analyze/tests/specs/suspicious/noLeakedRender/issue10514.invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noLeakedRender/issue10514.invalid.jsx.snap
@@ -1,0 +1,54 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue10514.invalid.jsx
+---
+# Input
+```jsx
+/* should generate diagnostics */
+const Component1 = ({ userId }) => {
+	return <div>{userId ? 1 : undefined}</div>;
+};
+
+const Component2 = ({ userId }) => {
+	return <div>{userId ? 1 : (undefined)}</div>;
+};
+
+```
+
+# Diagnostics
+```
+issue10514.invalid.jsx:3:15 lint/suspicious/noLeakedRender ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Potential leaked value that might cause unintended rendering.
+  
+    1 │ /* should generate diagnostics */
+    2 │ const Component1 = ({ userId }) => {
+  > 3 │ 	return <div>{userId ? 1 : undefined}</div>;
+      │ 	             ^^^^^^^^^^^^^^^^^^^^^^
+    4 │ };
+    5 │ 
+  
+  i This happens when you use ternary operators in JSX with alternate values that could be variables.
+  
+  i Replace with a safe alternate value like an empty string , null or another JSX element.
+  
+
+```
+
+```
+issue10514.invalid.jsx:7:15 lint/suspicious/noLeakedRender ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Potential leaked value that might cause unintended rendering.
+  
+    6 │ const Component2 = ({ userId }) => {
+  > 7 │ 	return <div>{userId ? 1 : (undefined)}</div>;
+      │ 	             ^^^^^^^^^^^^^^^^^^^^^^^^
+    8 │ };
+    9 │ 
+  
+  i This happens when you use ternary operators in JSX with alternate values that could be variables.
+  
+  i Replace with a safe alternate value like an empty string , null or another JSX element.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noLeakedRender/issue10514.valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noLeakedRender/issue10514.valid.jsx
@@ -1,0 +1,16 @@
+/* should not generate diagnostics */
+const Component1 = ({ isMobile, decorations }) => {
+	return <div>{isMobile ? null : decorations}</div>;
+};
+
+const Component2 = ({ state }) => {
+	return <div>{state === 'WAIT' ? 'Move to WAIT' : state}</div>;
+};
+
+const Component3 = ({ isPending, loader, userResults }) => {
+	return <div>{isPending ? loader : userResults}</div>;
+};
+
+const Component4 = ({ condition, fallback }) => {
+	return <div>{condition ? <Content /> : (fallback)}</div>;
+};

--- a/crates/biome_js_analyze/tests/specs/suspicious/noLeakedRender/issue10514.valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noLeakedRender/issue10514.valid.jsx.snap
@@ -1,0 +1,24 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue10514.valid.jsx
+---
+# Input
+```jsx
+/* should not generate diagnostics */
+const Component1 = ({ isMobile, decorations }) => {
+	return <div>{isMobile ? null : decorations}</div>;
+};
+
+const Component2 = ({ state }) => {
+	return <div>{state === 'WAIT' ? 'Move to WAIT' : state}</div>;
+};
+
+const Component3 = ({ isPending, loader, userResults }) => {
+	return <div>{isPending ? loader : userResults}</div>;
+};
+
+const Component4 = ({ condition, fallback }) => {
+	return <div>{condition ? <Content /> : (fallback)}</div>;
+};
+
+```


### PR DESCRIPTION
## Summary

Refs #10514.

The ternary branch of `noLeakedRender` reported every alternate that was a bare identifier, so `<div>{isMobile ? null : decorations}</div>` was flagged.

The guard tested two mutually exclusive variants of the same enum:

```rust
let is_alternate_identifier = matches!(alternate, AnyJsExpression::JsIdentifierExpression(_));
let is_jsx_element_alt = matches!(alternate, AnyJsExpression::JsxTagExpression(_));
if !is_alternate_identifier || is_jsx_element_alt {
```

An expression cannot be both, so `|| is_jsx_element_alt` was unreachable and the check reduced to flagging any identifier alternate. The intended target was `undefined`, which is a `JsIdentifierExpression` rather than a keyword. The existing specs pin that intent: `{userId ? 1 : null}` is valid and `{userId ? 1 : undefined}` is invalid.

This narrows the check to `undefined` using the existing `is_undefined()` helper, and adds `omit_parentheses()`, which also closes a gap where `(undefined)` was a `JsParenthesizedExpression` and escaped detection entirely.

The logical AND cases in the same issue are not addressed. They are safe only given their TypeScript types, and this rule is `Semantic` / `RuleDomain::React` rather than `Typed` / `RuleDomain::Types`, so it has no type information to work from. Suppressing them without types would mean assuming any destructured parameter is safe, which would defeat the rule. Moving it to the type inference service seems like a call for the team, so I have used `Refs` rather than `Fixes`.

## Test Plan

Two spec files following the existing `issue8288.*` convention in the same directory:

- `issue10514.valid.jsx` covers the three reported false positives plus a parenthesized alternate, which exercises `omit_parentheses`.
- `issue10514.invalid.jsx` covers `userId ? 1 : undefined` and `userId ? 1 : (undefined)`, confirming real leaks are still reported and the parenthesized form is not a hole.

`cargo test -p biome_js_analyze no_leaked_render` passes 6 tests, including the four that existed before, and no pre-existing snapshot changed. `cargo fmt` and `cargo clippy -p biome_js_analyze` are clean. A changeset is included.

## Docs

Not applicable. No rule options or public API changed.

## AI disclosure

The fix and tests here were written with Claude Code, working from my direction on the approach, in particular the decision to narrow the check to `undefined` rather than widen it, and to leave the logical AND cases to the team since they need type information this rule does not have.
