### PR TITLE
feat(css): js traverse, source order paths, cache traverse

### DIFF
--- a/crates/biome_css_semantic/src/semantic_model/model.rs
+++ b/crates/biome_css_semantic/src/semantic_model/model.rs
@@ -116,11 +116,18 @@ pub(crate) struct SemanticModelData {
     pub(crate) all_rules: Vec<RuleData>,
     /// IDs of top-level rules only
     pub(crate) top_level_rule_ids: Vec<RuleId>,
-    /// Map of names declared in `:root` or through an `@property` rule.
+    /// Custom property names declared in `:root` or by an `@property` rule.
+    ///
+    /// The associated data retains the `:root` declaration. `@property` data is
+    /// stored separately because the same name may be declared more than once.
     pub(crate) global_custom_variables: FxHashMap<TokenText, CssGlobalCustomVariableData>,
-    /// Authored `@property` rules in source order.
+    /// Every authored `@property` rule in source order, including declarations
+    /// shadowed by a later rule with the same name.
     pub(crate) at_property_rules: Vec<CssPropertyAtRuleData>,
-    /// Index of the last authored `@property` rule for each name.
+    /// The effective `@property` rule for each name.
+    ///
+    /// Each value indexes the last matching declaration in
+    /// [`Self::at_property_rules`].
     pub(crate) last_at_property_by_name: FxHashMap<TokenText, usize>,
     /// Map from text range to RuleId
     pub(crate) range_to_rule_id: BTreeMap<TextRange, RuleId>,

--- a/crates/biome_js_analyze/src/lint/correctness/no_private_imports.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_private_imports.rs
@@ -174,7 +174,7 @@ impl Rule for NoPrivateImports {
             .is_static_import()
             .then(|| node.inner_string_text())
             .flatten()
-            .and_then(|specifier| module_info.static_import_paths.get(specifier.text()))
+            .and_then(|specifier| module_info.import_paths.get(specifier.text()))
             .and_then(JsImportPath::as_path)
             .filter(|path| !BiomePath::new(path).is_dependency())
         else {

--- a/crates/biome_js_analyze/src/lint/suspicious/no_import_cycles.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_import_cycles.rs
@@ -171,10 +171,11 @@ impl Rule for NoImportCycles {
         let JsImportPath {
             resolved_path,
             phase,
+            ..
         } = module_info.get_import_path_by_js_node(node)?;
 
         let options = ctx.options();
-        if options.ignore_types() && *phase == JsImportPhase::Type {
+        if options.ignore_types() && node.is_static_import() && *phase == JsImportPhase::Type {
             return None;
         }
 
@@ -252,9 +253,10 @@ fn find_cycle(
         for JsImportPath {
             resolved_path,
             phase,
+            kind,
         } in module_info.all_import_paths()
         {
-            if options.ignore_types() && phase == JsImportPhase::Type {
+            if options.ignore_types() && !kind.is_dynamic() && phase == JsImportPhase::Type {
                 continue;
             }
 

--- a/crates/biome_module_graph/src/css_module_info/mod.rs
+++ b/crates/biome_module_graph/src/css_module_info/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod traverse;
 mod visitor;
 
+use crate::ImportPathMap;
 use biome_languages::css::EmbeddingStyleApplicability;
 use biome_resolver::ResolvedPath;
 use biome_rowan::{Text, TextRange, TextSize, TokenText};
@@ -8,7 +9,7 @@ use camino::Utf8PathBuf;
 use indexmap::IndexMap;
 use std::collections::BTreeSet;
 use std::hash::{Hash, Hasher};
-use std::ops::{Deref, DerefMut};
+use std::ops::Deref;
 use std::sync::Arc;
 pub use traverse::{CssClassStep, CssTraversalStep, ImportTreeDisplay, ImportTreeNode};
 pub(crate) use visitor::CssModuleVisitor;
@@ -135,7 +136,7 @@ impl CssModuleInfo {
                 .0
                 .imports
                 .iter()
-                .map(|(_, static_import)| static_import.specifier.to_string())
+                .map(|import| import.specifier.to_string())
                 .collect(),
             classes: self
                 .0
@@ -151,10 +152,8 @@ impl CssModuleInfo {
 pub struct CssModuleInfoInner {
     /// Map of all static imports found in the module.
     ///
-    /// Maps each import occurrence's source range to a [CssImport], preserving
-    /// duplicate imports and source order. The resolved path may be looked up as
-    /// a key in the [ModuleGraph::data] map, although it is not required to exist
-    /// (for instance, if the path is outside the project's scope).
+    /// Preserves duplicate imports and source order. Resolved paths may be
+    /// looked up in the module graph, although they are not required to exist.
     pub imports: CssImports,
 
     /// Map of all CSS class names to their selector ranges in this file.
@@ -168,22 +167,7 @@ pub struct CssModuleInfoInner {
     pub classes: IndexMap<TextRange, TokenText>,
 }
 
-#[derive(Debug, Default, Clone)]
-pub struct CssImports(pub(crate) IndexMap<TextRange, CssImport>);
-
-impl Deref for CssImports {
-    type Target = IndexMap<TextRange, CssImport>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for CssImports {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
+pub type CssImports = ImportPathMap<CssImport>;
 
 /// Represents an import to one or more symbols from an external path.
 ///
@@ -191,6 +175,9 @@ impl DerefMut for CssImports {
 /// images, and so on.
 #[derive(Clone, Debug, PartialEq, Hash, Eq)]
 pub struct CssImport {
+    /// Source range of this import occurrence.
+    pub range: TextRange,
+
     /// The specifier for the imported as it appeared in the source text.
     pub specifier: Text,
 

--- a/crates/biome_module_graph/src/css_module_info/traverse.rs
+++ b/crates/biome_module_graph/src/css_module_info/traverse.rs
@@ -1,9 +1,7 @@
-use crate::CssPropertyDefinition;
 use crate::db::ModuleDb;
 use crate::module_graph::{ModuleInfo, ModuleInfoKind};
-use crate::traverse::{
-    UpwardTraversal, UpwardTraversalAction, UpwardTraversalVisitor, UpwardTraversalWork,
-};
+use crate::traverse::{UpwardTraversalAction, UpwardTraversalVisitor};
+use crate::{CssPropertyDefinition, JsImportPath, JsImportPhase, JsModuleInfo};
 use biome_console::markup;
 use biome_css_semantic::db::{
     css_property_definitions_from_snippet, css_property_definitions_from_source,
@@ -62,7 +60,6 @@ pub struct ImportTreeNode {
 /// from global inline styles.
 pub(crate) struct CssClassTraversal<'db> {
     db: &'db dyn ModuleDb,
-    stack: Vec<UpwardTraversalWork<CssClassStep, ()>>,
     visited: FxHashSet<Utf8PathBuf>,
 }
 
@@ -74,7 +71,6 @@ impl<'db> CssClassTraversal<'db> {
     pub(crate) fn new(db: &'db dyn ModuleDb, start: &Utf8Path) -> Self {
         Self {
             db,
-            stack: vec![UpwardTraversalWork::explore(start.to_path_buf(), ())],
             visited: [start.to_path_buf()].into_iter().collect(),
         }
     }
@@ -83,6 +79,10 @@ impl<'db> CssClassTraversal<'db> {
 impl UpwardTraversalVisitor for CssClassTraversal<'_> {
     type Branch = ();
     type Item = CssClassStep;
+
+    fn db(&self) -> &dyn ModuleDb {
+        self.db
+    }
 
     fn should_visit_importer(
         &self,
@@ -113,16 +113,16 @@ impl UpwardTraversalVisitor for CssClassTraversal<'_> {
 
         let items = match importer {
             ModuleInfoKind::Js(js_info) => js_info
-                .static_import_paths
-                .values()
+                .import_paths
+                .iter()
+                .filter(|import| import.kind.is_static())
                 .filter_map(|import_path| css_class_step(db, import_path.as_path()?))
                 .collect(),
             ModuleInfoKind::Html(html_info) => {
                 let mut items = html_info
                     .imported_stylesheets
                     .iter()
-                    .chain(html_info.static_import_paths.values())
-                    .chain(html_info.dynamic_import_paths.values())
+                    .chain(html_info.import_paths.iter())
                     .filter_map(|import_path| css_class_step(db, import_path.as_path()?))
                     .collect::<Vec<_>>();
                 items.push(CssClassStep {
@@ -141,24 +141,16 @@ impl UpwardTraversalVisitor for CssClassTraversal<'_> {
     }
 }
 
-impl UpwardTraversal for CssClassTraversal<'_> {
-    fn db(&self) -> &dyn ModuleDb {
-        self.db
-    }
-
-    fn stack(&mut self) -> &mut Vec<UpwardTraversalWork<Self::Item, Self::Branch>> {
-        &mut self.stack
-    }
-}
-
 /// Finds the nearest CSS `@property` definitions available to a module.
 ///
 /// It searches modules that import the starting module. Each import path is
 /// searched separately and stops at the first definition it finds.
 pub(crate) struct CssPropertyTraversal<'db, 'name> {
+    /// Module information and parsed sources used during the search.
     db: &'db dyn ModuleDb,
-    stack: Vec<UpwardTraversalWork<CssPropertyDefinition, CssPropertyBranch>>,
+    /// Custom property name being resolved.
     name: &'name str,
+    /// Definitions already returned through another import path.
     yielded: FxHashSet<CssPropertyDefinition>,
 }
 
@@ -176,7 +168,7 @@ struct CssPropertyBranchNode {
 
 impl CssPropertyBranch {
     /// Starts a branch with `path` as its first visited module.
-    fn new(path: Utf8PathBuf) -> Self {
+    pub(crate) fn new(path: Utf8PathBuf) -> Self {
         Self::default().with_path(path)
     }
 
@@ -202,12 +194,10 @@ impl CssPropertyBranch {
 }
 
 impl<'db, 'name> CssPropertyTraversal<'db, 'name> {
-    /// Starts a traversal that resolves definitions for `name`.
-    pub(crate) fn new(db: &'db dyn ModuleDb, start: &Utf8Path, name: &'name str) -> Self {
-        let branch = CssPropertyBranch::new(start.to_path_buf());
+    /// Creates a visitor that resolves definitions for `name`.
+    pub(crate) fn new(db: &'db dyn ModuleDb, name: &'name str) -> Self {
         Self {
             db,
-            stack: vec![UpwardTraversalWork::explore(start.to_path_buf(), branch)],
             name,
             yielded: FxHashSet::default(),
         }
@@ -237,84 +227,7 @@ impl<'db, 'name> CssPropertyTraversal<'db, 'name> {
             },
         }
     }
-}
 
-impl UpwardTraversalVisitor for CssPropertyTraversal<'_, '_> {
-    type Branch = CssPropertyBranch;
-    type Item = CssPropertyDefinition;
-
-    fn should_visit_importer(
-        &self,
-        imported_path: &Utf8Path,
-        importer: ModuleInfo,
-        branch: &Self::Branch,
-    ) -> bool {
-        let importer_path = importer.path(self.db);
-        !branch.contains(importer_path) && imports_path(&importer.kind(self.db), imported_path)
-    }
-
-    /// Resolves the definition visible from each authored edge to `imported_path`.
-    ///
-    /// CSS importers prefer their local definition, then preceding sibling
-    /// imports. HTML importers prefer definitions from globally applicable
-    /// embedded styles, then preceding CSS contexts. JavaScript importers search
-    /// preceding CSS contexts.
-    fn visit_importer(
-        &mut self,
-        imported_path: &Utf8Path,
-        importer: ModuleInfo,
-        branch: &Self::Branch,
-    ) -> Vec<UpwardTraversalAction<Self::Item, Self::Branch>> {
-        let db = self.db;
-        let importer_path = importer.path(db);
-        let next_branch = branch.with_path(importer_path.to_path_buf());
-        let importer = importer.kind(db);
-        match importer {
-            ModuleInfoKind::Css(info) => info
-                .imports
-                .iter()
-                .filter(|(_, import)| import.resolved_path.as_path() == Some(imported_path))
-                .map(|(child_range, _)| {
-                    let definition = self.local_property_definition(importer_path).or_else(|| {
-                        self.last_property_in_imports_before(
-                            &info,
-                            *child_range,
-                            next_branch.clone(),
-                        )
-                    });
-                    self.action(definition, next_branch.clone())
-                })
-                .collect(),
-            ModuleInfoKind::Js(info) => {
-                let imports = info
-                    .static_import_paths
-                    .values()
-                    .chain(info.dynamic_import_paths.values())
-                    .filter_map(|import| import.as_path())
-                    .collect::<Vec<_>>();
-                self.actions_for_ordered_imports(imported_path, &imports, next_branch, None)
-            }
-            ModuleInfoKind::Html(info) => {
-                let local_definition = self.global_html_property_definition(importer_path);
-                let imports = info
-                    .imported_stylesheets
-                    .iter()
-                    .chain(info.static_import_paths.values())
-                    .chain(info.dynamic_import_paths.values())
-                    .filter_map(|import| import.as_path())
-                    .collect::<Vec<_>>();
-                self.actions_for_ordered_imports(
-                    imported_path,
-                    &imports,
-                    next_branch,
-                    local_definition,
-                )
-            }
-        }
-    }
-}
-
-impl CssPropertyTraversal<'_, '_> {
     /// Evaluates every occurrence of `imported_path` in an ordered import list.
     ///
     /// For each occurrence, preceding imports are searched from nearest to
@@ -331,8 +244,9 @@ impl CssPropertyTraversal<'_, '_> {
             .enumerate()
             .filter(|(_, path)| **path == imported_path)
             .map(|(child_index, _)| {
+                let preceding_imports = imports.iter().take(child_index);
                 let definition = local_definition.clone().or_else(|| {
-                    imports.iter().take(child_index).rev().find_map(|path| {
+                    preceding_imports.rev().find_map(|path| {
                         self.last_property_in_css_context_from(path, next_branch.clone())
                     })
                 });
@@ -353,12 +267,24 @@ impl CssPropertyTraversal<'_, '_> {
             let branch = CssPropertyBranch::new(path.to_path_buf());
             info.imported_stylesheets
                 .iter()
-                .chain(info.static_import_paths.values())
-                .chain(info.dynamic_import_paths.values())
+                .chain(info.import_paths.iter())
                 .rev()
                 .filter_map(|import| import.as_path())
                 .find_map(|path| self.last_property_in_css_context_from(path, branch.clone()))
         })
+    }
+
+    /// Returns the last visible definition imported by a JavaScript module.
+    pub(crate) fn last_property_in_js_context(
+        &self,
+        path: &Utf8Path,
+    ) -> Option<CssPropertyDefinition> {
+        let info = self.db.js_module_info_for_path(path)?;
+        let branch = CssPropertyBranch::new(path.to_path_buf());
+        js_import_paths_in_source_order(&info)
+            .rev()
+            .filter_map(|import| import.as_path())
+            .find_map(|path| self.last_property_in_css_context_from(path, branch.clone()))
     }
 
     /// Returns the last visible definition in a CSS import context.
@@ -390,7 +316,7 @@ impl CssPropertyTraversal<'_, '_> {
             }
 
             if let Some(info) = self.db.css_module_info_for_path(&path) {
-                stack.extend(info.imports.values().filter_map(|import| {
+                stack.extend(info.imports.iter().filter_map(|import| {
                     let path = import.resolved_path.as_path()?;
                     if branch.contains(path) {
                         return None;
@@ -413,8 +339,8 @@ impl CssPropertyTraversal<'_, '_> {
         info.imports
             .iter()
             .rev()
-            .filter(|(range, _)| range.start() < child_range.start())
-            .find_map(|(_, import)| {
+            .filter(|import| import.range.start() < child_range.start())
+            .find_map(|import| {
                 let path = import.resolved_path.as_path()?;
                 self.last_property_in_css_context_from(path, branch.clone())
             })
@@ -469,35 +395,108 @@ impl CssPropertyTraversal<'_, '_> {
     }
 }
 
-impl UpwardTraversal for CssPropertyTraversal<'_, '_> {
+impl UpwardTraversalVisitor for CssPropertyTraversal<'_, '_> {
+    type Branch = CssPropertyBranch;
+    type Item = CssPropertyDefinition;
+
     fn db(&self) -> &dyn ModuleDb {
         self.db
     }
 
-    fn stack(&mut self) -> &mut Vec<UpwardTraversalWork<Self::Item, Self::Branch>> {
-        &mut self.stack
+    fn should_visit_importer(
+        &self,
+        imported_path: &Utf8Path,
+        importer: ModuleInfo,
+        branch: &Self::Branch,
+    ) -> bool {
+        let importer_path = importer.path(self.db);
+        !branch.contains(importer_path) && imports_path(&importer.kind(self.db), imported_path)
+    }
+
+    /// Resolves the definition visible from each import of `imported_path`.
+    ///
+    /// CSS importers prefer their local definition, then preceding sibling
+    /// imports. HTML importers prefer definitions from globally applicable
+    /// embedded styles, then preceding CSS contexts. JavaScript importers search
+    /// preceding CSS contexts.
+    fn visit_importer(
+        &mut self,
+        imported_path: &Utf8Path,
+        importer: ModuleInfo,
+        branch: &Self::Branch,
+    ) -> Vec<UpwardTraversalAction<Self::Item, Self::Branch>> {
+        let db = self.db;
+        let importer_path = importer.path(db);
+        let next_branch = branch.with_path(importer_path.to_path_buf());
+        let importer = importer.kind(db);
+        match importer {
+            ModuleInfoKind::Css(info) => info
+                .imports
+                .iter()
+                .filter(|import| import.resolved_path.as_path() == Some(imported_path))
+                .map(|child_import| {
+                    let local_definition = self.local_property_definition(importer_path);
+                    let definition = local_definition.or_else(|| {
+                        self.last_property_in_imports_before(
+                            &info,
+                            child_import.range,
+                            next_branch.clone(),
+                        )
+                    });
+                    self.action(definition, next_branch.clone())
+                })
+                .collect(),
+            ModuleInfoKind::Js(info) => {
+                let imports = js_import_paths_in_source_order(&info)
+                    .filter_map(|import| import.as_path())
+                    .collect::<Vec<_>>();
+                self.actions_for_ordered_imports(imported_path, &imports, next_branch, None)
+            }
+            ModuleInfoKind::Html(info) => {
+                let local_definition = self.global_html_property_definition(importer_path);
+                let imports = info
+                    .imported_stylesheets
+                    .iter()
+                    .chain(info.import_paths.iter())
+                    .filter_map(|import| import.as_path())
+                    .collect::<Vec<_>>();
+                self.actions_for_ordered_imports(
+                    imported_path,
+                    &imports,
+                    next_branch,
+                    local_definition,
+                )
+            }
+        }
     }
 }
 
-/// Returns whether `module` imports `path` through a supported import edge.
+/// Returns whether `module` imports `path` through a supported import.
 fn imports_path(module: &ModuleInfoKind, path: &Utf8Path) -> bool {
     match module {
         ModuleInfoKind::Js(info) => info
-            .static_import_paths
-            .values()
-            .chain(info.dynamic_import_paths.values())
+            .import_paths
+            .iter()
+            .filter(|import| import.kind.is_dynamic() || import.phase != JsImportPhase::Type)
             .any(|import| import.as_path() == Some(path)),
         ModuleInfoKind::Css(info) => info
             .imports
-            .values()
+            .iter()
             .any(|import| import.resolved_path.as_path() == Some(path)),
         ModuleInfoKind::Html(info) => info
             .imported_stylesheets
             .iter()
-            .chain(info.static_import_paths.values())
-            .chain(info.dynamic_import_paths.values())
+            .chain(info.import_paths.iter())
             .any(|import| import.as_path() == Some(path)),
     }
+}
+
+fn js_import_paths_in_source_order(
+    info: &JsModuleInfo,
+) -> impl DoubleEndedIterator<Item = &JsImportPath> {
+    info.import_paths
+        .iter()
+        .filter(|import| import.kind.is_dynamic() || import.phase != JsImportPhase::Type)
 }
 
 /// Returns the CSS classes defined by the module at `path`, or `None` when the

--- a/crates/biome_module_graph/src/css_module_info/visitor.rs
+++ b/crates/biome_module_graph/src/css_module_info/visitor.rs
@@ -91,9 +91,10 @@ impl<'a> CssModuleVisitor<'a> {
         let resolved_path = self.resolved_path_from_specifier(&specifier);
 
         let text: Text = specifier.into();
-        imports.insert(
-            node.range(),
+        imports.push(
+            text.clone(),
             CssImport {
+                range: node.range(),
                 specifier: text,
                 resolved_path,
             },

--- a/crates/biome_module_graph/src/db/queries/css.rs
+++ b/crates/biome_module_graph/src/db/queries/css.rs
@@ -1,6 +1,8 @@
 use super::SymbolFromModuleInfo;
-use crate::css_module_info::traverse::{CssClassStep, CssClassTraversal, CssPropertyTraversal};
-use crate::traverse::UpwardTraversal;
+use crate::css_module_info::traverse::{
+    CssClassStep, CssClassTraversal, CssPropertyBranch, CssPropertyTraversal,
+};
+use crate::traverse::UpwardTraversalVisitor;
 use crate::{CssPropertyDefinition, ImportTreeNode, ModuleDb, ModuleInfo, ModuleInfoKind};
 use biome_css_syntax::{TextRange, TextSize};
 use camino::{Utf8Path, Utf8PathBuf};
@@ -22,7 +24,11 @@ pub fn css_classes_for_module(db: &dyn ModuleDb, module: ModuleInfo) -> Vec<CssC
     };
 
     let mut results = Vec::new();
-    for import_path in js_info.static_import_paths.values() {
+    for import_path in js_info
+        .import_paths
+        .iter()
+        .filter(|import| import.kind.is_static())
+    {
         if let Some(path) = import_path.as_path()
             && let Some(target) = db.module_for_path(path)
             && let ModuleInfoKind::Css(css_info) = target.kind(db)
@@ -62,13 +68,12 @@ pub fn transitive_importers_of(db: &dyn ModuleDb, module: ModuleInfo) -> Vec<Utf
             }
             let imports_current = match &module_info {
                 ModuleInfoKind::Js(js_info) => js_info
-                    .static_import_paths
-                    .values()
-                    .chain(js_info.dynamic_import_paths.values())
+                    .import_paths
+                    .iter()
                     .any(|p| p.as_path() == Some(current.as_path())),
                 ModuleInfoKind::Css(css_info) => css_info
                     .imports
-                    .values()
+                    .iter()
                     .any(|p| p.resolved_path.as_path() == Some(current.as_path())),
                 ModuleInfoKind::Html(html_info) => {
                     html_info
@@ -76,12 +81,8 @@ pub fn transitive_importers_of(db: &dyn ModuleDb, module: ModuleInfo) -> Vec<Utf
                         .iter()
                         .any(|p| p.as_path() == Some(current.as_path()))
                         || html_info
-                            .static_import_paths
-                            .values()
-                            .any(|p| p.as_path() == Some(current.as_path()))
-                        || html_info
-                            .dynamic_import_paths
-                            .values()
+                            .import_paths
+                            .iter()
                             .any(|p| p.as_path() == Some(current.as_path()))
                 }
             };
@@ -116,7 +117,11 @@ pub fn traverse_import_tree_for_classes(
     let mut results = Vec::new();
 
     if let Some(js_info) = db.js_module_info_for_path(module.path(db)) {
-        for import_path in js_info.static_import_paths.values() {
+        for import_path in js_info
+            .import_paths
+            .iter()
+            .filter(|import| import.kind.is_static())
+        {
             if let Some(path) = import_path.as_path()
                 && let Some(css_info) = db.css_module_info_for_path(path)
             {
@@ -128,7 +133,8 @@ pub fn traverse_import_tree_for_classes(
         }
     }
 
-    let traversal = CssClassTraversal::new(db, module.path(db)).into_upward_iter();
+    let start = module.path(db);
+    let traversal = CssClassTraversal::new(db, start).into_upward_iter(start.to_path_buf(), ());
     results.extend(traversal);
     results
 }
@@ -171,11 +177,7 @@ pub fn traverse_import_tree_for_html_classes(
             }
         }
 
-        for import_path in html_info
-            .static_import_paths
-            .values()
-            .chain(html_info.dynamic_import_paths.values())
-        {
+        for import_path in html_info.import_paths.iter() {
             if let Some(path) = import_path.as_path()
                 && let Some(css_info) = db.css_module_info_for_path(path)
             {
@@ -190,19 +192,23 @@ pub fn traverse_import_tree_for_html_classes(
     inline_steps
         .into_iter()
         .chain(linked_steps)
-        .chain(CssClassTraversal::new(db, module.path(db)).into_upward_iter())
+        .chain(
+            CssClassTraversal::new(db, module.path(db))
+                .into_upward_iter(module.path(db).to_path_buf(), ()),
+        )
         .collect()
 }
 
-/// Returns the nearest visible `@property` definitions for a CSS or HTML-like module.
+/// Returns the nearest visible `@property` definitions for a CSS, JavaScript, or HTML-like module.
 ///
 /// A CSS module's local definition takes precedence over definitions reached
-/// through its imports. An HTML-like module first searches all of its embedded
-/// styles, including component-scoped styles, before its linked stylesheets and
-/// imports. Every importer is then traversed as an independent branch. A branch
-/// stops at its first visible definition, and only sibling imports authored
-/// before the child edge are visible. Component-scoped styles do not escape an
-/// HTML-like importer.
+/// through its imports. A JavaScript module searches the CSS files it imports.
+/// An HTML-like module first searches all of its embedded styles, including
+/// component-scoped styles, before its linked stylesheets and imports. Every
+/// importer is then traversed as an independent branch. A branch stops at its
+/// first visible definition, and only sibling imports authored before the child
+/// edge are visible. Component-scoped styles do not escape an HTML-like
+/// importer.
 /// Definitions reached through the same authored rule are deduplicated, while
 /// definitions from separate branches remain separate. Result order is
 /// unspecified.
@@ -214,17 +220,22 @@ pub fn css_property_definitions<'db>(
     let module = *property.module(db);
     let path = module.path(db);
     let name = property.name(db);
-    let traversal = CssPropertyTraversal::new(db, path, &name);
+    let traversal = CssPropertyTraversal::new(db, &name);
     let definition = match module.kind(db) {
         ModuleInfoKind::Css(_) => traversal.last_property_in_css_context(path),
         ModuleInfoKind::Html(_) => traversal.last_property_in_html_context(path),
-        ModuleInfoKind::Js(_) => return Vec::new(),
+        ModuleInfoKind::Js(_) => traversal.last_property_in_js_context(path),
     };
     if let Some(definition) = definition {
         return vec![definition];
     }
 
-    traversal.into_upward_iter().collect()
+    traversal
+        .into_upward_iter(
+            path.to_path_buf(),
+            CssPropertyBranch::new(path.to_path_buf()),
+        )
+        .collect()
 }
 
 /// Returns `true` if the given CSS `class_name` is referenced in any
@@ -314,8 +325,9 @@ pub fn build_import_tree_for_js(db: &dyn ModuleDb, module: ModuleInfo) -> Option
 
     if let Some(js_info) = module.kind(db).as_js_module_info() {
         root.css_imports = js_info
-            .static_import_paths
-            .values()
+            .import_paths
+            .iter()
+            .filter(|import| import.kind.is_static())
             .filter_map(|import_path| {
                 let path = import_path.as_path()?;
                 db.css_module_info_for_path(path)?;
@@ -342,7 +354,7 @@ pub fn build_import_tree_for_html(db: &dyn ModuleDb, module: ModuleInfo) -> Opti
     let css_imports: Vec<_> = html_info
         .imported_stylesheets
         .iter()
-        .chain(html_info.static_import_paths.values())
+        .chain(html_info.import_paths.iter())
         .filter_map(|stylesheet_path| {
             let path = stylesheet_path.as_path()?;
             db.css_module_info_for_path(path)?;
@@ -392,11 +404,7 @@ fn is_class_used_in_component_tree<'db>(
                 {
                     return true;
                 }
-                for import_path in js_info
-                    .static_import_paths
-                    .values()
-                    .chain(js_info.dynamic_import_paths.values())
-                {
+                for import_path in js_info.import_paths.iter() {
                     if let Some(path) = import_path.as_path()
                         && let Some(module) = db.module_for_path(path)
                     {
@@ -445,7 +453,7 @@ fn search_css_class_transitive<'db>(
         }
 
         // Follow @import edges
-        for import in css_info.imports.values() {
+        for import in css_info.imports.iter() {
             if let Some(imported_path) = import.resolved_path.as_path()
                 && let Some(module) = db.module_for_path(imported_path)
             {
@@ -472,15 +480,13 @@ pub(crate) fn build_parent_nodes(
 
         let imports_current = match module_info {
             ModuleInfoKind::Js(js_info) => js_info
-                .static_import_paths
-                .values()
-                .chain(js_info.dynamic_import_paths.values())
+                .import_paths
+                .iter()
                 .any(|p| p.as_path() == Some(current_path)),
             ModuleInfoKind::Html(html_info) => html_info
                 .imported_stylesheets
                 .iter()
-                .chain(html_info.static_import_paths.values())
-                .chain(html_info.dynamic_import_paths.values())
+                .chain(html_info.import_paths.iter())
                 .any(|p| p.as_path() == Some(current_path)),
             ModuleInfoKind::Css(_) => false,
         };
@@ -488,8 +494,9 @@ pub(crate) fn build_parent_nodes(
         if imports_current {
             let css_imports: Vec<Utf8PathBuf> = match module_info {
                 ModuleInfoKind::Js(js_info) => js_info
-                    .static_import_paths
-                    .values()
+                    .import_paths
+                    .iter()
+                    .filter(|import| import.kind.is_static())
                     .filter_map(|import_path| {
                         let path = import_path.as_path()?;
                         db.css_module_info_for_path(path)?;
@@ -499,8 +506,7 @@ pub(crate) fn build_parent_nodes(
                 ModuleInfoKind::Html(html_info) => html_info
                     .imported_stylesheets
                     .iter()
-                    .chain(html_info.static_import_paths.values())
-                    .chain(html_info.dynamic_import_paths.values())
+                    .chain(html_info.import_paths.iter())
                     .filter_map(|stylesheet_path| {
                         let path = stylesheet_path.as_path()?;
                         db.css_module_info_for_path(path)?;

--- a/crates/biome_module_graph/src/db/type_inference/mod.rs
+++ b/crates/biome_module_graph/src/db/type_inference/mod.rs
@@ -249,8 +249,9 @@ fn inference_scc(
         db.unwind_if_revision_cancelled();
 
         let dependency_paths = source_info
-            .static_import_paths
-            .values()
+            .import_paths
+            .iter()
+            .filter(|import| import.kind.is_static())
             .map(|import| &import.resolved_path)
             .chain(
                 source_info

--- a/crates/biome_module_graph/src/format_module_graph.rs
+++ b/crates/biome_module_graph/src/format_module_graph.rs
@@ -516,11 +516,11 @@ impl Format<FormatTypeContext> for CssImports {
         &self,
         f: &mut biome_formatter::formatter::Formatter<FormatTypeContext>,
     ) -> FormatResult<()> {
-        if self.0.is_empty() {
+        if self.is_empty() {
             return write!(f, [token("No imports")]);
         }
         let mut joiner = f.join();
-        for (_, import) in &self.0 {
+        for import in self.iter() {
             let entry = format_with(|f| {
                 write!(
                     f,
@@ -772,8 +772,8 @@ impl Format<FormatTypeContext> for HtmlModuleInfoInner {
 
         let script_imports_section = format_with(|f| {
             let mut sorted: Vec<_> = self
-                .static_import_paths
-                .iter()
+                .import_paths
+                .named_iter()
                 .map(|(specifier, resolved)| {
                     let resolved_str = resolved.as_path().map_or("<unresolved>".to_string(), |p| {
                         p.as_str().replace('\\', "/")

--- a/crates/biome_module_graph/src/html_module_info/mod.rs
+++ b/crates/biome_module_graph/src/html_module_info/mod.rs
@@ -1,11 +1,12 @@
 mod visitor;
 
+use crate::ImportPathMap;
 use crate::css_module_info::{CssClassDefinition, CssClassReference};
 use biome_css_syntax::{AnyCssRoot, TextRange};
 use biome_js_syntax::AnyJsRoot;
 use biome_languages::CssFileSource;
 use biome_resolver::ResolvedPath;
-use biome_rowan::{Text, TextSize, TokenText};
+use biome_rowan::{TextSize, TokenText};
 use indexmap::IndexMap;
 use indexmap::IndexSet;
 use std::collections::BTreeSet;
@@ -59,15 +60,13 @@ impl HtmlModuleInfo {
         style_classes: IndexSet<CssClassDefinition>,
         referenced_classes: Vec<CssClassReference>,
         imported_stylesheets: Vec<ResolvedPath>,
-        static_import_paths: IndexMap<Text, ResolvedPath>,
-        dynamic_import_paths: IndexMap<Text, ResolvedPath>,
+        import_paths: ImportPathMap<ResolvedPath>,
     ) -> Self {
         let info = HtmlModuleInfoInner {
             style_classes,
             referenced_classes,
             imported_stylesheets,
-            static_import_paths,
-            dynamic_import_paths,
+            import_paths,
         };
         Self(Arc::new(info))
     }
@@ -115,15 +114,8 @@ pub struct HtmlModuleInfoInner {
     /// `<link rel="stylesheet" href="...">`.
     pub imported_stylesheets: Vec<ResolvedPath>,
 
-    /// Resolved paths of JS/TS modules imported from embedded `<script>` blocks.
-    ///
-    /// Keys are the raw import specifiers (e.g. `"./Button.vue"`); values are
-    /// their resolved absolute paths. Only static imports (`import … from "…"`)
-    /// are tracked here — dynamic imports are ignored for upward-traversal.
-    pub static_import_paths: IndexMap<Text, ResolvedPath>,
-
-    /// Resolved paths of JS/TS modules imported from dynamic imports.
-    pub dynamic_import_paths: IndexMap<Text, ResolvedPath>,
+    /// Resolved paths imported from embedded `<script>` blocks in source order.
+    pub import_paths: ImportPathMap<ResolvedPath>,
 }
 
 impl HtmlModuleInfoInner {

--- a/crates/biome_module_graph/src/html_module_info/visitor.rs
+++ b/crates/biome_module_graph/src/html_module_info/visitor.rs
@@ -1,3 +1,4 @@
+use crate::ImportPathMap;
 use crate::css_module_info::{CssClassDefinition, CssClassReference};
 use crate::html_module_info::{HtmlEmbeddedContent, HtmlModuleInfo};
 use crate::module_graph::ModuleGraphFsProxy;
@@ -12,7 +13,7 @@ use biome_languages::css::EmbeddingStyleApplicability;
 use biome_resolver::{ResolveOptions, ResolvedPath, resolve};
 use biome_rowan::{AstNode, AstSeparatedList, Text, TextSize, TokenText, WalkEvent};
 use camino::{Utf8Path, Utf8PathBuf};
-use indexmap::{IndexMap, IndexSet};
+use indexmap::IndexSet;
 
 pub const SUPPORTED_CSS_EXTENSIONS: &[&str] = &["css"];
 
@@ -60,8 +61,7 @@ impl<'a> HtmlModuleVisitor<'a> {
         let mut style_classes = IndexSet::default();
         let mut referenced_classes = Vec::new();
         let mut imported_stylesheets = Vec::new();
-        let mut static_import_paths = IndexMap::default();
-        let mut dynamic_import_paths = IndexMap::default();
+        let mut import_paths = ImportPathMap::default();
 
         // Walk the HTML CST to collect class= references and <link> stylesheets.
         // Void elements like <link> and <meta> parse as HtmlSelfClosingElement;
@@ -88,13 +88,9 @@ impl<'a> HtmlModuleVisitor<'a> {
                 HtmlEmbeddedContent::Css(css_root, file_source, content_offset) => {
                     collect_css_classes(css_root, &mut style_classes, file_source, *content_offset);
                 }
-                // JS block: collect static import paths for upward traversal.
+                // JS block: collect import paths for upward traversal.
                 HtmlEmbeddedContent::Js(js_root) => {
-                    self.collect_js_imports(
-                        js_root,
-                        &mut static_import_paths,
-                        &mut dynamic_import_paths,
-                    );
+                    self.collect_js_imports(js_root, &mut import_paths);
                 }
             }
         }
@@ -103,25 +99,21 @@ impl<'a> HtmlModuleVisitor<'a> {
             style_classes,
             referenced_classes,
             imported_stylesheets,
-            static_import_paths,
-            dynamic_import_paths,
+            import_paths,
         )
     }
 
     /// Walks a parsed JS/TS root (from an embedded `<script>` block) and
-    /// collects all static import specifiers with their resolved paths.
+    /// collects all static and dynamic import specifiers with their resolved paths.
     fn collect_js_imports(
         &self,
         js_root: &AnyJsRoot,
-        static_import_paths: &mut IndexMap<Text, ResolvedPath>,
-        dynamic_import_paths: &mut IndexMap<Text, ResolvedPath>,
+        import_paths: &mut ImportPathMap<ResolvedPath>,
     ) {
         for event in js_root.syntax().preorder() {
             let WalkEvent::Enter(node) = event else {
                 continue;
             };
-            // Only handle static module sources (import … from "…").
-            // Skip dynamic imports (import("…") / require("…")).
             if let Some(any_source) = AnyJsImportLike::cast_ref(&node) {
                 match any_source {
                     AnyJsImportLike::JsModuleSource(source) => {
@@ -129,9 +121,7 @@ impl<'a> HtmlModuleVisitor<'a> {
                             continue;
                         };
                         let resolved = self.resolved_js_path_from_specifier(specifier.text());
-                        static_import_paths
-                            .entry(Text::from(specifier))
-                            .or_insert(resolved);
+                        import_paths.insert(Text::from(specifier), resolved);
                     }
                     // require("") isn't actually supported in the environments we're interested in. For example require() shouldn't be
                     // supported in HTML-ish languages.
@@ -155,9 +145,7 @@ impl<'a> HtmlModuleVisitor<'a> {
                         };
 
                         let resolved = self.resolved_js_path_from_specifier(argument.text());
-                        dynamic_import_paths
-                            .entry(Text::from(argument))
-                            .or_insert(resolved);
+                        import_paths.insert(Text::from(argument), resolved);
                     }
                 }
             }

--- a/crates/biome_module_graph/src/import_path_map.rs
+++ b/crates/biome_module_graph/src/import_path_map.rs
@@ -1,0 +1,129 @@
+use biome_rowan::Text;
+use rustc_hash::FxHashMap;
+use std::iter::FusedIterator;
+
+/// Import paths stored in source order with lookup by specifier.
+///
+/// [`Self::insert`] keeps only the last occurrence of a specifier. [`Self::push`]
+/// keeps every occurrence for languages where an import's position is
+/// significant. In both cases, [`Self::get`] returns the last stored occurrence.
+#[derive(Clone, Debug)]
+pub struct ImportPathMap<P> {
+    entries: Vec<(Text, P)>,
+    indices: FxHashMap<Text, usize>,
+}
+
+impl<P> Default for ImportPathMap<P> {
+    fn default() -> Self {
+        Self {
+            entries: Vec::new(),
+            indices: FxHashMap::default(),
+        }
+    }
+}
+
+impl<P> ImportPathMap<P> {
+    /// Replaces an earlier import with the same specifier and moves the new
+    /// value to its source-order position.
+    pub(crate) fn insert(&mut self, specifier: Text, path: P) {
+        self.insert_with(specifier, path, |_, _| {});
+    }
+
+    /// Inserts an import after merging an earlier occurrence with the new path.
+    pub(crate) fn insert_with(
+        &mut self,
+        specifier: Text,
+        mut path: P,
+        merge: impl FnOnce(&P, &mut P),
+    ) {
+        if let Some(index) = self.indices.get(specifier.text()).copied() {
+            debug_assert!(index < self.entries.len());
+            merge(&self.entries[index].1, &mut path);
+            self.entries.remove(index);
+            self.indices.remove(specifier.text());
+            for entry_index in self.indices.values_mut() {
+                if *entry_index > index {
+                    *entry_index -= 1;
+                }
+            }
+        }
+
+        let index = self.entries.len();
+        self.entries.push((specifier.clone(), path));
+        self.indices.insert(specifier, index);
+    }
+
+    /// Appends an import without removing earlier occurrences of its specifier.
+    pub(crate) fn push(&mut self, specifier: Text, path: P) {
+        let index = self.entries.len();
+        self.entries.push((specifier.clone(), path));
+        self.indices.insert(specifier, index);
+    }
+
+    /// Returns the last path stored for `specifier`.
+    pub fn get(&self, specifier: &str) -> Option<&P> {
+        let index = *self.indices.get(specifier)?;
+        self.entries.get(index).map(|(_, path)| path)
+    }
+
+    /// Returns import paths in source order.
+    pub fn iter(&self) -> ImportPathMapIterator<'_, P> {
+        ImportPathMapIterator {
+            inner: self.entries.iter(),
+        }
+    }
+
+    /// Returns specifiers and paths in source order.
+    pub fn named_iter(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = (&Text, &P)> + ExactSizeIterator + FusedIterator {
+        self.entries
+            .iter()
+            .map(|(specifier, path)| (specifier, path))
+    }
+
+    /// Returns the number of stored imports.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Returns `true` when no imports are stored.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub(crate) fn get_index(&self, index: usize) -> Option<&P> {
+        self.entries.get(index).map(|(_, path)| path)
+    }
+}
+
+/// Iterator over import paths in an [`ImportPathMap`].
+pub struct ImportPathMapIterator<'a, P> {
+    inner: std::slice::Iter<'a, (Text, P)>,
+}
+
+impl<'a, P> Iterator for ImportPathMapIterator<'a, P> {
+    type Item = &'a P;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|(_, path)| path)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+impl<P> DoubleEndedIterator for ImportPathMapIterator<'_, P> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner.next_back().map(|(_, path)| path)
+    }
+}
+
+impl<P> ExactSizeIterator for ImportPathMapIterator<'_, P> {
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+}
+
+impl<P> FusedIterator for ImportPathMapIterator<'_, P> {}

--- a/crates/biome_module_graph/src/js_module_info.rs
+++ b/crates/biome_module_graph/src/js_module_info.rs
@@ -7,6 +7,7 @@ pub(crate) use scope::TsBindingReferenceExt;
 mod utils;
 mod visitor;
 
+use crate::ImportPathMap;
 use crate::css_module_info::CssClassReference;
 use biome_js_semantic::{JsDeclarationKind, ScopeId};
 use biome_js_syntax::AnyJsImportLike;
@@ -117,8 +118,9 @@ impl JsModuleInfo {
                 .collect(),
 
             static_import_paths: self
-                .static_import_paths
-                .iter()
+                .import_paths
+                .named_iter()
+                .filter(|(_, import)| import.kind.is_static())
                 .map(|(specifier, JsImportPath { resolved_path, .. })| {
                     (
                         specifier.to_string(),
@@ -134,8 +136,9 @@ impl JsModuleInfo {
                 .collect::<BTreeSet<_>>(),
 
             dynamic_imports: self
-                .dynamic_import_paths
-                .iter()
+                .import_paths
+                .named_iter()
+                .filter(|(_, import)| import.kind.is_dynamic())
                 .map(|(text, _)| text.to_string())
                 .collect::<BTreeSet<_>>(),
 
@@ -157,8 +160,9 @@ impl JsModuleInfo {
             .get(name)
             .and_then(|import| import.resolved_path.as_path())
             .or_else(|| {
-                self.dynamic_import_paths
+                self.import_paths
                     .get(name)
+                    .filter(|import| import.kind.is_dynamic())
                     .and_then(|import| import.resolved_path.as_path())
             })
     }
@@ -223,29 +227,15 @@ pub struct JsModuleInfoInner {
     /// [Self::blanket_reexports].
     pub static_imports: Imports,
 
-    /// Map of all the paths from static imports in the module.
-    ///
-    /// Maps from the source specifier name to a [JsImportPath] with the
-    /// absolute path it resolves to. The resolved path may be looked up as key
-    /// in the [ModuleDb] map, although it is not required to exist
-    /// (for instance, if the path is outside the project's scope).
-    pub static_import_paths: IndexMap<Text, JsImportPath>,
-
-    /// Map of all dynamic import paths found in the module for which the import
-    /// specifier could be statically determined.
+    /// Static and dynamic import paths in source order.
     ///
     /// Dynamic imports for which the specifier cannot be statically determined
     /// (for instance, because a template string with variables is used) will be
-    /// omitted from this map.
-    ///
-    /// Maps from the source specifier name to a [JsImportPath] with the
-    /// absolute path it resolves to. The resolved path may be looked up as key
-    /// in the [ModuleDb] map, although it is not required to exist
-    /// (for instance, if the path is outside the project's scope).
+    /// omitted.
     ///
     /// Paths found in `require()` expressions in CommonJS sources are also
-    /// included with the dynamic import paths.
-    pub dynamic_import_paths: IndexMap<Text, JsImportPath>,
+    /// included as dynamic imports.
+    pub import_paths: ImportPathMap<JsImportPath>,
 
     /// Map of exports from the module.
     ///
@@ -347,10 +337,37 @@ pub enum JsImportPhase {
     Type,
 }
 
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+pub enum JsImportKind {
+    #[default]
+    Static,
+    Dynamic,
+    StaticAndDynamic,
+}
+
+impl JsImportKind {
+    pub const fn is_static(self) -> bool {
+        matches!(self, Self::Static | Self::StaticAndDynamic)
+    }
+
+    pub const fn is_dynamic(self) -> bool {
+        matches!(self, Self::Dynamic | Self::StaticAndDynamic)
+    }
+
+    fn union(self, other: Self) -> Self {
+        if self == other {
+            self
+        } else {
+            Self::StaticAndDynamic
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct JsImportPath {
     pub resolved_path: ResolvedPath,
     pub phase: JsImportPhase,
+    pub kind: JsImportKind,
 }
 
 impl JsImportPath {
@@ -424,12 +441,7 @@ impl JsModuleInfoInner {
     /// Returns the information about a given import by its syntax node.
     pub fn get_import_path_by_js_node(&self, node: &AnyJsImportLike) -> Option<&JsImportPath> {
         let specifier_text = node.inner_string_text()?;
-        let specifier = specifier_text.text();
-        if node.is_static_import() {
-            self.static_import_paths.get(specifier)
-        } else {
-            self.dynamic_import_paths.get(specifier)
-        }
+        self.import_paths.get(specifier_text.text())
     }
 
     pub fn types(&self) -> Vec<&TypeData> {
@@ -556,21 +568,9 @@ impl Iterator for ImportPathIterator {
     type Item = JsImportPath;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let num_static_imports = self.module_info.static_import_paths.len();
-        let resolved_path = if self.index < num_static_imports {
-            let resolved_path = &self.module_info.static_import_paths[self.index];
-            self.index += 1;
-            resolved_path
-        } else if self.index < self.module_info.dynamic_import_paths.len() + num_static_imports {
-            let resolved_path =
-                &self.module_info.dynamic_import_paths[self.index - num_static_imports];
-            self.index += 1;
-            resolved_path
-        } else {
-            return None;
-        };
-
-        Some(resolved_path.clone())
+        let path = self.module_info.import_paths.get_index(self.index)?.clone();
+        self.index += 1;
+        Some(path)
     }
 }
 

--- a/crates/biome_module_graph/src/js_module_info/collector.rs
+++ b/crates/biome_module_graph/src/js_module_info/collector.rs
@@ -23,7 +23,20 @@ use super::{
     is_named_type_declaration,
 };
 use crate::js_module_info::{scope::TsBindingReferenceExt, utils::reached_too_many_types};
-use crate::{BindingTypeData, JsImportPath, JsImportPhase};
+use crate::{BindingTypeData, ImportPathMap, JsImportKind, JsImportPath, JsImportPhase};
+
+fn merge_import_paths(previous: &JsImportPath, current: &mut JsImportPath) {
+    if previous.kind.is_static() && !current.kind.is_static() {
+        current.phase = previous.phase;
+    }
+    current.kind = previous.kind.union(current.kind);
+    if current.phase == JsImportPhase::Type
+        && previous.kind.is_static()
+        && previous.phase != JsImportPhase::Type
+    {
+        current.phase = previous.phase;
+    }
+}
 
 /// Responsible for collecting all the information from which to build the
 /// [`JsModuleInfo`].
@@ -45,13 +58,8 @@ pub(super) struct JsModuleInfoCollector {
     /// Map of parsed declarations, for caching purposes.
     parsed_expressions: FxHashMap<TextRange, ResolvedTypeId>,
 
-    /// Map with all static import paths, from the source specifier to the
-    /// resolved path.
-    static_import_paths: IndexMap<Text, JsImportPath>,
-
-    /// Map with all dynamic import paths, from the import source to the
-    /// resolved path.
-    dynamic_import_paths: IndexMap<Text, JsImportPath>,
+    /// Static and dynamic import paths in source order.
+    import_paths: ImportPathMap<JsImportPath>,
 
     /// All collected exports.
     ///
@@ -138,8 +146,7 @@ impl JsModuleInfoCollector {
             function_parameters: FxHashMap::default(),
             variable_declarations: FxHashMap::default(),
             parsed_expressions: FxHashMap::default(),
-            static_import_paths: IndexMap::new(),
-            dynamic_import_paths: IndexMap::new(),
+            import_paths: ImportPathMap::default(),
             exports: Vec::new(),
             blanket_reexports: Vec::new(),
             types: TypeStore::default(),
@@ -199,8 +206,7 @@ impl JsModuleInfoCollector {
                 let source = node.source().ok()?;
                 let source_token = source.as_js_module_source()?.value_token().ok()?;
                 let source = inner_string_text(&source_token);
-                let JsImportPath { resolved_path, .. } =
-                    self.static_import_paths.get(source.text())?;
+                let JsImportPath { resolved_path, .. } = self.import_paths.get(source.text())?;
 
                 let default_specifier = node.default_specifier().ok()?;
                 let local_name = default_specifier.local_name().ok()?;
@@ -255,8 +261,7 @@ impl JsModuleInfoCollector {
                 let source = node.source().ok()?;
                 let source_token = source.as_js_module_source()?.value_token().ok()?;
                 let source = inner_string_text(&source_token);
-                let JsImportPath { resolved_path, .. } =
-                    self.static_import_paths.get(source.text())?;
+                let JsImportPath { resolved_path, .. } = self.import_paths.get(source.text())?;
 
                 let local_name = node.default_specifier().ok()?.local_name().ok()?;
                 let local_name = local_name.as_js_identifier_binding()?;
@@ -274,8 +279,7 @@ impl JsModuleInfoCollector {
                 let source = node.source().ok()?;
                 let source_token = source.as_js_module_source()?.value_token().ok()?;
                 let source = inner_string_text(&source_token);
-                let JsImportPath { resolved_path, .. } =
-                    self.static_import_paths.get(source.text())?;
+                let JsImportPath { resolved_path, .. } = self.import_paths.get(source.text())?;
 
                 for specifier in node.named_specifiers().ok()?.specifiers() {
                     let specifier = specifier.ok()?;
@@ -300,8 +304,7 @@ impl JsModuleInfoCollector {
                 let source = node.source().ok()?;
                 let source_token = source.as_js_module_source()?.value_token().ok()?;
                 let source = inner_string_text(&source_token);
-                let JsImportPath { resolved_path, .. } =
-                    self.static_import_paths.get(source.text())?;
+                let JsImportPath { resolved_path, .. } = self.import_paths.get(source.text())?;
 
                 let specifier = node.namespace_specifier().ok()?;
                 let local_name = specifier.local_name().ok()?;
@@ -356,13 +359,13 @@ impl JsModuleInfoCollector {
         resolved_path: ResolvedPath,
         phase: JsImportPhase,
     ) {
-        self.static_import_paths.insert(
-            specifier.into(),
-            JsImportPath {
-                resolved_path,
-                phase,
-            },
-        );
+        let import_path = JsImportPath {
+            resolved_path,
+            phase,
+            kind: JsImportKind::Static,
+        };
+        self.import_paths
+            .insert_with(specifier.into(), import_path, merge_import_paths);
     }
 
     pub fn register_dynamic_import_path(
@@ -371,13 +374,13 @@ impl JsModuleInfoCollector {
         resolved_path: ResolvedPath,
         phase: JsImportPhase,
     ) {
-        self.dynamic_import_paths.insert(
-            specifier.into(),
-            JsImportPath {
-                resolved_path,
-                phase,
-            },
-        );
+        let import_path = JsImportPath {
+            resolved_path,
+            phase,
+            kind: JsImportKind::Dynamic,
+        };
+        self.import_paths
+            .insert_with(specifier.into(), import_path, merge_import_paths);
     }
 
     fn finalise(&mut self, semantic_model: &SemanticModel) -> FinalisedModuleTypes {
@@ -1214,8 +1217,7 @@ impl JsModuleInfo {
 
         Self(Arc::new(JsModuleInfoInner {
             static_imports: Imports(collector.static_imports),
-            static_import_paths: collector.static_import_paths,
-            dynamic_import_paths: collector.dynamic_import_paths,
+            import_paths: collector.import_paths,
             exports: Exports(finalised.exports),
             raw_exports: Exports(finalised.raw_exports),
             blanket_reexports: collector.blanket_reexports,

--- a/crates/biome_module_graph/src/js_module_info/module_resolver.rs
+++ b/crates/biome_module_graph/src/js_module_info/module_resolver.rs
@@ -228,7 +228,11 @@ impl ModuleResolver {
         let mut i = 0;
         while i < self.modules.len() {
             let module = self.modules[i].clone();
-            for JsImportPath { resolved_path, .. } in module.static_import_paths.values() {
+            for JsImportPath { resolved_path, .. } in module
+                .import_paths
+                .iter()
+                .filter(|import| import.kind.is_static())
+            {
                 self.register_module(resolved_path.clone());
             }
 
@@ -450,9 +454,9 @@ impl TypeResolver for ModuleResolver {
                 .and_then(|import| {
                     // TODO: Determine if this is a type-only import
                     // JsImport doesn't store phase information directly
-                    // We may need to look it up from static_import_paths
+                    // We may need to look it up from import_paths
                     let type_only = module
-                        .static_import_paths
+                        .import_paths
                         .get(import.specifier.text())
                         .is_some_and(|path| path.phase == crate::JsImportPhase::Type);
 
@@ -536,14 +540,14 @@ fn resolve_binding_as_import(
     }
 
     // Resolve the import directly from static_imports.
-    // Note: We don't need to check dynamic_import_paths because:
+    // Note: We don't need to check dynamic imports because:
     // - Dynamic imports (import('./foo')) return Promises and don't create direct bindings
     // - CommonJS require() calls are expressions that return values, not import bindings
     // - Only static imports (import { foo } from '...') create bindings that
     //   is_binding_imported() recognizes as imported
     let import = module.static_imports.get(name.text())?;
     let type_only = module
-        .static_import_paths
+        .import_paths
         .get(import.specifier.text())
         .is_some_and(|path| path.phase == crate::JsImportPhase::Type);
 

--- a/crates/biome_module_graph/src/lib.rs
+++ b/crates/biome_module_graph/src/lib.rs
@@ -9,6 +9,7 @@ mod db;
 mod diagnostics;
 mod format_module_graph;
 mod html_module_info;
+mod import_path_map;
 pub mod js_module_info;
 mod module_graph;
 mod path_info_cache;
@@ -28,9 +29,10 @@ pub use db::queries::*;
 pub use db::{ModuleDb, ModuleGraphGeneration, TypeDb, module_for_key};
 pub use diagnostics::ModuleDiagnostic;
 pub use html_module_info::{HtmlEmbeddedContent, HtmlModuleInfo, SerializedHtmlModuleInfo};
+pub use import_path_map::{ImportPathMap, ImportPathMapIterator};
 pub use js_module_info::{
-    BindingTypeData, JsExport, JsExportedSymbolLookup, JsImport, JsImportPath, JsImportPhase,
-    JsModuleInfo, JsModuleInfoDiagnostic, JsOwnExport, JsReexport, ModuleResolver,
+    BindingTypeData, JsExport, JsExportedSymbolLookup, JsImport, JsImportKind, JsImportPath,
+    JsImportPhase, JsModuleInfo, JsModuleInfoDiagnostic, JsOwnExport, JsReexport, ModuleResolver,
     SerializedJsModuleInfo, TypeInferenceMode,
 };
 pub use module_graph::{

--- a/crates/biome_module_graph/src/module_graph.rs
+++ b/crates/biome_module_graph/src/module_graph.rs
@@ -111,7 +111,7 @@ pub fn resolve_css_module(
 
     let module = visitor.visit();
     let mut dependencies = ModuleDependencies::default();
-    for (_, import) in module.0.imports.deref() {
+    for import in module.0.imports.iter() {
         if let Some(p) = import.resolved_path.as_path() {
             dependencies.insert(p.to_path_buf());
         }
@@ -146,11 +146,7 @@ pub fn resolve_html_module(
             dependencies.insert(p.to_path_buf());
         }
     }
-    for resolved_path in module
-        .static_import_paths
-        .values()
-        .chain(module.dynamic_import_paths.values())
-    {
+    for resolved_path in module.import_paths.iter() {
         if let Some(p) = resolved_path.as_path() {
             dependencies.insert(p.to_path_buf());
         }

--- a/crates/biome_module_graph/src/traverse.rs
+++ b/crates/biome_module_graph/src/traverse.rs
@@ -35,6 +35,21 @@ pub(crate) trait UpwardTraversalVisitor {
     /// A value yielded by the traversal.
     type Item;
 
+    /// Returns the module database searched for importers.
+    fn db(&self) -> &dyn ModuleDb;
+
+    /// Wraps this visitor in an upward traversal iterator.
+    fn into_upward_iter(
+        self,
+        start: Utf8PathBuf,
+        branch: Self::Branch,
+    ) -> UpwardTraversalIterator<Self>
+    where
+        Self: Sized,
+    {
+        TraversalIterator(UpwardTraversal::new(self, start, branch))
+    }
+
     /// Returns whether `importer` should be visited from `imported_path`.
     fn should_visit_importer(
         &self,
@@ -68,7 +83,7 @@ pub(crate) struct UpwardTraversalAction<Item, Branch> {
 }
 
 /// Work waiting to be processed by an [UpwardTraversal].
-pub(crate) enum UpwardTraversalWork<Item, Branch> {
+enum UpwardTraversalWork<Item, Branch> {
     /// Finds modules that import `imported_path`.
     ExploreImporters {
         imported_path: Utf8PathBuf,
@@ -80,7 +95,7 @@ pub(crate) enum UpwardTraversalWork<Item, Branch> {
 }
 
 impl<Item, Branch> UpwardTraversalWork<Item, Branch> {
-    pub(crate) fn explore(imported_path: Utf8PathBuf, branch: Branch) -> Self {
+    fn explore(imported_path: Utf8PathBuf, branch: Branch) -> Self {
         Self::ExploreImporters {
             imported_path,
             branch,
@@ -92,31 +107,46 @@ impl<Item, Branch> UpwardTraversalWork<Item, Branch> {
 ///
 /// The visitor chooses which importers to visit and whether to continue from
 /// them. Importer and item order are unspecified.
-pub(crate) trait UpwardTraversal: UpwardTraversalVisitor {
-    fn db(&self) -> &dyn ModuleDb;
+pub(crate) struct UpwardTraversal<V>
+where
+    V: UpwardTraversalVisitor,
+{
+    visitor: V,
+    stack: Vec<UpwardTraversalWork<V::Item, V::Branch>>,
+}
 
-    fn stack(&mut self) -> &mut Vec<UpwardTraversalWork<Self::Item, Self::Branch>>;
-
-    /// Wraps this traversal in the standard-library iterator interface.
-    fn into_upward_iter(self) -> UpwardTraversalIterator<Self>
-    where
-        Self: Sized,
-    {
-        TraversalIterator(UpwardTraversalAdapter(self))
+impl<V> UpwardTraversal<V>
+where
+    V: UpwardTraversalVisitor,
+{
+    fn new(visitor: V, start: Utf8PathBuf, branch: V::Branch) -> Self {
+        Self {
+            visitor,
+            stack: vec![UpwardTraversalWork::explore(start, branch)],
+        }
     }
+}
 
-    /// Returns the next item produced while exploring importers.
-    fn next_upward(&mut self) -> Option<Self::Item> {
+impl<V> Traversal for UpwardTraversal<V>
+where
+    V: UpwardTraversalVisitor,
+{
+    type Item = V::Item;
+
+    fn next_item(&mut self) -> Option<Self::Item> {
         loop {
-            match self.stack().pop()? {
+            match self.stack.pop()? {
                 UpwardTraversalWork::Emit(item) => return Some(item),
                 UpwardTraversalWork::ExploreImporters {
                     imported_path,
                     branch,
                 } => {
                     let mut importers = Vec::new();
-                    self.db().for_each_module(&mut |importer| {
-                        if self.should_visit_importer(&imported_path, importer, &branch) {
+                    self.visitor.db().for_each_module(&mut |importer| {
+                        if self
+                            .visitor
+                            .should_visit_importer(&imported_path, importer, &branch)
+                        {
                             importers.push(importer);
                         }
                     });
@@ -124,8 +154,10 @@ pub(crate) trait UpwardTraversal: UpwardTraversalVisitor {
                     let mut items = Vec::new();
                     let mut explorations = Vec::new();
                     for importer in importers {
-                        let importer_path = importer.path(self.db()).to_path_buf();
-                        let actions = self.visit_importer(&imported_path, importer, &branch);
+                        let importer_path = importer.path(self.visitor.db()).to_path_buf();
+                        let actions =
+                            self.visitor
+                                .visit_importer(&imported_path, importer, &branch);
                         for action in actions {
                             for item in action.items {
                                 items.push(UpwardTraversalWork::Emit(item));
@@ -138,27 +170,13 @@ pub(crate) trait UpwardTraversal: UpwardTraversalVisitor {
                             }
                         }
                     }
-                    self.stack().extend(explorations);
-                    self.stack().extend(items.into_iter().rev());
+                    self.stack.extend(explorations);
+                    self.stack.extend(items.into_iter().rev());
                 }
             }
         }
     }
 }
 
-/// Adapts an [UpwardTraversal] to the direction-neutral [Traversal] interface.
-pub(crate) struct UpwardTraversalAdapter<T>(T);
-
-impl<T> Traversal for UpwardTraversalAdapter<T>
-where
-    T: UpwardTraversal,
-{
-    type Item = T::Item;
-
-    fn next_item(&mut self) -> Option<Self::Item> {
-        self.0.next_upward()
-    }
-}
-
 /// Iterator adapter for an [UpwardTraversal].
-pub(crate) type UpwardTraversalIterator<T> = TraversalIterator<UpwardTraversalAdapter<T>>;
+pub(crate) type UpwardTraversalIterator<V> = TraversalIterator<UpwardTraversal<V>>;

--- a/crates/biome_module_graph/tests/snap/mod.rs
+++ b/crates/biome_module_graph/tests/snap/mod.rs
@@ -92,8 +92,9 @@ impl<'a> ModuleGraphSnapshot<'a> {
                             .collect();
 
                         let side_effect_paths: Vec<_> = data
-                            .static_import_paths
-                            .iter()
+                            .import_paths
+                            .named_iter()
+                            .filter(|(_, import)| import.kind.is_static())
                             .filter(|(specifier, _)| {
                                 let s = specifier.text().to_string();
                                 !named_import_specifiers.contains(&s)

--- a/crates/biome_module_graph/tests/spec_tests.rs
+++ b/crates/biome_module_graph/tests/spec_tests.rs
@@ -25,10 +25,10 @@ use biome_json_value::{JsonObject, JsonString};
 use biome_languages::css::{CssEmbeddingKind, EmbeddingHtmlKind, EmbeddingStyleApplicability};
 use biome_languages::{CssFileSource, DocumentFileSource, HtmlFileSource, JsFileSource};
 use biome_module_graph::{
-    HtmlEmbeddedContent, ImportSymbol, JsExport, JsExportedSymbolLookup, JsImport, JsImportPath,
-    JsImportPhase, JsModuleInfoDiagnostic, JsOwnExport, JsReexport, ModuleDb, ModuleDiagnostic,
-    ModuleInfo, ModuleInfoKind, ModuleResolver, PathInfoCache, ResolvedPath, SymbolFromModuleInfo,
-    TypeInferenceMode, css_property_definitions, find_js_exported_symbol,
+    HtmlEmbeddedContent, ImportSymbol, JsExport, JsExportedSymbolLookup, JsImport, JsImportKind,
+    JsImportPath, JsImportPhase, JsModuleInfoDiagnostic, JsOwnExport, JsReexport, ModuleDb,
+    ModuleDiagnostic, ModuleInfo, ModuleInfoKind, ModuleResolver, PathInfoCache, ResolvedPath,
+    SymbolFromModuleInfo, TypeInferenceMode, css_property_definitions, find_js_exported_symbol,
     is_class_referenced_by_importers, resolve_css_module, resolve_html_module,
     resolve_js_module_with_inference_mode, transitive_importers_of,
     traverse_import_tree_for_classes, traverse_import_tree_for_html_classes,
@@ -459,6 +459,56 @@ fn css_property_query_deduplicates_diamonds_and_stops_cycles() {
 }
 
 #[test]
+fn css_property_query_does_not_cache_branch_specific_empty_results() {
+    let db = build_css_property_db(&[
+        ("/leaf.css", ".leaf { color: var(--value); }"),
+        (
+            "/definition.css",
+            "@property --value { syntax: \"<color>\"; inherits: true; initial-value: red; }",
+        ),
+        ("/right.css", "@import \"leaf.css\";"),
+        (
+            "/left.css",
+            "@import \"leaf.css\";\n@import \"definition.css\";",
+        ),
+        ("/join.css", "@import \"right.css\";\n@import \"left.css\";"),
+        ("/root.css", "@import \"left.css\";\n@import \"join.css\";"),
+    ]);
+    let module = db.module_for_path(Utf8Path::new("/leaf.css")).unwrap();
+    let property = SymbolFromModuleInfo::new(&db, "--value", module);
+
+    let definitions = css_property_definitions(&db, property);
+
+    assert_eq!(definitions.len(), 1);
+    assert_eq!(definitions[0].module_path, Utf8Path::new("/definition.css"));
+}
+
+#[test]
+fn css_property_query_preserves_branch_specific_continuations() {
+    let db = build_css_property_db(&[
+        ("/leaf.css", ".leaf { color: var(--value); }"),
+        (
+            "/definition.css",
+            "@property --value { syntax: \"<color>\"; inherits: true; initial-value: red; }",
+        ),
+        ("/b.css", "@import \"leaf.css\";"),
+        (
+            "/a.css",
+            "@import \"leaf.css\";\n@import \"definition.css\";\n@import \"y.css\";",
+        ),
+        ("/x.css", "@import \"b.css\";\n@import \"a.css\";"),
+        ("/y.css", "@import \"x.css\";"),
+    ]);
+    let module = db.module_for_path(Utf8Path::new("/leaf.css")).unwrap();
+    let property = SymbolFromModuleInfo::new(&db, "--value", module);
+
+    let definitions = css_property_definitions(&db, property);
+
+    assert_eq!(definitions.len(), 1);
+    assert_eq!(definitions[0].module_path, Utf8Path::new("/definition.css"));
+}
+
+#[test]
 fn css_property_query_reads_the_current_semantic_model() {
     let mut db = build_css_property_db(&[(
         "/value.css",
@@ -522,6 +572,168 @@ fn css_property_query_skips_non_css_sibling_imports() {
     let module = db.module_for_path(Utf8Path::new("/leaf.css")).unwrap();
     let property = SymbolFromModuleInfo::new(&db, "--value", module);
     assert!(css_property_definitions(&db, property).is_empty());
+}
+
+#[test]
+fn css_property_query_reads_stylesheets_imported_by_js() {
+    let property_style =
+        r#"@property --value { syntax: "<color>"; inherits: true; initial-value: red; }"#;
+    for source in ["import './theme.css';", "import('./theme.css');"] {
+        let db = build_css_property_db(&[("/theme.css", property_style)]);
+        let fs = MemoryFileSystem::default();
+        fs.insert("/theme.css".into(), property_style);
+        fs.insert("/app.js".into(), source);
+        let paths = [BiomePath::new("/app.js")];
+        let roots = get_added_js_paths(&fs, &paths);
+        add_js_modules(&db, &fs, &ProjectLayout::default(), &roots, false);
+
+        let module = db.module_for_path(Utf8Path::new("/app.js")).unwrap();
+        let property = SymbolFromModuleInfo::new(&db, "--value", module);
+        let definitions = css_property_definitions(&db, property);
+
+        assert_eq!(definitions.len(), 1, "{source}");
+        assert_eq!(definitions[0].module_path, Utf8Path::new("/theme.css"));
+    }
+}
+
+#[test]
+fn css_property_query_preserves_js_import_order() {
+    let db = build_css_property_db(&[
+        (
+            "/first.css",
+            r#"@property --value { syntax: "<color>"; inherits: true; initial-value: red; }"#,
+        ),
+        (
+            "/second.css",
+            r#"@property --value { syntax: "<length>"; inherits: true; initial-value: 0px; }"#,
+        ),
+    ]);
+    let fs = MemoryFileSystem::default();
+    fs.insert("/first.css".into(), "");
+    fs.insert("/second.css".into(), "");
+    fs.insert(
+        "/app.js".into(),
+        "import('./first.css'); import './second.css';",
+    );
+    let paths = [BiomePath::new("/app.js")];
+    let roots = get_added_js_paths(&fs, &paths);
+    add_js_modules(&db, &fs, &ProjectLayout::default(), &roots, false);
+
+    let module = db.module_for_path(Utf8Path::new("/app.js")).unwrap();
+    let property = SymbolFromModuleInfo::new(&db, "--value", module);
+    let definitions = css_property_definitions(&db, property);
+
+    assert_eq!(definitions.len(), 1);
+    assert_eq!(definitions[0].module_path, Utf8Path::new("/second.css"));
+}
+
+#[test]
+fn js_import_paths_are_deduplicated_at_the_last_occurrence() {
+    fn assert_iterator<I>(_: I)
+    where
+        I: DoubleEndedIterator + ExactSizeIterator + std::iter::FusedIterator,
+    {
+    }
+
+    let fs = MemoryFileSystem::default();
+    fs.insert("/first.css".into(), "");
+    fs.insert("/second.css".into(), "");
+    fs.insert("/third.css".into(), "");
+    fs.insert(
+        "/app.ts".into(),
+        "import './first.css'; import type Second from './second.css'; import('./second.css'); import('./first.css'); import type { First } from './first.css'; import('./third.css'); import type Third from './third.css';",
+    );
+    let paths = [BiomePath::new("/app.ts")];
+    let roots = get_added_js_paths(&fs, &paths);
+    let db = WorkspaceDb::default();
+    add_js_modules(&db, &fs, &ProjectLayout::default(), &roots, false);
+    let info = db
+        .js_module_info_for_path(Utf8Path::new("/app.ts"))
+        .unwrap();
+
+    assert_iterator(info.import_paths.iter());
+    assert_eq!(
+        info.import_paths
+            .named_iter()
+            .map(|(specifier, _)| specifier.text())
+            .collect::<Vec<_>>(),
+        ["./second.css", "./first.css", "./third.css"]
+    );
+
+    let mut imports = info.import_paths.iter();
+    assert_eq!(imports.len(), 3);
+    let first = imports.next().unwrap();
+    assert_eq!(first.kind, JsImportKind::StaticAndDynamic);
+    assert_eq!(first.phase, JsImportPhase::Type);
+    let third = imports.next_back().unwrap();
+    assert_eq!(third.kind, JsImportKind::StaticAndDynamic);
+    assert_eq!(third.phase, JsImportPhase::Type);
+    let second = imports.next().unwrap();
+    assert_eq!(second.kind, JsImportKind::StaticAndDynamic);
+    assert_eq!(second.phase, JsImportPhase::Default);
+    assert!(imports.next().is_none());
+    assert!(imports.next().is_none());
+}
+
+#[test]
+fn css_property_query_ignores_type_only_js_imports() {
+    let property_style =
+        r#"@property --value { syntax: "<color>"; inherits: true; initial-value: red; }"#;
+    let db = build_css_property_db(&[("/theme.css", property_style)]);
+    let fs = MemoryFileSystem::default();
+    fs.insert("/theme.css".into(), property_style);
+    fs.insert(
+        "/app.ts".into(),
+        "import type { Theme } from './theme.css';",
+    );
+    fs.insert("/component.ts".into(), "export type Component = true;");
+    fs.insert(
+        "/parent.ts".into(),
+        "import './theme.css'; import type { Component } from './component.ts';",
+    );
+    let paths = [
+        BiomePath::new("/app.ts"),
+        BiomePath::new("/component.ts"),
+        BiomePath::new("/parent.ts"),
+    ];
+    let roots = get_added_js_paths(&fs, &paths);
+    add_js_modules(&db, &fs, &ProjectLayout::default(), &roots, false);
+
+    for path in ["/app.ts", "/component.ts"] {
+        let module = db.module_for_path(Utf8Path::new(path)).unwrap();
+        let property = SymbolFromModuleInfo::new(&db, "--value", module);
+        assert!(css_property_definitions(&db, property).is_empty(), "{path}");
+    }
+}
+
+#[test]
+fn css_property_query_traverses_js_importers() {
+    let property_style =
+        r#"@property --value { syntax: "<color>"; inherits: true; initial-value: red; }"#;
+    for (parent_source, finds_definition) in [
+        ("import './theme.css'; import './component.js';", true),
+        ("import './component.js'; import './theme.css';", false),
+        ("import('./theme.css'); import './component.js';", true),
+        ("import './component.js'; import('./theme.css');", false),
+    ] {
+        let db = build_css_property_db(&[("/theme.css", property_style)]);
+        let fs = MemoryFileSystem::default();
+        fs.insert("/theme.css".into(), property_style);
+        fs.insert("/component.js".into(), "export const component = true;");
+        fs.insert("/parent.js".into(), parent_source);
+        let paths = [
+            BiomePath::new("/component.js"),
+            BiomePath::new("/parent.js"),
+        ];
+        let roots = get_added_js_paths(&fs, &paths);
+        add_js_modules(&db, &fs, &ProjectLayout::default(), &roots, false);
+
+        let module = db.module_for_path(Utf8Path::new("/component.js")).unwrap();
+        let property = SymbolFromModuleInfo::new(&db, "--value", module);
+        let definitions = css_property_definitions(&db, property);
+
+        assert_eq!(definitions.len(), usize::from(finds_definition));
+    }
 }
 
 #[test]
@@ -804,6 +1016,29 @@ fn css_property_query_follows_stylesheets_imported_from_html_scripts() {
 }
 
 #[test]
+fn css_property_query_preserves_html_script_import_order() {
+    let first = r#"@property --value { syntax: "<color>"; inherits: true; initial-value: red; }"#;
+    let second = r#"@property --value { syntax: "<length>"; inherits: true; initial-value: 0px; }"#;
+    let script = "import('./first.css'); import './second.css';";
+    let source = format!("<script>{script}</script>");
+    let db = build_html_property_db(
+        "/index.html",
+        &source,
+        HtmlFileSource::html(),
+        &[],
+        &[script],
+        &[("/first.css", first), ("/second.css", second)],
+    );
+    let module = db.module_for_path(Utf8Path::new("/index.html")).unwrap();
+    let property = SymbolFromModuleInfo::new(&db, "--value", module);
+
+    let definitions = css_property_definitions(&db, property);
+
+    assert_eq!(definitions.len(), 1);
+    assert_eq!(definitions[0].module_path, Utf8Path::new("/second.css"));
+}
+
+#[test]
 fn css_imports_preserve_duplicate_occurrences() {
     let db = build_css_property_db(&[
         ("/theme.css", ""),
@@ -818,7 +1053,7 @@ fn css_imports_preserve_duplicate_occurrences() {
         .unwrap();
 
     assert_eq!(info.imports.len(), 3);
-    assert!(info.imports.keys().is_sorted());
+    assert!(info.imports.iter().map(|import| import.range).is_sorted());
 }
 
 #[test]
@@ -2978,10 +3213,11 @@ fn test_resolve_swr_types() {
         )))
         .expect("module must exist");
     assert_eq!(
-        index_module.static_import_paths.get("swr"),
+        index_module.import_paths.get("swr"),
         Some(&JsImportPath {
             resolved_path: ResolvedPath::from_path(format!("{swr_path}/dist/index/index.d.mts")),
             phase: JsImportPhase::Default,
+            kind: JsImportKind::Static,
         })
     );
 
@@ -2989,14 +3225,13 @@ fn test_resolve_swr_types() {
         .js_module_info_for_path(Utf8Path::new(&format!("{swr_path}/dist/index/index.d.mts")))
         .expect("module must exist");
     assert_eq!(
-        swr_index_module
-            .static_import_paths
-            .get("../_internal/index.mjs"),
+        swr_index_module.import_paths.get("../_internal/index.mjs"),
         Some(&JsImportPath {
             resolved_path: ResolvedPath::from_path(format!(
                 "{swr_path}/dist/_internal/index.d.mts"
             )),
             phase: JsImportPhase::Default,
+            kind: JsImportKind::Static,
         })
     );
 
@@ -3114,12 +3349,12 @@ fn test_node_builtin_imports_resolve_to_builtin_error() {
         .js_module_info_for_path(Utf8Path::new("/src/index.ts"))
         .unwrap();
 
-    // All three `node:*` specifiers must be present in static_import_paths.
+    // All three `node:*` specifiers must be present in import_paths.
     for specifier in ["node:fs", "node:path", "node:url"] {
         let import_path = module
-            .static_import_paths
+            .import_paths
             .get(specifier)
-            .unwrap_or_else(|| panic!("specifier `{specifier}` not found in static_import_paths"));
+            .unwrap_or_else(|| panic!("specifier `{specifier}` not found in import_paths"));
 
         assert_eq!(
             import_path.resolved_path.error(),
@@ -3497,7 +3732,7 @@ fn test_namespace_reexport_type_inference() {
 }
 
 /// Verifies that a JSX file that imports a CSS file shows:
-/// - the CSS import edge in `static_import_paths`
+/// - the CSS import path in `import_paths`
 /// - `referenced_classes` populated from `className="..."` attributes
 /// - the CSS module info showing the defined classes
 #[test]
@@ -3541,8 +3776,8 @@ export function App() {
         .expect("App.jsx must be in module graph");
     assert!(
         app_info
-            .static_import_paths
-            .values()
+            .import_paths
+            .iter()
             .any(|p| p.as_path() == Some(Utf8Path::new("/src/styles.css"))),
         "App.jsx must have a resolved import edge to styles.css"
     );
@@ -4623,7 +4858,7 @@ fn test_vue_upward_traversal() {
         .expect("App.vue must be in module graph");
 
     assert!(
-        !app_info.static_import_paths.is_empty(),
+        !app_info.import_paths.is_empty(),
         "App.vue should have static import paths (app.css and Page.vue)"
     );
 
@@ -4632,7 +4867,7 @@ fn test_vue_upward_traversal() {
         .expect("Page.vue must be in module graph");
 
     assert!(
-        !page_info.static_import_paths.is_empty(),
+        !page_info.import_paths.is_empty(),
         "Page.vue should have static import paths (Button.vue)"
     );
 

--- a/crates/biome_service/src/file_handlers/html/go_to.rs
+++ b/crates/biome_service/src/file_handlers/html/go_to.rs
@@ -160,10 +160,7 @@ fn resolve_import_definition(
     result: &mut GoToDefinitionResult,
 ) -> Option<()> {
     let module_info = module_db.html_module_info_for_path(current_path)?;
-    let html_import = module_info
-        .static_import_paths
-        .get(source)
-        .or_else(|| module_info.dynamic_import_paths.get(source))?;
+    let html_import = module_info.import_paths.get(source)?;
 
     let target_path = html_import.as_path()?;
 

--- a/crates/biome_service/src/file_handlers/javascript/go_to.rs
+++ b/crates/biome_service/src/file_handlers/javascript/go_to.rs
@@ -219,10 +219,7 @@ fn resolve_import_definition(
     let module_info = module_db.module_info_for_path(current_path)?;
     match module_info {
         ModuleInfoKind::Js(module_info) => {
-            let import_path = module_info
-                .static_import_paths
-                .get(specifier)
-                .or(module_info.dynamic_import_paths.get(specifier))?;
+            let import_path = module_info.import_paths.get(specifier)?;
 
             let target_path = import_path.resolved_path.as_path()?;
 
@@ -258,10 +255,7 @@ fn resolve_import_definition(
         }
         ModuleInfoKind::Css(_) => {}
         ModuleInfoKind::Html(module_info) => {
-            let resolved_path = module_info
-                .static_import_paths
-                .get(specifier)
-                .or(module_info.dynamic_import_paths.get(specifier))?;
+            let resolved_path = module_info.import_paths.get(specifier)?;
 
             let target_path = resolved_path.as_path()?;
 


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

### Discover JavaScript files

Much like the previous PR, this one enables traversal of JavaScript files to find imported CSS files and property definitions.

### Source order imports

Before this PR, imports were stored unsing a `IndexMap`, `Text` as a key. This was incorrect because we lose the order of how files are imported. For CSS, order is quite important. 

This PR creates an abstract type called `ImportPathMap`, which all modules now use.

### Better traversal

Now the stack is part of the traversal itself.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added new tests

<!-- What demonstrates that your implementation is correct? -->

## Docs

After this PR, we should be able to start creating lint rules 🙌 

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
