### PR TITLE
fix(lint/noUselessFragments): panic when fixing a fragment used as a JSX attribute value

### DIFF
--- a/.changeset/red-deer-doubt.md
+++ b/.changeset/red-deer-doubt.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10806](https://github.com/biomejs/biome/issues/10806): [`noUselessFragments`](https://biomejs.dev/linter/rules/no-useless-fragments/) no longer causes Biome to panic when its unsafe fix removes a fragment used as a JSX attribute value.

--- a/crates/biome_cli/tests/commands/check.rs
+++ b/crates/biome_cli/tests/commands/check.rs
@@ -49,6 +49,24 @@ console.log(a);
 
 const APPLY_SUGGESTED_AFTER: &str = "const a = 4;\nconsole.log(a);\n";
 
+const JSX_FRAGMENT_ATTRIBUTE_BEFORE: &str = r#"const cases = (
+  <>
+    <Component selfClosing={<><div /></>} />
+    <Component nested={<><><span /></></>} />
+    <Component expression={<>{value}</>} />
+  </>
+);
+"#;
+
+const JSX_FRAGMENT_ATTRIBUTE_AFTER: &str = r#"const cases = (
+	<>
+		<Component selfClosing={<div />} />
+		<Component nested={<span />} />
+		<Component expression={value} />
+	</>
+);
+"#;
+
 const NO_DEBUGGER_BEFORE: &str = "debugger;\n";
 const NO_DEBUGGER_AFTER: &str = "debugger;\n";
 
