### PR TITLE
feat(graph): traversal of HTML-ish files

### DIFF
--- a/crates/biome_css_semantic/src/semantic_model/builder.rs
+++ b/crates/biome_css_semantic/src/semantic_model/builder.rs
@@ -17,6 +17,8 @@ pub struct SemanticModelBuilder {
     /// IDs of top-level rules only
     top_level_rule_ids: Vec<RuleId>,
     global_custom_variables: FxHashMap<TokenText, CssGlobalCustomVariableData>,
+    at_property_rules: Vec<CssPropertyAtRuleData>,
+    last_at_property_by_name: FxHashMap<TokenText, usize>,
     /// Stack of rule IDs to keep track of the current rule hierarchy
     current_rule_stack: Vec<RuleId>,
     /// Map from text range to RuleId
@@ -33,6 +35,8 @@ impl SemanticModelBuilder {
             top_level_rule_ids: Vec::new(),
             current_rule_stack: Vec::new(),
             global_custom_variables: FxHashMap::default(),
+            at_property_rules: Vec::new(),
+            last_at_property_by_name: FxHashMap::default(),
             range_to_rule_id: BTreeMap::default(),
             is_in_root_selector: false,
         }
@@ -121,6 +125,8 @@ impl SemanticModelBuilder {
             all_rules: self.all_rules,
             top_level_rule_ids: self.top_level_rule_ids,
             global_custom_variables: self.global_custom_variables,
+            at_property_rules: self.at_property_rules,
+            last_at_property_by_name: self.last_at_property_by_name,
             range_to_rule_id: self.range_to_rule_id,
         };
         SemanticModel::new(data)
@@ -266,17 +272,19 @@ impl SemanticModelBuilder {
             } => {
                 if let Ok(property_name) = property.value_token() {
                     let property_name = property_name.token_text_trimmed();
-                    let variable = self
-                        .global_custom_variables
-                        .entry(property_name)
+                    self.global_custom_variables
+                        .entry(property_name.clone())
                         .or_default();
-                    variable.at_property = Some(CssPropertyAtRuleData {
+                    let index = self.at_property_rules.len();
+                    self.at_property_rules.push(CssPropertyAtRuleData {
+                        name: property_name.clone(),
                         property: AstPtr::new(&property),
                         initial_value,
                         syntax,
                         inherits,
                         range,
                     });
+                    self.last_at_property_by_name.insert(property_name, index);
                 }
             }
         }

--- a/crates/biome_css_semantic/src/semantic_model/db.rs
+++ b/crates/biome_css_semantic/src/semantic_model/db.rs
@@ -2,6 +2,24 @@ use crate::model::SemanticModel;
 use crate::semantic_model;
 use biome_css_syntax::AnyCssRoot;
 use biome_db::{AnyParsedSource, Db, ParsedSnippet, ParsedSource};
+use biome_rowan::{TextRange, TokenText};
+
+/// The name and source range of an effective `@property` rule.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CssPropertyDefinition {
+    name: TokenText,
+    range: TextRange,
+}
+
+impl CssPropertyDefinition {
+    pub fn name(&self) -> &str {
+        self.name.text()
+    }
+
+    pub fn range(&self) -> TextRange {
+        self.range
+    }
+}
 
 #[salsa::tracked(returns(ref))]
 pub(crate) fn css_model_from_parsed_source(db: &dyn Db, file: ParsedSource) -> SemanticModel {
@@ -13,6 +31,37 @@ pub(crate) fn css_model_from_parsed_source(db: &dyn Db, file: ParsedSource) -> S
 pub(crate) fn css_model_from_parsed_snippet(db: &dyn Db, file: ParsedSnippet) -> SemanticModel {
     let parsed: AnyCssRoot = file.parsed(db).tree();
     semantic_model(&parsed)
+}
+
+/// Returns effective `@property` rules from a parsed CSS document.
+#[salsa::tracked(returns(ref))]
+pub fn css_property_definitions_from_source(
+    db: &dyn Db,
+    file: ParsedSource,
+) -> Vec<CssPropertyDefinition> {
+    let _ = file.parsed(db);
+    collect_property_definitions(css_model_from_parsed_source(db, file))
+}
+
+/// Returns effective `@property` rules from an embedded CSS document.
+#[salsa::tracked(returns(ref))]
+pub fn css_property_definitions_from_snippet(
+    db: &dyn Db,
+    file: ParsedSnippet,
+) -> Vec<CssPropertyDefinition> {
+    let _ = file.parsed(db);
+    collect_property_definitions(css_model_from_parsed_snippet(db, file))
+}
+
+fn collect_property_definitions(model: &SemanticModel) -> Vec<CssPropertyDefinition> {
+    model
+        .global_custom_variables()
+        .at_properties()
+        .map(|property| CssPropertyDefinition {
+            name: property.name().clone(),
+            range: property.range(),
+        })
+        .collect()
 }
 
 pub fn css_semantic_model<'db>(db: &'db dyn Db, file: &AnyParsedSource) -> &'db SemanticModel {
@@ -281,6 +330,39 @@ mod tests {
 
         let new_parsed = parse_css(
             r#"@property --value { syntax: "<length>"; inherits: true; initial-value: 10px; }"#,
+            CssFileSource::css(),
+            CssParserOptions::default(),
+        )
+        .into();
+        salsa::Setter::to(file.set_parsed(&mut db), new_parsed);
+
+        db.clear_salsa_events();
+        assert_eq!(
+            property_syntax_type(&db, file),
+            Some(PropertySyntaxType::Length)
+        );
+        let events = db.take_salsa_events();
+
+        assert_function_query_was_run(&db, css_model_from_parsed_source, file, &events);
+        assert_function_query_was_run(&db, property_syntax_type, file, &events);
+    }
+
+    #[test]
+    fn shadowed_at_property_change_recomputes_downstream() {
+        let mut db = TestDb::new();
+        let file = make_file(
+            &db,
+            r#"@property --value { syntax: "<color>"; inherits: true; initial-value: red; }
+@property --value { syntax: "<length>"; inherits: true; initial-value: 1px; }"#,
+        );
+        assert_eq!(
+            property_syntax_type(&db, file),
+            Some(PropertySyntaxType::Length)
+        );
+
+        let new_parsed = parse_css(
+            r#"@property --value { syntax: "<number>"; inherits: true; initial-value: 1; }
+@property --value { syntax: "<length>"; inherits: true; initial-value: 1px; }"#,
             CssFileSource::css(),
             CssParserOptions::default(),
         )

--- a/crates/biome_css_semantic/src/semantic_model/mod.rs
+++ b/crates/biome_css_semantic/src/semantic_model/mod.rs
@@ -466,6 +466,40 @@ or>";
         };
 
         assert_eq!(diagnostic.kind(), PropertySyntaxErrorKind::ExpectedTypeName);
+        assert_eq!(model.global_custom_variables().at_properties().count(), 1);
+    }
+
+    #[test]
+    fn test_effective_at_properties_follow_last_definition_order() {
+        let parse = parse_css(
+            r#"@property --b { syntax: "<color>"; inherits: true; initial-value: red; }
+@property --a { syntax: "<length>"; inherits: true; initial-value: 1px; }
+@property --b { syntax: "<number>"; inherits: true; initial-value: 1; }
+@property --c { syntax: "<percentage>"; inherits: true; initial-value: 1%; }"#,
+            CssFileSource::css(),
+            CssParserOptions::default(),
+        );
+
+        let model = super::semantic_model(&parse.tree());
+        let properties = model
+            .global_custom_variables()
+            .at_properties()
+            .collect::<Vec<_>>();
+        let names = properties
+            .iter()
+            .map(|property| property.name().text())
+            .collect::<Vec<_>>();
+
+        assert_eq!(names, ["--a", "--b", "--c"]);
+        let PropertySyntaxResult::Value(PropertySyntax::Components(components)) =
+            properties[1].syntax()
+        else {
+            panic!("expected the last --b syntax");
+        };
+        assert_eq!(
+            components[0].name,
+            PropertySyntaxComponentName::Type(PropertySyntaxType::Number)
+        );
     }
 
     #[test]

