### PR TITLE
feat(css): property semantic model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,6 +447,7 @@ dependencies = [
  "biome_db",
  "biome_formatter",
  "biome_languages",
+ "biome_property_codec",
  "biome_rowan",
  "biome_string_case",
  "camino",

--- a/crates/biome_css_semantic/Cargo.toml
+++ b/crates/biome_css_semantic/Cargo.toml
@@ -13,14 +13,15 @@ include              = ["!**/tests/**/*", "src/**/*"]
 publish              = true
 
 [dependencies]
-biome_css_syntax  = { workspace = true }
-biome_db          = { workspace = true }
-biome_formatter   = { workspace = true }
-biome_languages   = { workspace = true, features = ["lang_css"] }
-biome_rowan       = { workspace = true }
-biome_string_case = { workspace = true }
-rustc-hash        = { workspace = true }
-salsa             = { workspace = true }
+biome_css_syntax     = { workspace = true }
+biome_db             = { workspace = true }
+biome_formatter      = { workspace = true }
+biome_languages      = { workspace = true, features = ["lang_css"] }
+biome_property_codec = { workspace = true }
+biome_rowan          = { workspace = true }
+biome_string_case    = { workspace = true }
+rustc-hash           = { workspace = true }
+salsa                = { workspace = true }
 
 [dev-dependencies]
 biome_css_parser = { path = "../biome_css_parser" }

--- a/crates/biome_css_semantic/src/events.rs
+++ b/crates/biome_css_semantic/src/events.rs
@@ -1,9 +1,13 @@
 use biome_css_syntax::{
-    AnyCssDashedIdentifier, AnyCssDeclarationName, AnyCssGenericPropertyValueOrExpression,
-    AnyCssProperty, AnyCssSelector, CssDeclaration, CssPropertyAtRule, CssRelativeSelector,
-    CssSyntaxKind::*,
+    AnyCssDashedIdentifier, AnyCssDeclarationName, AnyCssGenericComponentValue,
+    AnyCssGenericPropertyValueOrExpression, AnyCssProperty, AnyCssSelector, AnyCssValue,
+    CssDashedIdentifier, CssDeclaration, CssPropertyAtRule, CssRelativeSelector, CssSyntaxKind::*,
 };
-use biome_rowan::{AstNode, AstSeparatedList, SyntaxNodeOptionExt, TextRange};
+use biome_property_codec::{
+    PropertySyntaxDiagnostic, PropertySyntaxErrorKind, PropertySyntaxParseDiagnostic,
+    PropertySyntaxResult, encode,
+};
+use biome_rowan::{AstNode, AstNodeList, AstSeparatedList, SyntaxNodeOptionExt, TextRange};
 use std::collections::VecDeque;
 
 use crate::model::{AnyCssSelectorLike, AnyRuleStart};
@@ -34,9 +38,9 @@ pub enum SemanticEvent {
     RootSelectorEnd,
     /// Indicates the start of an `@property` rule
     AtProperty {
-        property: CssProperty,
+        property: CssDashedIdentifier,
         initial_value: Option<CssPropertyInitialValueKind>,
-        syntax: Option<String>,
+        syntax: PropertySyntaxResult,
         inherits: Option<bool>,
         range: TextRange,
     },
@@ -222,7 +226,7 @@ impl SemanticEventExtractor {
         };
 
         let mut initial_value = None;
-        let mut syntax = None;
+        let mut syntax = PropertySyntaxResult::Missing;
         let mut inherits = None;
 
         for declaration in decls.declarations().into_iter().filter_map(|d| {
@@ -233,42 +237,45 @@ impl SemanticEventExtractor {
                 declaration.property()
                 && let Ok(prop_name) = prop.name()
             {
-                match prop_name.to_trimmed_string().as_str() {
-                    "initial-value" => {
-                        let Ok(value) = prop.value() else {
-                            continue;
-                        };
-                        initial_value = Some(match value {
-                            AnyCssGenericPropertyValueOrExpression::CssCustomPropertyValue(value) => {
-                                CssPropertyInitialValueKind::from(value)
-                            }
-                            AnyCssGenericPropertyValueOrExpression::CssGenericComponentValueList(
-                                list,
-                            ) => CssPropertyInitialValueKind::from(list),
-                            AnyCssGenericPropertyValueOrExpression::ScssExpression(expr) => {
-                                CssPropertyInitialValueKind::from(expr)
-                            }
-                        });
-                    }
-                    "syntax" => {
-                        let Ok(value) = prop.value() else {
-                            continue;
-                        };
-                        syntax = Some(value.to_trimmed_string().clone());
-                    }
-                    "inherits" => {
-                        let Ok(value) = prop.value() else {
-                            continue;
-                        };
-                        inherits = Some(value.to_trimmed_string().eq_ignore_ascii_case("true"));
-                    }
-                    _ => {}
+                let prop_name = prop_name.to_trimmed_string();
+                if prop_name.eq_ignore_ascii_case("initial-value") {
+                    let Ok(value) = prop.value() else {
+                        continue;
+                    };
+                    initial_value = Some(match value {
+                        AnyCssGenericPropertyValueOrExpression::CssCustomPropertyValue(value) => {
+                            CssPropertyInitialValueKind::from(value)
+                        }
+                        AnyCssGenericPropertyValueOrExpression::CssGenericComponentValueList(
+                            list,
+                        ) => CssPropertyInitialValueKind::from(list),
+                        AnyCssGenericPropertyValueOrExpression::ScssExpression(expr) => {
+                            CssPropertyInitialValueKind::from(expr)
+                        }
+                    });
+                } else if prop_name.eq_ignore_ascii_case("syntax") {
+                    let Ok(value) = prop.value() else {
+                        continue;
+                    };
+                    syntax = parse_property_syntax(value);
+                } else if prop_name.eq_ignore_ascii_case("inherits") {
+                    let Ok(value) = prop.value() else {
+                        continue;
+                    };
+                    let value = value.to_trimmed_string();
+                    inherits = if value.eq_ignore_ascii_case("true") {
+                        Some(true)
+                    } else if value.eq_ignore_ascii_case("false") {
+                        Some(false)
+                    } else {
+                        None
+                    };
                 }
             }
         }
 
         self.stash.push_back(SemanticEvent::AtProperty {
-            property: CssProperty::from(property_name),
+            property: property_name,
             initial_value,
             syntax,
             inherits,
@@ -303,4 +310,27 @@ impl SemanticEventExtractor {
     pub fn pop(&mut self) -> Option<SemanticEvent> {
         self.stash.pop_front()
     }
+}
+
+fn parse_property_syntax(value: AnyCssGenericPropertyValueOrExpression) -> PropertySyntaxResult {
+    let range = value.range();
+    let Some(list) = value.as_css_generic_component_value_list() else {
+        return invalid_property_syntax(range);
+    };
+    let mut components = list.iter();
+    let Some(AnyCssGenericComponentValue::AnyCssValue(AnyCssValue::CssString(string))) =
+        components.next()
+    else {
+        return invalid_property_syntax(range);
+    };
+    if components.next().is_some() {
+        return invalid_property_syntax(range);
+    }
+    encode(&string)
+}
+
+fn invalid_property_syntax(range: TextRange) -> PropertySyntaxResult {
+    PropertySyntaxResult::Error(PropertySyntaxDiagnostic::Parse(
+        PropertySyntaxParseDiagnostic::new(PropertySyntaxErrorKind::ExpectedString, range),
+    ))
 }

--- a/crates/biome_css_semantic/src/semantic_model/builder.rs
+++ b/crates/biome_css_semantic/src/semantic_model/builder.rs
@@ -4,8 +4,8 @@ use rustc_hash::FxHashMap;
 use std::collections::BTreeMap;
 
 use super::model::{
-    CssGlobalCustomVariableData, CssModelDeclarationData, ResolvedSelector, RuleData, RuleId,
-    SelectorData, SemanticModel, SemanticModelData, Specificity, selector_tokens,
+    CssGlobalCustomVariableData, CssModelDeclarationData, CssPropertyAtRuleData, ResolvedSelector,
+    RuleData, RuleId, SelectorData, SemanticModel, SemanticModelData, Specificity, selector_tokens,
 };
 use crate::events::SemanticEvent;
 use crate::model::AnyRuleStart;
@@ -231,15 +231,16 @@ impl SemanticModelBuilder {
                     && let Ok(property_name) = property.value()
                 {
                     if is_global_var {
-                        self.global_custom_variables.insert(
-                            property_name.clone(),
-                            CssGlobalCustomVariableData::Root(CssModelDeclarationData {
-                                declaration: AstPtr::new(&node),
-                                property: AstPtr::new(&property),
-                                value: value.clone(),
-                                property_name: property_name.clone(),
-                            }),
-                        );
+                        let variable = self
+                            .global_custom_variables
+                            .entry(property_name.clone())
+                            .or_default();
+                        variable.root = Some(CssModelDeclarationData {
+                            declaration: AstPtr::new(&node),
+                            property: AstPtr::new(&property),
+                            value: value.clone(),
+                            property_name: property_name.clone(),
+                        });
                     }
                     let current_rule = &mut self.all_rules[current_rule_id.index()];
                     current_rule.declarations.push(CssModelDeclarationData {
@@ -263,17 +264,19 @@ impl SemanticModelBuilder {
                 inherits,
                 range,
             } => {
-                if let Ok(property_name) = property.value() {
-                    self.global_custom_variables.insert(
-                        property_name,
-                        CssGlobalCustomVariableData::AtProperty {
-                            _property: AstPtr::new(&property),
-                            initial_value,
-                            syntax,
-                            inherits,
-                            _range: range,
-                        },
-                    );
+                if let Ok(property_name) = property.value_token() {
+                    let property_name = property_name.token_text_trimmed();
+                    let variable = self
+                        .global_custom_variables
+                        .entry(property_name)
+                        .or_default();
+                    variable.at_property = Some(CssPropertyAtRuleData {
+                        property: AstPtr::new(&property),
+                        initial_value,
+                        syntax,
+                        inherits,
+                        range,
+                    });
                 }
             }
         }

--- a/crates/biome_css_semantic/src/semantic_model/db.rs
+++ b/crates/biome_css_semantic/src/semantic_model/db.rs
@@ -42,6 +42,9 @@ mod tests {
     };
     use biome_languages::css::CssFileSource;
     use biome_languages::{DocumentFileSource, LanguageDb};
+    use biome_property_codec::{
+        PropertySyntax, PropertySyntaxComponentName, PropertySyntaxResult, PropertySyntaxType,
+    };
     use camino::{Utf8Path, Utf8PathBuf};
     use salsa::Storage;
 
@@ -115,6 +118,24 @@ mod tests {
     fn rule_count(db: &dyn LanguageDb, file: ParsedSource) -> usize {
         let model = css_model_from_parsed_source(db, file);
         model.rules().len()
+    }
+
+    #[salsa::tracked]
+    fn property_syntax_type(db: &dyn LanguageDb, file: ParsedSource) -> Option<PropertySyntaxType> {
+        let model = css_model_from_parsed_source(db, file);
+        let at_property = model
+            .global_custom_variables()
+            .get("--value")?
+            .at_property()?;
+        let PropertySyntaxResult::Value(PropertySyntax::Components(components)) =
+            at_property.syntax()
+        else {
+            return None;
+        };
+        let PropertySyntaxComponentName::Type(syntax_type) = components.first()?.name else {
+            return None;
+        };
+        Some(syntax_type)
     }
 
     #[test]
@@ -223,6 +244,68 @@ mod tests {
 
         assert_function_query_was_run(&db, css_model_from_parsed_source, file, &events);
         assert_function_query_was_not_run(&db, rule_count, file, &events);
+    }
+
+    #[test]
+    fn at_property_whitespace_change_does_not_recompute_downstream() {
+        let mut db = TestDb::new();
+        let file = make_file(
+            &db,
+            r#"@property --value { syntax: "<color>"; inherits: true; initial-value: red; }"#,
+        );
+        assert_eq!(
+            property_syntax_type(&db, file),
+            Some(PropertySyntaxType::Color)
+        );
+
+        let new_parsed = parse_css(
+            r#"@property  --value  { syntax:  "<color>"; inherits:  true; initial-value:  red; }"#,
+            CssFileSource::css(),
+            CssParserOptions::default(),
+        )
+        .into();
+        salsa::Setter::to(file.set_parsed(&mut db), new_parsed);
+
+        db.clear_salsa_events();
+        assert_eq!(
+            property_syntax_type(&db, file),
+            Some(PropertySyntaxType::Color)
+        );
+        let events = db.take_salsa_events();
+
+        assert_function_query_was_run(&db, css_model_from_parsed_source, file, &events);
+        assert_function_query_was_not_run(&db, property_syntax_type, file, &events);
+    }
+
+    #[test]
+    fn at_property_syntax_change_recomputes_downstream() {
+        let mut db = TestDb::new();
+        let file = make_file(
+            &db,
+            r#"@property --value { syntax: "<color>"; inherits: true; initial-value: red; }"#,
+        );
+        assert_eq!(
+            property_syntax_type(&db, file),
+            Some(PropertySyntaxType::Color)
+        );
+
+        let new_parsed = parse_css(
+            r#"@property --value { syntax: "<length>"; inherits: true; initial-value: 10px; }"#,
+            CssFileSource::css(),
+            CssParserOptions::default(),
+        )
+        .into();
+        salsa::Setter::to(file.set_parsed(&mut db), new_parsed);
+
+        db.clear_salsa_events();
+        assert_eq!(
+            property_syntax_type(&db, file),
+            Some(PropertySyntaxType::Length)
+        );
+        let events = db.take_salsa_events();
+
+        assert_function_query_was_run(&db, css_model_from_parsed_source, file, &events);
+        assert_function_query_was_run(&db, property_syntax_type, file, &events);
     }
 
     #[test]

--- a/crates/biome_css_semantic/src/semantic_model/mod.rs
+++ b/crates/biome_css_semantic/src/semantic_model/mod.rs
@@ -35,6 +35,10 @@ pub fn semantic_model(root: &AnyCssRoot) -> SemanticModel {
 mod tests {
     use biome_css_parser::{CssParserOptions, parse_css};
     use biome_languages::CssFileSource;
+    use biome_property_codec::{
+        PropertySyntax, PropertySyntaxComponentName, PropertySyntaxErrorKind, PropertySyntaxResult,
+        PropertySyntaxType,
+    };
     use biome_rowan::TextRange;
 
     #[test]
@@ -238,6 +242,230 @@ mod tests {
         let item_size = global_custom_variables.contains_key("--item-size");
 
         assert!(item_size);
+    }
+
+    #[test]
+    fn test_at_property_semantic_data() {
+        let parse = parse_css(
+            r#"@property --item-size {
+  SYNTAX: "<percentage> | auto";
+  InHeRiTs: false;
+  INITIAL-VALUE: 40%;
+}"#,
+            CssFileSource::css(),
+            CssParserOptions::default(),
+        );
+
+        let model = super::semantic_model(&parse.tree());
+        let variable = model
+            .global_custom_variables()
+            .get("--item-size")
+            .expect("expected custom property");
+        let at_property = variable.at_property().expect("expected at-property data");
+
+        assert_eq!(at_property.name().text(), "--item-size");
+        assert_eq!(at_property.inherits(), Some(false));
+        assert!(at_property.initial_value().is_some());
+        assert_eq!(
+            at_property
+                .name_node()
+                .value_token()
+                .unwrap()
+                .text_trimmed(),
+            "--item-size"
+        );
+        let PropertySyntaxResult::Value(PropertySyntax::Components(components)) =
+            at_property.syntax()
+        else {
+            panic!("expected parsed property syntax");
+        };
+        assert_eq!(components.len(), 2);
+        assert_eq!(
+            components[0].name,
+            PropertySyntaxComponentName::Type(PropertySyntaxType::Percentage)
+        );
+        assert_eq!(
+            components[1].name,
+            PropertySyntaxComponentName::CustomIdentifier("auto".into())
+        );
+    }
+
+    #[test]
+    fn test_at_property_syntax_states() {
+        let parse = parse_css(
+            r#"@property --invalid {
+  syntax: "<unknown>";
+  inherits: true;
+}
+@property --missing {
+  inherits: true;
+}
+@property --unquoted {
+  syntax: color;
+  inherits: yes;
+}"#,
+            CssFileSource::css(),
+            CssParserOptions::default(),
+        );
+
+        let model = super::semantic_model(&parse.tree());
+        let variables = model.global_custom_variables();
+        let invalid = variables.get("--invalid").unwrap().at_property().unwrap();
+        let missing = variables.get("--missing").unwrap().at_property().unwrap();
+        let unquoted = variables.get("--unquoted").unwrap().at_property().unwrap();
+
+        let PropertySyntaxResult::Error(diagnostic) = invalid.syntax() else {
+            panic!("expected invalid syntax");
+        };
+        assert_eq!(diagnostic.kind(), PropertySyntaxErrorKind::ExpectedTypeName);
+        assert_eq!(missing.syntax(), &PropertySyntaxResult::Missing);
+        let PropertySyntaxResult::Error(diagnostic) = unquoted.syntax() else {
+            panic!("expected a string diagnostic, got {:#?}", unquoted.syntax());
+        };
+        assert_eq!(diagnostic.kind(), PropertySyntaxErrorKind::ExpectedString);
+        assert_eq!(unquoted.inherits(), None);
+    }
+
+    #[test]
+    fn test_at_property_decodes_css_string_escapes() {
+        let source = r#"@property --escaped {
+  syntax: "\3c color\3e ";
+  inherits: true;
+  initial-value: red;
+}
+@property --continued {
+  syntax: "<col\
+or>";
+  inherits: true;
+  initial-value: red;
+}
+@property --invalid-escaped {
+  syntax: "\3c unknown\3e ";
+  inherits: true;
+}
+@property --empty {
+  syntax: "";
+  inherits: true;
+}
+@property --identifier {
+  syntax: "\\66 oo";
+  inherits: true;
+}"#;
+        let parse = parse_css(source, CssFileSource::css(), CssParserOptions::default());
+
+        let model = super::semantic_model(&parse.tree());
+        let variables = model.global_custom_variables();
+        for name in ["--escaped", "--continued"] {
+            let at_property = variables.get(name).unwrap().at_property().unwrap();
+            let PropertySyntaxResult::Value(PropertySyntax::Components(components)) =
+                at_property.syntax()
+            else {
+                panic!("expected a parsed syntax for {name}");
+            };
+            assert_eq!(
+                components[0].name,
+                PropertySyntaxComponentName::Type(PropertySyntaxType::Color)
+            );
+        }
+
+        let escaped = variables.get("--escaped").unwrap().at_property().unwrap();
+        let PropertySyntaxResult::Value(PropertySyntax::Components(components)) = escaped.syntax()
+        else {
+            unreachable!();
+        };
+        let start = source.find("\\3c color\\3e ").unwrap() as u32;
+        let end = start + "\\3c color\\3e ".len() as u32;
+        assert_eq!(
+            components[0].range,
+            TextRange::new(start.into(), end.into())
+        );
+
+        let invalid = variables
+            .get("--invalid-escaped")
+            .unwrap()
+            .at_property()
+            .unwrap();
+        let PropertySyntaxResult::Error(diagnostic) = invalid.syntax() else {
+            panic!("expected invalid escaped syntax");
+        };
+        let start = source.find("\\3c unknown\\3e ").unwrap() as u32;
+        let end = start + "\\3c unknown\\3e ".len() as u32;
+        assert_eq!(diagnostic.kind(), PropertySyntaxErrorKind::ExpectedTypeName);
+        assert_eq!(diagnostic.range(), TextRange::new(start.into(), end.into()));
+
+        let empty = variables.get("--empty").unwrap().at_property().unwrap();
+        let PropertySyntaxResult::Error(diagnostic) = empty.syntax() else {
+            panic!("expected empty syntax");
+        };
+        assert_eq!(diagnostic.kind(), PropertySyntaxErrorKind::Empty);
+
+        let identifier = variables
+            .get("--identifier")
+            .unwrap()
+            .at_property()
+            .unwrap();
+        let PropertySyntaxResult::Value(PropertySyntax::Components(components)) =
+            identifier.syntax()
+        else {
+            panic!("expected an escaped custom identifier");
+        };
+        assert_eq!(
+            components[0].name,
+            PropertySyntaxComponentName::CustomIdentifier("foo".into())
+        );
+    }
+
+    #[test]
+    fn test_root_declaration_and_at_property_coexist() {
+        let parse = parse_css(
+            r#"@property --color {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: black;
+}
+:root {
+  --color: red;
+}"#,
+            CssFileSource::css(),
+            CssParserOptions::default(),
+        );
+
+        let model = super::semantic_model(&parse.tree());
+        let variable = model.global_custom_variables().get("--color").unwrap();
+
+        assert!(variable.is_at_property());
+        assert!(variable.is_root());
+        assert!(variable.at_property().is_some());
+    }
+
+    #[test]
+    fn test_last_at_property_rule_wins() {
+        let parse = parse_css(
+            r#"@property --color {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: black;
+}
+@property --color {
+  syntax: "<unknown>";
+  inherits: true;
+}"#,
+            CssFileSource::css(),
+            CssParserOptions::default(),
+        );
+
+        let model = super::semantic_model(&parse.tree());
+        let at_property = model
+            .global_custom_variables()
+            .get("--color")
+            .unwrap()
+            .at_property()
+            .unwrap();
+        let PropertySyntaxResult::Error(diagnostic) = at_property.syntax() else {
+            panic!("expected the last authored rule");
+        };
+
+        assert_eq!(diagnostic.kind(), PropertySyntaxErrorKind::ExpectedTypeName);
     }
 
     #[test]

--- a/crates/biome_css_semantic/src/semantic_model/model.rs
+++ b/crates/biome_css_semantic/src/semantic_model/model.rs
@@ -5,6 +5,7 @@ use biome_css_syntax::{
     CssQualifiedRule, CssScopeAtRule, CssStartingStyleAtRule, CssSupportsAtRule, CssSyntaxKind,
     CssSyntaxNode, CssSyntaxToken, ScssExpression,
 };
+use biome_property_codec::PropertySyntaxResult;
 use biome_rowan::{
     AstNode, AstNodeList, AstPtr, Direction, SendNode, SyntaxKind, SyntaxResult, TextRange,
     TextSize, TokenText, declare_node_union,
@@ -663,12 +664,16 @@ impl std::fmt::Display for Specificity {
     }
 }
 
-/// Stored data for a CSS declaration.
+/// Source handles and semantic data retained for a CSS declaration.
 #[derive(Debug, Clone)]
 pub(crate) struct CssModelDeclarationData {
+    /// The complete declaration node.
     pub(crate) declaration: AstPtr<CssDeclaration>,
+    /// The declaration name node.
     pub(crate) property: AstPtr<CssProperty>,
+    /// The trimmed property-name token used for lookup and semantic equality.
     pub(crate) property_name: TokenText,
+    /// The declaration value classified by its CSS or SCSS syntax shape.
     pub(crate) value: CssPropertyInitialValueKind,
 }
 
@@ -749,18 +754,23 @@ impl CssProperty {
     }
 }
 
+/// A declaration value retained by the semantic model.
 #[derive(Debug, Clone)]
 pub enum CssPropertyInitialValueKind {
+    /// A standard CSS component-value list.
     GenericComponent(AstPtr<CssGenericComponentValueList>),
+    /// A custom-property value.
     CustomProperty(AstPtr<CssCustomPropertyValue>),
+    /// A CSS Modules `composes` value.
     Composes(AstPtr<CssComposesPropertyValue>),
+    /// An SCSS expression.
     ScssExpression(AstPtr<ScssExpression>),
 }
 
 impl CssPropertyInitialValueKind {
     /// Compares values from potentially different syntax trees by restoring each
-    /// stored pointer with its own root. Direct pointer equality would include
-    /// source ranges, so the restored nodes are reduced to semantic token pairs.
+    /// stored pointer with its own root. Source ranges do not affect semantic
+    /// equality.
     fn semantic_eq(&self, other: &Self, self_root: &AnyCssRoot, other_root: &AnyCssRoot) -> bool {
         match (self, other) {
             (Self::GenericComponent(a), Self::GenericComponent(b)) => {
@@ -928,53 +938,62 @@ fn has_custom_property_component_gap_before(token: &CssSyntaxToken) -> bool {
         })
 }
 
-/// Stored data for a CSS global custom variable declaration.
+/// Combines the declaration sources associated with one global custom-property name.
+///
+/// The `:root` declaration and `@property` rule are independent facets. A custom
+/// property may have either facet or both.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct CssGlobalCustomVariableData {
+    /// The declaration from a `:root` rule, if one is retained for the name.
+    pub(crate) root: Option<CssModelDeclarationData>,
+    /// The authored `@property` rule, if one is retained for the name.
+    pub(crate) at_property: Option<CssPropertyAtRuleData>,
+}
+
+/// Authored descriptors and source handles retained for an `@property` rule.
+///
+/// Invalid or incomplete descriptor sets remain represented. Descriptor validity
+/// is available through the individual fields rather than through the presence of
+/// this structure.
 #[derive(Debug, Clone)]
-pub(crate) enum CssGlobalCustomVariableData {
-    Root(CssModelDeclarationData),
-    AtProperty {
-        _property: AstPtr<CssProperty>,
-        syntax: Option<String>,
-        inherits: Option<bool>,
-        initial_value: Option<CssPropertyInitialValueKind>,
-        _range: TextRange,
-    },
+pub(crate) struct CssPropertyAtRuleData {
+    /// The custom-property name node in the rule declarator.
+    pub(crate) property: AstPtr<CssDashedIdentifier>,
+    /// The parsed `syntax` descriptor, including missing and invalid states.
+    pub(crate) syntax: PropertySyntaxResult,
+    /// The `inherits` descriptor when its value is `true` or `false`.
+    pub(crate) inherits: Option<bool>,
+    /// The `initial-value` descriptor when a value node is present.
+    pub(crate) initial_value: Option<CssPropertyInitialValueKind>,
+    /// The absolute source range of the complete rule.
+    pub(crate) range: TextRange,
 }
 
 impl CssGlobalCustomVariableData {
     /// Compares global custom variable semantics using the root that owns each
-    /// side's stored pointers. This allows `:root` declarations and `@property`
-    /// initial values to compare their restored value nodes without relying on
-    /// pointer ranges.
+    /// side's stored pointers.
     fn semantic_eq(&self, other: &Self, self_root: &AnyCssRoot, other_root: &AnyCssRoot) -> bool {
-        match (self, other) {
-            (Self::Root(this), Self::Root(other)) => this.semantic_eq(other, self_root, other_root),
-            (
-                Self::AtProperty {
-                    inherits: self_inherits,
-                    initial_value: self_initial_value,
-                    syntax: self_syntax,
-                    ..
-                },
-                Self::AtProperty {
-                    inherits: other_inherits,
-                    initial_value: other_initial_value,
-                    syntax: other_syntax,
-                    ..
-                },
-            ) => {
-                self_inherits == other_inherits
-                    && match (self_initial_value, other_initial_value) {
-                        (Some(self_value), Some(other_value)) => {
-                            self_value.semantic_eq(other_value, self_root, other_root)
-                        }
-                        (None, None) => true,
-                        _ => false,
-                    }
-                    && self_syntax == other_syntax
-            }
+        (match (&self.root, &other.root) {
+            (Some(this), Some(other)) => this.semantic_eq(other, self_root, other_root),
+            (None, None) => true,
+            _ => false,
+        }) && match (&self.at_property, &other.at_property) {
+            (Some(this), Some(other)) => this.semantic_eq(other, self_root, other_root),
+            (None, None) => true,
             _ => false,
         }
+    }
+}
+
+impl CssPropertyAtRuleData {
+    fn semantic_eq(&self, other: &Self, self_root: &AnyCssRoot, other_root: &AnyCssRoot) -> bool {
+        self.inherits == other.inherits
+            && match (&self.initial_value, &other.initial_value) {
+                (Some(this), Some(other)) => this.semantic_eq(other, self_root, other_root),
+                (None, None) => true,
+                _ => false,
+            }
+            && self.syntax.semantic_eq(&other.syntax)
     }
 }
 
@@ -1003,39 +1022,126 @@ impl CssGlobalCustomVariable {
         &self.data.global_custom_variables[&self.name]
     }
 
+    /// Returns the custom property name.
     pub fn name(&self) -> &TokenText {
         &self.name
     }
 
+    /// Returns whether the property has an `@property` rule.
     pub fn is_at_property(&self) -> bool {
-        matches!(self.value(), CssGlobalCustomVariableData::AtProperty { .. })
+        self.value().at_property.is_some()
     }
 
+    /// Returns whether the property is declared in a `:root` rule.
     pub fn is_root(&self) -> bool {
-        matches!(self.value(), CssGlobalCustomVariableData::Root(_))
+        self.value().root.is_some()
+    }
+
+    /// Returns the semantic data for the `@property` rule, if present.
+    pub fn at_property(&self) -> Option<CssPropertyAtRule> {
+        self.value()
+            .at_property
+            .as_ref()
+            .map(|_| CssPropertyAtRule {
+                data: self.data.clone(),
+                name: self.name.clone(),
+            })
     }
 }
 
+/// The descriptors and source data declared by an `@property` rule.
+///
+/// This view represents the authored rule even when its descriptors do not
+/// form a valid browser registration.
+#[derive(Debug, Clone)]
+pub struct CssPropertyAtRule {
+    data: Arc<SemanticModelData>,
+    name: TokenText,
+}
+
+impl CssPropertyAtRule {
+    fn value(&self) -> &CssPropertyAtRuleData {
+        // SAFETY: Instances are created only for names with an `@property` rule.
+        self.data.global_custom_variables[&self.name]
+            .at_property
+            .as_ref()
+            .expect("the custom property should have an at-property rule")
+    }
+
+    /// Returns the authored custom property name.
+    pub fn name(&self) -> &TokenText {
+        &self.name
+    }
+
+    /// Returns the custom property name node from the rule declarator.
+    pub fn name_node(&self) -> CssDashedIdentifier {
+        self.value().property.to_node(self.data.root().syntax())
+    }
+
+    /// Returns the parsed `syntax` descriptor.
+    pub fn syntax(&self) -> &PropertySyntaxResult {
+        &self.value().syntax
+    }
+
+    /// Returns the `inherits` descriptor when it is `true` or `false`.
+    pub fn inherits(&self) -> Option<bool> {
+        self.value().inherits
+    }
+
+    /// Returns the `initial-value` descriptor, if present.
+    pub fn initial_value(&self) -> Option<CssPropertyInitialValue> {
+        self.value()
+            .initial_value
+            .clone()
+            .map(|kind| CssPropertyInitialValue {
+                data: self.data.clone(),
+                kind,
+            })
+    }
+
+    /// Returns the absolute source range of the `@property` rule.
+    pub fn range(&self) -> TextRange {
+        self.value().range
+    }
+}
+
+/// A view over global custom properties indexed by name.
 #[derive(Debug)]
 pub struct GlobalCustomVariables<'a> {
     pub(crate) data: &'a Arc<SemanticModelData>,
 }
 
 impl<'a> GlobalCustomVariables<'a> {
+    /// Returns whether a custom property with `name` is present.
     pub fn contains_key(&self, name: impl AsRef<str>) -> bool {
         self.data
             .global_custom_variables
             .contains_key(name.as_ref())
     }
 
+    /// Returns the number of custom properties.
     pub fn len(&self) -> usize {
         self.data.global_custom_variables.len()
     }
 
+    /// Returns whether the collection contains no custom properties.
     pub fn is_empty(&self) -> bool {
         self.data.global_custom_variables.is_empty()
     }
 
+    /// Returns the custom property with `name`, if present.
+    pub fn get(&self, name: impl AsRef<str>) -> Option<CssGlobalCustomVariable> {
+        let (name, _) = self
+            .data
+            .global_custom_variables
+            .get_key_value(name.as_ref())?;
+        Some(CssGlobalCustomVariable {
+            data: self.data.clone(),
+            name: name.clone(),
+        })
+    }
+
+    /// Returns all custom properties in unspecified order.
     pub fn iter(&self) -> impl Iterator<Item = (&TokenText, CssGlobalCustomVariable)> + '_ {
         self.data.global_custom_variables.keys().map(|name| {
             (

--- a/crates/biome_css_semantic/src/tests/eq.rs
+++ b/crates/biome_css_semantic/src/tests/eq.rs
@@ -175,6 +175,47 @@ fn at_property_syntax_change_is_not_eq() {
 }
 
 #[test]
+fn at_property_whitespace_change_is_eq() {
+    assert_eq!(
+        build_model(
+            r#"@property --foo { syntax: "<color>"; inherits: true; initial-value: red; }"#
+        ),
+        build_model(
+            r#"@property  --foo  { syntax:  "<color>"; inherits:  true; initial-value:  red; }"#
+        ),
+        "@property whitespace should not affect semantic eq"
+    );
+}
+
+#[test]
+fn at_property_syntax_ranges_do_not_affect_eq() {
+    assert_eq!(
+        build_model(r#"@property --foo { syntax: "*"; inherits: true; }"#),
+        build_model(r#"@property --foo { syntax: " * "; inherits: true; }"#),
+        "universal syntax ranges should not affect semantic eq"
+    );
+
+    assert_eq!(
+        build_model(r#"@property --foo { syntax: "<unknown>"; inherits: true; }"#),
+        build_model("\n@property --foo { syntax: \"<unknown>\"; inherits: true; }"),
+        "diagnostic ranges should not affect semantic eq"
+    );
+}
+
+#[test]
+fn at_property_initial_value_change_is_not_eq() {
+    assert_ne!(
+        build_model(
+            r#"@property --foo { syntax: "<color>"; inherits: true; initial-value: red; }"#
+        ),
+        build_model(
+            r#"@property --foo { syntax: "<color>"; inherits: true; initial-value: blue; }"#
+        ),
+        "different @property initial values should produce different models"
+    );
+}
+
+#[test]
 fn at_property_inherits_change_is_not_eq() {
     assert_ne!(
         build_model(

--- a/crates/biome_property_codec/src/data.rs
+++ b/crates/biome_property_codec/src/data.rs
@@ -7,7 +7,6 @@ use biome_formatter::{
     write,
 };
 use biome_rowan::TextRange;
-use biome_unicode_table::is_css_non_ascii;
 
 // #region Data structure definition
 
@@ -20,6 +19,30 @@ pub enum PropertySyntaxResult {
     Error(PropertySyntaxDiagnostic),
     /// The parsed and normalized descriptor value.
     Value(PropertySyntax),
+}
+
+impl PropertySyntaxResult {
+    /// Compares parsed descriptor semantics without considering source ranges.
+    pub fn semantic_eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Missing, Self::Missing) => true,
+            (Self::Error(left), Self::Error(right)) => left.kind() == right.kind(),
+            (
+                Self::Value(PropertySyntax::Universal { .. }),
+                Self::Value(PropertySyntax::Universal { .. }),
+            ) => true,
+            (
+                Self::Value(PropertySyntax::Components(left)),
+                Self::Value(PropertySyntax::Components(right)),
+            ) => {
+                left.len() == right.len()
+                    && left.iter().zip(right).all(|(left, right)| {
+                        left.name == right.name && left.multiplier == right.multiplier
+                    })
+            }
+            _ => false,
+        }
+    }
 }
 
 /// A diagnostic produced while processing an `@property` `syntax` descriptor.
@@ -60,7 +83,8 @@ pub struct PropertySyntaxParseDiagnostic {
 }
 
 impl PropertySyntaxParseDiagnostic {
-    pub(crate) const fn new(kind: PropertySyntaxErrorKind, range: TextRange) -> Self {
+    /// Creates a parse diagnostic for `kind` at an absolute source `range`.
+    pub const fn new(kind: PropertySyntaxErrorKind, range: TextRange) -> Self {
         Self { kind, range }
     }
 }
@@ -72,6 +96,8 @@ pub enum PropertySyntaxErrorKind {
     Empty,
     /// A component is missing where the grammar requires one.
     ExpectedComponent,
+    /// The descriptor value is not a CSS string.
+    ExpectedString,
     /// Adjacent components are not separated by `|`.
     ExpectedPipe,
     /// A data type name is missing, malformed, or unsupported.
@@ -91,6 +117,7 @@ impl std::fmt::Display for PropertySyntaxErrorKind {
         match self {
             Self::Empty => fmt.write_str("The property syntax cannot be empty."),
             Self::ExpectedComponent => fmt.write_str("Expected a property syntax component."),
+            Self::ExpectedString => fmt.write_str("Use a string for the property syntax."),
             Self::ExpectedPipe => fmt.write_str("Separate property syntax components with `|`."),
             Self::ExpectedTypeName => fmt.write_str("Use a supported property syntax type."),
             Self::InvalidCustomIdentifier => {
@@ -114,6 +141,7 @@ impl biome_console::fmt::Display for PropertySyntaxErrorKind {
         match self {
             Self::Empty => fmt.write_str("The property syntax cannot be empty."),
             Self::ExpectedComponent => fmt.write_str("Expected a property syntax component."),
+            Self::ExpectedString => fmt.write_str("Use a string for the property syntax."),
             Self::ExpectedPipe => fmt.write_markup(biome_console::markup! {
                 "Separate property syntax components with "<Emphasis>"|"</Emphasis>"."
             }),
@@ -151,6 +179,7 @@ impl Advices for PropertySyntaxErrorKind {
                     ", or a custom identifier at this position."
                 },
             ),
+            Self::ExpectedString => Ok(()),
             Self::ExpectedTypeName => {
                 visitor.record_log(
                     LogCategory::Info,
@@ -312,27 +341,6 @@ impl PropertySyntaxType {
             Self::Url => "url",
         }
     }
-
-    pub(crate) fn from_name(name: &[u8]) -> Option<Self> {
-        Some(match name {
-            b"angle" => Self::Angle,
-            b"color" => Self::Color,
-            b"custom-ident" => Self::CustomIdent,
-            b"image" => Self::Image,
-            b"integer" => Self::Integer,
-            b"length" => Self::Length,
-            b"length-percentage" => Self::LengthPercentage,
-            b"number" => Self::Number,
-            b"percentage" => Self::Percentage,
-            b"resolution" => Self::Resolution,
-            b"string" => Self::String,
-            b"time" => Self::Time,
-            b"transform-function" => Self::TransformFunction,
-            b"transform-list" => Self::TransformList,
-            b"url" => Self::Url,
-            _ => return None,
-        })
-    }
 }
 
 impl biome_console::fmt::Display for PropertySyntaxType {
@@ -478,8 +486,7 @@ impl Format<PropertyFmtContext> for FormatCustomIdentifier<'_> {
             let requires_hex_escape = byte <= 0x1f
                 || byte == 0x7f
                 || (index == 0 && byte.is_ascii_digit())
-                || (index == 1 && bytes[0] == b'-' && byte.is_ascii_digit())
-                || (byte >= 0x80 && !char::from_u32(code_point).is_some_and(is_css_non_ascii));
+                || (index == 1 && bytes[0] == b'-' && byte.is_ascii_digit());
             let requires_simple_escape = (bytes.len() == 1 && byte == b'-')
                 || (byte.is_ascii()
                     && !byte.is_ascii_alphanumeric()

--- a/crates/biome_property_codec/src/decoder.rs
+++ b/crates/biome_property_codec/src/decoder.rs
@@ -2,8 +2,12 @@ use crate::data::{PropertyFmtContext, PropertySyntax};
 
 /// Formats a parsed property syntax as a normalized syntax string.
 pub fn decode(value: &PropertySyntax) -> String {
+    // SAFETY: Formatting `PropertySyntax` only writes its in-memory data and
+    // does not resolve syntax tokens or source nodes.
     let formatted = biome_formatter::format!(PropertyFmtContext::default(), [&value])
         .expect("property syntax formatting should not fail");
+    // SAFETY: The formatter output contains no source maps or verbatim ranges
+    // that can fail during printing.
     formatted
         .print()
         .expect("property syntax should produce a valid document")
@@ -13,11 +17,12 @@ pub fn decode(value: &PropertySyntax) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{PropertySyntaxResult, encode};
+    use crate::PropertySyntaxResult;
+    use crate::encoder::encode_decoded;
     use biome_rowan::TextRange;
 
     fn round_trip(source: &str) -> String {
-        let syntax = match encode(
+        let syntax = match encode_decoded(
             source,
             TextRange::new(0.into(), (source.len() as u32).into()),
         ) {
@@ -44,14 +49,15 @@ mod tests {
     fn decodes_escaped_identifiers() {
         assert_eq!(round_trip("\\66 oo | \\+"), "foo | \\+");
         assert_eq!(round_trip("\\31 foo | \\1f914"), "\\31 foo | 🤔");
-        assert_eq!(round_trip("\\a7"), "\\a7 ");
+        assert_eq!(round_trip("\\a7"), "§");
         assert_eq!(round_trip("\\-"), "\\-");
+        assert_eq!(round_trip("\u{80}"), "\u{80}");
     }
 
     #[test]
     fn encoding_after_decoding_preserves_the_model() {
         let source = "foo | <color># | <length>+";
-        let first = match encode(
+        let first = match encode_decoded(
             source,
             TextRange::new(0.into(), (source.len() as u32).into()),
         ) {
@@ -59,7 +65,7 @@ mod tests {
             result => panic!("expected value, got {result:?}"),
         };
         let decoded = decode(&first);
-        let second = match encode(
+        let second = match encode_decoded(
             &decoded,
             TextRange::new(0.into(), (decoded.len() as u32).into()),
         ) {

--- a/crates/biome_property_codec/src/encoder.rs
+++ b/crates/biome_property_codec/src/encoder.rs
@@ -3,60 +3,220 @@ use crate::data::{
     PropertySyntaxErrorKind, PropertySyntaxMultiplier, PropertySyntaxParseDiagnostic,
     PropertySyntaxResult, PropertySyntaxType, RESERVED_CUSTOM_IDENTIFIERS,
 };
-use biome_css_syntax::{is_css_newline_byte, is_css_whitespace_byte};
-use biome_rowan::{TextRange, TextSize};
+use biome_css_syntax::{CssString, is_css_newline_byte, is_css_whitespace_byte};
+use biome_rowan::{AstNode, TextRange, TextSize};
 use biome_unicode_table::{
     Dispatch::{DIG, IDT, MIN, ZER},
-    is_css_non_ascii, lookup_byte,
+    lookup_byte,
 };
 
-/// Parses the decoded value of an `@property` `syntax` descriptor.
-///
-/// `range` must be the absolute source range occupied by `value`. Returned
-/// diagnostics and syntax components use absolute source ranges within it.
+/// Decodes and parses the value of a CSS string used as an `@property`
+/// `syntax` descriptor.
 ///
 /// The grammar follows the CSS Properties and Values API
 /// [syntax-string parsing algorithms](https://drafts.css-houdini.org/css-properties-values-api-1/#parsing-syntax).
-pub fn encode(value: &str, range: TextRange) -> PropertySyntaxResult {
-    match Encoder::new(value, range).encode() {
+pub fn encode(string: &CssString) -> PropertySyntaxResult {
+    let range = string.range();
+    let Ok(token) = string.value_token() else {
+        return invalid_css_string(range);
+    };
+    let Ok(value) = string.inner_string_text() else {
+        return invalid_css_string(range);
+    };
+    let source_start = token.text_trimmed_range().start() + TextSize::from(1);
+
+    match Encoder::new(DecodedCursor::new_css_string(value.text(), source_start)).encode() {
         Ok(value) => PropertySyntaxResult::Value(value),
         Err(diagnostic) => PropertySyntaxResult::Error(PropertySyntaxDiagnostic::Parse(diagnostic)),
     }
 }
 
-struct Encoder<'source> {
+#[cfg(test)]
+pub(crate) fn encode_decoded(value: &str, range: TextRange) -> PropertySyntaxResult {
+    match Encoder::new(DecodedCursor::new(value, range.start())).encode() {
+        Ok(value) => PropertySyntaxResult::Value(value),
+        Err(diagnostic) => PropertySyntaxResult::Error(PropertySyntaxDiagnostic::Parse(diagnostic)),
+    }
+}
+
+fn invalid_css_string(range: TextRange) -> PropertySyntaxResult {
+    PropertySyntaxResult::Error(PropertySyntaxDiagnostic::Parse(
+        PropertySyntaxParseDiagnostic::new(PropertySyntaxErrorKind::ExpectedString, range),
+    ))
+}
+
+fn decode_css_code_point(value: u32) -> char {
+    if value == 0 || value > 0x0010_ffff || (0xd800..=0xdfff).contains(&value) {
+        '\u{fffd}'
+    } else {
+        // SAFETY: The invalid scalar value ranges are rejected above.
+        char::from_u32(value).expect("the escape should decode to a character")
+    }
+}
+
+#[derive(Clone, Copy)]
+struct DecodedCharacter {
+    value: char,
+    source_start: usize,
+    source_end: usize,
+}
+
+#[derive(Clone)]
+struct DecodedCursor<'source> {
     source: &'source str,
-    bytes: &'source [u8],
+    source_start: TextSize,
     position: usize,
-    source_range: TextRange,
+    decode_css_escapes: bool,
+}
+
+impl<'source> DecodedCursor<'source> {
+    #[cfg(test)]
+    fn new(source: &'source str, source_start: TextSize) -> Self {
+        Self {
+            source,
+            source_start,
+            position: 0,
+            decode_css_escapes: false,
+        }
+    }
+
+    fn new_css_string(source: &'source str, source_start: TextSize) -> Self {
+        Self {
+            source,
+            source_start,
+            position: 0,
+            decode_css_escapes: true,
+        }
+    }
+
+    fn source_range(&self, start: usize, end: usize) -> TextRange {
+        TextRange::new(
+            self.source_start + TextSize::from(start as u32),
+            self.source_start + TextSize::from(end as u32),
+        )
+    }
+}
+
+impl Iterator for DecodedCursor<'_> {
+    type Item = DecodedCharacter;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let source_start = self.position;
+            let character = self.source.get(self.position..)?.chars().next()?;
+            self.position += character.len_utf8();
+
+            if !self.decode_css_escapes || character != '\\' {
+                return Some(DecodedCharacter {
+                    value: if self.decode_css_escapes && character == '\0' {
+                        '\u{fffd}'
+                    } else {
+                        character
+                    },
+                    source_start,
+                    source_end: self.position,
+                });
+            }
+
+            let Some(escaped) = self.source.get(self.position..)?.chars().next() else {
+                return Some(DecodedCharacter {
+                    value: '\u{fffd}',
+                    source_start,
+                    source_end: self.position,
+                });
+            };
+            if is_css_newline(escaped) {
+                self.position += escaped.len_utf8();
+                if escaped == '\r'
+                    && self
+                        .source
+                        .get(self.position..)
+                        .is_some_and(|rest| rest.starts_with('\n'))
+                {
+                    self.position += 1;
+                }
+                continue;
+            }
+
+            let value = if escaped.is_ascii_hexdigit() {
+                let mut code_point = 0_u32;
+                let mut digits = 0;
+                while digits < 6 {
+                    let Some(character) = self.source.get(self.position..)?.chars().next() else {
+                        break;
+                    };
+                    let Some(digit) = character.to_digit(16) else {
+                        break;
+                    };
+                    code_point = code_point * 16 + digit;
+                    self.position += character.len_utf8();
+                    digits += 1;
+                }
+                if let Some(whitespace) = self.source.get(self.position..)?.chars().next()
+                    && is_css_whitespace(whitespace)
+                {
+                    self.position += whitespace.len_utf8();
+                    if whitespace == '\r'
+                        && self
+                            .source
+                            .get(self.position..)
+                            .is_some_and(|rest| rest.starts_with('\n'))
+                    {
+                        self.position += 1;
+                    }
+                }
+                decode_css_code_point(code_point)
+            } else {
+                self.position += escaped.len_utf8();
+                escaped
+            };
+
+            return Some(DecodedCharacter {
+                value,
+                source_start,
+                source_end: self.position,
+            });
+        }
+    }
+}
+
+struct Encoder<'source> {
+    cursor: DecodedCursor<'source>,
+    current: Option<DecodedCharacter>,
+    source_end: usize,
 }
 
 impl<'source> Encoder<'source> {
-    fn new(source: &'source str, range: TextRange) -> Self {
+    fn new(mut cursor: DecodedCursor<'source>) -> Self {
+        let source_end = cursor.source.len();
+        let current = cursor.next();
         Self {
-            source,
-            bytes: source.as_bytes(),
-            position: 0,
-            source_range: range,
+            cursor,
+            current,
+            source_end,
         }
     }
 
     fn encode(mut self) -> Result<PropertySyntax, PropertySyntaxParseDiagnostic> {
         self.consume_whitespace();
-        let content_start = self.position;
+        let content_start = self.position();
         let content_end = self.trimmed_end();
 
         if content_start == content_end {
-            return Err(self.error(PropertySyntaxErrorKind::Empty, 0, self.bytes.len()));
+            return Err(self.error(PropertySyntaxErrorKind::Empty, 0, self.source_end));
         }
 
-        if self.byte_range(content_start, content_end) == [b'*'] {
+        if self.current_character() == '*'
+            && self
+                .current
+                .is_some_and(|current| current.source_end == content_end)
+        {
             return Ok(PropertySyntax::Universal {
                 range: self.range(content_start, content_end),
             });
         }
 
-        if self.byte_at(content_start) == b'*' {
+        if self.current_character() == '*' {
             return Err(self.error(
                 PropertySyntaxErrorKind::InvalidUniversalSyntax,
                 content_start,
@@ -67,31 +227,32 @@ impl<'source> Encoder<'source> {
         let mut components = Vec::new();
         loop {
             components.push(self.consume_component(content_start, content_end)?);
-            let component_end = self.position;
+            let component_end = self.position();
             self.consume_whitespace_until(content_end);
-            if self.position == content_end {
+            if self.at_end(content_end) {
                 break;
             }
-            let current = self.current_byte();
-            if current != b'|' {
-                let kind = if self.position > component_end && matches!(current, b'+' | b'#') {
+            let current = self.current_character();
+            if current != '|' {
+                let position = self.position();
+                let kind = if position > component_end && matches!(current, '+' | '#') {
                     PropertySyntaxErrorKind::UnexpectedWhitespace
                 } else {
                     PropertySyntaxErrorKind::ExpectedPipe
                 };
                 let (start, end) = if kind == PropertySyntaxErrorKind::UnexpectedWhitespace {
-                    (component_end, self.position)
+                    (component_end, position)
                 } else {
-                    (self.position, content_end)
+                    (position, content_end)
                 };
                 return Err(self.error(kind, start, end));
             }
-            self.position += 1;
-            if self.position == content_end {
+            let pipe = self.bump();
+            if self.at_end(content_end) {
                 return Err(self.error(
                     PropertySyntaxErrorKind::ExpectedComponent,
-                    self.position - 1,
-                    self.position,
+                    pipe.source_start,
+                    pipe.source_end,
                 ));
             }
         }
@@ -105,14 +266,15 @@ impl<'source> Encoder<'source> {
         content_end: usize,
     ) -> Result<PropertySyntaxComponent, PropertySyntaxParseDiagnostic> {
         self.consume_whitespace_until(content_end);
-        if self.position == content_end {
+        if self.at_end(content_end) {
+            let position = self.position();
             return Err(self.error(
                 PropertySyntaxErrorKind::ExpectedComponent,
-                self.position,
-                self.position,
+                position,
+                position,
             ));
         }
-        if self.current_byte() == b'*' {
+        if self.current_character() == '*' {
             return Err(self.error(
                 PropertySyntaxErrorKind::InvalidUniversalSyntax,
                 content_start,
@@ -120,17 +282,18 @@ impl<'source> Encoder<'source> {
             ));
         }
 
-        let start = self.position;
-        let name = if self.current_byte() == b'<' {
+        let start = self.position();
+        let name = if self.current_character() == '<' {
             PropertySyntaxComponentName::Type(self.consume_type(content_end)?)
         } else if self.would_start_identifier(content_end) {
             let identifier = self.consume_identifier(content_end)?;
             PropertySyntaxComponentName::CustomIdentifier(identifier.into_boxed_str())
         } else {
+            let current = self.current();
             return Err(self.error(
                 PropertySyntaxErrorKind::ExpectedComponent,
-                self.position,
-                self.position + self.current_len(),
+                current.source_start,
+                current.source_end,
             ));
         };
 
@@ -139,25 +302,26 @@ impl<'source> Encoder<'source> {
             PropertySyntaxComponentName::Type(PropertySyntaxType::TransformList)
         );
         if pre_multiplied
-            && self.position < content_end
-            && matches!(self.current_byte(), b'+' | b'#')
+            && !self.at_end(content_end)
+            && matches!(self.current_character(), '+' | '#')
         {
+            let current = self.current();
             return Err(self.error(
                 PropertySyntaxErrorKind::MultiplierAfterTransformList,
-                self.position,
-                self.position + 1,
+                current.source_start,
+                current.source_end,
             ));
         }
-        let multiplier = if pre_multiplied || self.position == content_end {
+        let multiplier = if pre_multiplied || self.at_end(content_end) {
             PropertySyntaxMultiplier::None
         } else {
-            match self.current_byte() {
-                b'+' => {
-                    self.position += 1;
+            match self.current_character() {
+                '+' => {
+                    self.bump();
                     PropertySyntaxMultiplier::SpaceSeparated
                 }
-                b'#' => {
-                    self.position += 1;
+                '#' => {
+                    self.bump();
                     PropertySyntaxMultiplier::CommaSeparated
                 }
                 _ => PropertySyntaxMultiplier::None,
@@ -167,7 +331,7 @@ impl<'source> Encoder<'source> {
         Ok(PropertySyntaxComponent {
             name,
             multiplier,
-            range: self.range(start, self.position),
+            range: self.range(start, self.position()),
         })
     }
 
@@ -175,34 +339,48 @@ impl<'source> Encoder<'source> {
         &mut self,
         content_end: usize,
     ) -> Result<PropertySyntaxType, PropertySyntaxParseDiagnostic> {
-        let start = self.position;
-        self.position += 1;
-        let name_start = self.position;
+        let start = self.position();
+        self.bump();
+        let mut candidates = [true; PropertySyntaxType::ALL.len()];
+        let mut name_len = 0;
 
-        while self.position < content_end {
-            let byte = self.current_byte();
-            if byte == b'>' {
-                let Some(ty) =
-                    PropertySyntaxType::from_name(self.byte_range(name_start, self.position))
+        while !self.at_end(content_end) {
+            let current = self.current();
+            let character = current.value;
+            if character == '>' {
+                let Some(ty) = candidates
+                    .iter()
+                    .copied()
+                    .zip(PropertySyntaxType::ALL)
+                    .find_map(|(candidate, syntax_type)| {
+                        (candidate && syntax_type.name().len() == name_len).then_some(syntax_type)
+                    })
                 else {
                     return Err(self.error(
                         PropertySyntaxErrorKind::ExpectedTypeName,
                         start,
-                        self.position + 1,
+                        current.source_end,
                     ));
                 };
-                self.position += 1;
+                self.bump();
                 return Ok(ty);
             }
-            if !matches!(lookup_byte(byte), IDT | MIN | DIG | ZER) {
-                let kind = if is_css_whitespace_byte(byte) {
+            if !character.is_ascii()
+                || !matches!(lookup_byte(character as u8), IDT | MIN | DIG | ZER)
+            {
+                let kind = if is_css_whitespace(character) {
                     PropertySyntaxErrorKind::UnexpectedWhitespace
                 } else {
                     PropertySyntaxErrorKind::ExpectedTypeName
                 };
-                return Err(self.error(kind, self.position, self.position + self.current_len()));
+                return Err(self.error(kind, current.source_start, current.source_end));
             }
-            self.position += 1;
+            for (candidate, syntax_type) in candidates.iter_mut().zip(PropertySyntaxType::ALL) {
+                *candidate &=
+                    syntax_type.name().as_bytes().get(name_len) == Some(&(character as u8));
+            }
+            name_len += 1;
+            self.bump();
         }
 
         Err(self.error(
@@ -218,25 +396,22 @@ impl<'source> Encoder<'source> {
         &mut self,
         content_end: usize,
     ) -> Result<String, PropertySyntaxParseDiagnostic> {
-        let start = self.position;
+        let start = self.position();
         let mut identifier = String::new();
-        while self.position < content_end {
-            let byte = self.current_byte();
-            if matches!(lookup_byte(byte), IDT | MIN | DIG | ZER) {
-                identifier.push(byte as char);
-                self.position += 1;
-            } else if byte == 0 {
-                identifier.push('\u{fffd}');
-                self.position += 1;
-            } else if byte == b'\\' && self.starts_valid_escape(content_end) {
-                identifier.push(self.consume_escaped_code_point(content_end));
-            } else if byte >= 0x80 {
-                let character = self.char_at(self.position);
-                if !is_css_non_ascii(character) {
-                    break;
-                }
+        while !self.at_end(content_end) {
+            let character = self.current_character();
+            if character.is_ascii() && matches!(lookup_byte(character as u8), IDT | MIN | DIG | ZER)
+            {
                 identifier.push(character);
-                self.position += character.len_utf8();
+                self.bump();
+            } else if character == '\0' {
+                identifier.push('\u{fffd}');
+                self.bump();
+            } else if character == '\\' && self.starts_valid_escape(content_end) {
+                identifier.push(self.consume_escaped_code_point(content_end));
+            } else if is_css_identifier_non_ascii(character) {
+                identifier.push(character);
+                self.bump();
             } else {
                 break;
             }
@@ -246,7 +421,7 @@ impl<'source> Encoder<'source> {
             return Err(self.error(
                 PropertySyntaxErrorKind::InvalidCustomIdentifier,
                 start,
-                self.position,
+                self.position(),
             ));
         }
 
@@ -256,63 +431,73 @@ impl<'source> Encoder<'source> {
     /// Implements CSS Syntax's
     /// [ident sequence lookahead](https://drafts.csswg.org/css-syntax-3/#would-start-an-identifier).
     fn would_start_identifier(&self, content_end: usize) -> bool {
-        let first = self.current_byte();
-        if first == 0 {
+        let first = self.current_character();
+        if first == '\0' {
             return true;
         }
-        if lookup_byte(first) == IDT || first >= 0x80 {
-            return first < 0x80 || is_css_non_ascii(self.char_at(self.position));
+        if (first.is_ascii() && lookup_byte(first as u8) == IDT)
+            || is_css_identifier_non_ascii(first)
+        {
+            return true;
         }
-        if first == b'\\' {
+        if first == '\\' {
             return self.starts_valid_escape(content_end);
         }
-        if first != b'-' || self.position + 1 >= content_end {
+        if first != '-' {
             return false;
         }
 
-        let second = self.byte_at(self.position + 1);
-        second == b'-'
-            || second == 0
-            || lookup_byte(second) == IDT
-            || (second >= 0x80 && is_css_non_ascii(self.char_at(self.position + 1)))
-            || (second == b'\\'
-                && self.position + 2 < content_end
-                && !is_css_newline_byte(self.byte_at(self.position + 2)))
+        let Some(second) = self
+            .nth(1)
+            .filter(|second| second.source_start < content_end)
+        else {
+            return false;
+        };
+        second.value == '-'
+            || second.value == '\0'
+            || (second.value.is_ascii() && lookup_byte(second.value as u8) == IDT)
+            || is_css_identifier_non_ascii(second.value)
+            || (second.value == '\\'
+                && self.nth(2).is_some_and(|third| {
+                    third.source_start < content_end && !is_css_newline(third.value)
+                }))
     }
 
     fn starts_valid_escape(&self, content_end: usize) -> bool {
-        self.position + 1 < content_end && !is_css_newline_byte(self.byte_at(self.position + 1))
+        self.nth(1)
+            .is_some_and(|next| next.source_start < content_end && !is_css_newline(next.value))
     }
 
     /// Implements CSS Syntax's
     /// [escaped code point algorithm](https://drafts.csswg.org/css-syntax-3/#consume-escaped-code-point).
     fn consume_escaped_code_point(&mut self, content_end: usize) -> char {
-        self.position += 1;
-        let first = self.current_byte();
+        self.bump();
+        let first = self.current_character();
         if !first.is_ascii_hexdigit() {
-            let character = self.char_at(self.position);
-            self.position += character.len_utf8();
+            let character = self.bump().value;
             return char::from_u32(preprocess_code_point(character as u32)).unwrap_or('\u{fffd}');
         }
 
         let mut value = 0_u32;
         let mut digits = 0;
-        while self.position < content_end && digits < 6 {
-            let Some(digit) = char::from(self.current_byte()).to_digit(16) else {
+        while !self.at_end(content_end) && digits < 6 {
+            let Some(digit) = self.current_character().to_digit(16) else {
                 break;
             };
             value = value * 16 + digit;
-            self.position += 1;
+            self.bump();
             digits += 1;
         }
-        if self.position < content_end && is_css_whitespace_byte(self.current_byte()) {
-            if self.current_byte() == b'\r'
-                && self.position + 1 < content_end
-                && self.byte_at(self.position + 1) == b'\n'
+        if !self.at_end(content_end) && is_css_whitespace(self.current_character()) {
+            if self.current_character() == '\r'
+                && self
+                    .nth(1)
+                    .is_some_and(|next| next.source_start < content_end && next.value == '\n')
             {
-                self.position += 2;
+                self.bump();
+                self.bump();
             } else {
-                self.position += 1;
+                self.bump();
             }
         }
 
@@ -320,75 +505,66 @@ impl<'source> Encoder<'source> {
     }
 
     fn consume_whitespace(&mut self) {
-        while self.position < self.bytes.len() && is_css_whitespace_byte(self.current_byte()) {
-            self.position += 1;
+        while self.current.is_some() && is_css_whitespace(self.current_character()) {
+            self.bump();
         }
     }
 
     fn consume_whitespace_until(&mut self, end: usize) {
-        while self.position < end && is_css_whitespace_byte(self.current_byte()) {
-            self.position += 1;
+        while !self.at_end(end) && is_css_whitespace(self.current_character()) {
+            self.bump();
         }
     }
 
     fn trimmed_end(&self) -> usize {
-        let mut end = self.bytes.len();
-        while end > self.position && is_css_whitespace_byte(self.byte_at(end - 1)) {
-            end -= 1;
+        let mut current = self.current;
+        let mut cursor = self.cursor.clone();
+        let mut end = self.position();
+        while let Some(character) = current {
+            if !is_css_whitespace(character.value) {
+                end = character.source_end;
+            }
+            current = cursor.next();
         }
         end
     }
 
-    fn current_len(&self) -> usize {
-        if self.position == self.bytes.len() {
-            0
-        } else if self.current_byte() < 0x80 {
-            1
-        } else {
-            self.char_at(self.position).len_utf8()
+    fn at_end(&self, end: usize) -> bool {
+        self.current
+            .is_none_or(|current| current.source_start >= end)
+    }
+
+    fn position(&self) -> usize {
+        self.current
+            .map_or(self.source_end, |current| current.source_start)
+    }
+
+    fn current(&self) -> DecodedCharacter {
+        debug_assert!(self.current.is_some());
+        // SAFETY: Parser operations call this only after checking the content
+        // boundary or otherwise establishing that the cursor is not at EOF.
+        self.current.expect("the cursor should not be at EOF")
+    }
+
+    fn current_character(&self) -> char {
+        self.current().value
+    }
+
+    fn bump(&mut self) -> DecodedCharacter {
+        let current = self.current();
+        self.current = self.cursor.next();
+        current
+    }
+
+    fn nth(&self, index: usize) -> Option<DecodedCharacter> {
+        if index == 0 {
+            return self.current;
         }
-    }
-
-    /// Returns the byte at the current non-EOF parser position.
-    fn current_byte(&self) -> u8 {
-        self.byte_at(self.position)
-    }
-
-    /// Returns the byte at a non-EOF parser position.
-    fn byte_at(&self, position: usize) -> u8 {
-        debug_assert!(position < self.bytes.len());
-        // SAFETY: Callers check the applicable input boundary before passing
-        // a byte position.
-        self.bytes[position]
-    }
-
-    /// Returns the bytes in a parser range.
-    fn byte_range(&self, start: usize, end: usize) -> &[u8] {
-        debug_assert!(start <= end);
-        debug_assert!(end <= self.bytes.len());
-        // SAFETY: Parser ranges are ordered byte offsets bounded by the input.
-        &self.bytes[start..end]
-    }
-
-    /// Returns the character at a non-EOF UTF-8 byte boundary.
-    fn char_at(&self, position: usize) -> char {
-        debug_assert!(position < self.source.len());
-        debug_assert!(self.source.is_char_boundary(position));
-        // SAFETY: Callers provide non-EOF positions reached by advancing over
-        // ASCII bytes or complete UTF-8 characters.
-        self.source[position..]
-            .chars()
-            .next()
-            .expect("the position should point to a character")
+        self.cursor.clone().nth(index - 1)
     }
 
     fn range(&self, start: usize, end: usize) -> TextRange {
-        let range = TextRange::new(
-            self.source_range.start() + TextSize::from(start as u32),
-            self.source_range.start() + TextSize::from(end as u32),
-        );
-        debug_assert!(range.end() <= self.source_range.end());
-        range
+        self.cursor.source_range(start, end)
     }
 
     fn error(
@@ -399,6 +575,18 @@ impl<'source> Encoder<'source> {
     ) -> PropertySyntaxParseDiagnostic {
         PropertySyntaxParseDiagnostic::new(kind, self.range(start, end))
     }
+}
+
+fn is_css_whitespace(character: char) -> bool {
+    character.is_ascii() && is_css_whitespace_byte(character as u8)
+}
+
+fn is_css_newline(character: char) -> bool {
+    character.is_ascii() && is_css_newline_byte(character as u8)
+}
+
+fn is_css_identifier_non_ascii(character: char) -> bool {
+    character >= '\u{80}'
 }
 
 fn is_invalid_custom_identifier(identifier: &str) -> bool {
@@ -422,7 +610,7 @@ mod tests {
     use biome_diagnostics::{DiagnosticExt, print_diagnostic_to_string};
 
     fn encode_value(value: &str) -> PropertySyntax {
-        match encode(
+        match encode_decoded(
             value,
             TextRange::new(10.into(), (10 + value.len() as u32).into()),
         ) {
@@ -432,7 +620,7 @@ mod tests {
     }
 
     fn encode_error(value: &str) -> PropertySyntaxDiagnostic {
-        match encode(
+        match encode_decoded(
             value,
             TextRange::new(10.into(), (10 + value.len() as u32).into()),
         ) {
@@ -527,7 +715,7 @@ mod tests {
 
     #[test]
     fn encodes_non_ascii_identifiers_using_byte_offsets() {
-        let PropertySyntax::Components(components) = encode_value("éclair | 色") else {
+        let PropertySyntax::Components(components) = encode_value("éclair | 色 | \u{80}") else {
             panic!("expected components");
         };
         assert_eq!(
@@ -538,6 +726,10 @@ mod tests {
         assert_eq!(
             components[1].name,
             PropertySyntaxComponentName::CustomIdentifier("色".into())
+        );
+        assert_eq!(
+            components[2].name,
+            PropertySyntaxComponentName::CustomIdentifier("\u{80}".into())
         );
     }
 
@@ -568,7 +760,7 @@ mod tests {
         for source in valid {
             assert!(
                 matches!(
-                    encode(
+                    encode_decoded(
                         source,
                         TextRange::new(0.into(), (source.len() as u32).into())
                     ),
@@ -638,7 +830,7 @@ mod tests {
         for source in invalid {
             assert!(
                 matches!(
-                    encode(
+                    encode_decoded(
                         source,
                         TextRange::new(0.into(), (source.len() as u32).into())
                     ),
@@ -653,6 +845,29 @@ mod tests {
     fn diagnostics_use_absolute_byte_ranges() {
         let diagnostic = encode_error("é | ?");
         assert_eq!(diagnostic.range(), TextRange::new(15.into(), 16.into()));
+    }
+
+    #[test]
+    fn css_string_cursor_decodes_source_spans() {
+        let mut cursor = DecodedCursor::new_css_string(r"\3c color\3e ", TextSize::from(10));
+
+        assert_eq!(
+            cursor.next().map(|character| (
+                character.value,
+                character.source_start,
+                character.source_end
+            )),
+            Some(('<', 0, 4))
+        );
+        assert_eq!(
+            cursor.next().map(|character| (
+                character.value,
+                character.source_start,
+                character.source_end
+            )),
+            Some(('c', 4, 5))
+        );
+        assert_eq!(cursor.last().map(|character| character.value), Some('>'));
     }
 
     #[test]
@@ -683,7 +898,7 @@ mod tests {
             let prefix = "@property --foo {\n  syntax: \"";
             let source = format!("{prefix}{value}\";\n}}\n");
             let start = prefix.len() as u32;
-            let diagnostic = match encode(
+            let diagnostic = match encode_decoded(
                 value,
                 TextRange::new(start.into(), (start + value.len() as u32).into()),
             ) {


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary


Part of https://github.com/biomejs/biome/issues/11146

This PR fixes the decoder by handling escaping. It creates a zero-copy `DecodedCharacter` that keeps track of the source maps and the semantics of the current character.

The rest of the semantics are the same. It accepts a `CssString` now.

The semantic model has been updated to create a new type that translates the CSS property `@property` into something that can be evaluated later by CSS lint rules.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added new tests

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
