### PR TITLE
perf(console): batch writes when printing instead of one char at a time

### DIFF
--- a/.changeset/icy-buttons-jump.md
+++ b/.changeset/icy-buttons-jump.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Improved performance when printing diagnostics to the console.

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -42,6 +42,7 @@ jobs:
       manifests: ${{ steps.outputs.outputs.manifests }}
       module_graph: ${{ steps.outputs.outputs.module_graph }}
       service: ${{ steps.outputs.outputs.service }}
+      console: ${{ steps.outputs.outputs.console }}
     steps:
       - name: Checkout Branch
         if: github.event_name == 'push'
@@ -161,6 +162,11 @@ jobs:
               - 'crates/biome_rowan/**/*.rs'
               - 'crates/biome_service/**/*.rs'
               - 'crates/biome_workspace_db/**/*.rs'
+            console:
+              - '.github/workflows/benchmark.yml'
+              - 'Cargo.lock'
+              - 'crates/biome_console/**/*.rs'
+              - 'crates/biome_console/Cargo.toml'
 
       - name: Set change outputs
         id: outputs
@@ -178,6 +184,7 @@ jobs:
           MANIFESTS: ${{ steps.filter.outputs.manifests }}
           MODULE_GRAPH: ${{ steps.filter.outputs.module_graph }}
           SERVICE: ${{ steps.filter.outputs.service }}
+          CONSOLE: ${{ steps.filter.outputs.console }}
         run: |
           if [ "$EVENT_NAME" = 'workflow_dispatch' ] || [ "$EVENT_NAME" = 'merge_group' ]; then
             JS=true
@@ -192,6 +199,7 @@ jobs:
             MANIFESTS=true
             MODULE_GRAPH=true
             SERVICE=true
+            CONSOLE=true
           fi
 
           echo "js=$JS" >> "$GITHUB_OUTPUT"
@@ -206,6 +214,7 @@ jobs:
           echo "manifests=$MANIFESTS" >> "$GITHUB_OUTPUT"
           echo "module_graph=$MODULE_GRAPH" >> "$GITHUB_OUTPUT"
           echo "service=$SERVICE" >> "$GITHUB_OUTPUT"
+          echo "console=$CONSOLE" >> "$GITHUB_OUTPUT"
 
   js:
     needs: changes
@@ -288,6 +297,20 @@ jobs:
           mode: simulation
           run: cargo codspeed run -p biome_service --bench pull_diagnostics
           token: ${{ secrets.CODSPEED_TOKEN }}