--- a/crates/biome_css_semantic/src/semantic_model/model.rs
+++ b/crates/biome_css_semantic/src/semantic_model/model.rs
@@ -116,8 +116,12 @@ pub(crate) struct SemanticModelData {
     pub(crate) all_rules: Vec<RuleData>,
     /// IDs of top-level rules only
     pub(crate) top_level_rule_ids: Vec<RuleId>,
-    /// Map of CSS variables declared in the `:root` selector or using the @property rule.
+    /// Map of names declared in `:root` or through an `@property` rule.
     pub(crate) global_custom_variables: FxHashMap<TokenText, CssGlobalCustomVariableData>,
+    /// Authored `@property` rules in source order.
+    pub(crate) at_property_rules: Vec<CssPropertyAtRuleData>,
+    /// Index of the last authored `@property` rule for each name.
+    pub(crate) last_at_property_by_name: FxHashMap<TokenText, usize>,
     /// Map from text range to RuleId
     pub(crate) range_to_rule_id: BTreeMap<TextRange, RuleId>,
 }
@@ -142,6 +146,13 @@ impl PartialEq for SemanticModel {
                 .all(|(self_rule, other_rule)| self_rule == other_rule)
             && self.data.top_level_rule_ids == other.data.top_level_rule_ids
             && self.data.range_to_rule_id.len() == other.data.range_to_rule_id.len()
+            && self.data.at_property_rules.len() == other.data.at_property_rules.len()
+            && self
+                .data
+                .at_property_rules
+                .iter()
+                .zip(&other.data.at_property_rules)
+                .all(|(this, other)| this.semantic_eq(other, &self_root, &other_root))
             && self.data.global_custom_variables.len() == other.data.global_custom_variables.len()
             && self.data.global_custom_variables.iter().all(|(key, val)| {
                 other
@@ -938,16 +949,11 @@ fn has_custom_property_component_gap_before(token: &CssSyntaxToken) -> bool {
         })
 }
 
-/// Combines the declaration sources associated with one global custom-property name.
-///
-/// The `:root` declaration and `@property` rule are independent facets. A custom
-/// property may have either facet or both.
+/// The `:root` declaration associated with one global custom-property name.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct CssGlobalCustomVariableData {
     /// The declaration from a `:root` rule, if one is retained for the name.
     pub(crate) root: Option<CssModelDeclarationData>,
-    /// The authored `@property` rule, if one is retained for the name.
-    pub(crate) at_property: Option<CssPropertyAtRuleData>,
 }
 
 /// Authored descriptors and source handles retained for an `@property` rule.