@@ -295,6 +313,48 @@ fn apply_suggested() {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "apply_suggested",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn check_write_unsafe_preserves_jsx_attribute_value_shape() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Utf8Path::new("fragment-attribute.tsx");
+    fs.insert(file_path.into(), JSX_FRAGMENT_ATTRIBUTE_BEFORE.as_bytes());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(
+            [
+                "check",
+                "--write",
+                "--unsafe",
+                "--only=complexity/noUselessFragments",
+                file_path.as_str(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    let mut buffer = String::new();
+    fs.open(file_path)
+        .unwrap()
+        .read_to_string(&mut buffer)
+        .unwrap();
+
+    assert_eq!(buffer, JSX_FRAGMENT_ATTRIBUTE_AFTER);
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "check_write_unsafe_preserves_jsx_attribute_value_shape",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_write_unsafe_preserves_jsx_attribute_value_shape.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_write_unsafe_preserves_jsx_attribute_value_shape.snap
@@ -1,0 +1,22 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `fragment-attribute.tsx`
+
+```tsx
+const cases = (
+	<>
+		<Component selfClosing={<div />} />
+		<Component nested={<span />} />
+		<Component expression={value} />
+	</>
+);
+
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file in <TIME>. Fixed 1 file.
+```

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
@@ -35,8 +35,6 @@ declare_lint_rule! {
     /// <></>
     /// ```
     ///
-    /// A fragment used as an attribute value is reported as well:
-    ///
     /// ```jsx,expect_diagnostic
     /// <Component prop={<><div /></>} />
     /// ```

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
@@ -39,8 +39,7 @@ declare_lint_rule! {
     /// <Component prop={<><div /></>} />
     /// ```
     ///
-    /// No code fix is offered when such a fragment holds nothing that can take its
-    /// place, since an attribute can't be left without a value:
+    /// The rule doesn't emit a code fix if the a fragment inside an attribute doesn't have any value:
     ///
     /// ```jsx,expect_diagnostic
     /// <Component prop={<>{}</>} />

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
@@ -35,6 +35,19 @@ declare_lint_rule! {
     /// <></>
     /// ```
     ///
+    /// A fragment used as an attribute value is reported as well:
+    ///
+    /// ```jsx,expect_diagnostic
+    /// <Component prop={<><div /></>} />
+    /// ```
+    ///
+    /// No code fix is offered when such a fragment holds nothing that can take its
+    /// place, since an attribute can't be left without a value:
+    ///
+    /// ```jsx,expect_diagnostic
+    /// <Component prop={<>{}</>} />
+    /// ```
+    ///
     /// ### Valid
     ///
     /// ```jsx

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
@@ -6,16 +6,13 @@ use biome_analyze::context::RuleContext;
 use biome_analyze::{FixKind, Rule, RuleDiagnostic, RuleSource, declare_lint_rule};
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_js_factory::make::{
-    JsxExpressionChildBuilder, js_string_literal_expression, jsx_expression_attribute_value,
-    jsx_expression_child, jsx_string, jsx_string_literal, jsx_tag_expression, token,
-};
+use biome_js_factory::make::{jsx_expression_attribute_value, jsx_tag_expression, token};
 use biome_js_semantic::SemanticModel;
 use biome_js_syntax::{
-    AnyJsExpression, AnyJsxChild, AnyJsxElementName, AnyJsxTag, JsLanguage, JsLogicalExpression,
-    JsParenthesizedExpression, JsSyntaxKind, JsxAttributeInitializerClause, JsxChildList,
-    JsxElement, JsxExpressionAttributeValue, JsxExpressionChild, JsxFragment, JsxOpeningElement,
-    JsxTagExpression, JsxText, T,
+    AnyJsExpression, AnyJsxAttributeValue, AnyJsxChild, AnyJsxElementName,
+    AnyJsxTag, JsLanguage, JsLogicalExpression, JsParenthesizedExpression, JsSyntaxKind,
+    JsxAttributeInitializerClause, JsxChildList, JsxElement, JsxExpressionAttributeValue,
+    JsxExpressionChild, JsxFragment, JsxOpeningElement, JsxTagExpression, JsxText, T,
 };
 use biome_rowan::{AstNode, AstNodeList, BatchMutation, BatchMutationExt, declare_node_union};
 use biome_rule_options::no_useless_fragments::NoUselessFragmentsOptions;
@@ -356,11 +353,6 @@ impl Rule for NoUselessFragments {
         let node = ctx.query();
         let mut mutation = ctx.root().begin();
 
-        let is_in_jsx_attr = node
-            .syntax()
-            .grand_parent()
-            .is_some_and(|parent| JsxExpressionAttributeValue::can_cast(parent.kind()));
-
         let is_in_list = node
             .syntax()
             .parent()
@@ -378,10 +370,7 @@ impl Rule for NoUselessFragments {
                 }
             }
         } else if let Some(parent) = node.parent::<JsxTagExpression>() {
-            let parent = match parent.parent::<JsxExpressionAttributeValue>() {
-                Some(grand_parent) => grand_parent.into_syntax(),
-                None => parent.into_syntax(),
-            };
+            let attribute_value = parent.parent::<JsxExpressionAttributeValue>();
             let child = node
                 .children()
                 .iter()
@@ -400,68 +389,57 @@ impl Rule for NoUselessFragments {
                 });
 
             if let Some(child) = child {
-                let new_node = match child {
-                    AnyJsxChild::JsxElement(node) => {
-                        let jsx_tag_expr = jsx_tag_expression(AnyJsxTag::JsxElement(node));
-                        if is_in_jsx_attr {
-                            let jsx_expr_attr_value = jsx_expression_attribute_value(
-                                token(T!['{']),
-                                AnyJsExpression::JsxTagExpression(jsx_tag_expr.clone()),
-                                token(T!['}']),
-                            );
-                            Some(jsx_expr_attr_value.into_syntax())
-                        } else {
-                            Some(jsx_tag_expr.into_syntax())
-                        }
-                    }
-                    AnyJsxChild::JsxFragment(node) => {
-                        Some(jsx_tag_expression(AnyJsxTag::JsxFragment(node)).into_syntax())
-                    }
-                    AnyJsxChild::JsxSelfClosingElement(node) => Some(
-                        jsx_tag_expression(AnyJsxTag::JsxSelfClosingElement(node)).into_syntax(),
+                match child {
+                    AnyJsxChild::JsxElement(node) => replace_fragment_with_expression(
+                        &mut mutation,
+                        attribute_value,
+                        parent,
+                        AnyJsExpression::JsxTagExpression(jsx_tag_expression(
+                            AnyJsxTag::JsxElement(node),
+                        )),
                     ),
-                    AnyJsxChild::JsxText(text) => {
-                        let new_value = text.value_token().ok()?.token_text();
-                        let new_value = new_value.trim();
-                        if parent.kind() == JsSyntaxKind::JSX_EXPRESSION_ATTRIBUTE_VALUE {
-                            Some(jsx_string(jsx_string_literal(new_value)).into_syntax())
-                        } else {
-                            Some(
-                                js_string_literal_expression(jsx_string_literal(new_value))
-                                    .into_syntax(),
-                            )
+                    AnyJsxChild::JsxFragment(node) => replace_fragment_with_expression(
+                        &mut mutation,
+                        attribute_value,
+                        parent,
+                        AnyJsExpression::JsxTagExpression(jsx_tag_expression(
+                            AnyJsxTag::JsxFragment(node),
+                        )),
+                    ),
+                    AnyJsxChild::JsxSelfClosingElement(node) => replace_fragment_with_expression(
+                        &mut mutation,
+                        attribute_value,
+                        parent,
+                        AnyJsExpression::JsxTagExpression(jsx_tag_expression(
+                            AnyJsxTag::JsxSelfClosingElement(node),
+                        )),
+                    ),
+                    // A fragment holding nothing but text is never reported here: `run`
+                    // skips it when the fragment is an attribute value, and everywhere
+                    // else the great-great-grandparent check rejects it, since a tag
+                    // expression is never the direct child of a fragment or an element.
+                    // Text fragments inside a child list take the `is_in_list` branch.
+                    AnyJsxChild::JsxText(_) => return None,
+                    AnyJsxChild::JsxExpressionChild(child) => match child.expression() {
+                        Some(expression) => replace_fragment_with_expression(
+                            &mut mutation,
+                            attribute_value,
+                            parent,
+                            expression,
+                        ),
+                        // An attribute always needs a value, so `prop={<>{}</>}` can't be
+                        // fixed, while `<>{}</>` on its own can simply be removed.
+                        None if attribute_value.is_some() => return None,
+                        None => {
+                            mutation.remove_element(AnyJsExpression::JsxTagExpression(parent).into())
                         }
-                    }
-                    AnyJsxChild::JsxExpressionChild(child) => {
-                        if is_in_jsx_attr
-                            || !JsxTagExpression::can_cast(node.syntax().parent()?.kind())
-                        {
-                            child.expression().map(|expression| {
-                                let jsx_expr_child =
-                                    jsx_expression_child(token(T!['{']), token(T!['}']));
-                                JsxExpressionChildBuilder::with_expression(
-                                    jsx_expr_child,
-                                    expression,
-                                )
-                                .build()
-                                .into_syntax()
-                            })
-                        } else {
-                            child
-                                .expression()
-                                .map(|expression| expression.into_syntax())
-                        }
-                    }
+                    },
 
-                    // can't apply a code action because it will create invalid syntax
-                    // for example `<>{...foo}</>` would become `{...foo}` which would produce
-                    // a syntax error
-                    AnyJsxChild::JsxSpreadChild(_) | AnyJsxChild::JsMetavariable(_) => return None,
-                };
-                if let Some(new_node) = new_node {
-                    mutation.replace_element(parent.into(), new_node.into());
-                } else {
-                    mutation.remove_element(parent.into());
+                    // Can't apply a code action because it would create invalid syntax.
+                    // For example, `<>{...foo}</>` would become `{...foo}`.
+                    AnyJsxChild::JsxSpreadChild(_) | AnyJsxChild::JsMetavariable(_) => {
+                        return None;
+                    }
                 }
             } else {
                 // can't apply a code action when there is no children because it will create invalid syntax
@@ -492,6 +470,34 @@ impl Rule for NoUselessFragments {
         ).note(markup! {
             "A fragment is redundant if it contains only one child, or if it is the child of a html element, and is not a keyed "<Hyperlink href="https://legacy.reactjs.org/docs/fragments.html#keyed-fragments">"fragment"</Hyperlink>"."
         }))
+    }
+}
+
+/// Replaces the useless fragment wrapped by `tag_expression` with `expression`.
+///
+/// `attribute_value` is the `{…}` the fragment is nested in when it is used as an
+/// attribute value. It has to be rebuilt around `expression`, because an attribute
+/// can't hold a bare expression: `prop={<><div /></>}` becomes `prop={<div />}`,
+/// not `prop=<div />`.
+fn replace_fragment_with_expression(
+    mutation: &mut BatchMutation<JsLanguage>,
+    attribute_value: Option<JsxExpressionAttributeValue>,
+    tag_expression: JsxTagExpression,
+    expression: AnyJsExpression,
+) {
+    match attribute_value {
+        Some(attribute_value) => mutation.replace_node(
+            AnyJsxAttributeValue::JsxExpressionAttributeValue(attribute_value),
+            AnyJsxAttributeValue::JsxExpressionAttributeValue(jsx_expression_attribute_value(
+                token(T!['{']),
+                expression,
+                token(T!['}']),
+            )),
+        ),
+        None => mutation.replace_node(
+            AnyJsExpression::JsxTagExpression(tag_expression),
+            expression,
+        ),
     }
 }
 

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_10806.tsx
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_10806.tsx
@@ -10,5 +10,6 @@ const cases = (
         />
         <Component nested={<><><span /></></>} />
         <Component expression={<>{value}</>} />
+        <Component emptyExpression={<>{}</>} />
     </>
 );

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_10806.tsx
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_10806.tsx
@@ -1,0 +1,14 @@
+/* should generate diagnostics */
+const cases = (
+    <>
+        <Component
+            overlays={
+                <>
+                    <div className="overlay" />
+                </>
+            }
+        />
+        <Component nested={<><><span /></></>} />
+        <Component expression={<>{value}</>} />
+    </>
+);

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_10806.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_10806.tsx.snap
@@ -1,0 +1,119 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue_10806.tsx
+---
+# Input
+```tsx
+/* should generate diagnostics */
+const cases = (
+    <>
+        <Component
+            overlays={
+                <>
+                    <div className="overlay" />
+                </>
+            }
+        />
+        <Component nested={<><><span /></></>} />
+        <Component expression={<>{value}</>} />
+    </>
+);
+
+```
+
+# Diagnostics
+```
+issue_10806.tsx:6:17 lint/complexity/noUselessFragments  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This fragment is unnecessary.
+  
+     4 │         <Component
+     5 │             overlays={
+   > 6 │                 <>
+       │                 ^^
+   > 7 │                     <div className="overlay" />
+   > 8 │                 </>
+       │                 ^^^
+     9 │             }
+    10 │         />
+  
+  i A fragment is redundant if it contains only one child, or if it is the child of a html element, and is not a keyed fragment.
+  
+  i Unsafe fix: Remove the Fragment
+  
+     3  3 │       <>
+     4  4 │           <Component
+     5    │ - ············overlays={
+     6    │ - ················<>
+     7    │ - ····················<div·className="overlay"·/>
+     8    │ - ················</>
+     9    │ - ············}
+        5 │ + ············overlays={<div·className="overlay"·/>}
+    10  6 │           />
+    11  7 │           <Component nested={<><><span /></></>} />
+  
+
+```
+
+```
+issue_10806.tsx:11:28 lint/complexity/noUselessFragments  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This fragment is unnecessary.
+  
+     9 │             }
+    10 │         />
+  > 11 │         <Component nested={<><><span /></></>} />
+       │                            ^^^^^^^^^^^^^^^^^^
+    12 │         <Component expression={<>{value}</>} />
+    13 │     </>
+  
+  i A fragment is redundant if it contains only one child, or if it is the child of a html element, and is not a keyed fragment.
+  
+  i Unsafe fix: Remove the Fragment
+  
+    11 │ ········<Component·nested={<><><span·/></></>}·/>
+       │                               --     ---         
+
+```
+
+```
+issue_10806.tsx:11:30 lint/complexity/noUselessFragments  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This fragment is unnecessary.
+  
+     9 │             }
+    10 │         />
+  > 11 │         <Component nested={<><><span /></></>} />
+       │                              ^^^^^^^^^^^^^
+    12 │         <Component expression={<>{value}</>} />
+    13 │     </>
+  
+  i A fragment is redundant if it contains only one child, or if it is the child of a html element, and is not a keyed fragment.
+  
+  i Unsafe fix: Remove the Fragment
+  
+    11 │ ········<Component·nested={<><><span·/></></>}·/>
+       │                               --     ---         
+
+```
+
+```
+issue_10806.tsx:12:32 lint/complexity/noUselessFragments  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This fragment is unnecessary.
+  
+    10 │         />
+    11 │         <Component nested={<><><span /></></>} />
+  > 12 │         <Component expression={<>{value}</>} />
+       │                                ^^^^^^^^^^^^
+    13 │     </>
+    14 │ );
+  
+  i A fragment is redundant if it contains only one child, or if it is the child of a html element, and is not a keyed fragment.
+  
+  i Unsafe fix: Remove the Fragment
+  
+    12 │ ········<Component·expression={<>{value}</>}·/>
+       │                                ---     ----    
+
+```

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_10806.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_10806.tsx.snap
@@ -16,6 +16,7 @@ const cases = (
         />
         <Component nested={<><><span /></></>} />
         <Component expression={<>{value}</>} />
+        <Component emptyExpression={<>{}</>} />
     </>
 );
 
@@ -65,7 +66,7 @@ issue_10806.tsx:11:28 lint/complexity/noUselessFragments  FIXABLE  ━━━━�
   > 11 │         <Component nested={<><><span /></></>} />
        │                            ^^^^^^^^^^^^^^^^^^
     12 │         <Component expression={<>{value}</>} />
-    13 │     </>
+    13 │         <Component emptyExpression={<>{}</>} />
   
   i A fragment is redundant if it contains only one child, or if it is the child of a html element, and is not a keyed fragment.
   
@@ -86,7 +87,7 @@ issue_10806.tsx:11:30 lint/complexity/noUselessFragments  FIXABLE  ━━━━�
   > 11 │         <Component nested={<><><span /></></>} />
        │                              ^^^^^^^^^^^^^
     12 │         <Component expression={<>{value}</>} />
-    13 │     </>
+    13 │         <Component emptyExpression={<>{}</>} />
   
   i A fragment is redundant if it contains only one child, or if it is the child of a html element, and is not a keyed fragment.
   
@@ -106,8 +107,8 @@ issue_10806.tsx:12:32 lint/complexity/noUselessFragments  FIXABLE  ━━━━�
     11 │         <Component nested={<><><span /></></>} />
   > 12 │         <Component expression={<>{value}</>} />
        │                                ^^^^^^^^^^^^
-    13 │     </>
-    14 │ );
+    13 │         <Component emptyExpression={<>{}</>} />
+    14 │     </>
   
   i A fragment is redundant if it contains only one child, or if it is the child of a html element, and is not a keyed fragment.
   
@@ -115,5 +116,22 @@ issue_10806.tsx:12:32 lint/complexity/noUselessFragments  FIXABLE  ━━━━�
   
     12 │ ········<Component·expression={<>{value}</>}·/>
        │                                ---     ----    
+
+```
+
+```
+issue_10806.tsx:13:37 lint/complexity/noUselessFragments ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This fragment is unnecessary.
+  
+    11 │         <Component nested={<><><span /></></>} />
+    12 │         <Component expression={<>{value}</>} />
+  > 13 │         <Component emptyExpression={<>{}</>} />
+       │                                     ^^^^^^^
+    14 │     </>
+    15 │ );
+  
+  i A fragment is redundant if it contains only one child, or if it is the child of a html element, and is not a keyed fragment.
+  
 
 ```


### PR DESCRIPTION
## Summary

Fixes #10806.

`noUselessFragments`' unsafe fix panicked with `Tried to cast node with kind JSX_TAG_EXPRESSION as AnyJsxAttributeValue` when the useless fragment was a JSX attribute value:

```jsx
<Component overlays={<><div className="overlay" /></>} />
```

Replacing a `JsxExpressionAttributeValue` requires a new `{…}` wrapper, but only the `JsxElement` arm built one. The other arms wrote a bare `JsxTagExpression` or a `JsxExpressionChild` into that slot, producing an invalid tree that panicked once the formatter reached it. `action` now branches on whether the fragment's parent is a `JsxExpressionAttributeValue` and rebuilds the braces for every child kind through a single helper.

Two behavior notes:

- `prop={<>{}</>}` no longer offers a fix. It used to remove the attribute value and produce `prop=`.
- The `JsxText` arms in this branch are removed as unreachable. `run` never signals a text-only fragment here, and text fragments in a child list take the `is_in_list` branch instead.

This PR was done with the help of Claude Code.

## Test Plan

- `noUselessFragments/issue_10806.tsx` covers the self-closing, nested-fragment, and expression-child cases.
- `check_write_unsafe_preserves_jsx_attribute_value_shape` in `crates/biome_cli/tests/commands/check.rs` covers the reported panic. It has to be a CLI test: `expression={<>{value}</>}` produced text that re-parses cleanly but an invalid tree, so only a path that formats the result reproduces it.
- Full analyzer spec corpus passes with no changes to existing snapshots.

## Docs

N/A. No rule metadata or options changed. Changeset: `.changeset/red-deer-doubt.md`.
