### PR TITLE
perf(noImportCycles): prune DFS traversals by grouping strongly connected components

### DIFF
--- a/.changeset/witty-rules-lick.md
+++ b/.changeset/witty-rules-lick.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Improved the performance of [`noImportCycles`](https://biomejs.dev/linter/rules/no-import-cycles/) by skipping graph traversals for imports that cannot be part of a cycle.

--- a/crates/biome_js_analyze/src/lint/suspicious/no_import_cycles.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_import_cycles.rs
@@ -5,7 +5,9 @@ use biome_analyze::{
 use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_syntax::AnyJsImportLike;
-use biome_module_graph::{JsImportPath, JsImportPhase, JsModuleInfo};
+use biome_module_graph::{
+    JsImportPath, JsImportPhase, JsModuleInfo, ModuleGraphGeneration, js_module_sccs,
+};
 use biome_resolver::ResolvedPath;
 use biome_rowan::AstNode;
 use biome_rule_options::no_import_cycles::NoImportCyclesOptions;
@@ -182,6 +184,12 @@ impl Rule for NoImportCycles {
 
         // Don't check for cycles through node_modules imports.
         if is_node_modules_path(resolved_path_path) {
+            return None;
+        }
+
+        let db = ctx.db();
+        let sccs = js_module_sccs(db, ModuleGraphGeneration::get(db));
+        if !sccs.contains_cycle_between(ctx.file_path(), resolved_path_path) {
             return None;
         }
 

--- a/crates/biome_module_graph/src/db/queries.rs
+++ b/crates/biome_module_graph/src/db/queries.rs
@@ -9,6 +9,7 @@
 //! whose behavior they implement.
 
 mod css;
+mod js_scc;
 mod type_inference;
 
 use crate::{JsExport, JsExportedSymbolLookup, JsOwnExport, ModuleDb, ModuleInfo, ModuleInfoKind};
@@ -17,6 +18,7 @@ use biome_jsdoc_comment::JsdocComment;
 
 pub use crate::db::type_inference::InferredModuleTypes;
 pub use css::*;
+pub use js_scc::*;
 pub use type_inference::*;
 
 // #region EXPORTED TRACKED QUERIES

--- a/crates/biome_module_graph/src/db/queries/js_scc.rs
+++ b/crates/biome_module_graph/src/db/queries/js_scc.rs
@@ -1,0 +1,185 @@
+use crate::{JsImportPath, ModuleDb, ModuleGraphGeneration, ModuleInfoKind};
+use camino::{Utf8Path, Utf8PathBuf};
+use rustc_hash::FxHashMap;
+
+/// Strongly connected components of the JavaScript import graph.
+///
+/// Two modules belong to the same component when each is reachable from the
+/// other by following imports. All resolved edges between indexed JavaScript
+/// modules are included, so callers may use this as a conservative prefilter
+/// when they traverse a narrower graph.
+///
+/// See: <https://en.wikipedia.org/wiki/Kosaraju%27s_algorithm>
+#[derive(Debug, Eq, PartialEq)]
+pub struct JsModuleSccs {
+    component_by_path: FxHashMap<Utf8PathBuf, u32>,
+    component_sizes: Box<[u32]>,
+}
+
+impl JsModuleSccs {
+    /// Returns whether `from` and `to` belong to the same component containing
+    /// more than one module.
+    pub fn contains_cycle_between(&self, from: &Utf8Path, to: &Utf8Path) -> bool {
+        // are they in the same component?
+        let (Some(&from_component), Some(&to_component)) = (
+            self.component_by_path.get(from),
+            self.component_by_path.get(to),
+        ) else {
+            // if not, then there can't possibly be a cycle between the 2 paths.
+            return false;
+        };
+
+        from_component == to_component && self.component_sizes[from_component as usize] > 1
+    }
+}
+
+/// Returns the strongly connected components of the JavaScript import graph.
+#[salsa::tracked(no_eq, returns(ref))]
+pub fn js_module_sccs(db: &dyn ModuleDb, generation: ModuleGraphGeneration) -> JsModuleSccs {
+    let _ = generation.value(db);
+
+    let mut id_by_path = FxHashMap::default();
+
+    db.for_each_module(&mut |module| {
+        if matches!(module.kind(db), ModuleInfoKind::Js(_)) {
+            id_by_path.insert(module.path(db).to_path_buf(), id_by_path.len() as u32);
+        }
+    });
+
+    let mut edges = vec![Vec::new(); id_by_path.len()];
+    db.for_each_module(&mut |module| {
+        let ModuleInfoKind::Js(module_info) = module.kind(db) else {
+            return;
+        };
+        let path = module.path(db);
+        let Some(&from_id) = id_by_path.get(path) else {
+            return;
+        };
+
+        for JsImportPath { resolved_path, .. } in module_info.all_import_paths() {
+            if let Some(target) = resolved_path.as_path()
+                && target != path
+                && let Some(&to_id) = id_by_path.get(target)
+            {
+                edges[from_id as usize].push(to_id);
+            }
+        }
+    });
+
+    let (component_by_id, component_sizes) = compute_sccs(&edges);
+    let component_by_path = id_by_path
+        .into_iter()
+        .map(|(path, id)| (path, component_by_id[id as usize]))
+        .collect();
+
+    JsModuleSccs {
+        component_by_path,
+        component_sizes: component_sizes.into_boxed_slice(),
+    }
+}
+
+/// Computes strongly connected components with Kosaraju's algorithm
+///
+/// See: <https://en.wikipedia.org/wiki/Kosaraju%27s_algorithm>
+fn compute_sccs(edges: &[Vec<u32>]) -> (Vec<u32>, Vec<u32>) {
+    let node_count = edges.len();
+    let mut visited = vec![false; node_count];
+    let mut next_edge = vec![0; node_count];
+    let mut finish_order = Vec::with_capacity(node_count);
+    let mut stack = Vec::new();
+
+    // First pass: DFS over the forward edges, recording each node in
+    // post-order once all its successors are explored. `next_edge` tracks a
+    // node's progress through its edge list so it can pause on the stack while
+    // a successor is explored.
+    for start in 0..node_count as u32 {
+        if visited[start as usize] {
+            continue;
+        }
+        visited[start as usize] = true;
+        stack.push(start);
+
+        while let Some(&node) = stack.last() {
+            let node = node as usize;
+            if let Some(&next) = edges[node].get(next_edge[node]) {
+                next_edge[node] += 1;
+                if !visited[next as usize] {
+                    visited[next as usize] = true;
+                    stack.push(next);
+                }
+            } else {
+                finish_order.push(node as u32);
+                stack.pop();
+            }
+        }
+    }
+
+    // Second pass: DFS over the transposed graph, starting nodes in reverse
+    // post-order. Each traversal that starts on an unassigned node reaches
+    // exactly the members of one component.
+    let mut reverse_edges = vec![Vec::new(); node_count];
+    for (from, targets) in edges.iter().enumerate() {
+        for &to in targets {
+            reverse_edges[to as usize].push(from as u32);
+        }
+    }
+
+    let mut component_by_id = vec![u32::MAX; node_count];
+    let mut component_sizes = Vec::new();
+
+    for &start in finish_order.iter().rev() {
+        if component_by_id[start as usize] != u32::MAX {
+            continue;
+        }
+
+        let component = component_sizes.len() as u32;
+        component_sizes.push(0);
+        stack.push(start);
+
+        while let Some(node) = stack.pop() {
+            let node = node as usize;
+            if component_by_id[node] != u32::MAX {
+                continue;
+            }
+
+            component_by_id[node] = component;
+            component_sizes[component as usize] += 1;
+            stack.extend(
+                reverse_edges[node]
+                    .iter()
+                    .copied()
+                    .filter(|predecessor| component_by_id[*predecessor as usize] == u32::MAX),
+            );
+        }
+    }
+
+    (component_by_id, component_sizes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::compute_sccs;
+
+    #[test]
+    fn separates_acyclic_nodes() {
+        let (components, sizes) = compute_sccs(&[vec![1], vec![2], vec![]]);
+
+        assert_ne!(components[0], components[1]);
+        assert_ne!(components[1], components[2]);
+        assert_ne!(components[0], components[2]);
+        assert!(components.iter().all(|&id| sizes[id as usize] == 1));
+    }
+
+    #[test]
+    fn groups_mutually_reachable_nodes() {
+        let (components, sizes) =
+            compute_sccs(&[vec![1], vec![2], vec![0], vec![0], vec![5], vec![4]]);
+
+        assert_eq!(components[0], components[1]);
+        assert_eq!(components[1], components[2]);
+        assert_eq!(sizes[components[0] as usize], 3);
+        assert_ne!(components[3], components[0]);
+        assert_eq!(components[4], components[5]);
+        assert_eq!(sizes[components[4] as usize], 2);
+    }
+}

--- a/crates/biome_module_graph/tests/js_scc.rs
+++ b/crates/biome_module_graph/tests/js_scc.rs
@@ -1,0 +1,92 @@
+use biome_fs::{BiomePath, MemoryFileSystem};
+use biome_module_graph::{
+    ModuleDb, ModuleGraphGeneration, ModuleInfoKind, PathInfoCache, js_module_sccs,
+    resolve_js_module,
+};
+use biome_project_layout::ProjectLayout;
+use biome_test_utils::get_added_js_paths;
+use biome_workspace_db::WorkspaceDb;
+use camino::{Utf8Path, Utf8PathBuf};
+
+fn resolve_module(fs: &MemoryFileSystem, path: &str) -> ModuleInfoKind {
+    let paths = [BiomePath::new(path)];
+    let mut added_paths = get_added_js_paths(fs, &paths);
+    let (path, root, semantic_model) = added_paths.pop().expect("module must parse");
+    let (module_info, _, _) = resolve_js_module(
+        root,
+        path,
+        fs,
+        &ProjectLayout::default(),
+        semantic_model,
+        &PathInfoCache::default(),
+        false,
+    );
+    ModuleInfoKind::Js(module_info)
+}
+
+fn module_db(files: &[(&str, &str)]) -> (MemoryFileSystem, WorkspaceDb) {
+    let fs = MemoryFileSystem::default();
+    for &(path, source) in files {
+        fs.insert(path.into(), source);
+    }
+
+    let mut db = WorkspaceDb::default();
+    for &(path, _) in files {
+        db.update_or_insert_module(Utf8PathBuf::from(path), resolve_module(&fs, path));
+    }
+    (fs, db)
+}
+
+#[test]
+fn scc_query_is_scoped_to_its_database() {
+    let (_, cyclic_db) = module_db(&[
+        ("/cyclic/a.js", "import './b.js';"),
+        ("/cyclic/b.js", "import './a.js';"),
+    ]);
+    let (_, acyclic_db) = module_db(&[
+        ("/acyclic/a.js", "import './b.js';"),
+        ("/acyclic/b.js", "export {};"),
+    ]);
+
+    assert_eq!(
+        cyclic_db.module_graph_generation(),
+        acyclic_db.module_graph_generation()
+    );
+    assert!(
+        js_module_sccs(&cyclic_db, ModuleGraphGeneration::get(&cyclic_db))
+            .contains_cycle_between(Utf8Path::new("/cyclic/a.js"), Utf8Path::new("/cyclic/b.js"))
+    );
+    assert!(
+        !js_module_sccs(&acyclic_db, ModuleGraphGeneration::get(&acyclic_db))
+            .contains_cycle_between(
+                Utf8Path::new("/acyclic/a.js"),
+                Utf8Path::new("/acyclic/b.js")
+            )
+    );
+}
+
+#[test]
+fn scc_query_recomputes_after_module_graph_changes() {
+    let (fs, mut db) = module_db(&[
+        ("/src/a.js", "import './b.js';"),
+        ("/src/b.js", "export {};"),
+    ]);
+
+    assert!(
+        !js_module_sccs(&db, ModuleGraphGeneration::get(&db))
+            .contains_cycle_between(Utf8Path::new("/src/a.js"), Utf8Path::new("/src/b.js"))
+    );
+
+    let generation = db.module_graph_generation();
+    fs.insert("/src/b.js".into(), "import './a.js';");
+    db.update_or_insert_module(
+        Utf8PathBuf::from("/src/b.js"),
+        resolve_module(&fs, "/src/b.js"),
+    );
+
+    assert_eq!(db.module_graph_generation(), generation);
+    assert!(
+        js_module_sccs(&db, ModuleGraphGeneration::get(&db))
+            .contains_cycle_between(Utf8Path::new("/src/a.js"), Utf8Path::new("/src/b.js"))
+    );
+}


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This PR adds a new `ImportCyclesDbService` that computes Strongly Connected Components (SCCs) to avoid doing DFS traversals if possible.

The algorithm is: https://en.wikipedia.org/wiki/Kosaraju%27s_algorithm

supercedes #11018

implemented by gpt 5.6 sol
<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
added unit tests, and existing tests pass

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