@@ -957,6 +963,8 @@ pub(crate) struct CssGlobalCustomVariableData {
 /// this structure.
 #[derive(Debug, Clone)]
 pub(crate) struct CssPropertyAtRuleData {
+    /// The authored custom-property name.
+    pub(crate) name: TokenText,
     /// The custom-property name node in the rule declarator.
     pub(crate) property: AstPtr<CssDashedIdentifier>,
     /// The parsed `syntax` descriptor, including missing and invalid states.
@@ -973,11 +981,7 @@ impl CssGlobalCustomVariableData {
     /// Compares global custom variable semantics using the root that owns each
     /// side's stored pointers.
     fn semantic_eq(&self, other: &Self, self_root: &AnyCssRoot, other_root: &AnyCssRoot) -> bool {
-        (match (&self.root, &other.root) {
-            (Some(this), Some(other)) => this.semantic_eq(other, self_root, other_root),
-            (None, None) => true,
-            _ => false,
-        }) && match (&self.at_property, &other.at_property) {
+        match (&self.root, &other.root) {
             (Some(this), Some(other)) => this.semantic_eq(other, self_root, other_root),
             (None, None) => true,
             _ => false,
@@ -987,7 +991,8 @@ impl CssGlobalCustomVariableData {
 
 impl CssPropertyAtRuleData {
     fn semantic_eq(&self, other: &Self, self_root: &AnyCssRoot, other_root: &AnyCssRoot) -> bool {
-        self.inherits == other.inherits
+        self.name == other.name
+            && self.inherits == other.inherits
             && match (&self.initial_value, &other.initial_value) {
                 (Some(this), Some(other)) => this.semantic_eq(other, self_root, other_root),
                 (None, None) => true,
@@ -1029,7 +1034,7 @@ impl CssGlobalCustomVariable {
 
     /// Returns whether the property has an `@property` rule.
     pub fn is_at_property(&self) -> bool {
-        self.value().at_property.is_some()
+        self.data.last_at_property_by_name.contains_key(&self.name)
     }
 
     /// Returns whether the property is declared in a `:root` rule.
@@ -1039,13 +1044,11 @@ impl CssGlobalCustomVariable {
 
     /// Returns the semantic data for the `@property` rule, if present.
     pub fn at_property(&self) -> Option<CssPropertyAtRule> {
-        self.value()
-            .at_property
-            .as_ref()
-            .map(|_| CssPropertyAtRule {
-                data: self.data.clone(),
-                name: self.name.clone(),
-            })
+        let index = *self.data.last_at_property_by_name.get(&self.name)?;
+        Some(CssPropertyAtRule {
+            data: self.data.clone(),
+            index,
+        })
     }
 }
 
@@ -1056,21 +1059,18 @@ impl CssGlobalCustomVariable {
 #[derive(Debug, Clone)]
 pub struct CssPropertyAtRule {
     data: Arc<SemanticModelData>,
-    name: TokenText,
+    index: usize,
 }
 
 impl CssPropertyAtRule {
     fn value(&self) -> &CssPropertyAtRuleData {
-        // SAFETY: Instances are created only for names with an `@property` rule.
-        self.data.global_custom_variables[&self.name]
-            .at_property
-            .as_ref()
-            .expect("the custom property should have an at-property rule")
+        // SAFETY: Instances are created only from indices stored by the semantic model builder.
+        &self.data.at_property_rules[self.index]
     }
 
     /// Returns the authored custom property name.
     pub fn name(&self) -> &TokenText {
-        &self.name
+        &self.value().name
     }
 
     /// Returns the custom property name node from the rule declarator.
@@ -1139,6 +1139,27 @@ impl<'a> GlobalCustomVariables<'a> {
             data: self.data.clone(),
             name: name.clone(),
         })
+    }
+
+    /// Returns effective `@property` rules in the source order of their last definitions.
+    ///
+    /// Each custom-property name occurs at most once. When a name is authored
+    /// multiple times, only its last rule is returned.
+    pub fn at_properties(&self) -> impl Iterator<Item = CssPropertyAtRule> + '_ {
+        self.data
+            .at_property_rules
+            .iter()
+            .enumerate()
+            .filter(|(index, rule)| {
+                self.data
+                    .last_at_property_by_name
+                    .get(&rule.name)
+                    .is_some_and(|last| last == index)
+            })
+            .map(|(index, _)| CssPropertyAtRule {
+                data: self.data.clone(),
+                index,
+            })
     }
 
     /// Returns all custom properties in unspecified order.

--- a/crates/biome_css_semantic/src/tests/eq.rs
+++ b/crates/biome_css_semantic/src/tests/eq.rs
@@ -229,6 +229,35 @@ fn at_property_inherits_change_is_not_eq() {
 }
 
 #[test]
+fn shadowed_at_property_change_is_not_eq() {
+    assert_ne!(
+        build_model(
+            r#"@property --foo { syntax: "<color>"; inherits: true; initial-value: red; }
+@property --foo { syntax: "<length>"; inherits: true; initial-value: 1px; }"#
+        ),
+        build_model(
+            r#"@property --foo { syntax: "<number>"; inherits: true; initial-value: 1; }
+@property --foo { syntax: "<length>"; inherits: true; initial-value: 1px; }"#
+        ),
+        "shadowed @property rules remain part of semantic equality"
+    );
+}
+
+#[test]
+fn shadowed_at_property_count_is_not_eq() {
+    assert_ne!(
+        build_model(
+            r#"@property --foo { syntax: "<color>"; inherits: true; initial-value: red; }
+@property --foo { syntax: "<length>"; inherits: true; initial-value: 1px; }"#
+        ),
+        build_model(
+            r#"@property --foo { syntax: "<length>"; inherits: true; initial-value: 1px; }"#
+        ),
+        "authored @property rule count remains part of semantic equality"
+    );
+}
+
+#[test]
 fn same_nested_structure_value_change_is_not_eq() {
     assert_ne!(
         build_model(".parent { color: red; .child { font-size: 12px; } }"),

--- a/crates/biome_module_graph/src/css_module_info/mod.rs
+++ b/crates/biome_module_graph/src/css_module_info/mod.rs
@@ -72,7 +72,7 @@ pub struct CssClassReference {
 /// Descriptor data remains owned by the defining document's semantic model.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct CssPropertyDefinition {
-    /// The CSS document that contains the definition.
+    /// The CSS or HTML-like document that contains the definition.
     pub module_path: Utf8PathBuf,
     /// The absolute source range of the complete `@property` rule.
     pub range: TextRange,

--- a/crates/biome_module_graph/src/css_module_info/traverse.rs
+++ b/crates/biome_module_graph/src/css_module_info/traverse.rs
@@ -5,8 +5,10 @@ use crate::traverse::{
     UpwardTraversal, UpwardTraversalAction, UpwardTraversalVisitor, UpwardTraversalWork,
 };
 use biome_console::markup;
-use biome_css_semantic::db::css_semantic_model;
-use biome_db::AnyParsedSource;
+use biome_css_semantic::db::{
+    css_property_definitions_from_snippet, css_property_definitions_from_source,
+};
+use biome_languages::CssFileSource;
 use biome_rowan::{TextRange, TokenText};
 use camino::{Utf8Path, Utf8PathBuf};
 use indexmap::IndexMap;
@@ -149,12 +151,10 @@ impl UpwardTraversal for CssClassTraversal<'_> {
     }
 }
 
-/// Traverses importer branches to resolve visible CSS `@property` definitions.
+/// Finds the nearest CSS `@property` definitions available to a module.
 ///
-/// Every authored edge is evaluated independently because preceding sibling
-/// imports differ by edge position. A branch stops at its nearest definition.
-/// Definitions reached through multiple paths are deduplicated by source path
-/// and range.
+/// It searches modules that import the starting module. Each import path is
+/// searched separately and stops at the first definition it finds.
 pub(crate) struct CssPropertyTraversal<'db, 'name> {
     db: &'db dyn ModuleDb,
     stack: Vec<UpwardTraversalWork<CssPropertyDefinition, CssPropertyBranch>>,
@@ -166,8 +166,8 @@ pub(crate) struct CssPropertyTraversal<'db, 'name> {
 ///
 /// Forking a branch shares its existing ancestry, while membership checks keep
 /// cycle detection local to that branch.
-#[derive(Clone)]
-pub(crate) struct CssPropertyBranch(Rc<CssPropertyBranchNode>);
+#[derive(Clone, Default)]
+pub(crate) struct CssPropertyBranch(Option<Rc<CssPropertyBranchNode>>);
 
 struct CssPropertyBranchNode {
     path: Utf8PathBuf,
@@ -177,12 +177,12 @@ struct CssPropertyBranchNode {
 impl CssPropertyBranch {
     /// Starts a branch with `path` as its first visited module.
     fn new(path: Utf8PathBuf) -> Self {
-        Self(Rc::new(CssPropertyBranchNode { path, parent: None }))
+        Self::default().with_path(path)
     }
 
     /// Returns whether `path` occurs in this branch's ancestry.
     fn contains(&self, path: &Utf8Path) -> bool {
-        let mut node = Some(&*self.0);
+        let mut node = self.0.as_deref();
         while let Some(current) = node {
             if current.path == path {
                 return true;
@@ -194,10 +194,10 @@ impl CssPropertyBranch {
 
     /// Forks this branch with `path` appended to its ancestry.
     fn with_path(&self, path: Utf8PathBuf) -> Self {
-        Self(Rc::new(CssPropertyBranchNode {
+        Self(Some(Rc::new(CssPropertyBranchNode {
             path,
-            parent: Some(self.0.clone()),
-        }))
+            parent: self.0.clone(),
+        })))
     }
 }
 
@@ -256,7 +256,9 @@ impl UpwardTraversalVisitor for CssPropertyTraversal<'_, '_> {
     /// Resolves the definition visible from each authored edge to `imported_path`.
     ///
     /// CSS importers prefer their local definition, then preceding sibling
-    /// imports. JavaScript and HTML importers search preceding CSS contexts.
+    /// imports. HTML importers prefer definitions from globally applicable
+    /// embedded styles, then preceding CSS contexts. JavaScript importers search
+    /// preceding CSS contexts.
     fn visit_importer(
         &mut self,
         imported_path: &Utf8Path,
@@ -273,16 +275,13 @@ impl UpwardTraversalVisitor for CssPropertyTraversal<'_, '_> {
                 .iter()
                 .filter(|(_, import)| import.resolved_path.as_path() == Some(imported_path))
                 .map(|(child_range, _)| {
-                    let definition = local_property_definition(db, importer_path, self.name)
-                        .or_else(|| {
-                            last_property_in_imports_before(
-                                db,
-                                &info,
-                                *child_range,
-                                self.name,
-                                &mut [importer_path.to_path_buf()].into_iter().collect(),
-                            )
-                        });
+                    let definition = self.local_property_definition(importer_path).or_else(|| {
+                        self.last_property_in_imports_before(
+                            &info,
+                            *child_range,
+                            next_branch.clone(),
+                        )
+                    });
                     self.action(definition, next_branch.clone())
                 })
                 .collect(),
@@ -293,15 +292,10 @@ impl UpwardTraversalVisitor for CssPropertyTraversal<'_, '_> {
                     .chain(info.dynamic_import_paths.values())
                     .filter_map(|import| import.as_path())
                     .collect::<Vec<_>>();
-                self.actions_for_ordered_imports(
-                    db,
-                    importer_path,
-                    imported_path,
-                    &imports,
-                    next_branch,
-                )
+                self.actions_for_ordered_imports(imported_path, &imports, next_branch, None)
             }
             ModuleInfoKind::Html(info) => {
+                let local_definition = self.global_html_property_definition(importer_path);
                 let imports = info
                     .imported_stylesheets
                     .iter()
@@ -310,11 +304,10 @@ impl UpwardTraversalVisitor for CssPropertyTraversal<'_, '_> {
                     .filter_map(|import| import.as_path())
                     .collect::<Vec<_>>();
                 self.actions_for_ordered_imports(
-                    db,
-                    importer_path,
                     imported_path,
                     &imports,
                     next_branch,
+                    local_definition,
                 )
             }
         }
@@ -328,24 +321,151 @@ impl CssPropertyTraversal<'_, '_> {
     /// farthest. Imports authored after the occurrence are not visible.
     fn actions_for_ordered_imports(
         &mut self,
-        db: &dyn ModuleDb,
-        importer_path: &Utf8Path,
         imported_path: &Utf8Path,
         imports: &[&Utf8Path],
         next_branch: CssPropertyBranch,
+        local_definition: Option<CssPropertyDefinition>,
     ) -> Vec<UpwardTraversalAction<CssPropertyDefinition, CssPropertyBranch>> {
         imports
             .iter()
             .enumerate()
             .filter(|(_, path)| **path == imported_path)
             .map(|(child_index, _)| {
-                let mut ancestry = [importer_path.to_path_buf()].into_iter().collect();
-                let definition = imports.iter().take(child_index).rev().find_map(|path| {
-                    last_property_in_css_context(db, path, self.name, &mut ancestry)
+                let definition = local_definition.clone().or_else(|| {
+                    imports.iter().take(child_index).rev().find_map(|path| {
+                        self.last_property_in_css_context_from(path, next_branch.clone())
+                    })
                 });
                 self.action(definition, next_branch.clone())
             })
             .collect()
+    }
+
+    /// Returns the last visible definition in an HTML-like document.
+    ///
+    /// Embedded styles take precedence over linked stylesheets and imports.
+    pub(crate) fn last_property_in_html_context(
+        &self,
+        path: &Utf8Path,
+    ) -> Option<CssPropertyDefinition> {
+        self.local_html_property_definition(path).or_else(|| {
+            let info = self.db.html_module_info_for_path(path)?;
+            let branch = CssPropertyBranch::new(path.to_path_buf());
+            info.imported_stylesheets
+                .iter()
+                .chain(info.static_import_paths.values())
+                .chain(info.dynamic_import_paths.values())
+                .rev()
+                .filter_map(|import| import.as_path())
+                .find_map(|path| self.last_property_in_css_context_from(path, branch.clone()))
+        })
+    }
+
+    /// Returns the last visible definition in a CSS import context.
+    ///
+    /// The stylesheet's local definition takes precedence. Otherwise, imports
+    /// are searched in reverse source order without revisiting a module in the
+    /// same branch.
+    pub(crate) fn last_property_in_css_context(
+        &self,
+        path: &Utf8Path,
+    ) -> Option<CssPropertyDefinition> {
+        self.last_property_in_css_context_from(path, CssPropertyBranch::default())
+    }
+
+    fn last_property_in_css_context_from(
+        &self,
+        path: &Utf8Path,
+        branch: CssPropertyBranch,
+    ) -> Option<CssPropertyDefinition> {
+        if branch.contains(path) {
+            return None;
+        }
+
+        let path = path.to_path_buf();
+        let mut stack = vec![(path.clone(), branch.with_path(path))];
+        while let Some((path, branch)) = stack.pop() {
+            if let Some(definition) = self.local_property_definition(&path) {
+                return Some(definition);
+            }
+
+            if let Some(info) = self.db.css_module_info_for_path(&path) {
+                stack.extend(info.imports.values().filter_map(|import| {
+                    let path = import.resolved_path.as_path()?;
+                    if branch.contains(path) {
+                        return None;
+                    }
+                    let path = path.to_path_buf();
+                    Some((path.clone(), branch.with_path(path)))
+                }));
+            }
+        }
+        None
+    }
+
+    /// Returns the last definition visible through imports preceding `child_range`.
+    fn last_property_in_imports_before(
+        &self,
+        info: &crate::CssModuleInfo,
+        child_range: TextRange,
+        branch: CssPropertyBranch,
+    ) -> Option<CssPropertyDefinition> {
+        info.imports
+            .iter()
+            .rev()
+            .filter(|(range, _)| range.start() < child_range.start())
+            .find_map(|(_, import)| {
+                let path = import.resolved_path.as_path()?;
+                self.last_property_in_css_context_from(path, branch.clone())
+            })
+    }
+
+    fn local_property_definition(&self, path: &Utf8Path) -> Option<CssPropertyDefinition> {
+        self.db.css_module_info_for_path(path)?;
+        let parsed = self.db.parsed_source_for_path(path)?;
+        let definition = css_property_definitions_from_source(self.db, parsed)
+            .iter()
+            .find(|definition| definition.name() == self.name)?;
+        Some(CssPropertyDefinition {
+            module_path: path.to_path_buf(),
+            range: definition.range(),
+        })
+    }
+
+    fn local_html_property_definition(&self, path: &Utf8Path) -> Option<CssPropertyDefinition> {
+        self.find_local_html_property_definition(path, |_| true)
+    }
+
+    fn global_html_property_definition(&self, path: &Utf8Path) -> Option<CssPropertyDefinition> {
+        self.find_local_html_property_definition(path, |source| {
+            source.embedding_applicability().is_global()
+        })
+    }
+
+    fn find_local_html_property_definition(
+        &self,
+        path: &Utf8Path,
+        includes: impl Fn(CssFileSource) -> bool,
+    ) -> Option<CssPropertyDefinition> {
+        self.db.html_module_info_for_path(path)?;
+        let source = self.db.parsed_source_for_path(path)?;
+        source.snippets(self.db).iter().rev().find_map(|snippet| {
+            let file_source = self
+                .db
+                .source_from_index(snippet.document_source_index(self.db))?
+                .to_css_file_source()?;
+            if !includes(file_source) {
+                return None;
+            }
+
+            let definition = css_property_definitions_from_snippet(self.db, *snippet)
+                .iter()
+                .find(|definition| definition.name() == self.name)?;
+            Some(CssPropertyDefinition {
+                module_path: path.to_path_buf(),
+                range: definition.range() + snippet.content_offset(self.db),
+            })
+        })
     }
 }
 
@@ -357,94 +477,6 @@ impl UpwardTraversal for CssPropertyTraversal<'_, '_> {
     fn stack(&mut self) -> &mut Vec<UpwardTraversalWork<Self::Item, Self::Branch>> {
         &mut self.stack
     }
-}
-
-/// Returns the last visible definition in a CSS import context.
-///
-/// The stylesheet's local definition takes precedence. Otherwise, imports are
-/// searched in reverse source order, and each imported stylesheet applies the
-/// same rule. Paths already present in `ancestry` are skipped. The traversal is
-/// iterative so authored import depth cannot overflow the call stack.
-pub(crate) fn last_property_in_css_context(
-    db: &dyn ModuleDb,
-    path: &Utf8Path,
-    name: &str,
-    ancestry: &mut FxHashSet<Utf8PathBuf>,
-) -> Option<CssPropertyDefinition> {
-    enum Work {
-        Visit(Utf8PathBuf),
-        Leave(Utf8PathBuf),
-    }
-
-    let mut stack = vec![Work::Visit(path.to_path_buf())];
-    while let Some(work) = stack.pop() {
-        match work {
-            Work::Visit(path) => {
-                if !ancestry.insert(path.clone()) {
-                    continue;
-                }
-                if let Some(definition) = local_property_definition(db, &path, name) {
-                    return Some(definition);
-                }
-
-                stack.push(Work::Leave(path.clone()));
-                if let Some(info) = db.css_module_info_for_path(&path) {
-                    stack.extend(info.imports.values().filter_map(|import| {
-                        import
-                            .resolved_path
-                            .as_path()
-                            .map(|path| Work::Visit(path.to_path_buf()))
-                    }));
-                }
-            }
-            Work::Leave(path) => {
-                ancestry.remove(&path);
-            }
-        }
-    }
-    None
-}
-
-/// Returns the last definition visible through imports preceding `child_range`.
-///
-/// Imports are searched in reverse source order. `child_range` identifies the
-/// authored edge to the child module, so later sibling imports are excluded.
-fn last_property_in_imports_before(
-    db: &dyn ModuleDb,
-    info: &crate::CssModuleInfo,
-    child_range: TextRange,
-    name: &str,
-    ancestry: &mut FxHashSet<Utf8PathBuf>,
-) -> Option<CssPropertyDefinition> {
-    info.imports
-        .iter()
-        .rev()
-        .filter(|(range, _)| range.start() < child_range.start())
-        .find_map(|(_, import)| {
-            let path = import.resolved_path.as_path()?;
-            last_property_in_css_context(db, path, name, ancestry)
-        })
-}
-
-/// Returns the local `@property` definition for `name` in a CSS module.
-///
-/// The parsed source is read directly so range-only edits invalidate tracked
-/// callers even when the semantic contents of the definition are unchanged.
-fn local_property_definition(
-    db: &dyn ModuleDb,
-    path: &Utf8Path,
-    name: &str,
-) -> Option<CssPropertyDefinition> {
-    db.css_module_info_for_path(path)?;
-    let parsed = db.parsed_source_for_path(path)?;
-    let _ = parsed.parsed(db);
-    let source = AnyParsedSource::ParsedSource(parsed);
-    let model = css_semantic_model(db, &source);
-    let at_property = model.global_custom_variables().get(name)?.at_property()?;
-    Some(CssPropertyDefinition {
-        module_path: path.to_path_buf(),
-        range: at_property.range(),
-    })
 }
 
 /// Returns whether `module` imports `path` through a supported import edge.

--- a/crates/biome_module_graph/src/db/mod.rs
+++ b/crates/biome_module_graph/src/db/mod.rs
@@ -3,6 +3,7 @@
 use crate::{CssModuleInfo, HtmlModuleInfo, JsModuleInfo, ModuleInfo, ModuleInfoKind};
 pub use biome_js_type_info::TypeDb;
 use biome_js_type_info::interned_types::ModuleKey;
+use biome_languages::LanguageDb;
 use camino::{Utf8Path, Utf8PathBuf};
 use salsa::plumbing::{AsId, FromId};
 
@@ -35,9 +36,9 @@ pub struct ModuleGraphGeneration {
     pub value: u64,
 }
 
-/// Extends `TypeDb` with module-graph-specific lookups.
+/// Extends `TypeDb` and `LanguageDb` with module-graph-specific lookups.
 #[salsa::db]
-pub trait ModuleDb: TypeDb {
+pub trait ModuleDb: TypeDb + LanguageDb {
     /// Returns the generation used when reading modules by file path.
     ///
     /// A database that can add, remove, or change the module associated with a

--- a/crates/biome_module_graph/src/db/queries/css.rs
+++ b/crates/biome_module_graph/src/db/queries/css.rs
@@ -1,7 +1,5 @@
 use super::SymbolFromModuleInfo;
-use crate::css_module_info::traverse::{
-    CssClassStep, CssClassTraversal, CssPropertyTraversal, last_property_in_css_context,
-};
+use crate::css_module_info::traverse::{CssClassStep, CssClassTraversal, CssPropertyTraversal};
 use crate::traverse::UpwardTraversal;
 use crate::{CssPropertyDefinition, ImportTreeNode, ModuleDb, ModuleInfo, ModuleInfoKind};
 use biome_css_syntax::{TextRange, TextSize};
@@ -196,12 +194,15 @@ pub fn traverse_import_tree_for_html_classes(
         .collect()
 }
 
-/// Returns the nearest visible `@property` definitions for a CSS module.
+/// Returns the nearest visible `@property` definitions for a CSS or HTML-like module.
 ///
-/// The current stylesheet's local definition takes precedence over definitions
-/// reached through its imports. Every importer is then traversed as an
-/// independent branch. A branch stops at its first visible definition, and only
-/// sibling imports authored before the child edge are visible.
+/// A CSS module's local definition takes precedence over definitions reached
+/// through its imports. An HTML-like module first searches all of its embedded
+/// styles, including component-scoped styles, before its linked stylesheets and
+/// imports. Every importer is then traversed as an independent branch. A branch
+/// stops at its first visible definition, and only sibling imports authored
+/// before the child edge are visible. Component-scoped styles do not escape an
+/// HTML-like importer.
 /// Definitions reached through the same authored rule are deduplicated, while
 /// definitions from separate branches remain separate. Result order is
 /// unspecified.
@@ -211,20 +212,19 @@ pub fn css_property_definitions<'db>(
     property: SymbolFromModuleInfo<'db>,
 ) -> Vec<CssPropertyDefinition> {
     let module = *property.module(db);
-    if !matches!(module.kind(db), ModuleInfoKind::Css(_)) {
-        return Vec::new();
-    }
-
     let path = module.path(db);
     let name = property.name(db);
-    let mut ancestry = FxHashSet::default();
-    if let Some(definition) = last_property_in_css_context(db, path, &name, &mut ancestry) {
+    let traversal = CssPropertyTraversal::new(db, path, &name);
+    let definition = match module.kind(db) {
+        ModuleInfoKind::Css(_) => traversal.last_property_in_css_context(path),
+        ModuleInfoKind::Html(_) => traversal.last_property_in_html_context(path),
+        ModuleInfoKind::Js(_) => return Vec::new(),
+    };
+    if let Some(definition) = definition {
         return vec![definition];
     }
 
-    CssPropertyTraversal::new(db, path, &name)
-        .into_upward_iter()
-        .collect()
+    traversal.into_upward_iter().collect()
 }
 
 /// Returns `true` if the given CSS `class_name` is referenced in any

--- a/crates/biome_module_graph/tests/spec_tests.rs
+++ b/crates/biome_module_graph/tests/spec_tests.rs
@@ -11,11 +11,12 @@ use biome_resolver::ResolveError;
 
 use crate::snap::ModuleGraphSnapshot;
 use biome_configuration::{Configuration, HtmlConfiguration};
-use biome_css_parser::{CssModulesKind, CssParserOptions, parse_css};
-use biome_db::{Db, ParsedSource};
+use biome_css_parser::{CssModulesKind, CssParserOptions, parse_css, parse_css_with_offset};
+use biome_db::{Db, ParsedSnippet, ParsedSource};
 use biome_deserialize::json::deserialize_from_json_str;
 use biome_fs::{BiomePath, FileSystem, MemoryFileSystem, OsFileSystem, normalize_path};
 use biome_html_parser::HtmlParserOptions;
+use biome_js_parser::JsParserOptions;
 use biome_js_semantic::ScopeId;
 use biome_js_syntax::AnyJsRoot;
 use biome_js_type_info::{TypeData, TypeResolver};
@@ -191,6 +192,122 @@ fn build_css_property_db(files: &[(&str, &str)]) -> WorkspaceDb {
     db
 }
 
+fn build_html_property_db(
+    path: &str,
+    source: &str,
+    file_source: HtmlFileSource,
+    styles: &[(&str, CssFileSource)],
+    scripts: &[&str],
+    external_css: &[(&str, &str)],
+) -> WorkspaceDb {
+    let fs = MemoryFileSystem::default();
+    fs.insert(path.into(), source);
+    for (path, source) in external_css {
+        fs.insert((*path).into(), *source);
+    }
+
+    let mut db = WorkspaceDb::default();
+    let layout = ProjectLayout::default();
+    let path_info_cache = PathInfoCache::default();
+    let host_path = BiomePath::new(path);
+    let host_parse = biome_html_parser::parse_html(source, HtmlParserOptions::from(&file_source));
+    let host_root = host_parse.tree();
+    let mut snippets = Vec::new();
+    let mut embedded = Vec::new();
+    let mut search_offset = 0;
+
+    for (style, css_source) in styles {
+        let relative_offset = source[search_offset..].find(style).unwrap();
+        let start = search_offset + relative_offset;
+        let end = start + style.len();
+        search_offset = end;
+        let start = TextSize::from(start as u32);
+        let range = TextRange::new(start, TextSize::from(end as u32));
+        let parse = parse_css_with_offset(style, *css_source, start, CssParserOptions::default());
+        embedded.push(HtmlEmbeddedContent::Css(parse.tree(), *css_source, start));
+        let source_index = db.insert_source((*css_source).into());
+        snippets.push(ParsedSnippet::new(
+            &db,
+            parse.into(),
+            range,
+            range,
+            start,
+            source_index,
+        ));
+    }
+
+    for script in scripts {
+        let start = source.find(script).unwrap();
+        let end = start + script.len();
+        let start = TextSize::from(start as u32);
+        let range = TextRange::new(start, TextSize::from(end as u32));
+        let parse = biome_js_parser::parse(
+            script,
+            JsFileSource::js_module(),
+            JsParserOptions::default(),
+        );
+        embedded.push(HtmlEmbeddedContent::Js(parse.tree()));
+        let source_index = db.insert_source(JsFileSource::js_module().into());
+        snippets.push(ParsedSnippet::new(
+            &db,
+            parse.into(),
+            range,
+            range,
+            start,
+            source_index,
+        ));
+    }
+    snippets.sort_by_key(|snippet| snippet.content_offset(&db));
+
+    let host_source_index = db.insert_source(file_source.into());
+    let parsed = ParsedSource::new(
+        &db,
+        host_path.as_path().to_path_buf(),
+        host_parse.into(),
+        host_source_index,
+        snippets,
+    );
+    db.insert_file(host_path.as_path(), parsed);
+    let (module_info, _, _) = resolve_html_module(
+        host_root,
+        &embedded,
+        &host_path,
+        &fs,
+        &layout,
+        &path_info_cache,
+    );
+    let module = ModuleInfo::new(
+        &db,
+        host_path.as_path().to_path_buf(),
+        ModuleInfoKind::Html(module_info),
+    );
+    db.insert_module(host_path.as_path().to_path_buf(), module);
+
+    for (path, source) in external_css {
+        let path = BiomePath::new(*path);
+        let parse = parse_css(source, CssFileSource::css(), CssParserOptions::default());
+        let root = parse.tree();
+        let source_index = db.insert_source(CssFileSource::css().into());
+        let parsed = ParsedSource::new(
+            &db,
+            path.as_path().to_path_buf(),
+            parse.into(),
+            source_index,
+            Vec::new(),
+        );
+        db.insert_file(path.as_path(), parsed);
+        let (module_info, _, _) = resolve_css_module(root, &path, &fs, &layout, &path_info_cache);
+        let module = ModuleInfo::new(
+            &db,
+            path.as_path().to_path_buf(),
+            ModuleInfoKind::Css(module_info),
+        );
+        db.insert_module(path.as_path().to_path_buf(), module);
+    }
+
+    db
+}
+
 #[test]
 fn css_property_query_uses_last_local_definition() {
     let source = r#"
@@ -308,6 +425,14 @@ fn css_property_query_continues_through_empty_parents() {
     assert_eq!(definitions[0].module_path, Utf8Path::new("/app.css"));
 }
 
+// This tests make sure that we resolve the same property. Given
+//                    /left.css
+//                   /         \
+// /leaf.css <-------           /root.css
+//                   \         /  defines --value
+//                    \right.css
+//
+// The definition defined in root.css should be the same and one.
 #[test]
 fn css_property_query_deduplicates_diamonds_and_stops_cycles() {
     let db = build_css_property_db(&[
@@ -364,8 +489,6 @@ fn css_property_query_reads_the_current_semantic_model() {
 
 #[test]
 fn css_property_query_skips_non_css_sibling_imports() {
-    use biome_js_parser::JsParserOptions;
-
     let mut db = build_css_property_db(&[("/leaf.css", ".leaf { color: var(--value); }")]);
     let fs = MemoryFileSystem::default();
     fs.insert("/leaf.css".into(), b".leaf { color: var(--value); }");
@@ -399,6 +522,285 @@ fn css_property_query_skips_non_css_sibling_imports() {
     let module = db.module_for_path(Utf8Path::new("/leaf.css")).unwrap();
     let property = SymbolFromModuleInfo::new(&db, "--value", module);
     assert!(css_property_definitions(&db, property).is_empty());
+}
+
+#[test]
+fn css_property_query_reads_html_like_embedded_styles() {
+    let style = r#"@property --value { syntax: "<color>"; inherits: true; initial-value: red; }"#;
+    let cases = [
+        ("/index.html", HtmlFileSource::html(), html_css_source()),
+        (
+            "/Component.vue",
+            HtmlFileSource::vue(),
+            vue_scoped_css_source(),
+        ),
+        (
+            "/Component.svelte",
+            HtmlFileSource::svelte(),
+            svelte_local_css_source(),
+        ),
+        (
+            "/Component.astro",
+            HtmlFileSource::astro(),
+            astro_local_css_source(),
+        ),
+    ];
+
+    for (path, file_source, css_source) in cases {
+        let source = format!("<style>{style}</style>");
+        let db =
+            build_html_property_db(path, &source, file_source, &[(style, css_source)], &[], &[]);
+        let module = db.module_for_path(Utf8Path::new(path)).unwrap();
+        let property = SymbolFromModuleInfo::new(&db, "--value", module);
+
+        let definitions = css_property_definitions(&db, property);
+
+        assert_eq!(definitions.len(), 1, "{path}");
+        assert_eq!(definitions[0].module_path, Utf8Path::new(path), "{path}");
+        assert!(
+            definitions[0].range.start()
+                >= TextSize::from(source.find("@property").unwrap() as u32),
+            "{path}"
+        );
+        assert!(
+            definitions[0].range.end() <= TextSize::from(source.find("</style>").unwrap() as u32),
+            "{path}"
+        );
+    }
+}
+
+#[test]
+fn css_property_query_tracks_html_style_offsets() {
+    let style = r#"@property --value { syntax: "<color>"; inherits: true; initial-value: red; }"#;
+    let source = format!("<style>{style}</style>");
+    let mut db = build_html_property_db(
+        "/index.html",
+        &source,
+        HtmlFileSource::html(),
+        &[(style, html_css_source())],
+        &[],
+        &[],
+    );
+    let original_range = {
+        let module = db.module_for_path(Utf8Path::new("/index.html")).unwrap();
+        let property = SymbolFromModuleInfo::new(&db, "--value", module);
+        css_property_definitions(&db, property)[0].range
+    };
+
+    let parsed = db
+        .parsed_source_for_path(Utf8Path::new("/index.html"))
+        .unwrap();
+    let snippet = parsed.snippets(&db)[0];
+    let next_offset = snippet.content_offset(&db) + TextSize::from(1);
+    let replacement = parse_css_with_offset(
+        style,
+        html_css_source(),
+        next_offset,
+        CssParserOptions::default(),
+    );
+    salsa::Setter::to(snippet.set_parsed(&mut db), replacement.into());
+    salsa::Setter::to(snippet.set_content_offset(&mut db), next_offset);
+
+    let module = db.module_for_path(Utf8Path::new("/index.html")).unwrap();
+    let property = SymbolFromModuleInfo::new(&db, "--value", module);
+    let definitions = css_property_definitions(&db, property);
+    assert_eq!(definitions[0].range, original_range + TextSize::from(1));
+}
+
+#[test]
+fn css_property_query_ignores_html_script_snippets() {
+    let style = r#"@property --value { syntax: "<color>"; inherits: true; initial-value: red; }"#;
+    let source = format!("<style>{style}</style><script>const value = 1;</script>");
+    let mut db = build_html_property_db(
+        "/index.html",
+        &source,
+        HtmlFileSource::html(),
+        &[(style, html_css_source())],
+        &[],
+        &[],
+    );
+    {
+        let module = db.module_for_path(Utf8Path::new("/index.html")).unwrap();
+        let property = SymbolFromModuleInfo::new(&db, "--value", module);
+        assert_eq!(css_property_definitions(&db, property).len(), 1);
+    }
+    let parsed = db
+        .parsed_source_for_path(Utf8Path::new("/index.html"))
+        .unwrap();
+    let mut snippets = parsed.snippets(&db).clone();
+    let script = biome_js_parser::parse(
+        "const value = 1;",
+        JsFileSource::js_module(),
+        JsParserOptions::default(),
+    );
+    let script_source = db.insert_source(JsFileSource::js_module().into());
+    snippets.push(ParsedSnippet::new(
+        &db,
+        script.into(),
+        TextRange::default(),
+        TextRange::default(),
+        TextSize::default(),
+        script_source,
+    ));
+    salsa::Setter::to(parsed.set_snippets(&mut db), snippets);
+
+    let module = db.module_for_path(Utf8Path::new("/index.html")).unwrap();
+    let property = SymbolFromModuleInfo::new(&db, "--value", module);
+    assert_eq!(css_property_definitions(&db, property).len(), 1);
+}
+
+#[test]
+fn css_property_query_tracks_html_style_parse_changes() {
+    let style = r#"@property --value { syntax: "<color>"; inherits: true; initial-value: red; }"#;
+    let source = format!("<style>{style}</style>");
+    let mut db = build_html_property_db(
+        "/index.html",
+        &source,
+        HtmlFileSource::html(),
+        &[(style, html_css_source())],
+        &[],
+        &[],
+    );
+    {
+        let module = db.module_for_path(Utf8Path::new("/index.html")).unwrap();
+        let property = SymbolFromModuleInfo::new(&db, "--value", module);
+        assert_eq!(css_property_definitions(&db, property).len(), 1);
+    }
+
+    let parsed = db
+        .parsed_source_for_path(Utf8Path::new("/index.html"))
+        .unwrap();
+    let snippet = parsed.snippets(&db)[0];
+    let replacement = parse_css_with_offset(
+        ".value { color: red; }",
+        html_css_source(),
+        snippet.content_offset(&db),
+        CssParserOptions::default(),
+    );
+    salsa::Setter::to(snippet.set_parsed(&mut db), replacement.into());
+
+    let module = db.module_for_path(Utf8Path::new("/index.html")).unwrap();
+    let property = SymbolFromModuleInfo::new(&db, "--value", module);
+    assert!(css_property_definitions(&db, property).is_empty());
+}
+
+#[test]
+fn css_property_query_uses_last_html_style_definition() {
+    let first = r#"@property --value { syntax: "<color>"; inherits: true; initial-value: red; }"#;
+    let second = r#"@property --value { syntax: "<length>"; inherits: true; initial-value: 0px; }"#;
+    let source = format!("<style>{first}</style><style>{second}</style>");
+    let db = build_html_property_db(
+        "/index.html",
+        &source,
+        HtmlFileSource::html(),
+        &[(first, html_css_source()), (second, html_css_source())],
+        &[],
+        &[],
+    );
+    let module = db.module_for_path(Utf8Path::new("/index.html")).unwrap();
+    let property = SymbolFromModuleInfo::new(&db, "--value", module);
+
+    let definitions = css_property_definitions(&db, property);
+
+    assert_eq!(definitions.len(), 1);
+    assert!(
+        definitions[0].range.start() >= TextSize::from(source.rfind("@property").unwrap() as u32)
+    );
+}
+
+#[test]
+fn css_property_query_only_exposes_global_html_importer_styles() {
+    let property_style =
+        r#"@property --value { syntax: "<color>"; inherits: true; initial-value: red; }"#;
+    let leaf = ".leaf { color: var(--value); }";
+    let source =
+        format!("<link rel=\"stylesheet\" href=\"./leaf.css\"><style>{property_style}</style>");
+
+    let mut db = build_html_property_db(
+        "/Global.vue",
+        &source,
+        HtmlFileSource::vue(),
+        &[(property_style, vue_global_css_source())],
+        &[],
+        &[("/leaf.css", leaf)],
+    );
+    let module = db.module_for_path(Utf8Path::new("/leaf.css")).unwrap();
+    let property = SymbolFromModuleInfo::new(&db, "--value", module);
+    let definitions = css_property_definitions(&db, property);
+    assert_eq!(definitions.len(), 1);
+    assert_eq!(definitions[0].module_path, Utf8Path::new("/Global.vue"));
+
+    let parsed = db
+        .parsed_source_for_path(Utf8Path::new("/Global.vue"))
+        .unwrap();
+    let snippet = parsed.snippets(&db)[0];
+    let local_source = db.insert_source(vue_scoped_css_source().into());
+    salsa::Setter::to(snippet.set_document_source_index(&mut db), local_source);
+    let module = db.module_for_path(Utf8Path::new("/leaf.css")).unwrap();
+    let property = SymbolFromModuleInfo::new(&db, "--value", module);
+    assert!(css_property_definitions(&db, property).is_empty());
+
+    let db = build_html_property_db(
+        "/Local.vue",
+        &source,
+        HtmlFileSource::vue(),
+        &[(property_style, vue_scoped_css_source())],
+        &[],
+        &[("/leaf.css", leaf)],
+    );
+    let module = db.module_for_path(Utf8Path::new("/leaf.css")).unwrap();
+    let property = SymbolFromModuleInfo::new(&db, "--value", module);
+    assert!(css_property_definitions(&db, property).is_empty());
+}
+
+#[test]
+fn css_property_query_follows_stylesheets_linked_from_html() {
+    let property_style =
+        r#"@property --value { syntax: "<color>"; inherits: true; initial-value: red; }"#;
+    let source = "<link rel=\"stylesheet\" href=\"./theme.css\">";
+    let db = build_html_property_db(
+        "/index.html",
+        source,
+        HtmlFileSource::html(),
+        &[],
+        &[],
+        &[("/theme.css", property_style)],
+    );
+    let module = db.module_for_path(Utf8Path::new("/index.html")).unwrap();
+    let property = SymbolFromModuleInfo::new(&db, "--value", module);
+
+    let definitions = css_property_definitions(&db, property);
+
+    assert_eq!(definitions.len(), 1);
+    assert_eq!(definitions[0].module_path, Utf8Path::new("/theme.css"));
+}
+
+#[test]
+fn css_property_query_follows_stylesheets_imported_from_html_scripts() {
+    let property_style =
+        r#"@property --value { syntax: "<color>"; inherits: true; initial-value: red; }"#;
+    for script in ["import './theme.css';", "import('./theme.css');"] {
+        let source = format!("<script>{script}</script>");
+        let db = build_html_property_db(
+            "/index.html",
+            &source,
+            HtmlFileSource::html(),
+            &[],
+            &[script],
+            &[("/theme.css", property_style)],
+        );
+        let module = db.module_for_path(Utf8Path::new("/index.html")).unwrap();
+        let property = SymbolFromModuleInfo::new(&db, "--value", module);
+
+        let definitions = css_property_definitions(&db, property);
+
+        assert_eq!(definitions.len(), 1, "{script}");
+        assert_eq!(
+            definitions[0].module_path,
+            Utf8Path::new("/theme.css"),
+            "{script}"
+        );
+    }
 }
 
 #[test]

--- a/crates/biome_module_graph/tests/spec_tests_v2.rs
+++ b/crates/biome_module_graph/tests/spec_tests_v2.rs
@@ -22,7 +22,7 @@ use biome_js_type_info::{
     },
 };
 use biome_json_parser::{JsonParserOptions, parse_json};
-use biome_languages::JsFileSource;
+use biome_languages::{DocumentFileSource, JsFileSource, LanguageDb};
 use biome_module_graph::{
     CallArgumentTypeInput, CallExpressionTypeInput, InferredModuleTypes, JsExport, JsOwnExport,
     ModuleDb, ModuleInfo, ModuleInfoKind, NormalizeTypeInput, PathInfoCache,
@@ -289,6 +289,13 @@ impl salsa::Database for TestModuleDb {}
 #[salsa::db]
 impl biome_db::Db for TestModuleDb {
     fn parsed_source_for_path(&self, _path: &Utf8Path) -> Option<ParsedSource> {
+        None
+    }
+}
+
+#[salsa::db]
+impl LanguageDb for TestModuleDb {
+    fn source_from_index(&self, _index: usize) -> Option<DocumentFileSource> {
         None
     }
 }


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR does two things.

Created via coding agent

### Custom properties resolution

It fixes the business logic of how custom properties should be resolved. When two custom properties with the same name are defined in the same document, only the last one is considered. 

The semantic model now tracks all the custom properties found in the document, and then it has a small map that tracks which one is the last one, indexed by name. This allows for an O(1) query.

### Traverse HTML files

The module graph now traverses HTML-ish files and looks for the custom properties. Same rules apply:
- first local defined CSS
- then importers
- eventually the global defined CSS

The first property to be found, is selected.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added new tests. 

TIL there's a type of test called "diamond test". I added a small comment that shows what it does.

<!-- What demonstrates that your implementation is correct? -->

## Docs

N/A

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
