### PR TITLE
feat(css): property syntax value codec

### DIFF
--- a/.changeset/hot-areas-double.md
+++ b/.changeset/hot-areas-double.md
@@ -1,5 +1,0 @@
----
-"@biomejs/biome": patch
----
-
-Fixed [#10905](https://github.com/biomejs/biome/issues/10905): Biome no longer crashes while analyzing incomplete CSS property values during editing.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,6 +1668,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "biome_property_codec"
+version = "0.1.0"
+dependencies = [
+ "biome_console",
+ "biome_css_syntax",
+ "biome_diagnostics",
+ "biome_formatter",
+ "biome_rowan",
+ "biome_unicode_table",
+ "insta",
+]
+
+[[package]]
 name = "biome_resolver"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ biome_json_syntax            = { path = "./crates/biome_json_syntax", version = 
 biome_json_value             = { path = "./crates/biome_json_value", version = "0.1.0" }
 biome_line_index             = { path = "./crates/biome_line_index", version = "0.1.0" }
 biome_lsp                    = { path = "./crates/biome_lsp" }
+biome_property_codec         = { path = "./crates/biome_property_codec", version = "0.1.0" }
 biome_lsp_converters         = { path = "./crates/biome_lsp_converters", version = "0.1.0" }
 biome_markdown_factory       = { path = "./crates/biome_markdown_factory", version = "0.0.1" }
 biome_markdown_formatter     = { path = "./crates/biome_markdown_formatter", version = "0.0.1" }
@@ -260,7 +261,8 @@ unused_macro_rules             = "warn"
 
 # Dev optimisations
 [profile.dev]
-debug = "line-tables-only"
+debug           = "line-tables-only"
+split-debuginfo = "unpacked"
 
 [profile.dev.package."*"]
 debug = false

--- a/crates/biome_property_codec/Cargo.toml
+++ b/crates/biome_property_codec/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name                 = "biome_property_codec"
+version              = "0.1.0"
+authors.workspace    = true
+edition.workspace    = true
+description          = "Encoder and decoder for CSS registered custom property syntax"
+homepage.workspace   = true
+repository.workspace = true
+license.workspace    = true
+keywords.workspace   = true
+categories.workspace = true
+
+[dependencies]
+biome_console       = { workspace = true }
+biome_css_syntax    = { workspace = true }
+biome_diagnostics   = { workspace = true }
+biome_formatter     = { workspace = true }
+biome_rowan         = { workspace = true }
+biome_unicode_table = { workspace = true }
+
+[dev-dependencies]
+insta = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/biome_property_codec/src/data.rs
+++ b/crates/biome_property_codec/src/data.rs
@@ -1,0 +1,512 @@
+use biome_diagnostics::{Advices, Diagnostic, LogCategory, Visit};
+use biome_formatter::formatter::Formatter;
+use biome_formatter::{
+    Buffer, Format, FormatContext, FormatOptions, FormatResult, IndentStyle, IndentWidth,
+    LineEnding, LineWidth, SourceMapGeneration, TrailingNewline, TransformSourceMap,
+    prelude::{PrinterOptions, space, text, token},
+    write,
+};
+use biome_rowan::TextRange;
+use biome_unicode_table::is_css_non_ascii;
+
+// #region Data structure definition
+
+/// The result of parsing an `@property` `syntax` descriptor.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PropertySyntaxResult {
+    /// The declaration has no `syntax` descriptor.
+    Missing,
+    /// The descriptor value does not conform to the registered property syntax grammar.
+    Error(PropertySyntaxDiagnostic),
+    /// The parsed and normalized descriptor value.
+    Value(PropertySyntax),
+}
+
+/// A diagnostic produced while processing an `@property` `syntax` descriptor.
+#[derive(Clone, Debug, Diagnostic, Eq, PartialEq)]
+pub enum PropertySyntaxDiagnostic {
+    /// The descriptor value could not be parsed.
+    Parse(PropertySyntaxParseDiagnostic),
+}
+
+impl PropertySyntaxDiagnostic {
+    /// Returns the reason the descriptor could not be processed.
+    pub const fn kind(&self) -> PropertySyntaxErrorKind {
+        match self {
+            Self::Parse(diagnostic) => diagnostic.kind,
+        }
+    }
+
+    /// Returns the absolute source range associated with the diagnostic.
+    pub const fn range(&self) -> TextRange {
+        match self {
+            Self::Parse(diagnostic) => diagnostic.range,
+        }
+    }
+}
+
+/// Describes a syntax error and its absolute source range.
+#[derive(Clone, Debug, Diagnostic, Eq, PartialEq)]
+#[diagnostic(category = "parse", severity = Error)]
+pub struct PropertySyntaxParseDiagnostic {
+    /// The reason parsing failed.
+    #[message]
+    #[description]
+    #[advice]
+    kind: PropertySyntaxErrorKind,
+    /// The absolute source range that caused the error.
+    #[location(span)]
+    range: TextRange,
+}
+
+impl PropertySyntaxParseDiagnostic {
+    pub(crate) const fn new(kind: PropertySyntaxErrorKind, range: TextRange) -> Self {
+        Self { kind, range }
+    }
+}
+
+/// The reason an `@property` `syntax` descriptor could not be parsed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PropertySyntaxErrorKind {
+    /// The descriptor contains no syntax components.
+    Empty,
+    /// A component is missing where the grammar requires one.
+    ExpectedComponent,
+    /// Adjacent components are not separated by `|`.
+    ExpectedPipe,
+    /// A data type name is missing, malformed, or unsupported.
+    ExpectedTypeName,
+    /// A custom identifier is malformed or is a CSS-wide keyword.
+    InvalidCustomIdentifier,
+    /// The universal syntax is combined with another component or a multiplier.
+    InvalidUniversalSyntax,
+    /// A multiplier follows the pre-multiplied `<transform-list>` type.
+    MultiplierAfterTransformList,
+    /// Whitespace occurs where the syntax grammar does not permit it.
+    UnexpectedWhitespace,
+}
+
+impl std::fmt::Display for PropertySyntaxErrorKind {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Empty => fmt.write_str("The property syntax cannot be empty."),
+            Self::ExpectedComponent => fmt.write_str("Expected a property syntax component."),
+            Self::ExpectedPipe => fmt.write_str("Separate property syntax components with `|`."),
+            Self::ExpectedTypeName => fmt.write_str("Use a supported property syntax type."),
+            Self::InvalidCustomIdentifier => {
+                fmt.write_str("Use a custom identifier that isn't reserved.")
+            }
+            Self::InvalidUniversalSyntax => {
+                fmt.write_str("The `*` can't appear with other syntax components.")
+            }
+            Self::MultiplierAfterTransformList => {
+                fmt.write_str("Remove the multiplier after `<transform-list>`.")
+            }
+            Self::UnexpectedWhitespace => {
+                fmt.write_str("Remove whitespace inside the type name or before the multiplier.")
+            }
+        }
+    }
+}
+
+impl biome_console::fmt::Display for PropertySyntaxErrorKind {
+    fn fmt(&self, fmt: &mut biome_console::fmt::Formatter<'_>) -> std::io::Result<()> {
+        match self {
+            Self::Empty => fmt.write_str("The property syntax cannot be empty."),
+            Self::ExpectedComponent => fmt.write_str("Expected a property syntax component."),
+            Self::ExpectedPipe => fmt.write_markup(biome_console::markup! {
+                "Separate property syntax components with "<Emphasis>"|"</Emphasis>"."
+            }),
+            Self::ExpectedTypeName => fmt.write_str("Use a supported property syntax type."),
+            Self::InvalidCustomIdentifier => {
+                fmt.write_str("Use a custom identifier that isn't reserved.")
+            }
+            Self::InvalidUniversalSyntax => fmt.write_markup(biome_console::markup! {
+                "The "<Emphasis>"*"</Emphasis>" can't appear with other syntax components."
+            }),
+            Self::MultiplierAfterTransformList => fmt.write_markup(biome_console::markup! {
+                "Remove the multiplier after "<Emphasis>"<transform-list>"</Emphasis>"."
+            }),
+            Self::UnexpectedWhitespace => {
+                fmt.write_str("Remove whitespace inside the type name or before the multiplier.")
+            }
+        }
+    }
+}
+
+impl Advices for PropertySyntaxErrorKind {
+    fn record(&self, visitor: &mut dyn Visit) -> std::io::Result<()> {
+        match self {
+            Self::Empty => visitor.record_log(
+                LogCategory::Info,
+                &biome_console::markup! {
+                    "Add a syntax component, such as "<Emphasis>"<length>"</Emphasis>
+                    ", or use "<Emphasis>"*"</Emphasis>" to accept any value."
+                },
+            ),
+            Self::ExpectedComponent => visitor.record_log(
+                LogCategory::Info,
+                &biome_console::markup! {
+                    "Add a data type, such as "<Emphasis>"<length>"</Emphasis>
+                    ", or a custom identifier at this position."
+                },
+            ),
+            Self::ExpectedTypeName => {
+                visitor.record_log(
+                    LogCategory::Info,
+                    &biome_console::markup! { "Supported types:" },
+                )?;
+                let types = PropertySyntaxType::ALL;
+                let types = types
+                    .iter()
+                    .map(|ty| ty as &dyn biome_console::fmt::Display)
+                    .collect::<Vec<_>>();
+                visitor.record_list(&types)
+            }
+            Self::InvalidCustomIdentifier => {
+                visitor.record_log(
+                    LogCategory::Info,
+                    &biome_console::markup! { "Reserved identifiers:" },
+                )?;
+                let identifiers = RESERVED_CUSTOM_IDENTIFIERS.map(FormatReservedCustomIdentifier);
+                let identifiers = identifiers
+                    .iter()
+                    .map(|identifier| identifier as &dyn biome_console::fmt::Display)
+                    .collect::<Vec<_>>();
+                visitor.record_list(&identifiers)
+            }
+            Self::InvalidUniversalSyntax => visitor.record_log(
+                LogCategory::Info,
+                &biome_console::markup! {
+                    "Remove "<Emphasis>"*"</Emphasis>" or remove the other syntax components."
+                },
+            ),
+            _ => Ok(()),
+        }
+    }
+}
+
+pub(crate) const RESERVED_CUSTOM_IDENTIFIERS: [&str; 6] = [
+    "default",
+    "inherit",
+    "initial",
+    "revert",
+    "revert-layer",
+    "unset",
+];
+
+/// The parsed value of an `@property` `syntax` descriptor.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PropertySyntax {
+    /// The universal syntax, which accepts any token sequence.
+    Universal {
+        /// The absolute source range of the `*` token.
+        range: TextRange,
+    },
+    /// An ordered list of syntax components separated by `|`.
+    Components(Box<[PropertySyntaxComponent]>),
+}
+
+/// A data type or custom identifier with an optional multiplier.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PropertySyntaxComponent {
+    /// The value matched by the component.
+    pub name: PropertySyntaxComponentName,
+    /// The repetition behavior applied to the component.
+    pub multiplier: PropertySyntaxMultiplier,
+    /// The absolute source range from the component name through its multiplier, if present.
+    pub range: TextRange,
+}
+
+/// The value matched by a property syntax component.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PropertySyntaxComponentName {
+    /// A registered property data type enclosed in angle brackets.
+    Type(PropertySyntaxType),
+    /// A case-sensitive custom identifier with CSS escapes resolved.
+    CustomIdentifier(Box<str>),
+}
+
+/// The repetition behavior of a property syntax component.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum PropertySyntaxMultiplier {
+    /// The component matches exactly one value.
+    #[default]
+    None,
+    /// The `+` multiplier, which matches one or more space-separated values.
+    SpaceSeparated,
+    /// The `#` multiplier, which matches one or more comma-separated values.
+    CommaSeparated,
+}
+
+/// A data type supported by the registered property syntax grammar.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PropertySyntaxType {
+    /// The `<angle>` data type.
+    Angle,
+    /// The `<color>` data type.
+    Color,
+    /// The `<custom-ident>` data type.
+    CustomIdent,
+    /// The `<image>` data type.
+    Image,
+    /// The `<integer>` data type.
+    Integer,
+    /// The `<length>` data type.
+    Length,
+    /// The `<length-percentage>` data type.
+    LengthPercentage,
+    /// The `<number>` data type.
+    Number,
+    /// The `<percentage>` data type.
+    Percentage,
+    /// The `<resolution>` data type.
+    Resolution,
+    /// The `<string>` data type.
+    String,
+    /// The `<time>` data type.
+    Time,
+    /// The `<transform-function>` data type.
+    TransformFunction,
+    /// The pre-multiplied `<transform-list>` data type.
+    TransformList,
+    /// The `<url>` data type.
+    Url,
+}
+
+impl PropertySyntaxType {
+    pub(crate) const ALL: [Self; 15] = [
+        Self::Angle,
+        Self::Color,
+        Self::CustomIdent,
+        Self::Image,
+        Self::Integer,
+        Self::Length,
+        Self::LengthPercentage,
+        Self::Number,
+        Self::Percentage,
+        Self::Resolution,
+        Self::String,
+        Self::Time,
+        Self::TransformFunction,
+        Self::TransformList,
+        Self::Url,
+    ];
+
+    pub(crate) const fn name(self) -> &'static str {
+        match self {
+            Self::Angle => "angle",
+            Self::Color => "color",
+            Self::CustomIdent => "custom-ident",
+            Self::Image => "image",
+            Self::Integer => "integer",
+            Self::Length => "length",
+            Self::LengthPercentage => "length-percentage",
+            Self::Number => "number",
+            Self::Percentage => "percentage",
+            Self::Resolution => "resolution",
+            Self::String => "string",
+            Self::Time => "time",
+            Self::TransformFunction => "transform-function",
+            Self::TransformList => "transform-list",
+            Self::Url => "url",
+        }
+    }
+
+    pub(crate) fn from_name(name: &[u8]) -> Option<Self> {
+        Some(match name {
+            b"angle" => Self::Angle,
+            b"color" => Self::Color,
+            b"custom-ident" => Self::CustomIdent,
+            b"image" => Self::Image,
+            b"integer" => Self::Integer,
+            b"length" => Self::Length,
+            b"length-percentage" => Self::LengthPercentage,
+            b"number" => Self::Number,
+            b"percentage" => Self::Percentage,
+            b"resolution" => Self::Resolution,
+            b"string" => Self::String,
+            b"time" => Self::Time,
+            b"transform-function" => Self::TransformFunction,
+            b"transform-list" => Self::TransformList,
+            b"url" => Self::Url,
+            _ => return None,
+        })
+    }
+}
+
+impl biome_console::fmt::Display for PropertySyntaxType {
+    fn fmt(&self, fmt: &mut biome_console::fmt::Formatter<'_>) -> std::io::Result<()> {
+        fmt.write_markup(biome_console::markup! {
+            <Emphasis>"<"{self.name()}">"</Emphasis>
+        })
+    }
+}
+
+/// Formats an identifier that cannot be used as a custom syntax component.
+struct FormatReservedCustomIdentifier<'a>(&'a str);
+
+impl biome_console::fmt::Display for FormatReservedCustomIdentifier<'_> {
+    fn fmt(&self, fmt: &mut biome_console::fmt::Formatter<'_>) -> std::io::Result<()> {
+        fmt.write_markup(biome_console::markup! {
+            <Emphasis>{self.0}</Emphasis>
+        })
+    }
+}
+
+// #endregion
+
+// #region Formatting
+
+/// Formatting options for normalized property syntax output.
+#[derive(Debug, Default)]
+pub struct PropertyFmtOptions;
+
+impl FormatOptions for PropertyFmtOptions {
+    fn indent_style(&self) -> IndentStyle {
+        IndentStyle::default()
+    }
+
+    fn indent_width(&self) -> IndentWidth {
+        IndentWidth::default()
+    }
+
+    fn line_width(&self) -> LineWidth {
+        LineWidth::default()
+    }
+
+    fn line_ending(&self) -> LineEnding {
+        LineEnding::default()
+    }
+
+    fn trailing_newline(&self) -> TrailingNewline {
+        false.into()
+    }
+
+    fn as_print_options(&self) -> PrinterOptions {
+        PrinterOptions {
+            indent_width: self.indent_width(),
+            print_width: self.line_width().into(),
+            line_ending: self.line_ending(),
+            indent_style: self.indent_style(),
+            source_map_generation: SourceMapGeneration::Disabled,
+        }
+    }
+}
+
+/// The formatter context used to serialize property syntax values.
+#[derive(Debug, Default)]
+pub struct PropertyFmtContext {
+    /// The options used to print the normalized syntax.
+    options: PropertyFmtOptions,
+}
+
+impl FormatContext for PropertyFmtContext {
+    type Options = PropertyFmtOptions;
+
+    fn options(&self) -> &Self::Options {
+        &self.options
+    }
+
+    fn source_map(&self) -> Option<&TransformSourceMap> {
+        None
+    }
+}
+
+impl Format<PropertyFmtContext> for PropertySyntax {
+    fn fmt(&self, f: &mut Formatter<PropertyFmtContext>) -> FormatResult<()> {
+        match self {
+            Self::Universal { .. } => write!(f, [token("*")]),
+            Self::Components(components) => {
+                for (index, component) in components.iter().enumerate() {
+                    if index > 0 {
+                        write!(f, [space(), token("|"), space()])?;
+                    }
+                    write!(f, [component])?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl Format<PropertyFmtContext> for PropertySyntaxComponent {
+    fn fmt(&self, f: &mut Formatter<PropertyFmtContext>) -> FormatResult<()> {
+        match &self.name {
+            PropertySyntaxComponentName::Type(ty) => {
+                write!(f, [token("<"), token(ty.name()), token(">")])?;
+            }
+            PropertySyntaxComponentName::CustomIdentifier(identifier) => {
+                write!(f, [FormatCustomIdentifier(identifier)])?;
+            }
+        }
+        match self.multiplier {
+            PropertySyntaxMultiplier::None => Ok(()),
+            PropertySyntaxMultiplier::SpaceSeparated => write!(f, [token("+")]),
+            PropertySyntaxMultiplier::CommaSeparated => write!(f, [token("#")]),
+        }
+    }
+}
+
+/// Serializes a decoded custom identifier as a valid CSS identifier.
+///
+/// Characters that cannot appear literally are escaped according to CSSOM's
+/// [identifier serialization algorithm](https://drafts.csswg.org/cssom/#serialize-an-identifier).
+/// Hexadecimal escapes include a trailing space so a following hexadecimal
+/// digit cannot become part of the escape sequence. A lone hyphen is escaped
+/// because it cannot start an identifier by itself.
+struct FormatCustomIdentifier<'a>(&'a str);
+
+impl Format<PropertyFmtContext> for FormatCustomIdentifier<'_> {
+    fn fmt(&self, f: &mut Formatter<PropertyFmtContext>) -> FormatResult<()> {
+        let bytes = self.0.as_bytes();
+        // Unescaped spans share the input string and produce one formatter element each.
+        let mut start = 0;
+        let mut index = 0;
+        while index < bytes.len() {
+            let byte = bytes[index];
+            let (code_point, code_point_len) = if byte.is_ascii() {
+                (u32::from(byte), 1)
+            } else {
+                debug_assert!(self.0.is_char_boundary(index));
+                let character = self.0[index..]
+                    .chars()
+                    .next()
+                    .expect("the index should point to a character");
+                (character as u32, character.len_utf8())
+            };
+            let requires_hex_escape = byte <= 0x1f
+                || byte == 0x7f
+                || (index == 0 && byte.is_ascii_digit())
+                || (index == 1 && bytes[0] == b'-' && byte.is_ascii_digit())
+                || (byte >= 0x80 && !char::from_u32(code_point).is_some_and(is_css_non_ascii));
+            let requires_simple_escape = (bytes.len() == 1 && byte == b'-')
+                || (byte.is_ascii()
+                    && !byte.is_ascii_alphanumeric()
+                    && !matches!(byte, b'-' | b'_')
+                    && !requires_hex_escape);
+
+            if requires_hex_escape || requires_simple_escape {
+                if start < index {
+                    write!(f, [text(&self.0[start..index], None)])?;
+                }
+                if requires_hex_escape {
+                    let escaped = std::format!("\\{code_point:x} ");
+                    write!(f, [text(&escaped, None)])?;
+                } else {
+                    write!(f, [token("\\"), text(&self.0[index..index + 1], None)])?;
+                }
+                index += code_point_len;
+                start = index;
+            } else {
+                index += code_point_len;
+            }
+        }
+        if start < bytes.len() {
+            write!(f, [text(&self.0[start..], None)])?;
+        }
+        Ok(())
+    }
+}
+
+// #endregion

--- a/crates/biome_property_codec/src/decoder.rs
+++ b/crates/biome_property_codec/src/decoder.rs
@@ -1,0 +1,72 @@
+use crate::data::{PropertyFmtContext, PropertySyntax};
+
+/// Formats a parsed property syntax as a normalized syntax string.
+pub fn decode(value: &PropertySyntax) -> String {
+    let formatted = biome_formatter::format!(PropertyFmtContext::default(), [&value])
+        .expect("property syntax formatting should not fail");
+    formatted
+        .print()
+        .expect("property syntax should produce a valid document")
+        .into_code()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{PropertySyntaxResult, encode};
+    use biome_rowan::TextRange;
+
+    fn round_trip(source: &str) -> String {
+        let syntax = match encode(
+            source,
+            TextRange::new(0.into(), (source.len() as u32).into()),
+        ) {
+            PropertySyntaxResult::Value(value) => value,
+            result => panic!("expected value, got {result:?}"),
+        };
+        decode(&syntax)
+    }
+
+    #[test]
+    fn decodes_canonical_spacing() {
+        assert_eq!(
+            round_trip("  <length>|auto  |  <color># "),
+            "<length> | auto | <color>#"
+        );
+    }
+
+    #[test]
+    fn decodes_universal_syntax() {
+        assert_eq!(round_trip(" * "), "*");
+    }
+
+    #[test]
+    fn decodes_escaped_identifiers() {
+        assert_eq!(round_trip("\\66 oo | \\+"), "foo | \\+");
+        assert_eq!(round_trip("\\31 foo | \\1f914"), "\\31 foo | 🤔");
+        assert_eq!(round_trip("\\a7"), "\\a7 ");
+        assert_eq!(round_trip("\\-"), "\\-");
+    }
+
+    #[test]
+    fn encoding_after_decoding_preserves_the_model() {
+        let source = "foo | <color># | <length>+";
+        let first = match encode(
+            source,
+            TextRange::new(0.into(), (source.len() as u32).into()),
+        ) {
+            PropertySyntaxResult::Value(value) => value,
+            result => panic!("expected value, got {result:?}"),
+        };
+        let decoded = decode(&first);
+        let second = match encode(
+            &decoded,
+            TextRange::new(0.into(), (decoded.len() as u32).into()),
+        ) {
+            PropertySyntaxResult::Value(value) => value,
+            result => panic!("expected value, got {result:?}"),
+        };
+
+        assert_eq!(first, second);
+    }
+}

--- a/crates/biome_property_codec/src/encoder.rs
+++ b/crates/biome_property_codec/src/encoder.rs
@@ -1,0 +1,707 @@
+use crate::data::{
+    PropertySyntax, PropertySyntaxComponent, PropertySyntaxComponentName, PropertySyntaxDiagnostic,
+    PropertySyntaxErrorKind, PropertySyntaxMultiplier, PropertySyntaxParseDiagnostic,
+    PropertySyntaxResult, PropertySyntaxType, RESERVED_CUSTOM_IDENTIFIERS,
+};
+use biome_css_syntax::{is_css_newline_byte, is_css_whitespace_byte};
+use biome_rowan::{TextRange, TextSize};
+use biome_unicode_table::{
+    Dispatch::{DIG, IDT, MIN, ZER},
+    is_css_non_ascii, lookup_byte,
+};
+
+/// Parses the decoded value of an `@property` `syntax` descriptor.
+///
+/// `range` must be the absolute source range occupied by `value`. Returned
+/// diagnostics and syntax components use absolute source ranges within it.
+///
+/// The grammar follows the CSS Properties and Values API
+/// [syntax-string parsing algorithms](https://drafts.css-houdini.org/css-properties-values-api-1/#parsing-syntax).
+pub fn encode(value: &str, range: TextRange) -> PropertySyntaxResult {
+    match Encoder::new(value, range).encode() {
+        Ok(value) => PropertySyntaxResult::Value(value),
+        Err(diagnostic) => PropertySyntaxResult::Error(PropertySyntaxDiagnostic::Parse(diagnostic)),
+    }
+}
+
+struct Encoder<'source> {
+    source: &'source str,
+    bytes: &'source [u8],
+    position: usize,
+    source_range: TextRange,
+}
+
+impl<'source> Encoder<'source> {
+    fn new(source: &'source str, range: TextRange) -> Self {
+        Self {
+            source,
+            bytes: source.as_bytes(),
+            position: 0,
+            source_range: range,
+        }
+    }
+
+    fn encode(mut self) -> Result<PropertySyntax, PropertySyntaxParseDiagnostic> {
+        self.consume_whitespace();
+        let content_start = self.position;
+        let content_end = self.trimmed_end();
+
+        if content_start == content_end {
+            return Err(self.error(PropertySyntaxErrorKind::Empty, 0, self.bytes.len()));
+        }
+
+        if self.byte_range(content_start, content_end) == [b'*'] {
+            return Ok(PropertySyntax::Universal {
+                range: self.range(content_start, content_end),
+            });
+        }
+
+        if self.byte_at(content_start) == b'*' {
+            return Err(self.error(
+                PropertySyntaxErrorKind::InvalidUniversalSyntax,
+                content_start,
+                content_end,
+            ));
+        }
+
+        let mut components = Vec::new();
+        loop {
+            components.push(self.consume_component(content_start, content_end)?);
+            let component_end = self.position;
+            self.consume_whitespace_until(content_end);
+            if self.position == content_end {
+                break;
+            }
+            let current = self.current_byte();
+            if current != b'|' {
+                let kind = if self.position > component_end && matches!(current, b'+' | b'#') {
+                    PropertySyntaxErrorKind::UnexpectedWhitespace
+                } else {
+                    PropertySyntaxErrorKind::ExpectedPipe
+                };
+                let (start, end) = if kind == PropertySyntaxErrorKind::UnexpectedWhitespace {
+                    (component_end, self.position)
+                } else {
+                    (self.position, content_end)
+                };
+                return Err(self.error(kind, start, end));
+            }
+            self.position += 1;
+            if self.position == content_end {
+                return Err(self.error(
+                    PropertySyntaxErrorKind::ExpectedComponent,
+                    self.position - 1,
+                    self.position,
+                ));
+            }
+        }
+
+        Ok(PropertySyntax::Components(components.into_boxed_slice()))
+    }
+
+    fn consume_component(
+        &mut self,
+        content_start: usize,
+        content_end: usize,
+    ) -> Result<PropertySyntaxComponent, PropertySyntaxParseDiagnostic> {
+        self.consume_whitespace_until(content_end);
+        if self.position == content_end {
+            return Err(self.error(
+                PropertySyntaxErrorKind::ExpectedComponent,
+                self.position,
+                self.position,
+            ));
+        }
+        if self.current_byte() == b'*' {
+            return Err(self.error(
+                PropertySyntaxErrorKind::InvalidUniversalSyntax,
+                content_start,
+                content_end,
+            ));
+        }
+
+        let start = self.position;
+        let name = if self.current_byte() == b'<' {
+            PropertySyntaxComponentName::Type(self.consume_type(content_end)?)
+        } else if self.would_start_identifier(content_end) {
+            let identifier = self.consume_identifier(content_end)?;
+            PropertySyntaxComponentName::CustomIdentifier(identifier.into_boxed_str())
+        } else {
+            return Err(self.error(
+                PropertySyntaxErrorKind::ExpectedComponent,
+                self.position,
+                self.position + self.current_len(),
+            ));
+        };
+
+        let pre_multiplied = matches!(
+            name,
+            PropertySyntaxComponentName::Type(PropertySyntaxType::TransformList)
+        );
+        if pre_multiplied
+            && self.position < content_end
+            && matches!(self.current_byte(), b'+' | b'#')
+        {
+            return Err(self.error(
+                PropertySyntaxErrorKind::MultiplierAfterTransformList,
+                self.position,
+                self.position + 1,
+            ));
+        }
+        let multiplier = if pre_multiplied || self.position == content_end {
+            PropertySyntaxMultiplier::None
+        } else {
+            match self.current_byte() {
+                b'+' => {
+                    self.position += 1;
+                    PropertySyntaxMultiplier::SpaceSeparated
+                }
+                b'#' => {
+                    self.position += 1;
+                    PropertySyntaxMultiplier::CommaSeparated
+                }
+                _ => PropertySyntaxMultiplier::None,
+            }
+        };
+
+        Ok(PropertySyntaxComponent {
+            name,
+            multiplier,
+            range: self.range(start, self.position),
+        })
+    }
+
+    fn consume_type(
+        &mut self,
+        content_end: usize,
+    ) -> Result<PropertySyntaxType, PropertySyntaxParseDiagnostic> {
+        let start = self.position;
+        self.position += 1;
+        let name_start = self.position;
+
+        while self.position < content_end {
+            let byte = self.current_byte();
+            if byte == b'>' {
+                let Some(ty) =
+                    PropertySyntaxType::from_name(self.byte_range(name_start, self.position))
+                else {
+                    return Err(self.error(
+                        PropertySyntaxErrorKind::ExpectedTypeName,
+                        start,
+                        self.position + 1,
+                    ));
+                };
+                self.position += 1;
+                return Ok(ty);
+            }
+            if !matches!(lookup_byte(byte), IDT | MIN | DIG | ZER) {
+                let kind = if is_css_whitespace_byte(byte) {
+                    PropertySyntaxErrorKind::UnexpectedWhitespace
+                } else {
+                    PropertySyntaxErrorKind::ExpectedTypeName
+                };
+                return Err(self.error(kind, self.position, self.position + self.current_len()));
+            }
+            self.position += 1;
+        }
+
+        Err(self.error(
+            PropertySyntaxErrorKind::ExpectedTypeName,
+            start,
+            content_end,
+        ))
+    }
+
+    /// Implements CSS Syntax's
+    /// [ident sequence algorithm](https://drafts.csswg.org/css-syntax-3/#consume-name).
+    fn consume_identifier(
+        &mut self,
+        content_end: usize,
+    ) -> Result<String, PropertySyntaxParseDiagnostic> {
+        let start = self.position;
+        let mut identifier = String::new();
+        while self.position < content_end {
+            let byte = self.current_byte();
+            if matches!(lookup_byte(byte), IDT | MIN | DIG | ZER) {
+                identifier.push(byte as char);
+                self.position += 1;
+            } else if byte == 0 {
+                identifier.push('\u{fffd}');
+                self.position += 1;
+            } else if byte == b'\\' && self.starts_valid_escape(content_end) {
+                identifier.push(self.consume_escaped_code_point(content_end));
+            } else if byte >= 0x80 {
+                let character = self.char_at(self.position);
+                if !is_css_non_ascii(character) {
+                    break;
+                }
+                identifier.push(character);
+                self.position += character.len_utf8();
+            } else {
+                break;
+            }
+        }
+
+        if is_invalid_custom_identifier(&identifier) {
+            return Err(self.error(
+                PropertySyntaxErrorKind::InvalidCustomIdentifier,
+                start,
+                self.position,
+            ));
+        }
+
+        Ok(identifier)
+    }
+
+    /// Implements CSS Syntax's
+    /// [ident sequence lookahead](https://drafts.csswg.org/css-syntax-3/#would-start-an-identifier).
+    fn would_start_identifier(&self, content_end: usize) -> bool {
+        let first = self.current_byte();
+        if first == 0 {
+            return true;
+        }
+        if lookup_byte(first) == IDT || first >= 0x80 {
+            return first < 0x80 || is_css_non_ascii(self.char_at(self.position));
+        }
+        if first == b'\\' {
+            return self.starts_valid_escape(content_end);
+        }
+        if first != b'-' || self.position + 1 >= content_end {
+            return false;
+        }
+
+        let second = self.byte_at(self.position + 1);
+        second == b'-'
+            || second == 0
+            || lookup_byte(second) == IDT
+            || (second >= 0x80 && is_css_non_ascii(self.char_at(self.position + 1)))
+            || (second == b'\\'
+                && self.position + 2 < content_end
+                && !is_css_newline_byte(self.byte_at(self.position + 2)))
+    }
+
+    fn starts_valid_escape(&self, content_end: usize) -> bool {
+        self.position + 1 < content_end && !is_css_newline_byte(self.byte_at(self.position + 1))
+    }
+
+    /// Implements CSS Syntax's
+    /// [escaped code point algorithm](https://drafts.csswg.org/css-syntax-3/#consume-escaped-code-point).
+    fn consume_escaped_code_point(&mut self, content_end: usize) -> char {
+        self.position += 1;
+        let first = self.current_byte();
+        if !first.is_ascii_hexdigit() {
+            let character = self.char_at(self.position);
+            self.position += character.len_utf8();
+            return char::from_u32(preprocess_code_point(character as u32)).unwrap_or('\u{fffd}');
+        }
+
+        let mut value = 0_u32;
+        let mut digits = 0;
+        while self.position < content_end && digits < 6 {
+            let Some(digit) = char::from(self.current_byte()).to_digit(16) else {
+                break;
+            };
+            value = value * 16 + digit;
+            self.position += 1;
+            digits += 1;
+        }
+        if self.position < content_end && is_css_whitespace_byte(self.current_byte()) {
+            if self.current_byte() == b'\r'
+                && self.position + 1 < content_end
+                && self.byte_at(self.position + 1) == b'\n'
+            {
+                self.position += 2;
+            } else {
+                self.position += 1;
+            }
+        }
+
+        char::from_u32(preprocess_code_point(value)).unwrap_or('\u{fffd}')
+    }
+
+    fn consume_whitespace(&mut self) {
+        while self.position < self.bytes.len() && is_css_whitespace_byte(self.current_byte()) {
+            self.position += 1;
+        }
+    }
+
+    fn consume_whitespace_until(&mut self, end: usize) {
+        while self.position < end && is_css_whitespace_byte(self.current_byte()) {
+            self.position += 1;
+        }
+    }
+
+    fn trimmed_end(&self) -> usize {
+        let mut end = self.bytes.len();
+        while end > self.position && is_css_whitespace_byte(self.byte_at(end - 1)) {
+            end -= 1;
+        }
+        end
+    }
+
+    fn current_len(&self) -> usize {
+        if self.position == self.bytes.len() {
+            0
+        } else if self.current_byte() < 0x80 {
+            1
+        } else {
+            self.char_at(self.position).len_utf8()
+        }
+    }
+
+    /// Returns the byte at the current non-EOF parser position.
+    fn current_byte(&self) -> u8 {
+        self.byte_at(self.position)
+    }
+
+    /// Returns the byte at a non-EOF parser position.
+    fn byte_at(&self, position: usize) -> u8 {
+        debug_assert!(position < self.bytes.len());
+        // SAFETY: Callers check the applicable input boundary before passing
+        // a byte position.
+        self.bytes[position]
+    }
+
+    /// Returns the bytes in a parser range.
+    fn byte_range(&self, start: usize, end: usize) -> &[u8] {
+        debug_assert!(start <= end);
+        debug_assert!(end <= self.bytes.len());
+        // SAFETY: Parser ranges are ordered byte offsets bounded by the input.
+        &self.bytes[start..end]
+    }
+
+    /// Returns the character at a non-EOF UTF-8 byte boundary.
+    fn char_at(&self, position: usize) -> char {
+        debug_assert!(position < self.source.len());
+        debug_assert!(self.source.is_char_boundary(position));
+        // SAFETY: Callers provide non-EOF positions reached by advancing over
+        // ASCII bytes or complete UTF-8 characters.
+        self.source[position..]
+            .chars()
+            .next()
+            .expect("the position should point to a character")
+    }
+
+    fn range(&self, start: usize, end: usize) -> TextRange {
+        let range = TextRange::new(
+            self.source_range.start() + TextSize::from(start as u32),
+            self.source_range.start() + TextSize::from(end as u32),
+        );
+        debug_assert!(range.end() <= self.source_range.end());
+        range
+    }
+
+    fn error(
+        &self,
+        kind: PropertySyntaxErrorKind,
+        start: usize,
+        end: usize,
+    ) -> PropertySyntaxParseDiagnostic {
+        PropertySyntaxParseDiagnostic::new(kind, self.range(start, end))
+    }
+}
+
+fn is_invalid_custom_identifier(identifier: &str) -> bool {
+    RESERVED_CUSTOM_IDENTIFIERS
+        .iter()
+        .any(|reserved| identifier.eq_ignore_ascii_case(reserved))
+}
+
+const fn preprocess_code_point(code_point: u32) -> u32 {
+    if code_point == 0 || code_point > 0x0010_ffff || (code_point >= 0xd800 && code_point <= 0xdfff)
+    {
+        0xfffd
+    } else {
+        code_point
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use biome_diagnostics::{DiagnosticExt, print_diagnostic_to_string};
+
+    fn encode_value(value: &str) -> PropertySyntax {
+        match encode(
+            value,
+            TextRange::new(10.into(), (10 + value.len() as u32).into()),
+        ) {
+            PropertySyntaxResult::Value(value) => value,
+            result => panic!("expected value, got {result:?}"),
+        }
+    }
+
+    fn encode_error(value: &str) -> PropertySyntaxDiagnostic {
+        match encode(
+            value,
+            TextRange::new(10.into(), (10 + value.len() as u32).into()),
+        ) {
+            PropertySyntaxResult::Error(error) => error,
+            result => panic!("expected error, got {result:?}"),
+        }
+    }
+
+    #[test]
+    fn encodes_universal_syntax() {
+        assert_eq!(
+            encode_value(" \t*\n"),
+            PropertySyntax::Universal {
+                range: TextRange::new(12.into(), 13.into())
+            }
+        );
+    }
+
+    #[test]
+    fn encodes_supported_types() {
+        let cases = [
+            ("<angle>", PropertySyntaxType::Angle),
+            ("<color>", PropertySyntaxType::Color),
+            ("<custom-ident>", PropertySyntaxType::CustomIdent),
+            ("<image>", PropertySyntaxType::Image),
+            ("<integer>", PropertySyntaxType::Integer),
+            ("<length>", PropertySyntaxType::Length),
+            ("<length-percentage>", PropertySyntaxType::LengthPercentage),
+            ("<number>", PropertySyntaxType::Number),
+            ("<percentage>", PropertySyntaxType::Percentage),
+            ("<resolution>", PropertySyntaxType::Resolution),
+            ("<string>", PropertySyntaxType::String),
+            ("<time>", PropertySyntaxType::Time),
+            (
+                "<transform-function>",
+                PropertySyntaxType::TransformFunction,
+            ),
+            ("<transform-list>", PropertySyntaxType::TransformList),
+            ("<url>", PropertySyntaxType::Url),
+        ];
+
+        for (source, expected) in cases {
+            let PropertySyntax::Components(components) = encode_value(source) else {
+                panic!("expected components for {source}");
+            };
+            assert_eq!(
+                components[0].name,
+                PropertySyntaxComponentName::Type(expected)
+            );
+        }
+    }
+
+    #[test]
+    fn encodes_ordered_alternatives_and_multipliers() {
+        let PropertySyntax::Components(components) = encode_value("foo | <color># | <length>+")
+        else {
+            panic!("expected components");
+        };
+        assert_eq!(components.len(), 3);
+        assert_eq!(
+            components[0].name,
+            PropertySyntaxComponentName::CustomIdentifier("foo".into())
+        );
+        assert_eq!(components[0].multiplier, PropertySyntaxMultiplier::None);
+        assert_eq!(
+            components[1].multiplier,
+            PropertySyntaxMultiplier::CommaSeparated
+        );
+        assert_eq!(
+            components[2].multiplier,
+            PropertySyntaxMultiplier::SpaceSeparated
+        );
+    }
+
+    #[test]
+    fn encodes_case_sensitive_and_escaped_identifiers() {
+        let PropertySyntax::Components(components) = encode_value("Red | red | \\66 oo") else {
+            panic!("expected components");
+        };
+        assert_eq!(
+            components
+                .iter()
+                .map(|component| &component.name)
+                .collect::<Vec<_>>(),
+            [
+                &PropertySyntaxComponentName::CustomIdentifier("Red".into()),
+                &PropertySyntaxComponentName::CustomIdentifier("red".into()),
+                &PropertySyntaxComponentName::CustomIdentifier("foo".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn encodes_non_ascii_identifiers_using_byte_offsets() {
+        let PropertySyntax::Components(components) = encode_value("éclair | 色") else {
+            panic!("expected components");
+        };
+        assert_eq!(
+            components[0].name,
+            PropertySyntaxComponentName::CustomIdentifier("éclair".into())
+        );
+        assert_eq!(components[0].range, TextRange::new(10.into(), 17.into()));
+        assert_eq!(
+            components[1].name,
+            PropertySyntaxComponentName::CustomIdentifier("色".into())
+        );
+    }
+
+    #[test]
+    fn accepts_web_platform_syntax_cases() {
+        let valid = [
+            "--foo",
+            "--foo | <color>",
+            "--foo+",
+            "<length>|<percentage>|<length-percentage>",
+            "<color> | <image> | <url> | <integer> | <angle>",
+            "<time> | <resolution> | <transform-list> | <custom-ident>",
+            "\t<color>\n|   foo",
+            "big | bigger | BIGGER",
+            "foo+|bar",
+            "banana\t",
+            "\nbanana\r\n",
+            "ba\x0c\n|\tna\r|nya",
+            "\\1F914",
+            "hmm\\1F914",
+            "\\1F914hmm",
+            "\\1F914 hmm",
+            "\\1F914\\1F914",
+            "⌘",
+            "☀",
+        ];
+
+        for source in valid {
+            assert!(
+                matches!(
+                    encode(
+                        source,
+                        TextRange::new(0.into(), (source.len() as u32).into())
+                    ),
+                    PropertySyntaxResult::Value(_)
+                ),
+                "source: {source}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_syntax() {
+        let cases = [
+            ("", PropertySyntaxErrorKind::Empty),
+            ("   ", PropertySyntaxErrorKind::Empty),
+            ("* | auto", PropertySyntaxErrorKind::InvalidUniversalSyntax),
+            ("<unknown>", PropertySyntaxErrorKind::ExpectedTypeName),
+            ("< color>", PropertySyntaxErrorKind::UnexpectedWhitespace),
+            ("<color >", PropertySyntaxErrorKind::UnexpectedWhitespace),
+            ("<color", PropertySyntaxErrorKind::ExpectedTypeName),
+            ("<color> #", PropertySyntaxErrorKind::UnexpectedWhitespace),
+            (
+                "<transform-list>+",
+                PropertySyntaxErrorKind::MultiplierAfterTransformList,
+            ),
+            ("auto || none", PropertySyntaxErrorKind::ExpectedComponent),
+            ("auto |", PropertySyntaxErrorKind::ExpectedComponent),
+            ("| auto", PropertySyntaxErrorKind::ExpectedComponent),
+            ("initial", PropertySyntaxErrorKind::InvalidCustomIdentifier),
+            ("DEFAULT", PropertySyntaxErrorKind::InvalidCustomIdentifier),
+        ];
+
+        for (source, expected) in cases {
+            assert_eq!(encode_error(source).kind(), expected, "source: {source}");
+        }
+    }
+
+    #[test]
+    fn rejects_web_platform_syntax_cases() {
+        let invalid = [
+            "banana,nya",
+            "<\\6c ength>",
+            "<banana>",
+            "<Number>",
+            "<LENGTH>",
+            "<length>++",
+            "<length>##",
+            "<length>+#",
+            "<length>#+",
+            "<length> | *",
+            "*|banana",
+            "*+",
+            "||",
+            "foo bar",
+            "foo foo foo",
+            "foo § bar",
+            "foo \\1F914 bar",
+            "<length> <number>",
+            "<length> <length> <length>",
+            "<length>|initial",
+            "<length>|INHERIT",
+            "<percentage>|unsEt",
+            "<color>|REVert",
+            "<integer>|deFAUlt",
+        ];
+
+        for source in invalid {
+            assert!(
+                matches!(
+                    encode(
+                        source,
+                        TextRange::new(0.into(), (source.len() as u32).into())
+                    ),
+                    PropertySyntaxResult::Error(_)
+                ),
+                "source: {source}"
+            );
+        }
+    }
+
+    #[test]
+    fn diagnostics_use_absolute_byte_ranges() {
+        let diagnostic = encode_error("é | ?");
+        assert_eq!(diagnostic.range(), TextRange::new(15.into(), 16.into()));
+    }
+
+    #[test]
+    fn preprocesses_null_code_points() {
+        let PropertySyntax::Components(components) = encode_value("\0replacement") else {
+            panic!("expected components");
+        };
+        assert_eq!(
+            components[0].name,
+            PropertySyntaxComponentName::CustomIdentifier("�replacement".into())
+        );
+    }
+
+    #[test]
+    fn parse_diagnostics() {
+        let mut snapshot = String::new();
+        for value in [
+            "   ",
+            "foo | | bar",
+            "foo bar",
+            "<unknown>",
+            "initial",
+            "* | auto",
+            "<length> | *",
+            "<transform-list>+",
+            "<color> #",
+        ] {
+            let prefix = "@property --foo {\n  syntax: \"";
+            let source = format!("{prefix}{value}\";\n}}\n");
+            let start = prefix.len() as u32;
+            let diagnostic = match encode(
+                value,
+                TextRange::new(start.into(), (start + value.len() as u32).into()),
+            ) {
+                PropertySyntaxResult::Error(diagnostic) => diagnostic,
+                result => panic!("expected error, got {result:?}"),
+            }
+            .with_file_path("property.css")
+            .with_file_source_code(source);
+
+            snapshot.push_str(&print_diagnostic_to_string(&diagnostic));
+            snapshot.push('\n');
+        }
+
+        let snapshot = snapshot
+            .lines()
+            .map(str::trim_end)
+            .collect::<Vec<_>>()
+            .join("\n");
+        insta::assert_snapshot!(snapshot);
+    }
+}

--- a/crates/biome_property_codec/src/lib.rs
+++ b/crates/biome_property_codec/src/lib.rs
@@ -1,0 +1,11 @@
+mod data;
+mod decoder;
+mod encoder;
+
+pub use data::{
+    PropertySyntax, PropertySyntaxComponent, PropertySyntaxComponentName, PropertySyntaxDiagnostic,
+    PropertySyntaxErrorKind, PropertySyntaxMultiplier, PropertySyntaxParseDiagnostic,
+    PropertySyntaxResult, PropertySyntaxType,
+};
+pub use decoder::decode;
+pub use encoder::encode;

--- a/crates/biome_property_codec/src/snapshots/biome_property_codec__encoder__tests__parse_diagnostics.snap
+++ b/crates/biome_property_codec/src/snapshots/biome_property_codec__encoder__tests__parse_diagnostics.snap
@@ -1,0 +1,144 @@
+---
+source: crates/biome_property_codec/src/encoder.rs
+expression: snapshot
+---
+property.css:2:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The property syntax cannot be empty.
+
+    1 │ @property --foo {
+  > 2 │   syntax: "   ";
+      │            ^^^
+    3 │ }
+    4 │
+
+  i Add a syntax component, such as <length>, or use * to accept any value.
+
+
+
+property.css:2:18 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a property syntax component.
+
+    1 │ @property --foo {
+  > 2 │   syntax: "foo | | bar";
+      │                  ^
+    3 │ }
+    4 │
+
+  i Add a data type, such as <length>, or a custom identifier at this position.
+
+
+
+property.css:2:16 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Separate property syntax components with |.
+
+    1 │ @property --foo {
+  > 2 │   syntax: "foo bar";
+      │                ^^^
+    3 │ }
+    4 │
+
+
+
+property.css:2:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use a supported property syntax type.
+
+    1 │ @property --foo {
+  > 2 │   syntax: "<unknown>";
+      │            ^^^^^^^^^
+    3 │ }
+    4 │
+
+  i Supported types:
+
+  - <angle>
+  - <color>
+  - <custom-ident>
+  - <image>
+  - <integer>
+  - <length>
+  - <length-percentage>
+  - <number>
+  - <percentage>
+  - <resolution>
+  - <string>
+  - <time>
+  - <transform-function>
+  - <transform-list>
+  - <url>
+
+
+
+property.css:2:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use a custom identifier that isn't reserved.
+
+    1 │ @property --foo {
+  > 2 │   syntax: "initial";
+      │            ^^^^^^^
+    3 │ }
+    4 │
+
+  i Reserved identifiers:
+
+  - default
+  - inherit
+  - initial
+  - revert
+  - revert-layer
+  - unset
+
+
+
+property.css:2:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The * can't appear with other syntax components.
+
+    1 │ @property --foo {
+  > 2 │   syntax: "* | auto";
+      │            ^^^^^^^^
+    3 │ }
+    4 │
+
+  i Remove * or remove the other syntax components.
+
+
+
+property.css:2:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The * can't appear with other syntax components.
+
+    1 │ @property --foo {
+  > 2 │   syntax: "<length> | *";
+      │            ^^^^^^^^^^^^
+    3 │ }
+    4 │
+
+  i Remove * or remove the other syntax components.
+
+
+
+property.css:2:28 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Remove the multiplier after <transform-list>.
+
+    1 │ @property --foo {
+  > 2 │   syntax: "<transform-list>+";
+      │                            ^
+    3 │ }
+    4 │
+
+
+
+property.css:2:19 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Remove whitespace inside the type name or before the multiplier.
+
+    1 │ @property --foo {
+  > 2 │   syntax: "<color> #";
+      │                   ^
+    3 │ }
+    4 │


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Part of https://github.com/biomejs/biome/issues/11146, it adds a codec for `syntax` **value** of a custom property 

Designed by me and implemented with a coding agent. 

This is part of a different crate because I didn't want to have it tied to the semantic model, so that we can use it inside the CSS formatter to correctly format it :)

The decoding is implemented via `biome_formatter`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added various tests

<!-- What demonstrates that your implementation is correct? -->

## Docs

N/A

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
