### PR TITLE
feat(lint): add noNonScalableViewport rule

### DIFF
--- a/.changeset/whole-oranges-tie.md
+++ b/.changeset/whole-oranges-tie.md
@@ -1,0 +1,11 @@
+---
+"@biomejs/biome": patch
+---
+
+Added the nursery rule [`noNonScalableViewport`](https://biomejs.dev/linter/rules/no-non-scalable-viewport), which reports viewport metadata that disables user scaling with `user-scalable=no`.
+
+For example:
+
+```html
+<meta name="viewport" content="width=device-width, user-scalable=no" />
+```

--- a/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
@@ -357,6 +357,18 @@ pub(crate) fn migrate_eslint_any_rule(
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
+        "@html-eslint/no-non-scalable-viewport" => {
+            if !options.include_nursery {
+                results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Nursery);
+                return false;
+            }
+            let group = rules.nursery.get_or_insert_with(Default::default);
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_non_scalable_viewport
+                .get_or_insert(Default::default());
+            rule.set_level(rule.level().max(rule_severity.into()));
+        }
         "@html-eslint/no-positive-tabindex" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
             let rule = group

--- a/crates/biome_configuration/src/analyzer/linter/rules.rs
+++ b/crates/biome_configuration/src/analyzer/linter/rules.rs
@@ -265,6 +265,7 @@ pub enum RuleName {
     NoNodejsModules,
     NoNonNullAssertedOptionalChain,
     NoNonNullAssertion,
+    NoNonScalableViewport,
     NoNoninteractiveElementInteractions,
     NoNoninteractiveElementToInteractiveRole,
     NoNoninteractiveTabindex,
@@ -785,6 +786,7 @@ impl RuleName {
             Self::NoNodejsModules => "noNodejsModules",
             Self::NoNonNullAssertedOptionalChain => "noNonNullAssertedOptionalChain",
             Self::NoNonNullAssertion => "noNonNullAssertion",
+            Self::NoNonScalableViewport => "noNonScalableViewport",
             Self::NoNoninteractiveElementInteractions => "noNoninteractiveElementInteractions",
             Self::NoNoninteractiveElementToInteractiveRole => {
                 "noNoninteractiveElementToInteractiveRole"
@@ -1305,6 +1307,7 @@ impl RuleName {
             Self::NoNodejsModules => RuleGroup::Correctness,
             Self::NoNonNullAssertedOptionalChain => RuleGroup::Suspicious,
             Self::NoNonNullAssertion => RuleGroup::Style,
+            Self::NoNonScalableViewport => RuleGroup::Nursery,
             Self::NoNoninteractiveElementInteractions => RuleGroup::A11y,
             Self::NoNoninteractiveElementToInteractiveRole => RuleGroup::A11y,
             Self::NoNoninteractiveTabindex => RuleGroup::A11y,
@@ -1830,6 +1833,7 @@ impl std::str::FromStr for RuleName {
             "noNodejsModules" => Ok(Self::NoNodejsModules),
             "noNonNullAssertedOptionalChain" => Ok(Self::NoNonNullAssertedOptionalChain),
             "noNonNullAssertion" => Ok(Self::NoNonNullAssertion),
+            "noNonScalableViewport" => Ok(Self::NoNonScalableViewport),
             "noNoninteractiveElementInteractions" => Ok(Self::NoNoninteractiveElementInteractions),
             "noNoninteractiveElementToInteractiveRole" => {
                 Ok(Self::NoNoninteractiveElementToInteractiveRole)

--- a/crates/biome_configuration/src/generated/linter_options_check.rs
+++ b/crates/biome_configuration/src/generated/linter_options_check.rs
@@ -841,6 +841,11 @@ pub fn config_side_rule_options_types() -> Vec<(&'static str, &'static str, Type
         "noNonNullAssertion",
         TypeId::of::<biome_rule_options::no_non_null_assertion::NoNonNullAssertionOptions>(),
     ));
+    result.push((
+        "nursery",
+        "noNonScalableViewport",
+        TypeId::of::<biome_rule_options::no_non_scalable_viewport::NoNonScalableViewportOptions>(),
+    ));
     result.push(("a11y", "noNoninteractiveElementInteractions", TypeId::of::<biome_rule_options::no_noninteractive_element_interactions::NoNoninteractiveElementInteractionsOptions>()));
     result.push(("a11y", "noNoninteractiveElementToInteractiveRole", TypeId::of::<biome_rule_options::no_noninteractive_element_to_interactive_role::NoNoninteractiveElementToInteractiveRoleOptions>()));
     result.push(("a11y", "noNoninteractiveTabindex", TypeId::of::<biome_rule_options::no_noninteractive_tabindex::NoNoninteractiveTabindexOptions>()));

--- a/crates/biome_diagnostics_categories/src/categories.rs
+++ b/crates/biome_diagnostics_categories/src/categories.rs
@@ -224,6 +224,7 @@ define_categories! {
     "lint/nursery/noMissingGenericFamilyKeyword": "https://biomejs.dev/linter/rules/no-missing-generic-family-keyword",
     "lint/nursery/noMisusedPromises": "https://biomejs.dev/linter/rules/no-misused-promises",
     "lint/nursery/noNegationInEqualityCheck": "https://biomejs.dev/linter/rules/no-negation-in-equality-check",
+    "lint/nursery/noNonScalableViewport": "https://biomejs.dev/linter/rules/no-non-scalable-viewport",
     "lint/nursery/noPlaywrightElementHandle": "https://biomejs.dev/linter/rules/no-playwright-element-handle",
     "lint/nursery/noPlaywrightEval": "https://biomejs.dev/linter/rules/no-playwright-eval",
     "lint/nursery/noPlaywrightForceOption": "https://biomejs.dev/linter/rules/no-playwright-force-option",

--- a/crates/biome_html_analyze/src/lint/nursery/no_non_scalable_viewport.rs
+++ b/crates/biome_html_analyze/src/lint/nursery/no_non_scalable_viewport.rs
@@ -1,0 +1,101 @@
+use biome_analyze::{
+    Ast, Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule,
+};
+use biome_console::markup;
+use biome_diagnostics::Severity;
+use biome_html_syntax::{T, element_ext::AnyHtmlTagElement};
+use biome_rowan::{AstNode, TextRange};
+use biome_rule_options::no_non_scalable_viewport::NoNonScalableViewportOptions;
+
+declare_lint_rule! {
+    /// Disallow disabling zoom with `user-scalable=no` in the `<meta name="viewport">` element.
+    ///
+    /// Disabling zoom can make page content difficult to read for people with low vision.
+    ///
+    /// See [WCAG 1.4.4](https://www.w3.org/WAI/WCAG21/Understanding/resize-text.html) and the
+    /// [html-eslint rule](https://html-eslint.org/docs/rules/no-non-scalable-viewport) for details.
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```html,expect_diagnostic
+    /// <meta name="viewport" content="width=device-width, user-scalable=no" />
+    /// ```
+    ///
+    /// ```html,expect_diagnostic
+    /// <meta name="viewport" content="user-scalable = no, width=device-width" />
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```html
+    /// <meta name="viewport" content="width=device-width, user-scalable=yes" />
+    /// <meta name="viewport" content="width=device-width" />
+    /// <meta name="viewport" content="user-scalable=nope" />
+    /// ```
+    ///
+    pub NoNonScalableViewport {
+        version: "next",
+        name: "noNonScalableViewport",
+        language: "html",
+        recommended: false,
+        severity: Severity::Error,
+        sources: &[RuleSource::HtmlEslint("no-non-scalable-viewport").same()],
+    }
+}
+
+impl Rule for NoNonScalableViewport {
+    type Query = Ast<AnyHtmlTagElement>;
+    type State = TextRange;
+    type Signals = Option<Self::State>;
+    type Options = NoNonScalableViewportOptions;
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let element = ctx.query();
+
+        if element.tag_name_kind() != Some(T![meta]) {
+            return None;
+        }
+
+        let name_attribute = element.find_attribute_or_vue_binding("name")?;
+        let content_attribute = element.find_attribute_or_vue_binding("content")?;
+        let name = name_attribute.as_static_value()?;
+        let content = content_attribute.as_static_value()?;
+
+        if !name.text().eq_ignore_ascii_case("viewport") {
+            return None;
+        }
+
+        has_non_scalable_viewport(content.text()).then_some(content_attribute.range())
+    }
+
+    fn diagnostic(_ctx: &RuleContext<Self>, range: &Self::State) -> Option<RuleDiagnostic> {
+        Some(
+            RuleDiagnostic::new(
+                rule_category!(),
+                *range,
+                markup! {
+                    "The viewport disables user scaling."
+                },
+            )
+            .note(markup! {
+                "Disabling zoom can make page content difficult to read for people with low vision."
+            })
+            .note(markup! {
+                "Remove the "<Emphasis>"user-scalable=no"</Emphasis>" directive from the "<Emphasis>"content"</Emphasis>" attribute."
+            }),
+        )
+    }
+}
+
+fn has_non_scalable_viewport(content: &str) -> bool {
+    content.split(',').any(|directive| {
+        let Some((property, value)) = directive.split_once('=') else {
+            return false;
+        };
+
+        property.trim().eq_ignore_ascii_case("user-scalable")
+            && value.trim().eq_ignore_ascii_case("no")
+    })
+}

--- a/crates/biome_html_analyze/tests/specs/nursery/noNonScalableViewport/invalid.html
+++ b/crates/biome_html_analyze/tests/specs/nursery/noNonScalableViewport/invalid.html
@@ -1,0 +1,4 @@
+<!-- should generate diagnostics -->
+<meta name="viewport" content="width=device-width, user-scalable=no">
+<meta NAME="VIEWPORT" CONTENT="user-scalable = no, initial-scale=1" />
+<meta name="viewport" content="USER-SCALABLE=NO" />

--- a/crates/biome_html_analyze/tests/specs/nursery/noNonScalableViewport/invalid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/nursery/noNonScalableViewport/invalid.html.snap
@@ -1,0 +1,74 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.html
+---
+# Input
+```html
+<!-- should generate diagnostics -->
+<meta name="viewport" content="width=device-width, user-scalable=no">
+<meta NAME="VIEWPORT" CONTENT="user-scalable = no, initial-scale=1" />
+<meta name="viewport" content="USER-SCALABLE=NO" />
+
+```
+
+# Diagnostics
+```
+invalid.html:2:23 lint/nursery/noNonScalableViewport ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The viewport disables user scaling.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <meta name="viewport" content="width=device-width, user-scalable=no">
+      │                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ <meta NAME="VIEWPORT" CONTENT="user-scalable = no, initial-scale=1" />
+    4 │ <meta name="viewport" content="USER-SCALABLE=NO" />
+  
+  i Disabling zoom can make page content difficult to read for people with low vision.
+  
+  i Remove the user-scalable=no directive from the content attribute.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.html:3:23 lint/nursery/noNonScalableViewport ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The viewport disables user scaling.
+  
+    1 │ <!-- should generate diagnostics -->
+    2 │ <meta name="viewport" content="width=device-width, user-scalable=no">
+  > 3 │ <meta NAME="VIEWPORT" CONTENT="user-scalable = no, initial-scale=1" />
+      │                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ <meta name="viewport" content="USER-SCALABLE=NO" />
+    5 │ 
+  
+  i Disabling zoom can make page content difficult to read for people with low vision.
+  
+  i Remove the user-scalable=no directive from the content attribute.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.html:4:23 lint/nursery/noNonScalableViewport ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The viewport disables user scaling.
+  
+    2 │ <meta name="viewport" content="width=device-width, user-scalable=no">
+    3 │ <meta NAME="VIEWPORT" CONTENT="user-scalable = no, initial-scale=1" />
+  > 4 │ <meta name="viewport" content="USER-SCALABLE=NO" />
+      │                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │ 
+  
+  i Disabling zoom can make page content difficult to read for people with low vision.
+  
+  i Remove the user-scalable=no directive from the content attribute.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/nursery/noNonScalableViewport/invalid.vue
+++ b/crates/biome_html_analyze/tests/specs/nursery/noNonScalableViewport/invalid.vue
@@ -1,0 +1,5 @@
+<!-- should generate diagnostics -->
+<template>
+	<meta :name="'viewport'" :content="'width=device-width, user-scalable=no'" />
+	<meta v-bind:name="'viewport'" v-bind:content="'user-scalable = no'" />
+</template>

--- a/crates/biome_html_analyze/tests/specs/nursery/noNonScalableViewport/invalid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/nursery/noNonScalableViewport/invalid.vue.snap
@@ -1,0 +1,56 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalid.vue
+---
+# Input
+```vue
+<!-- should generate diagnostics -->
+<template>
+	<meta :name="'viewport'" :content="'width=device-width, user-scalable=no'" />
+	<meta v-bind:name="'viewport'" v-bind:content="'user-scalable = no'" />
+</template>
+
+```
+
+# Diagnostics
+```
+invalid.vue:3:27 lint/nursery/noNonScalableViewport ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The viewport disables user scaling.
+  
+    1 │ <!-- should generate diagnostics -->
+    2 │ <template>
+  > 3 │ 	<meta :name="'viewport'" :content="'width=device-width, user-scalable=no'" />
+      │ 	                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ 	<meta v-bind:name="'viewport'" v-bind:content="'user-scalable = no'" />
+    5 │ </template>
+  
+  i Disabling zoom can make page content difficult to read for people with low vision.
+  
+  i Remove the user-scalable=no directive from the content attribute.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.vue:4:33 lint/nursery/noNonScalableViewport ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The viewport disables user scaling.
+  
+    2 │ <template>
+    3 │ 	<meta :name="'viewport'" :content="'width=device-width, user-scalable=no'" />
+  > 4 │ 	<meta v-bind:name="'viewport'" v-bind:content="'user-scalable = no'" />
+      │ 	                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │ </template>
+    6 │ 
+  
+  i Disabling zoom can make page content difficult to read for people with low vision.
+  
+  i Remove the user-scalable=no directive from the content attribute.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/nursery/noNonScalableViewport/valid.html
+++ b/crates/biome_html_analyze/tests/specs/nursery/noNonScalableViewport/valid.html
@@ -1,0 +1,9 @@
+<!-- should not generate diagnostics -->
+<meta name="viewport" content="width=device-width, user-scalable=yes">
+<meta name="viewport" content="width=device-width" />
+<meta name="viewport" content="user-scalable=nope" />
+<meta name="viewport" content="not-user-scalable=no" />
+<meta name="viewport" content="user-scalable" />
+<meta name="other" content="user-scalable=no" />
+<meta content="user-scalable=no" />
+<div name="viewport" content="user-scalable=no"></div>

--- a/crates/biome_html_analyze/tests/specs/nursery/noNonScalableViewport/valid.html.snap
+++ b/crates/biome_html_analyze/tests/specs/nursery/noNonScalableViewport/valid.html.snap
@@ -1,0 +1,17 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.html
+---
+# Input
+```html
+<!-- should not generate diagnostics -->
+<meta name="viewport" content="width=device-width, user-scalable=yes">
+<meta name="viewport" content="width=device-width" />
+<meta name="viewport" content="user-scalable=nope" />
+<meta name="viewport" content="not-user-scalable=no" />
+<meta name="viewport" content="user-scalable" />
+<meta name="other" content="user-scalable=no" />
+<meta content="user-scalable=no" />
+<div name="viewport" content="user-scalable=no"></div>
+
+```

--- a/crates/biome_html_analyze/tests/specs/nursery/noNonScalableViewport/valid.vue
+++ b/crates/biome_html_analyze/tests/specs/nursery/noNonScalableViewport/valid.vue
@@ -1,0 +1,7 @@
+<!-- should not generate diagnostics -->
+<template>
+	<meta :name="name" :content="content" />
+	<meta name="viewport" :content="content" />
+	<meta name="viewport" content="user-scalable=yes" />
+	<Meta name="viewport" content="user-scalable=no" />
+</template>

--- a/crates/biome_html_analyze/tests/specs/nursery/noNonScalableViewport/valid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/nursery/noNonScalableViewport/valid.vue.snap
@@ -1,0 +1,15 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: valid.vue
+---
+# Input
+```vue
+<!-- should not generate diagnostics -->
+<template>
+	<meta :name="name" :content="content" />
+	<meta name="viewport" :content="content" />
+	<meta name="viewport" content="user-scalable=yes" />
+	<Meta name="viewport" content="user-scalable=no" />
+</template>
+
+```

--- a/crates/biome_js_analyze/src/lint/nursery/no_non_scalable_viewport.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_non_scalable_viewport.rs
@@ -1,0 +1,104 @@
+use biome_analyze::{
+    Ast, Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule,
+};
+use biome_console::markup;
+use biome_diagnostics::Severity;
+use biome_js_syntax::jsx_ext::AnyJsxElement;
+use biome_rowan::{AstNode, TextRange};
+use biome_rule_options::no_non_scalable_viewport::NoNonScalableViewportOptions;
+
+declare_lint_rule! {
+    /// Disallow disabling zoom with `user-scalable=no` in the `<meta name="viewport">` element.
+    ///
+    /// Disabling zoom can make page content difficult to read for people with low vision.
+    ///
+    /// See [WCAG 1.4.4](https://www.w3.org/WAI/WCAG21/Understanding/resize-text.html) and the
+    /// [html-eslint rule](https://html-eslint.org/docs/rules/no-non-scalable-viewport) for details.
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```jsx,expect_diagnostic
+    /// <meta name="viewport" content="width=device-width, user-scalable=no" />
+    /// ```
+    ///
+    /// ```jsx,expect_diagnostic
+    /// <meta name={"viewport"} content={"user-scalable=no"} />
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```jsx
+    /// <>
+    ///   <meta name="viewport" content="width=device-width, user-scalable=yes" />
+    ///   <meta name="viewport" content="width=device-width" />
+    ///   <Meta name="viewport" content="user-scalable=no" />
+    /// </>
+    /// ```
+    ///
+    pub NoNonScalableViewport {
+        version: "next",
+        name: "noNonScalableViewport",
+        language: "jsx",
+        recommended: false,
+        severity: Severity::Error,
+        sources: &[RuleSource::HtmlEslint("no-non-scalable-viewport").inspired()],
+    }
+}
+
+impl Rule for NoNonScalableViewport {
+    type Query = Ast<AnyJsxElement>;
+    type State = TextRange;
+    type Signals = Option<Self::State>;
+    type Options = NoNonScalableViewportOptions;
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let element = ctx.query();
+        let name = element.name_value_token().ok()?;
+
+        if name.text_trimmed() != "meta" {
+            return None;
+        }
+
+        let name_attribute = element.find_attribute_by_name("name")?;
+        let content_attribute = element.find_attribute_by_name("content")?;
+        let name_value = name_attribute.as_static_value()?;
+        let content_value = content_attribute.as_static_value()?;
+
+        if !name_value.text().eq_ignore_ascii_case("viewport") {
+            return None;
+        }
+
+        has_non_scalable_viewport(content_value.text()).then_some(content_attribute.range())
+    }
+
+    fn diagnostic(_ctx: &RuleContext<Self>, range: &Self::State) -> Option<RuleDiagnostic> {
+        Some(
+            RuleDiagnostic::new(
+                rule_category!(),
+                *range,
+                markup! {
+                    "The viewport disables user scaling."
+                },
+            )
+            .note(markup! {
+                "Disabling zoom can make page content difficult to read for people with low vision."
+            })
+            .note(markup! {
+                "Remove the "<Emphasis>"user-scalable=no"</Emphasis>" directive from the "<Emphasis>"content"</Emphasis>" attribute."
+            }),
+        )
+    }
+}
+
+fn has_non_scalable_viewport(content: &str) -> bool {
+    content.split(',').any(|directive| {
+        let Some((property, value)) = directive.split_once('=') else {
+            return false;
+        };
+
+        property.trim().eq_ignore_ascii_case("user-scalable")
+            && value.trim().eq_ignore_ascii_case("no")
+    })
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noNonScalableViewport/invalid.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/noNonScalableViewport/invalid.jsx
@@ -1,0 +1,10 @@
+/* should generate diagnostics */
+const Invalid = () => (
+	<>
+		<meta name="viewport" content="width=device-width, user-scalable=no" />
+		<meta name="viewport" content="user-scalable=no"></meta>
+		<meta name="viewport" content="user-scalable = no, width=device-width" />
+		<meta name={"VIEWPORT"} content={"USER-SCALABLE=NO"} />
+		<meta name="viewport" content={`user-scalable=no`} />
+	</>
+);

--- a/crates/biome_js_analyze/tests/specs/nursery/noNonScalableViewport/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noNonScalableViewport/invalid.jsx.snap
@@ -1,0 +1,124 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid.jsx
+---
+# Input
+```jsx
+/* should generate diagnostics */
+const Invalid = () => (
+	<>
+		<meta name="viewport" content="width=device-width, user-scalable=no" />
+		<meta name="viewport" content="user-scalable=no"></meta>
+		<meta name="viewport" content="user-scalable = no, width=device-width" />
+		<meta name={"VIEWPORT"} content={"USER-SCALABLE=NO"} />
+		<meta name="viewport" content={`user-scalable=no`} />
+	</>
+);
+
+```
+
+# Diagnostics
+```
+invalid.jsx:4:25 lint/nursery/noNonScalableViewport ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The viewport disables user scaling.
+  
+    2 │ const Invalid = () => (
+    3 │ 	<>
+  > 4 │ 		<meta name="viewport" content="width=device-width, user-scalable=no" />
+      │ 		                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │ 		<meta name="viewport" content="user-scalable=no"></meta>
+    6 │ 		<meta name="viewport" content="user-scalable = no, width=device-width" />
+  
+  i Disabling zoom can make page content difficult to read for people with low vision.
+  
+  i Remove the user-scalable=no directive from the content attribute.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.jsx:5:25 lint/nursery/noNonScalableViewport ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The viewport disables user scaling.
+  
+    3 │ 	<>
+    4 │ 		<meta name="viewport" content="width=device-width, user-scalable=no" />
+  > 5 │ 		<meta name="viewport" content="user-scalable=no"></meta>
+      │ 		                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │ 		<meta name="viewport" content="user-scalable = no, width=device-width" />
+    7 │ 		<meta name={"VIEWPORT"} content={"USER-SCALABLE=NO"} />
+  
+  i Disabling zoom can make page content difficult to read for people with low vision.
+  
+  i Remove the user-scalable=no directive from the content attribute.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.jsx:6:25 lint/nursery/noNonScalableViewport ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The viewport disables user scaling.
+  
+    4 │ 		<meta name="viewport" content="width=device-width, user-scalable=no" />
+    5 │ 		<meta name="viewport" content="user-scalable=no"></meta>
+  > 6 │ 		<meta name="viewport" content="user-scalable = no, width=device-width" />
+      │ 		                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    7 │ 		<meta name={"VIEWPORT"} content={"USER-SCALABLE=NO"} />
+    8 │ 		<meta name="viewport" content={`user-scalable=no`} />
+  
+  i Disabling zoom can make page content difficult to read for people with low vision.
+  
+  i Remove the user-scalable=no directive from the content attribute.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.jsx:7:27 lint/nursery/noNonScalableViewport ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The viewport disables user scaling.
+  
+    5 │ 		<meta name="viewport" content="user-scalable=no"></meta>
+    6 │ 		<meta name="viewport" content="user-scalable = no, width=device-width" />
+  > 7 │ 		<meta name={"VIEWPORT"} content={"USER-SCALABLE=NO"} />
+      │ 		                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    8 │ 		<meta name="viewport" content={`user-scalable=no`} />
+    9 │ 	</>
+  
+  i Disabling zoom can make page content difficult to read for people with low vision.
+  
+  i Remove the user-scalable=no directive from the content attribute.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.jsx:8:25 lint/nursery/noNonScalableViewport ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The viewport disables user scaling.
+  
+     6 │ 		<meta name="viewport" content="user-scalable = no, width=device-width" />
+     7 │ 		<meta name={"VIEWPORT"} content={"USER-SCALABLE=NO"} />
+   > 8 │ 		<meta name="viewport" content={`user-scalable=no`} />
+       │ 		                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     9 │ 	</>
+    10 │ );
+  
+  i Disabling zoom can make page content difficult to read for people with low vision.
+  
+  i Remove the user-scalable=no directive from the content attribute.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noNonScalableViewport/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/noNonScalableViewport/valid.jsx
@@ -1,0 +1,19 @@
+/* should not generate diagnostics */
+const dynamicName = "viewport";
+const dynamicContent = "user-scalable=no";
+
+const Valid = () => (
+	<>
+		<div name="viewport" content="user-scalable=no" />
+		<Meta name="viewport" content="user-scalable=no" />
+		<meta name="other" content="user-scalable=no" />
+		<meta name="viewport" />
+		<meta content="user-scalable=no" />
+		<meta name="viewport" content="user-scalable=yes" />
+		<meta name="viewport" content="user-scalable=nope" />
+		<meta name="viewport" content="not-user-scalable=no" />
+		<meta name={dynamicName} content="user-scalable=no" />
+		<meta name="viewport" content={dynamicContent} />
+		<meta {...props} />
+	</>
+);

--- a/crates/biome_js_analyze/tests/specs/nursery/noNonScalableViewport/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noNonScalableViewport/valid.jsx.snap
@@ -1,0 +1,27 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.jsx
+---
+# Input
+```jsx
+/* should not generate diagnostics */
+const dynamicName = "viewport";
+const dynamicContent = "user-scalable=no";
+
+const Valid = () => (
+	<>
+		<div name="viewport" content="user-scalable=no" />
+		<Meta name="viewport" content="user-scalable=no" />
+		<meta name="other" content="user-scalable=no" />
+		<meta name="viewport" />
+		<meta content="user-scalable=no" />
+		<meta name="viewport" content="user-scalable=yes" />
+		<meta name="viewport" content="user-scalable=nope" />
+		<meta name="viewport" content="not-user-scalable=no" />
+		<meta name={dynamicName} content="user-scalable=no" />
+		<meta name="viewport" content={dynamicContent} />
+		<meta {...props} />
+	</>
+);
+
+```

--- a/crates/biome_rule_options/src/lib.rs
+++ b/crates/biome_rule_options/src/lib.rs
@@ -177,6 +177,7 @@ pub mod no_next_async_client_component;
 pub mod no_nodejs_modules;
 pub mod no_non_null_asserted_optional_chain;
 pub mod no_non_null_assertion;
+pub mod no_non_scalable_viewport;
 pub mod no_noninteractive_element_interactions;
 pub mod no_noninteractive_element_to_interactive_role;
 pub mod no_noninteractive_tabindex;

--- a/crates/biome_rule_options/src/no_non_scalable_viewport.rs
+++ b/crates/biome_rule_options/src/no_non_scalable_viewport.rs
@@ -1,0 +1,6 @@
+use biome_deserialize_macros::{Deserializable, Merge};
+use serde::{Deserialize, Serialize};
+#[derive(Default, Clone, Debug, Deserialize, Deserializable, Merge, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields, default)]
+pub struct NoNonScalableViewportOptions {}

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -2463,7 +2463,7 @@ See https://biomejs.dev/linter/rules/no-negation-in-equality-check
 	noNegationInEqualityCheck?: NoNegationInEqualityCheckConfiguration;
 	/**
 	* Disallow disabling zoom with user-scalable=no in the \<meta name="viewport"> element.
-See https://biomejs.dev/linter/rules/no-non-scalable-viewport
+See https://biomejs.dev/linter/rules/no-non-scalable-viewport 
 	 */
 	noNonScalableViewport?: NoNonScalableViewportConfiguration;
 	/**

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -2462,6 +2462,11 @@ See https://biomejs.dev/linter/rules/no-negation-in-equality-check
 	 */
 	noNegationInEqualityCheck?: NoNegationInEqualityCheckConfiguration;
 	/**
+	* Disallow disabling zoom with user-scalable=no in the \<meta name="viewport"> element.
+See https://biomejs.dev/linter/rules/no-non-scalable-viewport
+	 */
+	noNonScalableViewport?: NoNonScalableViewportConfiguration;
+	/**
 	* Disallow usage of element handles (page.$() and page.$$()).
 See https://biomejs.dev/linter/rules/no-playwright-element-handle 
 	 */
@@ -4708,6 +4713,9 @@ export type NoMisusedPromisesConfiguration =
 export type NoNegationInEqualityCheckConfiguration =
 	| RulePlainConfiguration
 	| RuleWithNoNegationInEqualityCheckOptions;
+export type NoNonScalableViewportConfiguration =
+	| RulePlainConfiguration
+	| RuleWithNoNonScalableViewportOptions;
 export type NoPlaywrightElementHandleConfiguration =
 	| RulePlainConfiguration
 	| RuleWithNoPlaywrightElementHandleOptions;
@@ -6578,6 +6586,10 @@ export interface RuleWithNoNegationInEqualityCheckOptions {
 	level: RulePlainConfiguration;
 	options?: NoNegationInEqualityCheckOptions;
 }
+export interface RuleWithNoNonScalableViewportOptions {
+	level: RulePlainConfiguration;
+	options?: NoNonScalableViewportOptions;
+}
 export interface RuleWithNoPlaywrightElementHandleOptions {
 	fix?: FixKind;
 	level: RulePlainConfiguration;
@@ -8346,6 +8358,7 @@ export type NoLoopFuncOptions = {};
 export type NoMisleadingReturnTypeOptions = {};
 export type NoMisusedPromisesOptions = {};
 export type NoNegationInEqualityCheckOptions = {};
+export type NoNonScalableViewportOptions = {};
 export type NoPlaywrightElementHandleOptions = {};
 export type NoPlaywrightEvalOptions = {};
 export type NoPlaywrightForceOptionOptions = {};
@@ -9800,6 +9813,7 @@ export type Category =
 	| "lint/nursery/noMissingGenericFamilyKeyword"
 	| "lint/nursery/noMisusedPromises"
 	| "lint/nursery/noNegationInEqualityCheck"
+	| "lint/nursery/noNonScalableViewport"
 	| "lint/nursery/noPlaywrightElementHandle"
 	| "lint/nursery/noPlaywrightEval"
 	| "lint/nursery/noPlaywrightForceOption"

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -4848,6 +4848,16 @@
 			"type": "object",
 			"additionalProperties": false
 		},
+		"NoNonScalableViewportConfiguration": {
+			"oneOf": [
+				{ "$ref": "#/$defs/RulePlainConfiguration" },
+				{ "$ref": "#/$defs/RuleWithNoNonScalableViewportOptions" }
+			]
+		},
+		"NoNonScalableViewportOptions": {
+			"type": "object",
+			"additionalProperties": false
+		},
 		"NoNoninteractiveElementInteractionsConfiguration": {
 			"oneOf": [
 				{ "$ref": "#/$defs/RulePlainConfiguration" },
@@ -6773,6 +6783,13 @@
 					"description": "Disallow negated expressions on the left side of an equality check.\nSee https://biomejs.dev/linter/rules/no-negation-in-equality-check",
 					"anyOf": [
 						{ "$ref": "#/$defs/NoNegationInEqualityCheckConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noNonScalableViewport": {
+					"description": "Disallow disabling zoom with user-scalable=no in the \\<meta name=\"viewport\"> element.\nSee https://biomejs.dev/linter/rules/no-non-scalable-viewport",
+					"anyOf": [
+						{ "$ref": "#/$defs/NoNonScalableViewportConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -9544,6 +9561,15 @@
 				"fix": { "anyOf": [{ "$ref": "#/$defs/FixKind" }, { "type": "null" }] },
 				"level": { "$ref": "#/$defs/RulePlainConfiguration" },
 				"options": { "$ref": "#/$defs/NoNonNullAssertionOptions" }
+			},
+			"additionalProperties": false,
+			"required": ["level"]
+		},
+		"RuleWithNoNonScalableViewportOptions": {
+			"type": "object",
+			"properties": {
+				"level": { "$ref": "#/$defs/RulePlainConfiguration" },
+				"options": { "$ref": "#/$defs/NoNonScalableViewportOptions" }
 			},
 			"additionalProperties": false,
 			"required": ["level"]


### PR DESCRIPTION
Fixes #10982

## Summary

Adds the opt-in nursery `noNonScalableViewport` rule for HTML and JSX. It reports static viewport metadata containing `user-scalable=no`, with WCAG guidance and no autofix.

This PR was implemented with help from Codex AI assistant.

## Test Plan

- `just test-lintrule noNonScalableViewport`
- `just test-doc`
- `just f`
- `just l`

## Docs

Rule documentation, fixtures, generated configuration, and a patch changeset are included.