+
+  console:
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group' || needs.changes.outputs.console == 'true'
+    permissions:
+      contents: read
+      pull-requests: write
+    name: Bench Console
+    runs-on: depot-ubuntu-24.04-arm-16
+    strategy:
+      matrix:
+        package:
+          - biome_console
+    steps: *bench_steps
 
   json:
     needs: changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,6 +318,7 @@ version = "0.5.7"
 dependencies = [
  "biome_markup",
  "biome_text_size",
+ "codspeed-criterion-compat",
  "schemars",
  "serde",
  "termcolor",

--- a/crates/biome_console/Cargo.toml
+++ b/crates/biome_console/Cargo.toml
@@ -14,6 +14,10 @@ publish              = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[[bench]]
+harness = false
+name    = "console"
+
 [dependencies]
 biome_markup         = { workspace = true }
 biome_text_size      = { workspace = true }
@@ -24,7 +28,8 @@ unicode-segmentation = "1.13.2"
 unicode-width        = { workspace = true }
 
 [dev-dependencies]
-trybuild = "=1.0.116"
+criterion = { package = "codspeed-criterion-compat", version = "=3.0.5" }
+trybuild  = "=1.0.116"
 
 [features]
 schema = ["biome_text_size/schema", "dep:schemars", "serde"]

--- a/crates/biome_console/benches/console.rs
+++ b/crates/biome_console/benches/console.rs
@@ -1,0 +1,76 @@
+use std::io;
+
+use biome_console::fmt::{MarkupElements, Termcolor, Write};
+use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
+use termcolor::{Ansi, NoColor};
+
+#[derive(Default)]
+struct BenchWriter {
+    bytes_written: usize,
+}
+
+impl io::Write for BenchWriter {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        let buffer = black_box(buffer);
+        self.bytes_written = self.bytes_written.wrapping_add(buffer.len());
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn bench_console(criterion: &mut Criterion) {
+    let ascii = "  123 | const answer = 42;\n".repeat(128);
+    let unicode = "  123 │ const answer = 42;\n    ━━━━━━━━━━━━━━━━━━━━━━━\n".repeat(64);
+    let sanitized = "source\0code\u{200B}diagnostic\n".repeat(128);
+    let mut group = criterion.benchmark_group("console");
+
+    group.throughput(Throughput::Bytes(ascii.len() as u64));
+    group.bench_function("ascii", |bencher| {
+        let mut writer = Termcolor(Ansi::new(BenchWriter::default()));
+        bencher.iter(|| {
+            Write::write_str(
+                &mut writer,
+                &MarkupElements::Root,
+                black_box(ascii.as_str()),
+            )
+            .unwrap();
+            black_box(&writer);
+        });
+    });
+
+    group.throughput(Throughput::Bytes(unicode.len() as u64));
+    group.bench_function("unicode_without_colors", |bencher| {
+        let mut writer = Termcolor(NoColor::new(BenchWriter::default()));
+        bencher.iter(|| {
+            Write::write_str(
+                &mut writer,
+                &MarkupElements::Root,
+                black_box(unicode.as_str()),
+            )
+            .unwrap();
+            black_box(&writer);
+        });
+    });
+
+    group.throughput(Throughput::Bytes(sanitized.len() as u64));
+    group.bench_function("sanitized", |bencher| {
+        let mut writer = Termcolor(Ansi::new(BenchWriter::default()));
+        bencher.iter(|| {
+            Write::write_str(
+                &mut writer,
+                &MarkupElements::Root,
+                black_box(sanitized.as_str()),
+            )
+            .unwrap();
+            black_box(&writer);
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(console, bench_console);
+criterion_main!(console);

--- a/crates/biome_console/src/write/termcolor.rs
+++ b/crates/biome_console/src/write/termcolor.rs
@@ -136,26 +136,55 @@ struct SanitizeAdapter<W> {
     error: io::Result<()>,
 }
 
+impl<W> SanitizeAdapter<W>
+where
+    W: WriteColor,
+{
+    fn write_verbatim(&mut self, bytes: &[u8]) -> fmt::Result {
+        if bytes.is_empty() {
+            return Ok(());
+        }
+
+        if let Err(err) = self.writer.write_all(bytes) {
+            self.error = Err(err);
+            return Err(fmt::Error);
+        }
+
+        Ok(())
+    }
+
+    fn write_character(&mut self, character: char, buffer: &mut [u8; 4]) -> fmt::Result {
+        character.encode_utf8(buffer);
+        self.write_verbatim(&buffer[..character.len_utf8()])
+    }
+}
+
 impl<W> fmt::Write for SanitizeAdapter<W>
 where
     W: WriteColor,
 {
     fn write_str(&mut self, content: &str) -> fmt::Result {
-        let mut buffer = [0; 4];
+        // Grapheme segmentation is considerably more expensive than validating ASCII bytes.
+        if content.is_ascii()
+            && content
+                .bytes()
+                .all(|byte| !byte.is_ascii_control() || byte.is_ascii_whitespace())
+        {
+            return self.write_verbatim(content.as_bytes());
+        }
 
-        for grapheme in content.graphemes(true) {
+        let mut buffer = [0; 4];
+        let supports_color = self.writer.supports_color();
+        let mut segment_start = 0;
+
+        for (offset, grapheme) in content.grapheme_indices(true) {
             let width = UnicodeWidthStr::width(grapheme);
             let is_whitespace = grapheme_is_whitespace(grapheme);
 
             if !is_whitespace && width == 0 {
-                let char_to_write = char::REPLACEMENT_CHARACTER;
-                char_to_write.encode_utf8(&mut buffer);
-
-                if let Err(err) = self.writer.write_all(&buffer[..char_to_write.len_utf8()]) {
-                    self.error = Err(err);
-                    return Err(fmt::Error);
-                }
-
+                self.write_verbatim(&content.as_bytes()[segment_start..offset])?;
+                self.write_character(char::REPLACEMENT_CHARACTER, &mut buffer)?;
+                segment_start = offset + grapheme.len();
                 continue;
             }
 
@@ -168,49 +197,35 @@ where
 
             if !is_ascii {
                 if cfg!(windows) {
-                    // On Windows, always convert all non-ASCII graphemes due to poor terminal support
-                    let replacement = unicode_to_ascii(grapheme.chars().nth(0).unwrap());
+                    let mut characters = grapheme.chars();
+                    let character = characters.next().unwrap();
+                    let replacement = unicode_to_ascii(character);
 
-                    replacement.encode_utf8(&mut buffer);
-
-                    if let Err(err) = self.writer.write_all(&buffer[..replacement.len_utf8()]) {
-                        self.error = Err(err);
-                        return Err(fmt::Error);
+                    if replacement != character || characters.next().is_some() {
+                        self.write_verbatim(&content.as_bytes()[segment_start..offset])?;
+                        self.write_character(replacement, &mut buffer)?;
+                        segment_start = offset + grapheme.len();
                     }
-
-                    continue;
-                } else if !self.writer.supports_color() {
+                } else if !supports_color {
                     // On non-Windows with colors disabled:
                     // Only convert single-codepoint graphemes (diagnostic symbols)
                     // Multi-codepoint graphemes (like emoji with modifiers) are preserved for source code fidelity
-                    let chars: Vec<char> = grapheme.chars().collect();
-                    if chars.len() == 1 {
-                        let replacement = unicode_to_ascii(chars[0]);
+                    let mut characters = grapheme.chars();
+                    let character = characters.next().unwrap();
+                    if characters.next().is_none() {
+                        let replacement = unicode_to_ascii(character);
 
-                        replacement.encode_utf8(&mut buffer);
-
-                        if let Err(err) = self.writer.write_all(&buffer[..replacement.len_utf8()]) {
-                            self.error = Err(err);
-                            return Err(fmt::Error);
+                        if replacement != character {
+                            self.write_verbatim(&content.as_bytes()[segment_start..offset])?;
+                            self.write_character(replacement, &mut buffer)?;
+                            segment_start = offset + grapheme.len();
                         }
-
-                        continue;
                     }
-                    // Multi-codepoint graphemes fall through to be written as-is below
-                }
-            }
-
-            for char in grapheme.chars() {
-                char.encode_utf8(&mut buffer);
-
-                if let Err(err) = self.writer.write_all(&buffer[..char.len_utf8()]) {
-                    self.error = Err(err);
-                    return Err(fmt::Error);
                 }
             }
         }
 
-        Ok(())
+        self.write_verbatim(&content.as_bytes()[segment_start..])
     }
 }
 
@@ -234,7 +249,11 @@ fn unicode_to_ascii(c: char) -> char {
 
 #[cfg(test)]
 mod tests {
-    use std::{fmt::Write, str::from_utf8};
+    use std::{
+        fmt::Write,
+        io::{self, Write as IoWrite},
+        str::from_utf8,
+    };
 
     use biome_markup::markup;
     use termcolor::Ansi;
@@ -243,6 +262,23 @@ mod tests {
     use crate::fmt::Formatter;
 
     use super::{SanitizeAdapter, Termcolor};
+
+    #[derive(Default)]
+    struct TestWriter {
+        buffer: Vec<u8>,
+        write_count: usize,
+    }
+
+    impl IoWrite for TestWriter {
+        fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+            self.write_count += 1;
+            self.buffer.write(buffer)
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            self.buffer.flush()
+        }
+    }
 
     #[test]
     fn test_sanitize() {
@@ -352,5 +388,63 @@ mod tests {
                 EXPECTED, actual
             );
         }
+    }
+
+    #[test]
+    fn test_safe_ascii_is_written_once() {
+        const INPUT: &str = "  1 | const answer = 42;\n\t= help: plain ASCII diagnostic\r\n";
+
+        let mut output = TestWriter::default();
+        {
+            let writer = termcolor::Ansi::new(&mut output);
+            let mut adapter = SanitizeAdapter {
+                writer,
+                error: Ok(()),
+            };
+            adapter.write_str(INPUT).unwrap();
+            adapter.error.unwrap();
+        }
+
+        assert_eq!(from_utf8(&output.buffer).unwrap(), INPUT);
+        assert_eq!(output.write_count, 1);
+    }
+
+    #[test]
+    fn test_sanitized_characters_split_verbatim_segments() {
+        const INPUT: &str = "first\0second\u{200B}third";
+        const OUTPUT: &str = "first\u{FFFD}second\u{FFFD}third";
+
+        let mut output = TestWriter::default();
+        {
+            let writer = termcolor::Ansi::new(&mut output);
+            let mut adapter = SanitizeAdapter {
+                writer,
+                error: Ok(()),
+            };
+            adapter.write_str(INPUT).unwrap();
+            adapter.error.unwrap();
+        }
+
+        assert_eq!(from_utf8(&output.buffer).unwrap(), OUTPUT);
+        assert_eq!(output.write_count, 5);
+    }
+
+    #[test]
+    fn test_unchanged_unicode_is_batched_without_colors() {
+        const INPUT: &str = "  1 │ source code\n    ━━━━━━━━━━━";
+
+        let mut output = TestWriter::default();
+        {
+            let writer = termcolor::NoColor::new(&mut output);
+            let mut adapter = SanitizeAdapter {
+                writer,
+                error: Ok(()),
+            };
+            adapter.write_str(INPUT).unwrap();
+            adapter.error.unwrap();
+        }
+
+        assert_eq!(from_utf8(&output.buffer).unwrap(), INPUT);
+        assert_eq!(output.write_count, 1);
     }
 }


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Previously, we would write one character at a time to console output. Now we batch sequences of characters that don't need sanitization to do less writes.

supercedes #10988

implemented by gpt 5.6 sol. some of the tests might be a bit silly.
<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
added benchmarks, ci should be green. ASCII shows about 50x improvement, unicode 2.25x improvement on my machine.

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
