### PR TITLE
fix(css_parser): tighten interpolated identifier boundaries

### DIFF
--- a/crates/biome_css_analyze/src/lint/suspicious/no_deprecated_media_type.rs
+++ b/crates/biome_css_analyze/src/lint/suspicious/no_deprecated_media_type.rs
@@ -78,7 +78,10 @@ impl Rule for NoDeprecatedMediaType {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
-        let media_type = node.value().ok().and_then(|v| v.value_token().ok())?;
+        let media_type = node
+            .value()
+            .ok()
+            .and_then(|value| value.as_css_identifier()?.value_token().ok())?;
         let media_type = media_type.text_trimmed();
 
         // Check allow list from options
@@ -107,7 +110,7 @@ impl Rule for NoDeprecatedMediaType {
             .query()
             .value()
             .ok()
-            .and_then(|v| v.value_token().ok())?;
+            .and_then(|value| value.as_css_identifier()?.value_token().ok())?;
         let media_type = media_type.text_trimmed();
         Some(
             RuleDiagnostic::new(

--- a/crates/biome_css_factory/src/generated/node_factory.rs
+++ b/crates/biome_css_factory/src/generated/node_factory.rs
@@ -1727,7 +1727,7 @@ pub fn css_media_or_condition(
         ],
     ))
 }
-pub fn css_media_type(value: CssIdentifier) -> CssMediaType {
+pub fn css_media_type(value: AnyCssMediaTypeName) -> CssMediaType {
     CssMediaType::unwrap_cast(SyntaxNode::new_detached(
         CssSyntaxKind::CSS_MEDIA_TYPE,
         [Some(SyntaxElement::Node(value.into_syntax()))],
@@ -4030,11 +4030,28 @@ pub fn scss_map_expression_pair(
         ],
     ))
 }
-pub fn scss_media_query(query: ScssInterpolation) -> ScssMediaQuery {
-    ScssMediaQuery::unwrap_cast(SyntaxNode::new_detached(
-        CssSyntaxKind::SCSS_MEDIA_QUERY,
-        [Some(SyntaxElement::Node(query.into_syntax()))],
-    ))
+pub fn scss_media_query(head: CssMediaTypeQuery) -> ScssMediaQueryBuilder {
+    ScssMediaQueryBuilder { head, tail: None }
+}
+pub struct ScssMediaQueryBuilder {
+    head: CssMediaTypeQuery,
+    tail: Option<CssMediaType>,
+}
+impl ScssMediaQueryBuilder {
+    pub fn with_tail(mut self, tail: CssMediaType) -> Self {
+        self.tail = Some(tail);
+        self
+    }
+    pub fn build(self) -> ScssMediaQuery {
+        ScssMediaQuery::unwrap_cast(SyntaxNode::new_detached(
+            CssSyntaxKind::SCSS_MEDIA_QUERY,
+            [
+                Some(SyntaxElement::Node(self.head.into_syntax())),
+                self.tail
+                    .map(|token| SyntaxElement::Node(token.into_syntax())),
+            ],
+        ))
+    }
 }
 pub fn scss_mixin_at_rule(
     mixin_token: SyntaxToken,

--- a/crates/biome_css_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_css_factory/src/generated/syntax_factory.rs
@@ -3646,7 +3646,7 @@ impl SyntaxFactory for CssSyntaxFactory {
                 let mut slots: RawNodeSlots<1usize> = RawNodeSlots::default();
                 let mut current_element = elements.next();
                 if let Some(element) = &current_element
-                    && CssIdentifier::can_cast(element.kind())
+                    && AnyCssMediaTypeName::can_cast(element.kind())
                 {
                     slots.mark_present();
                     current_element = elements.next();
@@ -8083,10 +8083,17 @@ impl SyntaxFactory for CssSyntaxFactory {
             }
             SCSS_MEDIA_QUERY => {
                 let mut elements = (&children).into_iter();
-                let mut slots: RawNodeSlots<1usize> = RawNodeSlots::default();
+                let mut slots: RawNodeSlots<2usize> = RawNodeSlots::default();
                 let mut current_element = elements.next();
                 if let Some(element) = &current_element
-                    && ScssInterpolation::can_cast(element.kind())
+                    && CssMediaTypeQuery::can_cast(element.kind())
+                {
+                    slots.mark_present();
+                    current_element = elements.next();
+                }
+                slots.next_slot();
+                if let Some(element) = &current_element
+                    && CssMediaType::can_cast(element.kind())
                 {
                     slots.mark_present();
                     current_element = elements.next();

--- a/crates/biome_css_formatter/src/css/any/media_type_name.rs
+++ b/crates/biome_css_formatter/src/css/any/media_type_name.rs
@@ -1,0 +1,15 @@
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
+
+use crate::prelude::*;
+use biome_css_syntax::AnyCssMediaTypeName;
+#[derive(Debug, Clone, Default)]
+pub(crate) struct FormatAnyCssMediaTypeName;
+impl FormatRule<AnyCssMediaTypeName> for FormatAnyCssMediaTypeName {
+    type Context = CssFormatContext;
+    fn fmt(&self, node: &AnyCssMediaTypeName, f: &mut CssFormatter) -> FormatResult<()> {
+        match node {
+            AnyCssMediaTypeName::CssIdentifier(node) => node.format().fmt(f),
+            AnyCssMediaTypeName::ScssInterpolatedIdentifier(node) => node.format().fmt(f),
+        }
+    }
+}

--- a/crates/biome_css_formatter/src/css/any/mod.rs
+++ b/crates/biome_css_formatter/src/css/any/mod.rs
@@ -72,6 +72,7 @@ pub(crate) mod media_in_parens;
 pub(crate) mod media_or_combinable_condition;
 pub(crate) mod media_query;
 pub(crate) mod media_type_condition;
+pub(crate) mod media_type_name;
 pub(crate) mod media_type_query;
 pub(crate) mod namespace_prefix;
 pub(crate) mod namespace_url;

--- a/crates/biome_css_formatter/src/generated.rs
+++ b/crates/biome_css_formatter/src/generated.rs
@@ -14686,6 +14686,31 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssMediaTypeCondition
         )
     }
 }
+impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssMediaTypeName {
+    type Format<'a> = FormatRefWithRule<
+        'a,
+        biome_css_syntax::AnyCssMediaTypeName,
+        crate::css::any::media_type_name::FormatAnyCssMediaTypeName,
+    >;
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule::new(
+            self,
+            crate::css::any::media_type_name::FormatAnyCssMediaTypeName::default(),
+        )
+    }
+}
+impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssMediaTypeName {
+    type Format = FormatOwnedWithRule<
+        biome_css_syntax::AnyCssMediaTypeName,
+        crate::css::any::media_type_name::FormatAnyCssMediaTypeName,
+    >;
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule::new(
+            self,
+            crate::css::any::media_type_name::FormatAnyCssMediaTypeName::default(),
+        )
+    }
+}
 impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssMediaTypeQuery {
     type Format<'a> = FormatRefWithRule<
         'a,

--- a/crates/biome_css_formatter/src/scss/auxiliary/media_query.rs
+++ b/crates/biome_css_formatter/src/scss/auxiliary/media_query.rs
@@ -11,9 +11,15 @@ impl FormatNodeRule<ScssMediaQuery> for FormatScssMediaQuery {
     }
 
     fn fmt_fields(&self, node: &ScssMediaQuery, f: &mut CssFormatter) -> FormatResult<()> {
-        let ScssMediaQueryFields { query } = node.as_fields();
+        let ScssMediaQueryFields { head, tail } = node.as_fields();
 
-        write!(f, [query.format()])
+        write!(f, [head.format()])?;
+
+        if let Some(tail) = tail {
+            write!(f, [space(), tail.format()])?;
+        }
+
+        Ok(())
     }
 
     fn fmt_leading_comments(

--- a/crates/biome_css_formatter/tests/specs/prettier/css/atrule/import.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/atrule/import.css.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
-assertion_line: 249
 info: css/atrule/import.css
 ---
 
@@ -143,16 +142,15 @@ $family: unquote("Droid+Sans");
  
  @import url("foo.css");
  @import url("foo.css");
-@@ -59,22 +61,24 @@
+@@ -59,22 +61,25 @@
  @import url("bluish.css") projection, tv;
  @import url("bluish.css") projection, tv;
  @import url("very-very-very-very-very-very-very-very-very-very-long-name.css")
 -  projection,
 -  tv;
--@import url("very-very-very-very-very-very-very-very-very-very-long-name.css")
--  projection tv;
 +  projection, tv;
-+@import url("very-very-very-very-very-very-very-very-very-very-long-name.css") projection tv;
+ @import url("very-very-very-very-very-very-very-very-very-very-long-name.css")
+   projection tv;
  @import url("landscape.css") screen and (orientation: landscape);
 -@import "rounded-corners", "text-shadow";
  @import "rounded-corners", "text-shadow";
@@ -250,7 +248,8 @@ $dir: 'fonts';
 @import url("bluish.css") projection, tv;
 @import url("very-very-very-very-very-very-very-very-very-very-long-name.css")
   projection, tv;
-@import url("very-very-very-very-very-very-very-very-very-very-long-name.css") projection tv;
+@import url("very-very-very-very-very-very-very-very-very-very-long-name.css")
+  projection tv;
 @import url("landscape.css") screen and (orientation: landscape);
 @import "rounded-corners", "text-shadow";
 @import 'rounded-corners', 'text-shadow';
@@ -274,18 +273,25 @@ $family: unquote("Droid+Sans");
 
 # Errors
 ```
-import.css:6:29 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+import.css:6:22 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × expected `,` but instead found `projection`
+  × Expected a media query but instead found 'screen projection'.
   
     4 │ @import url("chrome://communicator/skin/");
     5 │ @import "common.css" screen, projection;
   > 6 │ @import "common.css" screen projection;
-      │                             ^^^^^^^^^^
+      │                      ^^^^^^^^^^^^^^^^^
     7 │ @import url('landscape.css') screen and (orientation:landscape);
     8 │ 
   
-  i Remove projection
+  i Expected a media query here.
+  
+    4 │ @import url("chrome://communicator/skin/");
+    5 │ @import "common.css" screen, projection;
+  > 6 │ @import "common.css" screen projection;
+      │                      ^^^^^^^^^^^^^^^^^
+    7 │ @import url('landscape.css') screen and (orientation:landscape);
+    8 │ 
   
 import.css:9:20 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -394,18 +400,25 @@ import.css:53:1 parse ━━━━━━━━━━━━━━━━━━━�
     54 │ 
     55 │ @import url("foo.css");
   
-import.css:73:91 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+import.css:73:80 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × expected `,` but instead found `tv`
+  × Expected a media query but instead found 'projection tv'.
   
     71 │   tv;
     72 │ @import url("very-very-very-very-very-very-very-very-very-very-long-name.css") projection,tv;
   > 73 │ @import url("very-very-very-very-very-very-very-very-very-very-long-name.css") projection tv;
-       │                                                                                           ^^
+       │                                                                                ^^^^^^^^^^^^^
     74 │ @import url('landscape.css') screen and (orientation:landscape);
     75 │ @import "rounded-corners", "text-shadow";
   
-  i Remove tv
+  i Expected a media query here.
+  
+    71 │   tv;
+    72 │ @import url("very-very-very-very-very-very-very-very-very-very-long-name.css") projection,tv;
+  > 73 │ @import url("very-very-very-very-very-very-very-very-very-very-long-name.css") projection tv;
+       │                                                                                ^^^^^^^^^^^^^
+    74 │ @import url('landscape.css') screen and (orientation:landscape);
+    75 │ @import "rounded-corners", "text-shadow";
   
 import.css:75:28 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -495,9 +508,4 @@ import.css:93:1 parse ━━━━━━━━━━━━━━━━━━━�
        │ 
   
 
-```
-
-# Lines exceeding max width of 80 characters
-```
-   65: @import url("very-very-very-very-very-very-very-very-very-very-long-name.css") projection tv;
 ```

--- a/crates/biome_css_formatter/tests/specs/prettier/css/no-semicolon/url.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/no-semicolon/url.css.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
-assertion_line: 249
 info: css/no-semicolon/url.css
 ---
 
@@ -33,16 +32,24 @@ info: css/no-semicolon/url.css
 
 # Errors
 ```
-url.css:2:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+url.css:1:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × expected `,` but instead found `l`
+  × Expected a media query but instead found 'ur
+      l'.
   
-    1 │ @import ur
+  > 1 │ @import ur
+      │         ^^
   > 2 │   l(//fonts.googleapis.com/css?family=Open+Sans:400,400italic);
       │   ^
     3 │ 
   
-  i Remove l
+  i Expected a media query here.
+  
+  > 1 │ @import ur
+      │         ^^
+  > 2 │   l(//fonts.googleapis.com/css?family=Open+Sans:400,400italic);
+      │   ^
+    3 │ 
   
 url.css:2:4 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/crates/biome_css_formatter/tests/specs/scss/at-rule/media-interpolated-fragments.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/at-rule/media-interpolated-fragments.scss
@@ -1,0 +1,17 @@
+$query:"and (min-width: 40rem)";
+$modifier:only;
+$type:screen;
+$suffix:color;
+
+@media print-#{$suffix}{.tight{color:red}}
+@media all    #{$query}{.separated{color:red}}
+@media #{$modifier}    screen{.modifier{color:red}}
+@media #{$modifier}   #{$type}{.both{color:red}}
+@media #{$type} and (color){.logical{color:red}}
+@media #{"only screen"} and #{"(min-width: 700px)"} and #{"(max-width: "+"1920px)"}{.chain{color:red}}
+@media scr#{"een, pri"}nt    a#{"nd (max-width: 300px)"}{.generated{color:red}}
+@media all   /* fragment */   #{$query}{.commented{color:red}}
+@media only#{$type}{.tight-only{color:red}}
+@media not#{$type}{.tight-not{color:red}}
+@media screen and#{$suffix}{.tight-and{color:red}}
+@media screen or#{$suffix}{.tight-or{color:red}}

--- a/crates/biome_css_formatter/tests/specs/scss/at-rule/media-interpolated-fragments.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/at-rule/media-interpolated-fragments.scss.snap
@@ -1,0 +1,100 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: scss/at-rule/media-interpolated-fragments.scss
+---
+
+# Input
+
+```scss
+$query:"and (min-width: 40rem)";
+$modifier:only;
+$type:screen;
+$suffix:color;
+
+@media print-#{$suffix}{.tight{color:red}}
+@media all    #{$query}{.separated{color:red}}
+@media #{$modifier}    screen{.modifier{color:red}}
+@media #{$modifier}   #{$type}{.both{color:red}}
+@media #{$type} and (color){.logical{color:red}}
+@media #{"only screen"} and #{"(min-width: 700px)"} and #{"(max-width: "+"1920px)"}{.chain{color:red}}
+@media scr#{"een, pri"}nt    a#{"nd (max-width: 300px)"}{.generated{color:red}}
+@media all   /* fragment */   #{$query}{.commented{color:red}}
+@media only#{$type}{.tight-only{color:red}}
+@media not#{$type}{.tight-not{color:red}}
+@media screen and#{$suffix}{.tight-and{color:red}}
+@media screen or#{$suffix}{.tight-or{color:red}}
+
+```
+
+
+# Formatted
+
+```scss
+$query: "and (min-width: 40rem)";
+$modifier: only;
+$type: screen;
+$suffix: color;
+
+@media print-#{$suffix} {
+	.tight {
+		color: red;
+	}
+}
+@media all #{$query} {
+	.separated {
+		color: red;
+	}
+}
+@media #{$modifier} screen {
+	.modifier {
+		color: red;
+	}
+}
+@media #{$modifier} #{$type} {
+	.both {
+		color: red;
+	}
+}
+@media #{$type} and (color) {
+	.logical {
+		color: red;
+	}
+}
+@media #{"only screen"} and #{"(min-width: 700px)"} and #{"(max-width: " +
+		"1920px)"} {
+	.chain {
+		color: red;
+	}
+}
+@media scr#{"een, pri"}nt a#{"nd (max-width: 300px)"} {
+	.generated {
+		color: red;
+	}
+}
+@media all /* fragment */ #{$query} {
+	.commented {
+		color: red;
+	}
+}
+@media only#{$type} {
+	.tight-only {
+		color: red;
+	}
+}
+@media not#{$type} {
+	.tight-not {
+		color: red;
+	}
+}
+@media screen and#{$suffix} {
+	.tight-and {
+		color: red;
+	}
+}
+@media screen or#{$suffix} {
+	.tight-or {
+		color: red;
+	}
+}
+
+```

--- a/crates/biome_css_parser/src/syntax/at_rule/media.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/media.rs
@@ -6,14 +6,12 @@ use crate::syntax::block::parse_conditional_block;
 use crate::syntax::parse_error::scss_only_syntax_error;
 use crate::syntax::scss::{
     is_at_scss_interpolated_media_in_parens, is_at_scss_media_condition, is_at_scss_media_query,
-    parse_scss_interpolated_media_in_parens, parse_scss_media_condition, parse_scss_media_query,
-    parse_scss_media_query_or_condition_query,
+    is_nth_at_scss_interpolated_identifier, is_nth_at_scss_interpolation, is_nth_source_tight,
+    parse_scss_interpolated_media_in_parens, parse_scss_interpolated_name,
+    parse_scss_media_condition, parse_scss_media_condition_from_query, parse_scss_media_query,
 };
 use crate::syntax::util::skip_possible_tailwind_syntax;
-use crate::syntax::{
-    CssSyntaxFeatures, is_at_identifier, is_at_metavariable, is_nth_at_identifier,
-    parse_metavariable, parse_regular_identifier,
-};
+use crate::syntax::{CssSyntaxFeatures, is_at_metavariable, parse_metavariable};
 use biome_css_syntax::CssSyntaxKind::*;
 use biome_css_syntax::{CssSyntaxKind, T};
 use biome_parser::SyntaxFeature;
@@ -107,10 +105,7 @@ impl ParseSeparatedList for MediaQueryList {
 
 #[inline]
 pub(crate) fn is_at_any_media_query(p: &mut CssParser) -> bool {
-    is_at_media_type_query(p)
-        || is_at_scss_media_query(p)
-        || is_at_metavariable(p)
-        || is_at_any_media_condition(p)
+    is_at_media_type_query(p) || is_at_metavariable(p) || is_at_any_media_condition(p)
 }
 
 /// Parses one media query list item.
@@ -126,14 +121,6 @@ pub(crate) fn is_at_any_media_query(p: &mut CssParser) -> bool {
 pub(crate) fn parse_any_media_query(p: &mut CssParser) -> ParsedSyntax {
     if is_at_media_type_query(p) {
         parse_any_media_type_query(p)
-    } else if is_at_scss_media_query(p) {
-        CssSyntaxFeatures::Scss.parse_exclusive_syntax(
-            p,
-            parse_scss_media_query_or_condition_query,
-            |p, marker| {
-                scss_only_syntax_error(p, "SCSS interpolated media queries", marker.range(p))
-            },
-        )
     } else if is_at_metavariable(p) {
         parse_metavariable(p)
     } else if is_at_any_media_condition(p) {
@@ -190,55 +177,166 @@ pub(crate) fn parse_any_media_condition(p: &mut CssParser) -> ParsedSyntax {
 
 const MODIFIER_TYPE_QUERY_SET: TokenSet<CssSyntaxKind> = token_set!(T![only], T![not]);
 
+/// Returns whether the current token starts a plain or interpolated media type name.
+///
+/// ```scss
+/// @media screen {}
+/// @media print-#{$suffix} {}
+/// ```
+#[inline]
+fn is_at_media_type_name(p: &mut CssParser) -> bool {
+    is_nth_at_scss_interpolated_identifier(p, 0)
+}
+
+/// Returns whether the current token has a source-tight SCSS interpolation
+/// suffix.
+///
+/// ```scss
+/// @media only#{$type} {}
+/// ```
+#[inline]
+fn is_at_source_tight_scss_interpolation_suffix(p: &mut CssParser) -> bool {
+    is_nth_at_scss_interpolation(p, 1) && is_nth_source_tight(p, 1)
+}
+
+/// Returns whether the current token is a standalone media-type modifier.
+///
+/// ```scss
+/// @media only #{$type} {}
+/// ```
+#[inline]
+fn is_at_media_type_modifier(p: &mut CssParser) -> bool {
+    p.at_ts(MODIFIER_TYPE_QUERY_SET)
+        && is_nth_at_scss_interpolated_identifier(p, 1)
+        && !is_at_source_tight_scss_interpolation_suffix(p)
+}
+
+/// Returns whether the current token is a standalone media condition operator.
+///
+/// A source-tight `and#{$suffix}` remains an interpolated media type name.
+///
+/// ```scss
+/// @media screen and (color) {}
+/// @media screen and#{$suffix} {}
+/// ```
+#[inline]
+pub(crate) fn is_at_media_condition_operator(p: &mut CssParser) -> bool {
+    (p.at(T![and]) || p.at(T![or])) && !is_at_source_tight_scss_interpolation_suffix(p)
+}
+
+/// Returns whether a second media-type-shaped fragment can follow the parsed
+/// head.
+///
+/// ```scss
+/// $query: "and (width >= 40rem)";
+/// @media all #{$query} {}
+/// ```
+#[inline]
+fn is_at_media_query_tail_candidate(p: &mut CssParser) -> bool {
+    !is_nth_source_tight(p, 0) && !is_at_media_condition_operator(p) && is_at_media_type_name(p)
+}
+
 #[inline]
 fn parse_any_media_type_query(p: &mut CssParser) -> ParsedSyntax {
     if !is_at_media_type_query(p) {
         return Absent;
     }
 
-    let media_type_query = parse_media_type_query(p);
+    let has_modifier = is_at_media_type_modifier(p);
+    let head = p.start();
+    if has_modifier {
+        p.bump_ts(MODIFIER_TYPE_QUERY_SET);
+    }
+    let head_has_interpolation = parse_media_type(p);
+    let head = head.complete(p, CSS_MEDIA_TYPE_QUERY);
+
+    // The list-level Tailwind skip runs after this parser returns, but the
+    // optional SCSS tail must not consume a Tailwind import clause as a name.
+    skip_possible_tailwind_syntax(p);
+
+    let has_tail = !has_modifier && is_at_media_query_tail_candidate(p);
+    let tail_has_interpolation = if has_tail { parse_media_type(p) } else { false };
+
+    if head_has_interpolation || tail_has_interpolation {
+        return CssSyntaxFeatures::Scss.parse_exclusive_syntax(
+            p,
+            |p| parse_scss_media_query_from_head(p, head),
+            |p, marker| {
+                scss_only_syntax_error(p, "SCSS interpolated media queries", marker.range(p))
+            },
+        );
+    }
+
+    if has_tail {
+        // `$query: "and (width >= 40rem)"; @media all #{$query} {}` may form
+        // a query after evaluation. `@media screen print {}` cannot.
+        let bogus = head.precede(p).complete(p, CSS_BOGUS_MEDIA_QUERY);
+        p.error(expected_media_query(p, bogus.range(p)));
+        return Present(bogus);
+    }
 
     if p.at(T![and]) {
-        let m = media_type_query.precede(p);
+        let m = head.precede(p);
         p.bump(T![and]);
         parse_any_media_type_condition(p).or_add_diagnostic(p, expected_any_media_condition);
         Present(m.complete(p, CSS_MEDIA_AND_TYPE_QUERY))
     } else {
-        media_type_query
+        Present(head)
     }
 }
+
+/// Parses a plain or interpolated media type and reports whether it contains
+/// interpolation.
+///
+/// ```scss
+/// @media print-#{$suffix} {}
+/// ```
+#[inline]
+fn parse_media_type(p: &mut CssParser) -> bool {
+    if !is_at_media_type_name(p) {
+        return false;
+    }
+
+    let media_type = p.start();
+    let has_interpolation = parse_scss_interpolated_name(p)
+        .ok()
+        .is_some_and(|name| name.kind(p) == SCSS_INTERPOLATED_IDENTIFIER);
+    media_type.complete(p, CSS_MEDIA_TYPE);
+
+    has_interpolation
+}
+
+/// Completes an interpolated media-type query and parses its condition chain.
+///
+/// ```scss
+/// $query: "and (width >= 40rem)";
+/// @media all #{$query} and (color) {}
+/// ```
+#[inline]
+fn parse_scss_media_query_from_head(p: &mut CssParser, head: CompletedMarker) -> ParsedSyntax {
+    let query = head.precede(p).complete(p, SCSS_MEDIA_QUERY);
+    let query = if is_at_media_condition_operator(p) {
+        parse_scss_media_condition_from_query(p, query)
+            .precede(p)
+            .complete(p, CSS_MEDIA_CONDITION_QUERY)
+    } else {
+        query
+    };
+
+    Present(query)
+}
+
+/// Returns whether a media-type query starts at the current token.
+///
+/// ```scss
+/// @media only #{$type} {}
+/// @media not #{$type} {}
+/// ```
 #[inline]
 fn is_at_media_type_query(p: &mut CssParser) -> bool {
-    (p.at_ts(MODIFIER_TYPE_QUERY_SET) && is_nth_at_identifier(p, 1))
-        || (is_at_identifier(p) && !p.at(T![not]))
-}
-#[inline]
-fn parse_media_type_query(p: &mut CssParser) -> ParsedSyntax {
-    if !is_at_media_type_query(p) {
-        return Absent;
-    }
-
-    let m = p.start();
-
-    p.eat_ts(MODIFIER_TYPE_QUERY_SET);
-    // Guarded by `is_at_media_type_query` above.
-    parse_media_type(p).ok();
-
-    Present(m.complete(p, CSS_MEDIA_TYPE_QUERY))
-}
-
-#[inline]
-fn parse_media_type(p: &mut CssParser) -> ParsedSyntax {
-    if !is_at_identifier(p) {
-        return Absent;
-    }
-
-    let m = p.start();
-
-    // Guarded by `is_at_identifier` above.
-    parse_regular_identifier(p).ok();
-
-    Present(m.complete(p, CSS_MEDIA_TYPE))
+    is_at_media_type_modifier(p)
+        || (is_at_media_type_name(p)
+            && (!p.at(T![not]) || is_at_source_tight_scss_interpolation_suffix(p)))
 }
 
 #[inline]

--- a/crates/biome_css_parser/src/syntax/scss/at_rule/media.rs
+++ b/crates/biome_css_parser/src/syntax/scss/at_rule/media.rs
@@ -45,17 +45,38 @@ pub(crate) fn parse_scss_media_query(p: &mut CssParser) -> ParsedSyntax {
     }
 
     let query = p.start();
-    let media_type_query = p.start();
+    parse_scss_media_type_query(p);
+    Present(query.complete(p, SCSS_MEDIA_QUERY))
+}
+
+/// Parses the media-type query nested in a bare interpolated media query.
+///
+/// ```scss
+/// @media #{$query} {}
+/// ```
+///
+/// `ScssMediaQuery` uses the shared media-type shape so bare interpolation and
+/// interpolated fragments have the same CST structure.
+#[inline]
+fn parse_scss_media_type_query(p: &mut CssParser) -> CompletedMarker {
+    let query = p.start();
+    parse_scss_media_type(p);
+    query.complete(p, CSS_MEDIA_TYPE_QUERY)
+}
+
+/// Parses the media type nested in a bare interpolated media query.
+///
+/// ```scss
+/// @media #{$query} {}
+/// ```
+#[inline]
+fn parse_scss_media_type(p: &mut CssParser) -> CompletedMarker {
     let media_type = p.start();
 
-    // Guarded by `is_at_scss_media_query` above.
+    // Guarded by `is_at_scss_media_query` before the enclosing query starts.
     parse_scss_interpolated_name(p).ok();
 
-    // `ScssMediaQuery` uses the shared media-type shape so bare interpolation
-    // and interpolated fragments have the same CST structure.
-    media_type.complete(p, CSS_MEDIA_TYPE);
-    media_type_query.complete(p, CSS_MEDIA_TYPE_QUERY);
-    Present(query.complete(p, SCSS_MEDIA_QUERY))
+    media_type.complete(p, CSS_MEDIA_TYPE)
 }
 
 /// Returns whether Sass interpolation starts a parenthesized media branch.

--- a/crates/biome_css_parser/src/syntax/scss/at_rule/media.rs
+++ b/crates/biome_css_parser/src/syntax/scss/at_rule/media.rs
@@ -1,14 +1,15 @@
 use super::super::{
-    is_at_scss_interpolation, is_nth_at_scss_interpolation, parse_scss_interpolation_or_identifier,
-    parse_scss_regular_interpolation,
+    complete_scss_interpolated_identifier, is_at_scss_interpolation, is_nth_at_scss_interpolation,
+    parse_scss_interpolated_name, parse_scss_interpolation_or_identifier,
 };
 use super::query_feature::parse_scss_interpolated_query_feature_from_head;
 use crate::parser::CssParser;
 use crate::syntax::at_rule::error::AnyInParensChainParseRecovery;
 use crate::syntax::at_rule::feature::expected_any_query_feature;
 use crate::syntax::at_rule::media::{
-    expected_any_media_in_parens, parse_any_media_condition_operand, parse_media_and_condition,
-    parse_media_not_condition, parse_media_or_condition, recover_missing_and_rhs,
+    expected_any_media_in_parens, is_at_media_condition_operator,
+    parse_any_media_condition_operand, parse_media_and_condition, parse_media_not_condition,
+    parse_media_or_condition, recover_missing_and_rhs,
 };
 use biome_css_syntax::CssSyntaxKind::*;
 use biome_css_syntax::T;
@@ -16,7 +17,13 @@ use biome_parser::parsed_syntax::ParsedSyntax::Present;
 use biome_parser::prelude::ParsedSyntax::Absent;
 use biome_parser::prelude::*;
 
-/// Returns true when Sass interpolation can start a media query operand.
+/// Returns whether Sass interpolation can start a media query operand.
+///
+/// Examples:
+/// ```scss
+/// @media #{$query} {}
+/// @media (color) and #{$query} {}
+/// ```
 #[inline]
 pub(crate) fn is_at_scss_media_query(p: &mut CssParser) -> bool {
     is_at_scss_interpolation(p)
@@ -37,17 +44,30 @@ pub(crate) fn parse_scss_media_query(p: &mut CssParser) -> ParsedSyntax {
         return Absent;
     }
 
-    let m = p.start();
-    // Guarded by `is_at_scss_media_query` above.
-    parse_scss_regular_interpolation(p).ok();
+    let query = p.start();
+    let media_type_query = p.start();
+    let media_type = p.start();
 
-    Present(m.complete(p, SCSS_MEDIA_QUERY))
+    // Guarded by `is_at_scss_media_query` above.
+    parse_scss_interpolated_name(p).ok();
+
+    // `ScssMediaQuery` uses the shared media-type shape so bare interpolation
+    // and interpolated fragments have the same CST structure.
+    media_type.complete(p, CSS_MEDIA_TYPE);
+    media_type_query.complete(p, CSS_MEDIA_TYPE_QUERY);
+    Present(query.complete(p, SCSS_MEDIA_QUERY))
 }
 
-/// Returns true when Sass interpolation starts a parenthesized media branch.
+/// Returns whether Sass interpolation starts a parenthesized media branch.
 ///
 /// The parser still decides after the shared head whether this is a nested
 /// media condition or a query feature.
+///
+/// Examples:
+/// ```scss
+/// @media (#{$query} and (color)) {}
+/// @media (#{$feature}: #{$value}) {}
+/// ```
 #[inline]
 pub(crate) fn is_at_scss_interpolated_media_in_parens(p: &mut CssParser) -> bool {
     p.at(T!['(']) && is_nth_at_scss_interpolation(p, 1)
@@ -80,7 +100,8 @@ pub(crate) fn parse_scss_interpolated_media_in_parens(p: &mut CssParser) -> Pars
     };
 
     let kind = if head.kind(p) == SCSS_INTERPOLATION && is_at_media_condition_operator(p) {
-        let query = head.precede(p).complete(p, SCSS_MEDIA_QUERY);
+        let name = complete_scss_interpolated_identifier(p, head);
+        let query = complete_scss_media_query_from_name(p, name);
         parse_scss_media_condition_from_query(p, query);
         CSS_MEDIA_CONDITION_IN_PARENS
     } else {
@@ -107,41 +128,54 @@ pub(crate) fn parse_scss_media_condition(p: &mut CssParser) -> ParsedSyntax {
         return Absent;
     }
 
-    parse_scss_media_query(p).map(|query| parse_scss_media_condition_from_query(p, query))
-}
-
-#[inline]
-pub(crate) fn is_at_scss_media_condition(p: &mut CssParser) -> bool {
-    is_at_scss_media_query(p)
-}
-
-/// Parses a media query list item that starts with Sass interpolation.
-///
-/// Examples:
-/// ```scss
-/// @media #{$query} {}
-/// @media #{$query} and not (color) {}
-/// @media #{$query} or (color) {}
-/// ```
-#[inline]
-pub(crate) fn parse_scss_media_query_or_condition_query(p: &mut CssParser) -> ParsedSyntax {
-    if !is_at_scss_media_query(p) {
-        return Absent;
-    }
-
     parse_scss_media_query(p).map(|query| {
         if is_at_media_condition_operator(p) {
             parse_scss_media_condition_from_query(p, query)
-                .precede(p)
-                .complete(p, CSS_MEDIA_CONDITION_QUERY)
         } else {
             query
         }
     })
 }
 
+/// Returns whether Sass interpolation can start a media condition.
+///
+/// Examples:
+/// ```scss
+/// @media #{$query} and not (color) {}
+/// @media #{$query} or (color) {}
+/// ```
 #[inline]
-fn parse_scss_media_condition_from_query(
+pub(crate) fn is_at_scss_media_condition(p: &mut CssParser) -> bool {
+    is_at_scss_media_query(p)
+}
+
+/// Completes an already-parsed interpolated name as a SCSS media query.
+///
+/// ```scss
+/// @media (#{$query} and (color)) {}
+/// ```
+///
+/// The parenthesized media parser shares the completed name with query-feature
+/// parsing until the following operator selects the media-query branch.
+#[inline]
+fn complete_scss_media_query_from_name(
+    p: &mut CssParser,
+    name: CompletedMarker,
+) -> CompletedMarker {
+    let media_type = name.precede(p).complete(p, CSS_MEDIA_TYPE);
+    let type_query = media_type.precede(p).complete(p, CSS_MEDIA_TYPE_QUERY);
+    type_query.precede(p).complete(p, SCSS_MEDIA_QUERY)
+}
+
+/// Extends `query` with the following SCSS media-condition operator.
+///
+/// Examples:
+/// ```scss
+/// @media #{$query} and not (color) {}
+/// @media #{$query} or (color) {}
+/// ```
+#[inline]
+pub(crate) fn parse_scss_media_condition_from_query(
     p: &mut CssParser,
     query: CompletedMarker,
 ) -> CompletedMarker {
@@ -150,11 +184,6 @@ fn parse_scss_media_condition_from_query(
         T![or] => parse_media_or_condition(p, query),
         _ => query,
     }
-}
-
-#[inline]
-fn is_at_media_condition_operator(p: &mut CssParser) -> bool {
-    p.at(T![and]) || p.at(T![or])
 }
 
 /// Parses an `and` chain after an interpolation-led media query.

--- a/crates/biome_css_parser/src/syntax/scss/at_rule/mod.rs
+++ b/crates/biome_css_parser/src/syntax/scss/at_rule/mod.rs
@@ -50,8 +50,8 @@ pub(crate) use keyframes::{
 };
 pub(crate) use media::{
     is_at_scss_interpolated_media_in_parens, is_at_scss_media_condition, is_at_scss_media_query,
-    parse_scss_interpolated_media_in_parens, parse_scss_media_condition, parse_scss_media_query,
-    parse_scss_media_query_or_condition_query,
+    parse_scss_interpolated_media_in_parens, parse_scss_media_condition,
+    parse_scss_media_condition_from_query, parse_scss_media_query,
 };
 pub(crate) use mixin_at_rule::parse_scss_mixin_at_rule;
 pub(crate) use query_feature::parse_scss_interpolated_query_feature;

--- a/crates/biome_css_parser/src/syntax/scss/at_rule/query_feature.rs
+++ b/crates/biome_css_parser/src/syntax/scss/at_rule/query_feature.rs
@@ -5,12 +5,10 @@ use crate::syntax::at_rule::feature::{
     parse_query_feature_range_comparison,
 };
 use crate::syntax::scss::{
-    is_at_scss_interpolation, is_nth_at_scss_interpolated_identifier,
-    parse_scss_interpolation_or_identifier,
+    complete_scss_interpolated_identifier, is_at_scss_interpolation,
+    is_nth_at_scss_interpolated_identifier, parse_scss_interpolation_or_identifier,
 };
-use biome_css_syntax::CssSyntaxKind::{
-    SCSS_INTERPOLATED_IDENTIFIER, SCSS_INTERPOLATED_IDENTIFIER_PART_LIST, SCSS_INTERPOLATION,
-};
+use biome_css_syntax::CssSyntaxKind::SCSS_INTERPOLATION;
 use biome_parser::CompletedMarker;
 use biome_parser::parsed_syntax::ParsedSyntax;
 use biome_parser::parsed_syntax::ParsedSyntax::{Absent, Present};
@@ -56,10 +54,7 @@ pub(crate) fn parse_scss_interpolated_query_feature_from_head(
 
     // `#{$feature}: value` and `#{$feature} <= 10px`: the interpolation is the name.
     let name = if head.kind(p) == SCSS_INTERPOLATION {
-        let parts = head
-            .precede(p)
-            .complete(p, SCSS_INTERPOLATED_IDENTIFIER_PART_LIST);
-        parts.precede(p).complete(p, SCSS_INTERPOLATED_IDENTIFIER)
+        complete_scss_interpolated_identifier(p, head)
     } else {
         head
     };
@@ -68,11 +63,22 @@ pub(crate) fn parse_scss_interpolated_query_feature_from_head(
     parse_query_feature_from_name(p, m)
 }
 
+/// Returns whether a comparison after interpolation is followed by a media
+/// feature name.
+///
+/// ```scss
+/// @media (#{$min} <= width <= #{$max}) {}
+/// ```
 #[inline]
 fn is_at_query_feature_name_after_comparison(p: &mut CssParser) -> bool {
     is_at_query_feature_range_comparison(p) && is_nth_at_scss_interpolated_identifier(p, 1)
 }
 
+/// Returns whether interpolation starts a media query feature.
+///
+/// ```scss
+/// @media (#{$feature}: #{$value}) {}
+/// ```
 #[inline]
 fn is_at_scss_interpolated_query_feature_start(p: &mut CssParser) -> bool {
     is_at_scss_interpolation(p)

--- a/crates/biome_css_parser/src/syntax/scss/identifiers/interpolated_dashed.rs
+++ b/crates/biome_css_parser/src/syntax/scss/identifiers/interpolated_dashed.rs
@@ -2,31 +2,48 @@ use crate::lexer::CssLexContext;
 use crate::parser::CssParser;
 use crate::syntax::scss::expression::parse_scss_regular_interpolation;
 use crate::syntax::scss::identifiers::interpolated_identifier::{
-    is_at_identifier_hyphen, is_nth_at_identifier_hyphen_part, parse_identifier_hyphen,
-    parse_identifier_hyphen_part, parse_scss_interpolated_identifier_parts,
+    is_at_identifier_hyphen, is_nth_at_identifier_hyphen_part, is_nth_source_tight,
+    parse_identifier_hyphen, parse_identifier_hyphen_part,
+    parse_scss_interpolated_identifier_parts,
 };
 use crate::syntax::scss::{
     is_at_scss_interpolation, is_nth_at_scss_interpolated_identifier, is_nth_at_scss_interpolation,
 };
 use crate::syntax::{is_at_dashed_identifier, parse_regular_identifier};
 use biome_css_syntax::CssSyntaxKind::SCSS_INTERPOLATED_DASHED_IDENTIFIER;
-use biome_parser::Parser;
 use biome_parser::prelude::ParsedSyntax;
 use biome_parser::prelude::ParsedSyntax::{Absent, Present};
 
+/// Returns whether the current token starts an interpolated custom-property
+/// name.
+///
+/// ```scss
+/// :root {
+///   --#{$prop}: 10px;
+///   --theme-#{$slot}: red;
+/// }
+/// ```
 #[inline]
 pub(crate) fn is_at_scss_interpolated_dashed_identifier(p: &mut CssParser) -> bool {
     is_at_dashed_identifier_with_interpolation_suffix(p)
         || is_nth_at_scss_interpolated_dashed_identifier(p, 0)
 }
 
+/// Returns whether the token at `n` starts an interpolated custom-property name
+/// with two source-tight hyphens.
+///
+/// ```scss
+/// :root {
+///   --#{$prop}: 10px;
+/// }
+/// ```
 #[inline]
 pub(crate) fn is_nth_at_scss_interpolated_dashed_identifier(p: &mut CssParser, n: usize) -> bool {
     is_nth_at_identifier_hyphen_part(p, n)
         && is_nth_at_identifier_hyphen_part(p, n + 1)
-        && !p.has_nth_preceding_whitespace(n + 1)
+        && is_nth_source_tight(p, n + 1)
         && is_nth_at_scss_interpolated_identifier(p, n + 2)
-        && !p.has_nth_preceding_whitespace(n + 2)
+        && is_nth_source_tight(p, n + 2)
 }
 
 /// Parses an interpolated custom-property name.
@@ -68,11 +85,16 @@ pub(crate) fn parse_scss_interpolated_dashed_identifier(p: &mut CssParser) -> Pa
     )
 }
 
+/// Returns whether a dashed identifier continues directly into interpolation.
+///
+/// ```scss
+/// :root {
+///   --theme-#{$slot}: red;
+/// }
+/// ```
 #[inline]
 fn is_at_dashed_identifier_with_interpolation_suffix(p: &mut CssParser) -> bool {
-    is_at_dashed_identifier(p)
-        && is_nth_at_scss_interpolation(p, 1)
-        && !p.has_nth_preceding_whitespace(1)
+    is_at_dashed_identifier(p) && is_nth_at_scss_interpolation(p, 1) && is_nth_source_tight(p, 1)
 }
 
 /// Parses one interpolation, source-tight hyphen, or plain identifier part in

--- a/crates/biome_css_parser/src/syntax/scss/identifiers/interpolated_identifier.rs
+++ b/crates/biome_css_parser/src/syntax/scss/identifiers/interpolated_identifier.rs
@@ -3,25 +3,72 @@ use crate::parser::CssParser;
 use crate::syntax::is_nth_at_identifier;
 use crate::syntax::scss::is_nth_at_scss_interpolation;
 use biome_css_syntax::CssSyntaxKind::{
-    EOF, SCSS_INTERPOLATED_IDENTIFIER_HYPHEN, SCSS_INTERPOLATED_IDENTIFIER_PART_LIST,
+    EOF, SCSS_INTERPOLATED_IDENTIFIER, SCSS_INTERPOLATED_IDENTIFIER_HYPHEN,
+    SCSS_INTERPOLATED_IDENTIFIER_PART_LIST, SCSS_INTERPOLATION,
 };
 use biome_css_syntax::T;
 use biome_parser::prelude::ParsedSyntax;
 use biome_parser::prelude::ParsedSyntax::{Absent, Present};
 use biome_parser::{CompletedMarker, Parser, ParserProgress};
 
+/// Returns whether the current token can start a plain or interpolated
+/// identifier.
+///
+/// ```scss
+/// .button {}
+/// .button-#{$state} {}
+/// ```
 #[inline]
 pub(crate) fn is_at_scss_interpolated_identifier(p: &mut CssParser) -> bool {
     is_nth_at_scss_interpolated_identifier(p, 0)
 }
 
+/// Returns whether the token at `n` can start a plain or interpolated
+/// identifier.
+///
+/// ```scss
+/// @media only screen {}
+/// @media only #{$type} {}
+/// ```
 #[inline]
 pub(crate) fn is_nth_at_scss_interpolated_identifier(p: &mut CssParser, n: usize) -> bool {
     is_nth_at_identifier(p, n) || is_nth_at_scss_interpolation(p, n)
 }
 
-/// Parses source-tight identifier parts after `first_part` until whitespace or
-/// unsupported syntax ends the identifier.
+/// Returns whether the token at `n` directly follows the preceding token in
+/// source text.
+///
+/// ```scss
+/// .button-#{$state} {}
+/// ```
+#[inline]
+pub(crate) fn is_nth_source_tight(p: &mut CssParser, n: usize) -> bool {
+    !p.has_nth_preceding_whitespace(n) && !p.has_nth_preceding_line_break(n)
+}
+
+/// Completes an already-parsed bare interpolation as an interpolated identifier.
+///
+/// ```scss
+/// @media (#{$query} and (color)) {}
+/// ```
+///
+/// Callers use this after syntax following a shared interpolation selects a
+/// name slot instead of an interpolation value slot.
+#[inline]
+pub(crate) fn complete_scss_interpolated_identifier(
+    p: &mut CssParser,
+    interpolation: CompletedMarker,
+) -> CompletedMarker {
+    debug_assert_eq!(interpolation.kind(p), SCSS_INTERPOLATION);
+
+    let parts = interpolation
+        .precede(p)
+        .complete(p, SCSS_INTERPOLATED_IDENTIFIER_PART_LIST);
+    parts.precede(p).complete(p, SCSS_INTERPOLATED_IDENTIFIER)
+}
+
+/// Parses source-tight identifier parts after `first_part` until whitespace, a
+/// line break, or unsupported syntax ends the identifier.
 ///
 /// Both interpolations and the intervening hyphens belong to one selector
 /// identifier:
@@ -36,7 +83,7 @@ pub(super) fn parse_scss_interpolated_identifier_parts(
     let list = first_part.precede(p);
     let mut progress = ParserProgress::default();
 
-    while !p.at(EOF) && !p.has_preceding_whitespace() {
+    while !p.at(EOF) && is_nth_source_tight(p, 0) {
         progress.assert_progressing(p);
 
         if parse_part(p).is_absent() {
@@ -56,9 +103,9 @@ pub(super) fn parse_scss_interpolated_identifier_parts(
 #[inline]
 pub(super) fn is_at_identifier_hyphen(p: &mut CssParser) -> bool {
     is_at_identifier_hyphen_part(p)
-        && !p.has_preceding_whitespace()
+        && is_nth_source_tight(p, 0)
         && is_nth_at_scss_interpolated_identifier(p, 1)
-        && !p.has_nth_preceding_whitespace(1)
+        && is_nth_source_tight(p, 1)
 }
 
 /// Parses a source-tight hyphen that continues an interpolated identifier.
@@ -91,6 +138,11 @@ pub(super) fn is_nth_at_identifier_hyphen_part(p: &mut CssParser, n: usize) -> b
     p.nth_at(n, T![-])
 }
 
+/// Returns whether the current token is a raw interpolated-identifier hyphen.
+///
+/// ```scss
+/// .-#{$name} {}
+/// ```
 #[inline]
 fn is_at_identifier_hyphen_part(p: &mut CssParser) -> bool {
     is_nth_at_identifier_hyphen_part(p, 0)

--- a/crates/biome_css_parser/src/syntax/scss/identifiers/interpolated_regular.rs
+++ b/crates/biome_css_parser/src/syntax/scss/identifiers/interpolated_regular.rs
@@ -1,17 +1,16 @@
 use crate::lexer::CssLexContext;
 use crate::parser::CssParser;
-use crate::syntax::parse_regular_identifier;
 use crate::syntax::scss::expression::parse_scss_regular_interpolation;
 use crate::syntax::scss::identifiers::interpolated_identifier::{
     is_at_identifier_hyphen, is_at_scss_interpolated_identifier, is_nth_at_identifier_hyphen_part,
-    parse_identifier_hyphen, parse_identifier_hyphen_part,
+    is_nth_source_tight, parse_identifier_hyphen, parse_identifier_hyphen_part,
     parse_scss_interpolated_identifier_parts,
 };
 use crate::syntax::scss::{
     is_at_scss_interpolation, is_nth_at_scss_interpolated_identifier, is_nth_at_scss_interpolation,
 };
+use crate::syntax::{is_nth_at_identifier, parse_regular_identifier};
 use biome_css_syntax::CssSyntaxKind::{SCSS_INTERPOLATED_IDENTIFIER, SCSS_INTERPOLATION};
-use biome_parser::Parser;
 use biome_parser::prelude::ParsedSyntax;
 use biome_parser::prelude::ParsedSyntax::{Absent, Present};
 
@@ -42,8 +41,8 @@ pub(crate) fn parse_scss_interpolated_name(p: &mut CssParser) -> ParsedSyntax {
 /// This is different from [`parse_scss_regular_interpolation`], which parses
 /// exactly one standalone interpolation value.
 /// This helper parses identifier grammar, so it can consume adjacent
-/// identifier and interpolation fragments with no intervening trivia and
-/// combine them into one identifier-shaped node.
+/// identifier and interpolation fragments with no intervening whitespace or
+/// line break and combine them into one identifier-shaped node.
 ///
 /// Examples:
 /// ```scss
@@ -65,10 +64,10 @@ pub(crate) fn parse_scss_interpolated_identifier(p: &mut CssParser) -> ParsedSyn
         return Absent;
     };
 
-    // A plain identifier only becomes an interpolated identifier when another
-    // identifier fragment follows with no separating trivia.
+    // A plain identifier only becomes an interpolated identifier when a
+    // source-tight fragment leading to interpolation follows.
     if first_fragment.kind(p) != SCSS_INTERPOLATION
-        && (p.has_preceding_whitespace() || !is_at_regular_identifier_part(p))
+        && (!is_nth_source_tight(p, 0) || !is_at_regular_interpolated_identifier_suffix(p))
     {
         return Present(first_fragment);
     }
@@ -77,6 +76,41 @@ pub(crate) fn parse_scss_interpolated_identifier(p: &mut CssParser) -> ParsedSyn
         parse_scss_interpolated_identifier_parts(p, first_fragment, parse_regular_identifier_part);
 
     Present(parts.precede(p).complete(p, SCSS_INTERPOLATED_IDENTIFIER))
+}
+
+/// Returns whether source-tight parts after the first parsed part lead to interpolation.
+///
+/// ```scss
+/// .button-#{$state} {}
+/// ```
+#[inline]
+fn is_at_regular_interpolated_identifier_suffix(p: &mut CssParser) -> bool {
+    if is_at_scss_interpolation(p) {
+        // `.button-#{$state} {}` continues directly with interpolation.
+        return true;
+    }
+
+    if is_at_identifier_hyphen(p) {
+        // `.#{$block}-#{$element} {}` continues through a raw hyphen.
+        return is_nth_at_scss_interpolation(p, 1)
+            || is_nth_at_identifier_before_interpolation(p, 1);
+    }
+
+    // `.#{$block}item#{$modifier} {}` has a plain fragment before interpolation.
+    is_nth_at_identifier_before_interpolation(p, 0)
+}
+
+/// Returns whether the token at `n` is a plain identifier followed directly by
+/// interpolation.
+///
+/// ```scss
+/// .#{$block}item#{$modifier} {}
+/// ```
+#[inline]
+fn is_nth_at_identifier_before_interpolation(p: &mut CssParser, n: usize) -> bool {
+    is_nth_at_identifier(p, n)
+        && is_nth_source_tight(p, n + 1)
+        && is_nth_at_scss_interpolation(p, n + 1)
 }
 
 /// Returns whether an interpolated identifier starts with a single hyphen.
@@ -90,7 +124,7 @@ pub(crate) fn parse_scss_interpolated_identifier(p: &mut CssParser) -> ParsedSyn
 #[inline]
 pub(crate) fn is_nth_at_scss_hyphen_interpolated_identifier(p: &mut CssParser, n: usize) -> bool {
     is_nth_at_identifier_hyphen_part(p, n)
-        && !p.has_nth_preceding_whitespace(n + 1)
+        && is_nth_source_tight(p, n + 1)
         && is_nth_at_scss_interpolation(p, n + 1)
 }
 
@@ -143,7 +177,7 @@ pub(crate) fn parse_scss_interpolation_or_identifier(p: &mut CssParser) -> Parse
             return Absent;
         };
 
-        if !p.has_preceding_whitespace() && is_at_regular_identifier_part(p) {
+        if is_nth_source_tight(p, 0) && is_at_regular_identifier_part(p) {
             let parts = parse_scss_interpolated_identifier_parts(
                 p,
                 interpolation,

--- a/crates/biome_css_parser/src/syntax/scss/identifiers/interpolated_selector.rs
+++ b/crates/biome_css_parser/src/syntax/scss/identifiers/interpolated_selector.rs
@@ -2,7 +2,7 @@ use crate::parser::CssParser;
 use crate::syntax::is_nth_at_identifier;
 use crate::syntax::scss::expression::parse_scss_selector_interpolation;
 use crate::syntax::scss::identifiers::interpolated_identifier::{
-    is_at_scss_interpolated_identifier, is_nth_at_identifier_hyphen_part,
+    is_at_scss_interpolated_identifier, is_nth_at_identifier_hyphen_part, is_nth_source_tight,
     parse_identifier_hyphen_part, parse_scss_interpolated_identifier_parts,
 };
 use crate::syntax::scss::{is_at_scss_interpolation, is_nth_at_scss_interpolation};
@@ -11,7 +11,6 @@ use crate::syntax::selector::{
     selector_lex_context,
 };
 use biome_css_syntax::CssSyntaxKind::{SCSS_INTERPOLATED_IDENTIFIER, SCSS_INTERPOLATION};
-use biome_parser::Parser;
 use biome_parser::prelude::ParsedSyntax;
 use biome_parser::prelude::ParsedSyntax::{Absent, Present};
 
@@ -53,15 +52,15 @@ pub(crate) fn is_nth_at_scss_interpolated_selector_identifier(p: &mut CssParser,
 #[inline]
 fn is_nth_at_scss_selector_hyphen_start(p: &mut CssParser, n: usize) -> bool {
     if !is_nth_at_identifier_hyphen_part(p, n)
-        || p.has_nth_preceding_whitespace(n)
-        || p.has_nth_preceding_whitespace(n + 1)
+        || !is_nth_source_tight(p, n)
+        || !is_nth_source_tight(p, n + 1)
     {
         return false;
     }
 
     is_nth_at_scss_interpolation(p, n + 1)
         || (is_nth_at_identifier_hyphen_part(p, n + 1)
-            && !p.has_nth_preceding_whitespace(n + 2)
+            && is_nth_source_tight(p, n + 2)
             && is_nth_at_scss_interpolation(p, n + 2))
 }
 
@@ -74,7 +73,7 @@ fn is_nth_at_scss_selector_hyphen_start(p: &mut CssParser, n: usize) -> bool {
 /// ```
 #[inline]
 fn is_nth_at_scss_selector_identifier_suffix(p: &mut CssParser, n: usize) -> bool {
-    if p.has_nth_preceding_whitespace(n) {
+    if !is_nth_source_tight(p, n) {
         return false;
     }
 
@@ -82,13 +81,13 @@ fn is_nth_at_scss_selector_identifier_suffix(p: &mut CssParser, n: usize) -> boo
         return true;
     }
 
-    if !is_nth_at_identifier_hyphen_part(p, n) || p.has_nth_preceding_whitespace(n + 1) {
+    if !is_nth_at_identifier_hyphen_part(p, n) || !is_nth_source_tight(p, n + 1) {
         return false;
     }
 
     is_nth_at_scss_interpolation(p, n + 1)
         || (is_nth_at_identifier_hyphen_part(p, n + 1)
-            && !p.has_nth_preceding_whitespace(n + 2)
+            && is_nth_source_tight(p, n + 2)
             && is_nth_at_scss_interpolation(p, n + 2))
 }
 
@@ -157,7 +156,7 @@ fn parse_scss_selector_identifier_with_fragment(
     // A plain selector identifier only becomes an interpolated identifier when
     // another selector identifier fragment follows with no separating trivia.
     if first_fragment.kind(p) != SCSS_INTERPOLATION
-        && (p.has_preceding_whitespace() || !is_at_selector_identifier_part(p))
+        && (!is_nth_source_tight(p, 0) || !is_at_selector_identifier_part(p))
     {
         return Present(first_fragment);
     }

--- a/crates/biome_css_parser/src/syntax/scss/identifiers/mod.rs
+++ b/crates/biome_css_parser/src/syntax/scss/identifiers/mod.rs
@@ -14,7 +14,8 @@ pub(crate) use interpolated_dashed::{
     parse_scss_interpolated_dashed_identifier,
 };
 pub(crate) use interpolated_identifier::{
-    is_at_scss_interpolated_identifier, is_nth_at_scss_interpolated_identifier,
+    complete_scss_interpolated_identifier, is_at_scss_interpolated_identifier,
+    is_nth_at_scss_interpolated_identifier,
 };
 pub(crate) use interpolated_regular::{
     is_nth_at_scss_hyphen_interpolated_identifier, parse_scss_hyphen_interpolated_identifier,

--- a/crates/biome_css_parser/src/syntax/scss/identifiers/mod.rs
+++ b/crates/biome_css_parser/src/syntax/scss/identifiers/mod.rs
@@ -15,7 +15,7 @@ pub(crate) use interpolated_dashed::{
 };
 pub(crate) use interpolated_identifier::{
     complete_scss_interpolated_identifier, is_at_scss_interpolated_identifier,
-    is_nth_at_scss_interpolated_identifier,
+    is_nth_at_scss_interpolated_identifier, is_nth_source_tight,
 };
 pub(crate) use interpolated_regular::{
     is_nth_at_scss_hyphen_interpolated_identifier, parse_scss_hyphen_interpolated_identifier,

--- a/crates/biome_css_parser/src/syntax/scss/mod.rs
+++ b/crates/biome_css_parser/src/syntax/scss/mod.rs
@@ -41,9 +41,9 @@ pub(crate) use function_name::{
     add_scss_variable_member_function_name_diagnostic, parse_scss_function_name,
 };
 pub(crate) use identifiers::{
-    is_at_scss_interpolated_dashed_identifier, is_at_scss_interpolated_identifier,
-    is_at_scss_interpolated_selector_identifier, is_at_scss_module_member_access,
-    is_at_scss_namespaced_variable, is_at_scss_variable,
+    complete_scss_interpolated_identifier, is_at_scss_interpolated_dashed_identifier,
+    is_at_scss_interpolated_identifier, is_at_scss_interpolated_selector_identifier,
+    is_at_scss_module_member_access, is_at_scss_namespaced_variable, is_at_scss_variable,
     is_nth_at_scss_hyphen_interpolated_identifier, is_nth_at_scss_interpolated_dashed_identifier,
     is_nth_at_scss_interpolated_identifier, is_nth_at_scss_interpolated_selector_identifier,
     is_nth_at_scss_module_member_access, parse_scss_hyphen_interpolated_identifier,

--- a/crates/biome_css_parser/src/syntax/scss/mod.rs
+++ b/crates/biome_css_parser/src/syntax/scss/mod.rs
@@ -19,7 +19,7 @@ pub(crate) use at_rule::{
     parse_scss_if_at_rule, parse_scss_import_at_rule, parse_scss_include_at_rule,
     parse_scss_interpolated_media_in_parens, parse_scss_interpolated_query_feature,
     parse_scss_keyframes_name, parse_scss_keyframes_selector, parse_scss_media_condition,
-    parse_scss_media_query, parse_scss_media_query_or_condition_query, parse_scss_mixin_at_rule,
+    parse_scss_media_condition_from_query, parse_scss_media_query, parse_scss_mixin_at_rule,
     parse_scss_return_at_rule, parse_scss_supports_interpolated_condition, parse_scss_use_at_rule,
     parse_scss_warn_at_rule, parse_scss_while_at_rule,
 };
@@ -46,11 +46,12 @@ pub(crate) use identifiers::{
     is_at_scss_module_member_access, is_at_scss_namespaced_variable, is_at_scss_variable,
     is_nth_at_scss_hyphen_interpolated_identifier, is_nth_at_scss_interpolated_dashed_identifier,
     is_nth_at_scss_interpolated_identifier, is_nth_at_scss_interpolated_selector_identifier,
-    is_nth_at_scss_module_member_access, parse_scss_hyphen_interpolated_identifier,
-    parse_scss_interpolated_dashed_identifier, parse_scss_interpolated_identifier,
-    parse_scss_interpolated_name, parse_scss_interpolation_or_identifier,
-    parse_scss_module_member_access, parse_scss_namespaced_variable,
-    parse_scss_selector_custom_identifier, parse_scss_selector_identifier, parse_scss_variable,
+    is_nth_at_scss_module_member_access, is_nth_source_tight,
+    parse_scss_hyphen_interpolated_identifier, parse_scss_interpolated_dashed_identifier,
+    parse_scss_interpolated_identifier, parse_scss_interpolated_name,
+    parse_scss_interpolation_or_identifier, parse_scss_module_member_access,
+    parse_scss_namespaced_variable, parse_scss_selector_custom_identifier,
+    parse_scss_selector_identifier, parse_scss_variable,
 };
 pub(crate) use parse_error::{
     expected_scss_expression, expected_scss_variable_modifier, scss_ellipsis_not_allowed,

--- a/crates/biome_css_parser/tests/css_test_suite/error/at_rule/media_interpolated_fragments.css
+++ b/crates/biome_css_parser/tests/css_test_suite/error/at_rule/media_interpolated_fragments.css
@@ -1,0 +1,3 @@
+@media print-#{$suffix} {}
+@media all #{$query} {}
+@media #{$modifier} screen {}

--- a/crates/biome_css_parser/tests/css_test_suite/error/at_rule/media_interpolated_fragments.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/at_rule/media_interpolated_fragments.css.snap
@@ -1,0 +1,297 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+@media print-#{$suffix} {}
+@media all #{$query} {}
+@media #{$modifier} screen {}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssAtRule {
+            at_token: AT@0..1 "@" [] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@1..7 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssBogusMediaQuery {
+                            items: [
+                                CssMediaTypeQuery {
+                                    modifier: missing (optional),
+                                    ty: CssMediaType {
+                                        value: ScssInterpolatedIdentifier {
+                                            items: ScssInterpolatedIdentifierPartList [
+                                                CssIdentifier {
+                                                    value_token: IDENT@7..13 "print-" [] [],
+                                                },
+                                                ScssInterpolation {
+                                                    hash_token: HASH@13..14 "#" [] [],
+                                                    l_curly_token: L_CURLY@14..15 "{" [] [],
+                                                    value: ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            ScssVariable {
+                                                                dollar_token: DOLLAR@15..16 "$" [] [],
+                                                                name: CssIdentifier {
+                                                                    value_token: IDENT@16..22 "suffix" [] [],
+                                                                },
+                                                            },
+                                                        ],
+                                                    },
+                                                    r_curly_token: R_CURLY@22..24 "}" [] [Whitespace(" ")],
+                                                },
+                                            ],
+                                        },
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@24..25 "{" [] [],
+                    rules: CssRuleList [],
+                    r_curly_token: R_CURLY@25..26 "}" [] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@26..28 "@" [Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@28..34 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssBogusMediaQuery {
+                            items: [
+                                CssMediaTypeQuery {
+                                    modifier: missing (optional),
+                                    ty: CssMediaType {
+                                        value: CssIdentifier {
+                                            value_token: IDENT@34..38 "all" [] [Whitespace(" ")],
+                                        },
+                                    },
+                                },
+                                CssMediaType {
+                                    value: ScssInterpolatedIdentifier {
+                                        items: ScssInterpolatedIdentifierPartList [
+                                            ScssInterpolation {
+                                                hash_token: HASH@38..39 "#" [] [],
+                                                l_curly_token: L_CURLY@39..40 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@40..41 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@41..46 "query" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                r_curly_token: R_CURLY@46..48 "}" [] [Whitespace(" ")],
+                                            },
+                                        ],
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@48..49 "{" [] [],
+                    rules: CssRuleList [],
+                    r_curly_token: R_CURLY@49..50 "}" [] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@50..52 "@" [Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@52..58 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssBogusMediaQuery {
+                            items: [
+                                CssMediaTypeQuery {
+                                    modifier: missing (optional),
+                                    ty: CssMediaType {
+                                        value: ScssInterpolatedIdentifier {
+                                            items: ScssInterpolatedIdentifierPartList [
+                                                ScssInterpolation {
+                                                    hash_token: HASH@58..59 "#" [] [],
+                                                    l_curly_token: L_CURLY@59..60 "{" [] [],
+                                                    value: ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            ScssVariable {
+                                                                dollar_token: DOLLAR@60..61 "$" [] [],
+                                                                name: CssIdentifier {
+                                                                    value_token: IDENT@61..69 "modifier" [] [],
+                                                                },
+                                                            },
+                                                        ],
+                                                    },
+                                                    r_curly_token: R_CURLY@69..71 "}" [] [Whitespace(" ")],
+                                                },
+                                            ],
+                                        },
+                                    },
+                                },
+                                CssMediaType {
+                                    value: CssIdentifier {
+                                        value_token: IDENT@71..78 "screen" [] [Whitespace(" ")],
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@78..79 "{" [] [],
+                    rules: CssRuleList [],
+                    r_curly_token: R_CURLY@79..80 "}" [] [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@80..81 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..81
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..80
+    0: CSS_AT_RULE@0..26
+      0: AT@0..1 "@" [] []
+      1: CSS_MEDIA_AT_RULE@1..26
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@1..24
+          0: MEDIA_KW@1..7 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@7..24
+            0: CSS_BOGUS_MEDIA_QUERY@7..24
+              0: CSS_MEDIA_TYPE_QUERY@7..24
+                0: (empty)
+                1: CSS_MEDIA_TYPE@7..24
+                  0: SCSS_INTERPOLATED_IDENTIFIER@7..24
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@7..24
+                      0: CSS_IDENTIFIER@7..13
+                        0: IDENT@7..13 "print-" [] []
+                      1: SCSS_INTERPOLATION@13..24
+                        0: HASH@13..14 "#" [] []
+                        1: L_CURLY@14..15 "{" [] []
+                        2: SCSS_EXPRESSION@15..22
+                          0: SCSS_EXPRESSION_ITEM_LIST@15..22
+                            0: SCSS_VARIABLE@15..22
+                              0: DOLLAR@15..16 "$" [] []
+                              1: CSS_IDENTIFIER@16..22
+                                0: IDENT@16..22 "suffix" [] []
+                        3: R_CURLY@22..24 "}" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@24..26
+          0: L_CURLY@24..25 "{" [] []
+          1: CSS_RULE_LIST@25..25
+          2: R_CURLY@25..26 "}" [] []
+    1: CSS_AT_RULE@26..50
+      0: AT@26..28 "@" [Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@28..50
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@28..48
+          0: MEDIA_KW@28..34 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@34..48
+            0: CSS_BOGUS_MEDIA_QUERY@34..48
+              0: CSS_MEDIA_TYPE_QUERY@34..38
+                0: (empty)
+                1: CSS_MEDIA_TYPE@34..38
+                  0: CSS_IDENTIFIER@34..38
+                    0: IDENT@34..38 "all" [] [Whitespace(" ")]
+              1: CSS_MEDIA_TYPE@38..48
+                0: SCSS_INTERPOLATED_IDENTIFIER@38..48
+                  0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@38..48
+                    0: SCSS_INTERPOLATION@38..48
+                      0: HASH@38..39 "#" [] []
+                      1: L_CURLY@39..40 "{" [] []
+                      2: SCSS_EXPRESSION@40..46
+                        0: SCSS_EXPRESSION_ITEM_LIST@40..46
+                          0: SCSS_VARIABLE@40..46
+                            0: DOLLAR@40..41 "$" [] []
+                            1: CSS_IDENTIFIER@41..46
+                              0: IDENT@41..46 "query" [] []
+                      3: R_CURLY@46..48 "}" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@48..50
+          0: L_CURLY@48..49 "{" [] []
+          1: CSS_RULE_LIST@49..49
+          2: R_CURLY@49..50 "}" [] []
+    2: CSS_AT_RULE@50..80
+      0: AT@50..52 "@" [Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@52..80
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@52..78
+          0: MEDIA_KW@52..58 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@58..78
+            0: CSS_BOGUS_MEDIA_QUERY@58..78
+              0: CSS_MEDIA_TYPE_QUERY@58..71
+                0: (empty)
+                1: CSS_MEDIA_TYPE@58..71
+                  0: SCSS_INTERPOLATED_IDENTIFIER@58..71
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@58..71
+                      0: SCSS_INTERPOLATION@58..71
+                        0: HASH@58..59 "#" [] []
+                        1: L_CURLY@59..60 "{" [] []
+                        2: SCSS_EXPRESSION@60..69
+                          0: SCSS_EXPRESSION_ITEM_LIST@60..69
+                            0: SCSS_VARIABLE@60..69
+                              0: DOLLAR@60..61 "$" [] []
+                              1: CSS_IDENTIFIER@61..69
+                                0: IDENT@61..69 "modifier" [] []
+                        3: R_CURLY@69..71 "}" [] [Whitespace(" ")]
+              1: CSS_MEDIA_TYPE@71..78
+                0: CSS_IDENTIFIER@71..78
+                  0: IDENT@71..78 "screen" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@78..80
+          0: L_CURLY@78..79 "{" [] []
+          1: CSS_RULE_LIST@79..79
+          2: R_CURLY@79..80 "}" [] []
+  2: EOF@80..81 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+media_interpolated_fragments.css:1:8 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated media queries are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+  > 1 │ @media print-#{$suffix} {}
+      │        ^^^^^^^^^^^^^^^^
+    2 │ @media all #{$query} {}
+    3 │ @media #{$modifier} screen {}
+  
+media_interpolated_fragments.css:2:8 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated media queries are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    1 │ @media print-#{$suffix} {}
+  > 2 │ @media all #{$query} {}
+      │        ^^^^^^^^^^^^^
+    3 │ @media #{$modifier} screen {}
+    4 │ 
+  
+media_interpolated_fragments.css:3:8 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × SCSS interpolated media queries are an SCSS only feature. Convert your file to an SCSS file or remove the syntax.
+  
+    1 │ @media print-#{$suffix} {}
+    2 │ @media all #{$query} {}
+  > 3 │ @media #{$modifier} screen {}
+      │        ^^^^^^^^^^^^^^^^^^^
+    4 │ 
+  
+```

--- a/crates/biome_css_parser/tests/css_test_suite/error/at_rule/scss_exclusive_values.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/at_rule/scss_exclusive_values.css.snap
@@ -1364,20 +1364,29 @@ CssRoot {
                     queries: CssMediaQueryList [
                         CssBogusMediaQuery {
                             items: [
-                                ScssInterpolation {
-                                    hash_token: HASH@1260..1261 "#" [] [],
-                                    l_curly_token: L_CURLY@1261..1262 "{" [] [],
-                                    value: ScssExpression {
-                                        items: ScssExpressionItemList [
-                                            ScssVariable {
-                                                dollar_token: DOLLAR@1262..1263 "$" [] [],
-                                                name: CssIdentifier {
-                                                    value_token: IDENT@1263..1268 "query" [] [],
+                                CssMediaTypeQuery {
+                                    modifier: missing (optional),
+                                    ty: CssMediaType {
+                                        value: ScssInterpolatedIdentifier {
+                                            items: ScssInterpolatedIdentifierPartList [
+                                                ScssInterpolation {
+                                                    hash_token: HASH@1260..1261 "#" [] [],
+                                                    l_curly_token: L_CURLY@1261..1262 "{" [] [],
+                                                    value: ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            ScssVariable {
+                                                                dollar_token: DOLLAR@1262..1263 "$" [] [],
+                                                                name: CssIdentifier {
+                                                                    value_token: IDENT@1263..1268 "query" [] [],
+                                                                },
+                                                            },
+                                                        ],
+                                                    },
+                                                    r_curly_token: R_CURLY@1268..1270 "}" [] [Whitespace(" ")],
                                                 },
-                                            },
-                                        ],
+                                            ],
+                                        },
                                     },
-                                    r_curly_token: R_CURLY@1268..1270 "}" [] [Whitespace(" ")],
                                 },
                             ],
                         },
@@ -2621,16 +2630,21 @@ CssRoot {
           0: MEDIA_KW@1254..1260 "media" [] [Whitespace(" ")]
           1: CSS_MEDIA_QUERY_LIST@1260..1270
             0: CSS_BOGUS_MEDIA_QUERY@1260..1270
-              0: SCSS_INTERPOLATION@1260..1270
-                0: HASH@1260..1261 "#" [] []
-                1: L_CURLY@1261..1262 "{" [] []
-                2: SCSS_EXPRESSION@1262..1268
-                  0: SCSS_EXPRESSION_ITEM_LIST@1262..1268
-                    0: SCSS_VARIABLE@1262..1268
-                      0: DOLLAR@1262..1263 "$" [] []
-                      1: CSS_IDENTIFIER@1263..1268
-                        0: IDENT@1263..1268 "query" [] []
-                3: R_CURLY@1268..1270 "}" [] [Whitespace(" ")]
+              0: CSS_MEDIA_TYPE_QUERY@1260..1270
+                0: (empty)
+                1: CSS_MEDIA_TYPE@1260..1270
+                  0: SCSS_INTERPOLATED_IDENTIFIER@1260..1270
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@1260..1270
+                      0: SCSS_INTERPOLATION@1260..1270
+                        0: HASH@1260..1261 "#" [] []
+                        1: L_CURLY@1261..1262 "{" [] []
+                        2: SCSS_EXPRESSION@1262..1268
+                          0: SCSS_EXPRESSION_ITEM_LIST@1262..1268
+                            0: SCSS_VARIABLE@1262..1268
+                              0: DOLLAR@1262..1263 "$" [] []
+                              1: CSS_IDENTIFIER@1263..1268
+                                0: IDENT@1263..1268 "query" [] []
+                        3: R_CURLY@1268..1270 "}" [] [Whitespace(" ")]
         1: CSS_RULE_BLOCK@1270..1291
           0: L_CURLY@1270..1271 "{" [] []
           1: CSS_RULE_LIST@1271..1289

--- a/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/media-interpolated-fragments.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/media-interpolated-fragments.scss
@@ -1,0 +1,5 @@
+$query: "and (color)";
+
+@media all #{$query} extra, print {}
+@media foo/* first */-/* second */bar {}
+@media print-#{$suffix {}

--- a/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/media-interpolated-fragments.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/media-interpolated-fragments.scss.snap
@@ -1,0 +1,373 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+$query: "and (color)";
+
+@media all #{$query} extra, print {}
+@media foo/* first */-/* second */bar {}
+@media print-#{$suffix {}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        ScssVariableDeclaration {
+            name: ScssVariable {
+                dollar_token: DOLLAR@0..1 "$" [] [],
+                name: CssIdentifier {
+                    value_token: IDENT@1..6 "query" [] [],
+                },
+            },
+            colon_token: COLON@6..8 ":" [] [Whitespace(" ")],
+            value: ScssExpression {
+                items: ScssExpressionItemList [
+                    CssString {
+                        value_token: CSS_STRING_LITERAL@8..21 "\"and (color)\"" [] [],
+                    },
+                ],
+            },
+            modifiers: ScssVariableModifierList [],
+            semicolon_token: SEMICOLON@21..22 ";" [] [],
+        },
+        CssAtRule {
+            at_token: AT@22..25 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@25..31 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        ScssMediaQuery {
+                            head: CssMediaTypeQuery {
+                                modifier: missing (optional),
+                                ty: CssMediaType {
+                                    value: CssIdentifier {
+                                        value_token: IDENT@31..35 "all" [] [Whitespace(" ")],
+                                    },
+                                },
+                            },
+                            tail: CssMediaType {
+                                value: ScssInterpolatedIdentifier {
+                                    items: ScssInterpolatedIdentifierPartList [
+                                        ScssInterpolation {
+                                            hash_token: HASH@35..36 "#" [] [],
+                                            l_curly_token: L_CURLY@36..37 "{" [] [],
+                                            value: ScssExpression {
+                                                items: ScssExpressionItemList [
+                                                    ScssVariable {
+                                                        dollar_token: DOLLAR@37..38 "$" [] [],
+                                                        name: CssIdentifier {
+                                                            value_token: IDENT@38..43 "query" [] [],
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                            r_curly_token: R_CURLY@43..45 "}" [] [Whitespace(" ")],
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                        missing separator,
+                        CssMediaTypeQuery {
+                            modifier: missing (optional),
+                            ty: CssMediaType {
+                                value: CssIdentifier {
+                                    value_token: IDENT@45..50 "extra" [] [],
+                                },
+                            },
+                        },
+                        COMMA@50..52 "," [] [Whitespace(" ")],
+                        CssMediaTypeQuery {
+                            modifier: missing (optional),
+                            ty: CssMediaType {
+                                value: CssIdentifier {
+                                    value_token: IDENT@52..58 "print" [] [Whitespace(" ")],
+                                },
+                            },
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@58..59 "{" [] [],
+                    rules: CssRuleList [],
+                    r_curly_token: R_CURLY@59..60 "}" [] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@60..62 "@" [Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@62..68 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssMediaTypeQuery {
+                            modifier: missing (optional),
+                            ty: CssMediaType {
+                                value: CssIdentifier {
+                                    value_token: IDENT@68..82 "foo" [] [Comments("/* first */")],
+                                },
+                            },
+                        },
+                        missing separator,
+                        CssBogusMediaQuery {
+                            items: [
+                                MINUS@82..95 "-" [] [Comments("/* second */")],
+                                IDENT@95..99 "bar" [] [Whitespace(" ")],
+                            ],
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@99..100 "{" [] [],
+                    rules: CssRuleList [],
+                    r_curly_token: R_CURLY@100..101 "}" [] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@101..103 "@" [Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@103..109 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssBogusMediaQuery {
+                            items: [
+                                CssBogusMediaQuery {
+                                    items: [
+                                        CssBogus {
+                                            items: [
+                                                CssBogusSupportsCondition {
+                                                    items: [
+                                                        CssBogus {
+                                                            items: [
+                                                                CssIdentifier {
+                                                                    value_token: IDENT@109..115 "print-" [] [],
+                                                                },
+                                                                CssBogus {
+                                                                    items: [
+                                                                        HASH@115..116 "#" [] [],
+                                                                        L_CURLY@116..117 "{" [] [],
+                                                                        CssBogus {
+                                                                            items: [
+                                                                                CssBogus {
+                                                                                    items: [
+                                                                                        ScssVariable {
+                                                                                            dollar_token: DOLLAR@117..118 "$" [] [],
+                                                                                            name: CssIdentifier {
+                                                                                                value_token: IDENT@118..125 "suffix" [] [Whitespace(" ")],
+                                                                                            },
+                                                                                        },
+                                                                                        CssBogusPropertyValue {
+                                                                                            items: [
+                                                                                                L_CURLY@125..126 "{" [] [],
+                                                                                            ],
+                                                                                        },
+                                                                                    ],
+                                                                                },
+                                                                            ],
+                                                                        },
+                                                                        R_CURLY@126..127 "}" [] [],
+                                                                    ],
+                                                                },
+                                                            ],
+                                                        },
+                                                    ],
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+                block: CssBogusBlock {
+                    items: [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@127..128 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..128
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..127
+    0: SCSS_VARIABLE_DECLARATION@0..22
+      0: SCSS_VARIABLE@0..6
+        0: DOLLAR@0..1 "$" [] []
+        1: CSS_IDENTIFIER@1..6
+          0: IDENT@1..6 "query" [] []
+      1: COLON@6..8 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@8..21
+        0: SCSS_EXPRESSION_ITEM_LIST@8..21
+          0: CSS_STRING@8..21
+            0: CSS_STRING_LITERAL@8..21 "\"and (color)\"" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@21..21
+      4: SEMICOLON@21..22 ";" [] []
+    1: CSS_AT_RULE@22..60
+      0: AT@22..25 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@25..60
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@25..58
+          0: MEDIA_KW@25..31 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@31..58
+            0: SCSS_MEDIA_QUERY@31..45
+              0: CSS_MEDIA_TYPE_QUERY@31..35
+                0: (empty)
+                1: CSS_MEDIA_TYPE@31..35
+                  0: CSS_IDENTIFIER@31..35
+                    0: IDENT@31..35 "all" [] [Whitespace(" ")]
+              1: CSS_MEDIA_TYPE@35..45
+                0: SCSS_INTERPOLATED_IDENTIFIER@35..45
+                  0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@35..45
+                    0: SCSS_INTERPOLATION@35..45
+                      0: HASH@35..36 "#" [] []
+                      1: L_CURLY@36..37 "{" [] []
+                      2: SCSS_EXPRESSION@37..43
+                        0: SCSS_EXPRESSION_ITEM_LIST@37..43
+                          0: SCSS_VARIABLE@37..43
+                            0: DOLLAR@37..38 "$" [] []
+                            1: CSS_IDENTIFIER@38..43
+                              0: IDENT@38..43 "query" [] []
+                      3: R_CURLY@43..45 "}" [] [Whitespace(" ")]
+            1: (empty)
+            2: CSS_MEDIA_TYPE_QUERY@45..50
+              0: (empty)
+              1: CSS_MEDIA_TYPE@45..50
+                0: CSS_IDENTIFIER@45..50
+                  0: IDENT@45..50 "extra" [] []
+            3: COMMA@50..52 "," [] [Whitespace(" ")]
+            4: CSS_MEDIA_TYPE_QUERY@52..58
+              0: (empty)
+              1: CSS_MEDIA_TYPE@52..58
+                0: CSS_IDENTIFIER@52..58
+                  0: IDENT@52..58 "print" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@58..60
+          0: L_CURLY@58..59 "{" [] []
+          1: CSS_RULE_LIST@59..59
+          2: R_CURLY@59..60 "}" [] []
+    2: CSS_AT_RULE@60..101
+      0: AT@60..62 "@" [Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@62..101
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@62..99
+          0: MEDIA_KW@62..68 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@68..99
+            0: CSS_MEDIA_TYPE_QUERY@68..82
+              0: (empty)
+              1: CSS_MEDIA_TYPE@68..82
+                0: CSS_IDENTIFIER@68..82
+                  0: IDENT@68..82 "foo" [] [Comments("/* first */")]
+            1: (empty)
+            2: CSS_BOGUS_MEDIA_QUERY@82..99
+              0: MINUS@82..95 "-" [] [Comments("/* second */")]
+              1: IDENT@95..99 "bar" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@99..101
+          0: L_CURLY@99..100 "{" [] []
+          1: CSS_RULE_LIST@100..100
+          2: R_CURLY@100..101 "}" [] []
+    3: CSS_AT_RULE@101..127
+      0: AT@101..103 "@" [Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@103..127
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@103..127
+          0: MEDIA_KW@103..109 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@109..127
+            0: CSS_BOGUS_MEDIA_QUERY@109..127
+              0: CSS_BOGUS_MEDIA_QUERY@109..127
+                0: CSS_BOGUS@109..127
+                  0: CSS_BOGUS_SUPPORTS_CONDITION@109..127
+                    0: CSS_BOGUS@109..127
+                      0: CSS_IDENTIFIER@109..115
+                        0: IDENT@109..115 "print-" [] []
+                      1: CSS_BOGUS@115..127
+                        0: HASH@115..116 "#" [] []
+                        1: L_CURLY@116..117 "{" [] []
+                        2: CSS_BOGUS@117..126
+                          0: CSS_BOGUS@117..126
+                            0: SCSS_VARIABLE@117..125
+                              0: DOLLAR@117..118 "$" [] []
+                              1: CSS_IDENTIFIER@118..125
+                                0: IDENT@118..125 "suffix" [] [Whitespace(" ")]
+                            1: CSS_BOGUS_PROPERTY_VALUE@125..126
+                              0: L_CURLY@125..126 "{" [] []
+                        3: R_CURLY@126..127 "}" [] []
+        1: CSS_BOGUS_BLOCK@127..127
+  2: EOF@127..128 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+media-interpolated-fragments.scss:3:22 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `,` but instead found `extra`
+  
+    1 │ $query: "and (color)";
+    2 │ 
+  > 3 │ @media all #{$query} extra, print {}
+      │                      ^^^^^
+    4 │ @media foo/* first */-/* second */bar {}
+    5 │ @media print-#{$suffix {}
+  
+  i Remove extra
+  
+media-interpolated-fragments.scss:4:22 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `,` but instead found `-`
+  
+    3 │ @media all #{$query} extra, print {}
+  > 4 │ @media foo/* first */-/* second */bar {}
+      │                      ^
+    5 │ @media print-#{$suffix {}
+    6 │ 
+  
+  i Remove -
+  
+media-interpolated-fragments.scss:5:24 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a SCSS expression but instead found '{'.
+  
+    3 │ @media all #{$query} extra, print {}
+    4 │ @media foo/* first */-/* second */bar {}
+  > 5 │ @media print-#{$suffix {}
+      │                        ^
+    6 │ 
+  
+  i Expected a SCSS expression here.
+  
+    3 │ @media all #{$query} extra, print {}
+    4 │ @media foo/* first */-/* second */bar {}
+  > 5 │ @media print-#{$suffix {}
+      │                        ^
+    6 │ 
+  
+media-interpolated-fragments.scss:6:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `{` but instead the file ends
+  
+    4 │ @media foo/* first */-/* second */bar {}
+    5 │ @media print-#{$suffix {}
+  > 6 │ 
+      │ 
+  
+  i the file ends here
+  
+    4 │ @media foo/* first */-/* second */bar {}
+    5 │ @media print-#{$suffix {}
+  > 6 │ 
+      │ 
+  
+```

--- a/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/media-interpolated-modifier-tail.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/media-interpolated-modifier-tail.scss
@@ -1,0 +1,4 @@
+$query: "and (color)";
+
+@media only screen #{$query} {}
+@media not print #{$query} {}

--- a/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/media-interpolated-modifier-tail.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/media-interpolated-modifier-tail.scss.snap
@@ -1,0 +1,263 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+$query: "and (color)";
+
+@media only screen #{$query} {}
+@media not print #{$query} {}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        ScssVariableDeclaration {
+            name: ScssVariable {
+                dollar_token: DOLLAR@0..1 "$" [] [],
+                name: CssIdentifier {
+                    value_token: IDENT@1..6 "query" [] [],
+                },
+            },
+            colon_token: COLON@6..8 ":" [] [Whitespace(" ")],
+            value: ScssExpression {
+                items: ScssExpressionItemList [
+                    CssString {
+                        value_token: CSS_STRING_LITERAL@8..21 "\"and (color)\"" [] [],
+                    },
+                ],
+            },
+            modifiers: ScssVariableModifierList [],
+            semicolon_token: SEMICOLON@21..22 ";" [] [],
+        },
+        CssAtRule {
+            at_token: AT@22..25 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@25..31 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssMediaTypeQuery {
+                            modifier: ONLY_KW@31..36 "only" [] [Whitespace(" ")],
+                            ty: CssMediaType {
+                                value: CssIdentifier {
+                                    value_token: IDENT@36..43 "screen" [] [Whitespace(" ")],
+                                },
+                            },
+                        },
+                        missing separator,
+                        ScssMediaQuery {
+                            head: CssMediaTypeQuery {
+                                modifier: missing (optional),
+                                ty: CssMediaType {
+                                    value: ScssInterpolatedIdentifier {
+                                        items: ScssInterpolatedIdentifierPartList [
+                                            ScssInterpolation {
+                                                hash_token: HASH@43..44 "#" [] [],
+                                                l_curly_token: L_CURLY@44..45 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@45..46 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@46..51 "query" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                r_curly_token: R_CURLY@51..53 "}" [] [Whitespace(" ")],
+                                            },
+                                        ],
+                                    },
+                                },
+                            },
+                            tail: missing (optional),
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@53..54 "{" [] [],
+                    rules: CssRuleList [],
+                    r_curly_token: R_CURLY@54..55 "}" [] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@55..57 "@" [Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@57..63 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssMediaTypeQuery {
+                            modifier: NOT_KW@63..67 "not" [] [Whitespace(" ")],
+                            ty: CssMediaType {
+                                value: CssIdentifier {
+                                    value_token: IDENT@67..73 "print" [] [Whitespace(" ")],
+                                },
+                            },
+                        },
+                        missing separator,
+                        ScssMediaQuery {
+                            head: CssMediaTypeQuery {
+                                modifier: missing (optional),
+                                ty: CssMediaType {
+                                    value: ScssInterpolatedIdentifier {
+                                        items: ScssInterpolatedIdentifierPartList [
+                                            ScssInterpolation {
+                                                hash_token: HASH@73..74 "#" [] [],
+                                                l_curly_token: L_CURLY@74..75 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@75..76 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@76..81 "query" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                r_curly_token: R_CURLY@81..83 "}" [] [Whitespace(" ")],
+                                            },
+                                        ],
+                                    },
+                                },
+                            },
+                            tail: missing (optional),
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@83..84 "{" [] [],
+                    rules: CssRuleList [],
+                    r_curly_token: R_CURLY@84..85 "}" [] [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@85..86 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..86
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..85
+    0: SCSS_VARIABLE_DECLARATION@0..22
+      0: SCSS_VARIABLE@0..6
+        0: DOLLAR@0..1 "$" [] []
+        1: CSS_IDENTIFIER@1..6
+          0: IDENT@1..6 "query" [] []
+      1: COLON@6..8 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@8..21
+        0: SCSS_EXPRESSION_ITEM_LIST@8..21
+          0: CSS_STRING@8..21
+            0: CSS_STRING_LITERAL@8..21 "\"and (color)\"" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@21..21
+      4: SEMICOLON@21..22 ";" [] []
+    1: CSS_AT_RULE@22..55
+      0: AT@22..25 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@25..55
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@25..53
+          0: MEDIA_KW@25..31 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@31..53
+            0: CSS_MEDIA_TYPE_QUERY@31..43
+              0: ONLY_KW@31..36 "only" [] [Whitespace(" ")]
+              1: CSS_MEDIA_TYPE@36..43
+                0: CSS_IDENTIFIER@36..43
+                  0: IDENT@36..43 "screen" [] [Whitespace(" ")]
+            1: (empty)
+            2: SCSS_MEDIA_QUERY@43..53
+              0: CSS_MEDIA_TYPE_QUERY@43..53
+                0: (empty)
+                1: CSS_MEDIA_TYPE@43..53
+                  0: SCSS_INTERPOLATED_IDENTIFIER@43..53
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@43..53
+                      0: SCSS_INTERPOLATION@43..53
+                        0: HASH@43..44 "#" [] []
+                        1: L_CURLY@44..45 "{" [] []
+                        2: SCSS_EXPRESSION@45..51
+                          0: SCSS_EXPRESSION_ITEM_LIST@45..51
+                            0: SCSS_VARIABLE@45..51
+                              0: DOLLAR@45..46 "$" [] []
+                              1: CSS_IDENTIFIER@46..51
+                                0: IDENT@46..51 "query" [] []
+                        3: R_CURLY@51..53 "}" [] [Whitespace(" ")]
+              1: (empty)
+        1: CSS_RULE_BLOCK@53..55
+          0: L_CURLY@53..54 "{" [] []
+          1: CSS_RULE_LIST@54..54
+          2: R_CURLY@54..55 "}" [] []
+    2: CSS_AT_RULE@55..85
+      0: AT@55..57 "@" [Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@57..85
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@57..83
+          0: MEDIA_KW@57..63 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@63..83
+            0: CSS_MEDIA_TYPE_QUERY@63..73
+              0: NOT_KW@63..67 "not" [] [Whitespace(" ")]
+              1: CSS_MEDIA_TYPE@67..73
+                0: CSS_IDENTIFIER@67..73
+                  0: IDENT@67..73 "print" [] [Whitespace(" ")]
+            1: (empty)
+            2: SCSS_MEDIA_QUERY@73..83
+              0: CSS_MEDIA_TYPE_QUERY@73..83
+                0: (empty)
+                1: CSS_MEDIA_TYPE@73..83
+                  0: SCSS_INTERPOLATED_IDENTIFIER@73..83
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@73..83
+                      0: SCSS_INTERPOLATION@73..83
+                        0: HASH@73..74 "#" [] []
+                        1: L_CURLY@74..75 "{" [] []
+                        2: SCSS_EXPRESSION@75..81
+                          0: SCSS_EXPRESSION_ITEM_LIST@75..81
+                            0: SCSS_VARIABLE@75..81
+                              0: DOLLAR@75..76 "$" [] []
+                              1: CSS_IDENTIFIER@76..81
+                                0: IDENT@76..81 "query" [] []
+                        3: R_CURLY@81..83 "}" [] [Whitespace(" ")]
+              1: (empty)
+        1: CSS_RULE_BLOCK@83..85
+          0: L_CURLY@83..84 "{" [] []
+          1: CSS_RULE_LIST@84..84
+          2: R_CURLY@84..85 "}" [] []
+  2: EOF@85..86 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+media-interpolated-modifier-tail.scss:3:20 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `,` but instead found `#`
+  
+    1 │ $query: "and (color)";
+    2 │ 
+  > 3 │ @media only screen #{$query} {}
+      │                    ^
+    4 │ @media not print #{$query} {}
+    5 │ 
+  
+  i Remove #
+  
+media-interpolated-modifier-tail.scss:4:18 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `,` but instead found `#`
+  
+    3 │ @media only screen #{$query} {}
+  > 4 │ @media not print #{$query} {}
+      │                  ^
+    5 │ 
+  
+  i Remove #
+  
+```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/media-interpolated-fragments.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/media-interpolated-fragments.scss
@@ -1,0 +1,35 @@
+$condition: "(min-width: 40rem)";
+$query-tail: "and (min-width: 40rem)";
+$modifier: only;
+$type: screen;
+$prefix: print;
+$suffix: color;
+
+@media #{$condition} {}
+@media bar#{12} {}
+@media #{$prefix}-screen {}
+@media scr#{"ee"}n {}
+@media print-#{$suffix} {}
+
+@media all #{$query-tail} {}
+@media screen
+#{$query-tail} {}
+@media #{$modifier} screen {}
+@media #{$modifier} #{$type} {}
+@media only #{$type} {}
+@media not #{$type} {}
+
+@media #{$type} and (color) {}
+@media all #{$query-tail} and (color) {}
+@media (color) and #{$condition} {}
+@media #{"only screen"} and #{"(min-width: 700px)"} and #{"(max-width: "+"1920px)"} {}
+@media scr#{"een, pri"}nt a#{"nd (max-width: 300px)"} {}
+
+@media screen, all #{$query-tail}, print-#{$suffix} {}
+
+@media only#{$type} {}
+@media not#{$type} {}
+@media screen and#{$suffix} {}
+@media screen or#{$suffix} {}
+@media only/**/#{$type} {}
+@media screen and/**/#{$suffix} {}

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/media-interpolated-fragments.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/media-interpolated-fragments.scss.snap
@@ -1,0 +1,2227 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+$condition: "(min-width: 40rem)";
+$query-tail: "and (min-width: 40rem)";
+$modifier: only;
+$type: screen;
+$prefix: print;
+$suffix: color;
+
+@media #{$condition} {}
+@media bar#{12} {}
+@media #{$prefix}-screen {}
+@media scr#{"ee"}n {}
+@media print-#{$suffix} {}
+
+@media all #{$query-tail} {}
+@media screen
+#{$query-tail} {}
+@media #{$modifier} screen {}
+@media #{$modifier} #{$type} {}
+@media only #{$type} {}
+@media not #{$type} {}
+
+@media #{$type} and (color) {}
+@media all #{$query-tail} and (color) {}
+@media (color) and #{$condition} {}
+@media #{"only screen"} and #{"(min-width: 700px)"} and #{"(max-width: "+"1920px)"} {}
+@media scr#{"een, pri"}nt a#{"nd (max-width: 300px)"} {}
+
+@media screen, all #{$query-tail}, print-#{$suffix} {}
+
+@media only#{$type} {}
+@media not#{$type} {}
+@media screen and#{$suffix} {}
+@media screen or#{$suffix} {}
+@media only/**/#{$type} {}
+@media screen and/**/#{$suffix} {}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        ScssVariableDeclaration {
+            name: ScssVariable {
+                dollar_token: DOLLAR@0..1 "$" [] [],
+                name: CssIdentifier {
+                    value_token: IDENT@1..10 "condition" [] [],
+                },
+            },
+            colon_token: COLON@10..12 ":" [] [Whitespace(" ")],
+            value: ScssExpression {
+                items: ScssExpressionItemList [
+                    CssString {
+                        value_token: CSS_STRING_LITERAL@12..32 "\"(min-width: 40rem)\"" [] [],
+                    },
+                ],
+            },
+            modifiers: ScssVariableModifierList [],
+            semicolon_token: SEMICOLON@32..33 ";" [] [],
+        },
+        ScssVariableDeclaration {
+            name: ScssVariable {
+                dollar_token: DOLLAR@33..35 "$" [Newline("\n")] [],
+                name: CssIdentifier {
+                    value_token: IDENT@35..45 "query-tail" [] [],
+                },
+            },
+            colon_token: COLON@45..47 ":" [] [Whitespace(" ")],
+            value: ScssExpression {
+                items: ScssExpressionItemList [
+                    CssString {
+                        value_token: CSS_STRING_LITERAL@47..71 "\"and (min-width: 40rem)\"" [] [],
+                    },
+                ],
+            },
+            modifiers: ScssVariableModifierList [],
+            semicolon_token: SEMICOLON@71..72 ";" [] [],
+        },
+        ScssVariableDeclaration {
+            name: ScssVariable {
+                dollar_token: DOLLAR@72..74 "$" [Newline("\n")] [],
+                name: CssIdentifier {
+                    value_token: IDENT@74..82 "modifier" [] [],
+                },
+            },
+            colon_token: COLON@82..84 ":" [] [Whitespace(" ")],
+            value: ScssExpression {
+                items: ScssExpressionItemList [
+                    CssIdentifier {
+                        value_token: IDENT@84..88 "only" [] [],
+                    },
+                ],
+            },
+            modifiers: ScssVariableModifierList [],
+            semicolon_token: SEMICOLON@88..89 ";" [] [],
+        },
+        ScssVariableDeclaration {
+            name: ScssVariable {
+                dollar_token: DOLLAR@89..91 "$" [Newline("\n")] [],
+                name: CssIdentifier {
+                    value_token: IDENT@91..95 "type" [] [],
+                },
+            },
+            colon_token: COLON@95..97 ":" [] [Whitespace(" ")],
+            value: ScssExpression {
+                items: ScssExpressionItemList [
+                    CssIdentifier {
+                        value_token: IDENT@97..103 "screen" [] [],
+                    },
+                ],
+            },
+            modifiers: ScssVariableModifierList [],
+            semicolon_token: SEMICOLON@103..104 ";" [] [],
+        },
+        ScssVariableDeclaration {
+            name: ScssVariable {
+                dollar_token: DOLLAR@104..106 "$" [Newline("\n")] [],
+                name: CssIdentifier {
+                    value_token: IDENT@106..112 "prefix" [] [],
+                },
+            },
+            colon_token: COLON@112..114 ":" [] [Whitespace(" ")],
+            value: ScssExpression {
+                items: ScssExpressionItemList [
+                    CssIdentifier {
+                        value_token: IDENT@114..119 "print" [] [],
+                    },
+                ],
+            },
+            modifiers: ScssVariableModifierList [],
+            semicolon_token: SEMICOLON@119..120 ";" [] [],
+        },
+        ScssVariableDeclaration {
+            name: ScssVariable {
+                dollar_token: DOLLAR@120..122 "$" [Newline("\n")] [],
+                name: CssIdentifier {
+                    value_token: IDENT@122..128 "suffix" [] [],
+                },
+            },
+            colon_token: COLON@128..130 ":" [] [Whitespace(" ")],
+            value: ScssExpression {
+                items: ScssExpressionItemList [
+                    CssIdentifier {
+                        value_token: IDENT@130..135 "color" [] [],
+                    },
+                ],
+            },
+            modifiers: ScssVariableModifierList [],
+            semicolon_token: SEMICOLON@135..136 ";" [] [],
+        },
+        CssAtRule {
+            at_token: AT@136..139 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@139..145 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        ScssMediaQuery {
+                            head: CssMediaTypeQuery {
+                                modifier: missing (optional),
+                                ty: CssMediaType {
+                                    value: ScssInterpolatedIdentifier {
+                                        items: ScssInterpolatedIdentifierPartList [
+                                            ScssInterpolation {
+                                                hash_token: HASH@145..146 "#" [] [],
+                                                l_curly_token: L_CURLY@146..147 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@147..148 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@148..157 "condition" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                r_curly_token: R_CURLY@157..159 "}" [] [Whitespace(" ")],
+                                            },
+                                        ],
+                                    },
+                                },
+                            },
+                            tail: missing (optional),
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@159..160 "{" [] [],
+                    rules: CssRuleList [],
+                    r_curly_token: R_CURLY@160..161 "}" [] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@161..163 "@" [Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@163..169 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        ScssMediaQuery {
+                            head: CssMediaTypeQuery {
+                                modifier: missing (optional),
+                                ty: CssMediaType {
+                                    value: ScssInterpolatedIdentifier {
+                                        items: ScssInterpolatedIdentifierPartList [
+                                            CssIdentifier {
+                                                value_token: IDENT@169..172 "bar" [] [],
+                                            },
+                                            ScssInterpolation {
+                                                hash_token: HASH@172..173 "#" [] [],
+                                                l_curly_token: L_CURLY@173..174 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        CssNumber {
+                                                            value_token: CSS_NUMBER_LITERAL@174..176 "12" [] [],
+                                                        },
+                                                    ],
+                                                },
+                                                r_curly_token: R_CURLY@176..178 "}" [] [Whitespace(" ")],
+                                            },
+                                        ],
+                                    },
+                                },
+                            },
+                            tail: missing (optional),
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@178..179 "{" [] [],
+                    rules: CssRuleList [],
+                    r_curly_token: R_CURLY@179..180 "}" [] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@180..182 "@" [Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@182..188 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        ScssMediaQuery {
+                            head: CssMediaTypeQuery {
+                                modifier: missing (optional),
+                                ty: CssMediaType {
+                                    value: ScssInterpolatedIdentifier {
+                                        items: ScssInterpolatedIdentifierPartList [
+                                            ScssInterpolation {
+                                                hash_token: HASH@188..189 "#" [] [],
+                                                l_curly_token: L_CURLY@189..190 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@190..191 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@191..197 "prefix" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                r_curly_token: R_CURLY@197..198 "}" [] [],
+                                            },
+                                            CssIdentifier {
+                                                value_token: IDENT@198..206 "-screen" [] [Whitespace(" ")],
+                                            },
+                                        ],
+                                    },
+                                },
+                            },
+                            tail: missing (optional),
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@206..207 "{" [] [],
+                    rules: CssRuleList [],
+                    r_curly_token: R_CURLY@207..208 "}" [] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@208..210 "@" [Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@210..216 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        ScssMediaQuery {
+                            head: CssMediaTypeQuery {
+                                modifier: missing (optional),
+                                ty: CssMediaType {
+                                    value: ScssInterpolatedIdentifier {
+                                        items: ScssInterpolatedIdentifierPartList [
+                                            CssIdentifier {
+                                                value_token: IDENT@216..219 "scr" [] [],
+                                            },
+                                            ScssInterpolation {
+                                                hash_token: HASH@219..220 "#" [] [],
+                                                l_curly_token: L_CURLY@220..221 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        CssString {
+                                                            value_token: CSS_STRING_LITERAL@221..225 "\"ee\"" [] [],
+                                                        },
+                                                    ],
+                                                },
+                                                r_curly_token: R_CURLY@225..226 "}" [] [],
+                                            },
+                                            CssIdentifier {
+                                                value_token: IDENT@226..228 "n" [] [Whitespace(" ")],
+                                            },
+                                        ],
+                                    },
+                                },
+                            },
+                            tail: missing (optional),
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@228..229 "{" [] [],
+                    rules: CssRuleList [],
+                    r_curly_token: R_CURLY@229..230 "}" [] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@230..232 "@" [Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@232..238 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        ScssMediaQuery {
+                            head: CssMediaTypeQuery {
+                                modifier: missing (optional),
+                                ty: CssMediaType {
+                                    value: ScssInterpolatedIdentifier {
+                                        items: ScssInterpolatedIdentifierPartList [
+                                            CssIdentifier {
+                                                value_token: IDENT@238..244 "print-" [] [],
+                                            },
+                                            ScssInterpolation {
+                                                hash_token: HASH@244..245 "#" [] [],
+                                                l_curly_token: L_CURLY@245..246 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@246..247 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@247..253 "suffix" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                r_curly_token: R_CURLY@253..255 "}" [] [Whitespace(" ")],
+                                            },
+                                        ],
+                                    },
+                                },
+                            },
+                            tail: missing (optional),
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@255..256 "{" [] [],
+                    rules: CssRuleList [],
+                    r_curly_token: R_CURLY@256..257 "}" [] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@257..260 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@260..266 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        ScssMediaQuery {
+                            head: CssMediaTypeQuery {
+                                modifier: missing (optional),
+                                ty: CssMediaType {
+                                    value: CssIdentifier {
+                                        value_token: IDENT@266..270 "all" [] [Whitespace(" ")],
+                                    },
+                                },
+                            },
+                            tail: CssMediaType {
+                                value: ScssInterpolatedIdentifier {
+                                    items: ScssInterpolatedIdentifierPartList [
+                                        ScssInterpolation {
+                                            hash_token: HASH@270..271 "#" [] [],
+                                            l_curly_token: L_CURLY@271..272 "{" [] [],
+                                            value: ScssExpression {
+                                                items: ScssExpressionItemList [
+                                                    ScssVariable {
+                                                        dollar_token: DOLLAR@272..273 "$" [] [],
+                                                        name: CssIdentifier {
+                                                            value_token: IDENT@273..283 "query-tail" [] [],
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                            r_curly_token: R_CURLY@283..285 "}" [] [Whitespace(" ")],
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@285..286 "{" [] [],
+                    rules: CssRuleList [],
+                    r_curly_token: R_CURLY@286..287 "}" [] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@287..289 "@" [Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@289..295 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        ScssMediaQuery {
+                            head: CssMediaTypeQuery {
+                                modifier: missing (optional),
+                                ty: CssMediaType {
+                                    value: CssIdentifier {
+                                        value_token: IDENT@295..301 "screen" [] [],
+                                    },
+                                },
+                            },
+                            tail: CssMediaType {
+                                value: ScssInterpolatedIdentifier {
+                                    items: ScssInterpolatedIdentifierPartList [
+                                        ScssInterpolation {
+                                            hash_token: HASH@301..303 "#" [Newline("\n")] [],
+                                            l_curly_token: L_CURLY@303..304 "{" [] [],
+                                            value: ScssExpression {
+                                                items: ScssExpressionItemList [
+                                                    ScssVariable {
+                                                        dollar_token: DOLLAR@304..305 "$" [] [],
+                                                        name: CssIdentifier {
+                                                            value_token: IDENT@305..315 "query-tail" [] [],
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                            r_curly_token: R_CURLY@315..317 "}" [] [Whitespace(" ")],
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@317..318 "{" [] [],
+                    rules: CssRuleList [],
+                    r_curly_token: R_CURLY@318..319 "}" [] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@319..321 "@" [Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@321..327 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        ScssMediaQuery {
+                            head: CssMediaTypeQuery {
+                                modifier: missing (optional),
+                                ty: CssMediaType {
+                                    value: ScssInterpolatedIdentifier {
+                                        items: ScssInterpolatedIdentifierPartList [
+                                            ScssInterpolation {
+                                                hash_token: HASH@327..328 "#" [] [],
+                                                l_curly_token: L_CURLY@328..329 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@329..330 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@330..338 "modifier" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                r_curly_token: R_CURLY@338..340 "}" [] [Whitespace(" ")],
+                                            },
+                                        ],
+                                    },
+                                },
+                            },
+                            tail: CssMediaType {
+                                value: CssIdentifier {
+                                    value_token: IDENT@340..347 "screen" [] [Whitespace(" ")],
+                                },
+                            },
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@347..348 "{" [] [],
+                    rules: CssRuleList [],
+                    r_curly_token: R_CURLY@348..349 "}" [] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@349..351 "@" [Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@351..357 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        ScssMediaQuery {
+                            head: CssMediaTypeQuery {
+                                modifier: missing (optional),
+                                ty: CssMediaType {
+                                    value: ScssInterpolatedIdentifier {
+                                        items: ScssInterpolatedIdentifierPartList [
+                                            ScssInterpolation {
+                                                hash_token: HASH@357..358 "#" [] [],
+                                                l_curly_token: L_CURLY@358..359 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@359..360 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@360..368 "modifier" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                r_curly_token: R_CURLY@368..370 "}" [] [Whitespace(" ")],
+                                            },
+                                        ],
+                                    },
+                                },
+                            },
+                            tail: CssMediaType {
+                                value: ScssInterpolatedIdentifier {
+                                    items: ScssInterpolatedIdentifierPartList [
+                                        ScssInterpolation {
+                                            hash_token: HASH@370..371 "#" [] [],
+                                            l_curly_token: L_CURLY@371..372 "{" [] [],
+                                            value: ScssExpression {
+                                                items: ScssExpressionItemList [
+                                                    ScssVariable {
+                                                        dollar_token: DOLLAR@372..373 "$" [] [],
+                                                        name: CssIdentifier {
+                                                            value_token: IDENT@373..377 "type" [] [],
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                            r_curly_token: R_CURLY@377..379 "}" [] [Whitespace(" ")],
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@379..380 "{" [] [],
+                    rules: CssRuleList [],
+                    r_curly_token: R_CURLY@380..381 "}" [] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@381..383 "@" [Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@383..389 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        ScssMediaQuery {
+                            head: CssMediaTypeQuery {
+                                modifier: ONLY_KW@389..394 "only" [] [Whitespace(" ")],
+                                ty: CssMediaType {
+                                    value: ScssInterpolatedIdentifier {
+                                        items: ScssInterpolatedIdentifierPartList [
+                                            ScssInterpolation {
+                                                hash_token: HASH@394..395 "#" [] [],
+                                                l_curly_token: L_CURLY@395..396 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@396..397 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@397..401 "type" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                r_curly_token: R_CURLY@401..403 "}" [] [Whitespace(" ")],
+                                            },
+                                        ],
+                                    },
+                                },
+                            },
+                            tail: missing (optional),
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@403..404 "{" [] [],
+                    rules: CssRuleList [],
+                    r_curly_token: R_CURLY@404..405 "}" [] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@405..407 "@" [Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@407..413 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        ScssMediaQuery {
+                            head: CssMediaTypeQuery {
+                                modifier: NOT_KW@413..417 "not" [] [Whitespace(" ")],
+                                ty: CssMediaType {
+                                    value: ScssInterpolatedIdentifier {
+                                        items: ScssInterpolatedIdentifierPartList [
+                                            ScssInterpolation {
+                                                hash_token: HASH@417..418 "#" [] [],
+                                                l_curly_token: L_CURLY@418..419 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@419..420 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@420..424 "type" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                r_curly_token: R_CURLY@424..426 "}" [] [Whitespace(" ")],
+                                            },
+                                        ],
+                                    },
+                                },
+                            },
+                            tail: missing (optional),
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@426..427 "{" [] [],
+                    rules: CssRuleList [],
+                    r_curly_token: R_CURLY@427..428 "}" [] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@428..431 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@431..437 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssMediaConditionQuery {
+                            condition: CssMediaAndCondition {
+                                left: ScssMediaQuery {
+                                    head: CssMediaTypeQuery {
+                                        modifier: missing (optional),
+                                        ty: CssMediaType {
+                                            value: ScssInterpolatedIdentifier {
+                                                items: ScssInterpolatedIdentifierPartList [
+                                                    ScssInterpolation {
+                                                        hash_token: HASH@437..438 "#" [] [],
+                                                        l_curly_token: L_CURLY@438..439 "{" [] [],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                ScssVariable {
+                                                                    dollar_token: DOLLAR@439..440 "$" [] [],
+                                                                    name: CssIdentifier {
+                                                                        value_token: IDENT@440..444 "type" [] [],
+                                                                    },
+                                                                },
+                                                            ],
+                                                        },
+                                                        r_curly_token: R_CURLY@444..446 "}" [] [Whitespace(" ")],
+                                                    },
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    tail: missing (optional),
+                                },
+                                and_token: AND_KW@446..450 "and" [] [Whitespace(" ")],
+                                right: CssMediaFeatureInParens {
+                                    l_paren_token: L_PAREN@450..451 "(" [] [],
+                                    feature: CssQueryFeatureBoolean {
+                                        name: CssIdentifier {
+                                            value_token: IDENT@451..456 "color" [] [],
+                                        },
+                                    },
+                                    r_paren_token: R_PAREN@456..458 ")" [] [Whitespace(" ")],
+                                },
+                            },
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@458..459 "{" [] [],
+                    rules: CssRuleList [],
+                    r_curly_token: R_CURLY@459..460 "}" [] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@460..462 "@" [Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@462..468 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssMediaConditionQuery {
+                            condition: CssMediaAndCondition {
+                                left: ScssMediaQuery {
+                                    head: CssMediaTypeQuery {
+                                        modifier: missing (optional),
+                                        ty: CssMediaType {
+                                            value: CssIdentifier {
+                                                value_token: IDENT@468..472 "all" [] [Whitespace(" ")],
+                                            },
+                                        },
+                                    },
+                                    tail: CssMediaType {
+                                        value: ScssInterpolatedIdentifier {
+                                            items: ScssInterpolatedIdentifierPartList [
+                                                ScssInterpolation {
+                                                    hash_token: HASH@472..473 "#" [] [],
+                                                    l_curly_token: L_CURLY@473..474 "{" [] [],
+                                                    value: ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            ScssVariable {
+                                                                dollar_token: DOLLAR@474..475 "$" [] [],
+                                                                name: CssIdentifier {
+                                                                    value_token: IDENT@475..485 "query-tail" [] [],
+                                                                },
+                                                            },
+                                                        ],
+                                                    },
+                                                    r_curly_token: R_CURLY@485..487 "}" [] [Whitespace(" ")],
+                                                },
+                                            ],
+                                        },
+                                    },
+                                },
+                                and_token: AND_KW@487..491 "and" [] [Whitespace(" ")],
+                                right: CssMediaFeatureInParens {
+                                    l_paren_token: L_PAREN@491..492 "(" [] [],
+                                    feature: CssQueryFeatureBoolean {
+                                        name: CssIdentifier {
+                                            value_token: IDENT@492..497 "color" [] [],
+                                        },
+                                    },
+                                    r_paren_token: R_PAREN@497..499 ")" [] [Whitespace(" ")],
+                                },
+                            },
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@499..500 "{" [] [],
+                    rules: CssRuleList [],
+                    r_curly_token: R_CURLY@500..501 "}" [] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@501..503 "@" [Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@503..509 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssMediaConditionQuery {
+                            condition: CssMediaAndCondition {
+                                left: CssMediaFeatureInParens {
+                                    l_paren_token: L_PAREN@509..510 "(" [] [],
+                                    feature: CssQueryFeatureBoolean {
+                                        name: CssIdentifier {
+                                            value_token: IDENT@510..515 "color" [] [],
+                                        },
+                                    },
+                                    r_paren_token: R_PAREN@515..517 ")" [] [Whitespace(" ")],
+                                },
+                                and_token: AND_KW@517..521 "and" [] [Whitespace(" ")],
+                                right: ScssMediaQuery {
+                                    head: CssMediaTypeQuery {
+                                        modifier: missing (optional),
+                                        ty: CssMediaType {
+                                            value: ScssInterpolatedIdentifier {
+                                                items: ScssInterpolatedIdentifierPartList [
+                                                    ScssInterpolation {
+                                                        hash_token: HASH@521..522 "#" [] [],
+                                                        l_curly_token: L_CURLY@522..523 "{" [] [],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                ScssVariable {
+                                                                    dollar_token: DOLLAR@523..524 "$" [] [],
+                                                                    name: CssIdentifier {
+                                                                        value_token: IDENT@524..533 "condition" [] [],
+                                                                    },
+                                                                },
+                                                            ],
+                                                        },
+                                                        r_curly_token: R_CURLY@533..535 "}" [] [Whitespace(" ")],
+                                                    },
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    tail: missing (optional),
+                                },
+                            },
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@535..536 "{" [] [],
+                    rules: CssRuleList [],
+                    r_curly_token: R_CURLY@536..537 "}" [] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@537..539 "@" [Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@539..545 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssMediaConditionQuery {
+                            condition: CssMediaAndCondition {
+                                left: ScssMediaQuery {
+                                    head: CssMediaTypeQuery {
+                                        modifier: missing (optional),
+                                        ty: CssMediaType {
+                                            value: ScssInterpolatedIdentifier {
+                                                items: ScssInterpolatedIdentifierPartList [
+                                                    ScssInterpolation {
+                                                        hash_token: HASH@545..546 "#" [] [],
+                                                        l_curly_token: L_CURLY@546..547 "{" [] [],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                CssString {
+                                                                    value_token: CSS_STRING_LITERAL@547..560 "\"only screen\"" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                        r_curly_token: R_CURLY@560..562 "}" [] [Whitespace(" ")],
+                                                    },
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    tail: missing (optional),
+                                },
+                                and_token: AND_KW@562..566 "and" [] [Whitespace(" ")],
+                                right: CssMediaAndCondition {
+                                    left: ScssMediaQuery {
+                                        head: CssMediaTypeQuery {
+                                            modifier: missing (optional),
+                                            ty: CssMediaType {
+                                                value: ScssInterpolatedIdentifier {
+                                                    items: ScssInterpolatedIdentifierPartList [
+                                                        ScssInterpolation {
+                                                            hash_token: HASH@566..567 "#" [] [],
+                                                            l_curly_token: L_CURLY@567..568 "{" [] [],
+                                                            value: ScssExpression {
+                                                                items: ScssExpressionItemList [
+                                                                    CssString {
+                                                                        value_token: CSS_STRING_LITERAL@568..588 "\"(min-width: 700px)\"" [] [],
+                                                                    },
+                                                                ],
+                                                            },
+                                                            r_curly_token: R_CURLY@588..590 "}" [] [Whitespace(" ")],
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                        },
+                                        tail: missing (optional),
+                                    },
+                                    and_token: AND_KW@590..594 "and" [] [Whitespace(" ")],
+                                    right: ScssMediaQuery {
+                                        head: CssMediaTypeQuery {
+                                            modifier: missing (optional),
+                                            ty: CssMediaType {
+                                                value: ScssInterpolatedIdentifier {
+                                                    items: ScssInterpolatedIdentifierPartList [
+                                                        ScssInterpolation {
+                                                            hash_token: HASH@594..595 "#" [] [],
+                                                            l_curly_token: L_CURLY@595..596 "{" [] [],
+                                                            value: ScssExpression {
+                                                                items: ScssExpressionItemList [
+                                                                    ScssBinaryExpression {
+                                                                        left: CssString {
+                                                                            value_token: CSS_STRING_LITERAL@596..610 "\"(max-width: \"" [] [],
+                                                                        },
+                                                                        operator: PLUS@610..611 "+" [] [],
+                                                                        right: CssString {
+                                                                            value_token: CSS_STRING_LITERAL@611..620 "\"1920px)\"" [] [],
+                                                                        },
+                                                                    },
+                                                                ],
+                                                            },
+                                                            r_curly_token: R_CURLY@620..622 "}" [] [Whitespace(" ")],
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                        },
+                                        tail: missing (optional),
+                                    },
+                                },
+                            },
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@622..623 "{" [] [],
+                    rules: CssRuleList [],
+                    r_curly_token: R_CURLY@623..624 "}" [] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@624..626 "@" [Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@626..632 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        ScssMediaQuery {
+                            head: CssMediaTypeQuery {
+                                modifier: missing (optional),
+                                ty: CssMediaType {
+                                    value: ScssInterpolatedIdentifier {
+                                        items: ScssInterpolatedIdentifierPartList [
+                                            CssIdentifier {
+                                                value_token: IDENT@632..635 "scr" [] [],
+                                            },
+                                            ScssInterpolation {
+                                                hash_token: HASH@635..636 "#" [] [],
+                                                l_curly_token: L_CURLY@636..637 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        CssString {
+                                                            value_token: CSS_STRING_LITERAL@637..647 "\"een, pri\"" [] [],
+                                                        },
+                                                    ],
+                                                },
+                                                r_curly_token: R_CURLY@647..648 "}" [] [],
+                                            },
+                                            CssIdentifier {
+                                                value_token: IDENT@648..651 "nt" [] [Whitespace(" ")],
+                                            },
+                                        ],
+                                    },
+                                },
+                            },
+                            tail: CssMediaType {
+                                value: ScssInterpolatedIdentifier {
+                                    items: ScssInterpolatedIdentifierPartList [
+                                        CssIdentifier {
+                                            value_token: IDENT@651..652 "a" [] [],
+                                        },
+                                        ScssInterpolation {
+                                            hash_token: HASH@652..653 "#" [] [],
+                                            l_curly_token: L_CURLY@653..654 "{" [] [],
+                                            value: ScssExpression {
+                                                items: ScssExpressionItemList [
+                                                    CssString {
+                                                        value_token: CSS_STRING_LITERAL@654..677 "\"nd (max-width: 300px)\"" [] [],
+                                                    },
+                                                ],
+                                            },
+                                            r_curly_token: R_CURLY@677..679 "}" [] [Whitespace(" ")],
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@679..680 "{" [] [],
+                    rules: CssRuleList [],
+                    r_curly_token: R_CURLY@680..681 "}" [] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@681..684 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@684..690 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        CssMediaTypeQuery {
+                            modifier: missing (optional),
+                            ty: CssMediaType {
+                                value: CssIdentifier {
+                                    value_token: IDENT@690..696 "screen" [] [],
+                                },
+                            },
+                        },
+                        COMMA@696..698 "," [] [Whitespace(" ")],
+                        ScssMediaQuery {
+                            head: CssMediaTypeQuery {
+                                modifier: missing (optional),
+                                ty: CssMediaType {
+                                    value: CssIdentifier {
+                                        value_token: IDENT@698..702 "all" [] [Whitespace(" ")],
+                                    },
+                                },
+                            },
+                            tail: CssMediaType {
+                                value: ScssInterpolatedIdentifier {
+                                    items: ScssInterpolatedIdentifierPartList [
+                                        ScssInterpolation {
+                                            hash_token: HASH@702..703 "#" [] [],
+                                            l_curly_token: L_CURLY@703..704 "{" [] [],
+                                            value: ScssExpression {
+                                                items: ScssExpressionItemList [
+                                                    ScssVariable {
+                                                        dollar_token: DOLLAR@704..705 "$" [] [],
+                                                        name: CssIdentifier {
+                                                            value_token: IDENT@705..715 "query-tail" [] [],
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                            r_curly_token: R_CURLY@715..716 "}" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                        COMMA@716..718 "," [] [Whitespace(" ")],
+                        ScssMediaQuery {
+                            head: CssMediaTypeQuery {
+                                modifier: missing (optional),
+                                ty: CssMediaType {
+                                    value: ScssInterpolatedIdentifier {
+                                        items: ScssInterpolatedIdentifierPartList [
+                                            CssIdentifier {
+                                                value_token: IDENT@718..724 "print-" [] [],
+                                            },
+                                            ScssInterpolation {
+                                                hash_token: HASH@724..725 "#" [] [],
+                                                l_curly_token: L_CURLY@725..726 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@726..727 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@727..733 "suffix" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                r_curly_token: R_CURLY@733..735 "}" [] [Whitespace(" ")],
+                                            },
+                                        ],
+                                    },
+                                },
+                            },
+                            tail: missing (optional),
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@735..736 "{" [] [],
+                    rules: CssRuleList [],
+                    r_curly_token: R_CURLY@736..737 "}" [] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@737..740 "@" [Newline("\n"), Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@740..746 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        ScssMediaQuery {
+                            head: CssMediaTypeQuery {
+                                modifier: missing (optional),
+                                ty: CssMediaType {
+                                    value: ScssInterpolatedIdentifier {
+                                        items: ScssInterpolatedIdentifierPartList [
+                                            CssIdentifier {
+                                                value_token: IDENT@746..750 "only" [] [],
+                                            },
+                                            ScssInterpolation {
+                                                hash_token: HASH@750..751 "#" [] [],
+                                                l_curly_token: L_CURLY@751..752 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@752..753 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@753..757 "type" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                r_curly_token: R_CURLY@757..759 "}" [] [Whitespace(" ")],
+                                            },
+                                        ],
+                                    },
+                                },
+                            },
+                            tail: missing (optional),
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@759..760 "{" [] [],
+                    rules: CssRuleList [],
+                    r_curly_token: R_CURLY@760..761 "}" [] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@761..763 "@" [Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@763..769 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        ScssMediaQuery {
+                            head: CssMediaTypeQuery {
+                                modifier: missing (optional),
+                                ty: CssMediaType {
+                                    value: ScssInterpolatedIdentifier {
+                                        items: ScssInterpolatedIdentifierPartList [
+                                            CssIdentifier {
+                                                value_token: IDENT@769..772 "not" [] [],
+                                            },
+                                            ScssInterpolation {
+                                                hash_token: HASH@772..773 "#" [] [],
+                                                l_curly_token: L_CURLY@773..774 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@774..775 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@775..779 "type" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                r_curly_token: R_CURLY@779..781 "}" [] [Whitespace(" ")],
+                                            },
+                                        ],
+                                    },
+                                },
+                            },
+                            tail: missing (optional),
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@781..782 "{" [] [],
+                    rules: CssRuleList [],
+                    r_curly_token: R_CURLY@782..783 "}" [] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@783..785 "@" [Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@785..791 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        ScssMediaQuery {
+                            head: CssMediaTypeQuery {
+                                modifier: missing (optional),
+                                ty: CssMediaType {
+                                    value: CssIdentifier {
+                                        value_token: IDENT@791..798 "screen" [] [Whitespace(" ")],
+                                    },
+                                },
+                            },
+                            tail: CssMediaType {
+                                value: ScssInterpolatedIdentifier {
+                                    items: ScssInterpolatedIdentifierPartList [
+                                        CssIdentifier {
+                                            value_token: IDENT@798..801 "and" [] [],
+                                        },
+                                        ScssInterpolation {
+                                            hash_token: HASH@801..802 "#" [] [],
+                                            l_curly_token: L_CURLY@802..803 "{" [] [],
+                                            value: ScssExpression {
+                                                items: ScssExpressionItemList [
+                                                    ScssVariable {
+                                                        dollar_token: DOLLAR@803..804 "$" [] [],
+                                                        name: CssIdentifier {
+                                                            value_token: IDENT@804..810 "suffix" [] [],
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                            r_curly_token: R_CURLY@810..812 "}" [] [Whitespace(" ")],
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@812..813 "{" [] [],
+                    rules: CssRuleList [],
+                    r_curly_token: R_CURLY@813..814 "}" [] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@814..816 "@" [Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@816..822 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        ScssMediaQuery {
+                            head: CssMediaTypeQuery {
+                                modifier: missing (optional),
+                                ty: CssMediaType {
+                                    value: CssIdentifier {
+                                        value_token: IDENT@822..829 "screen" [] [Whitespace(" ")],
+                                    },
+                                },
+                            },
+                            tail: CssMediaType {
+                                value: ScssInterpolatedIdentifier {
+                                    items: ScssInterpolatedIdentifierPartList [
+                                        CssIdentifier {
+                                            value_token: IDENT@829..831 "or" [] [],
+                                        },
+                                        ScssInterpolation {
+                                            hash_token: HASH@831..832 "#" [] [],
+                                            l_curly_token: L_CURLY@832..833 "{" [] [],
+                                            value: ScssExpression {
+                                                items: ScssExpressionItemList [
+                                                    ScssVariable {
+                                                        dollar_token: DOLLAR@833..834 "$" [] [],
+                                                        name: CssIdentifier {
+                                                            value_token: IDENT@834..840 "suffix" [] [],
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                            r_curly_token: R_CURLY@840..842 "}" [] [Whitespace(" ")],
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@842..843 "{" [] [],
+                    rules: CssRuleList [],
+                    r_curly_token: R_CURLY@843..844 "}" [] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@844..846 "@" [Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@846..852 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        ScssMediaQuery {
+                            head: CssMediaTypeQuery {
+                                modifier: missing (optional),
+                                ty: CssMediaType {
+                                    value: ScssInterpolatedIdentifier {
+                                        items: ScssInterpolatedIdentifierPartList [
+                                            CssIdentifier {
+                                                value_token: IDENT@852..860 "only" [] [Comments("/**/")],
+                                            },
+                                            ScssInterpolation {
+                                                hash_token: HASH@860..861 "#" [] [],
+                                                l_curly_token: L_CURLY@861..862 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@862..863 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@863..867 "type" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                r_curly_token: R_CURLY@867..869 "}" [] [Whitespace(" ")],
+                                            },
+                                        ],
+                                    },
+                                },
+                            },
+                            tail: missing (optional),
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@869..870 "{" [] [],
+                    rules: CssRuleList [],
+                    r_curly_token: R_CURLY@870..871 "}" [] [],
+                },
+            },
+        },
+        CssAtRule {
+            at_token: AT@871..873 "@" [Newline("\n")] [],
+            rule: CssMediaAtRule {
+                declarator: CssMediaAtRuleDeclarator {
+                    media_token: MEDIA_KW@873..879 "media" [] [Whitespace(" ")],
+                    queries: CssMediaQueryList [
+                        ScssMediaQuery {
+                            head: CssMediaTypeQuery {
+                                modifier: missing (optional),
+                                ty: CssMediaType {
+                                    value: CssIdentifier {
+                                        value_token: IDENT@879..886 "screen" [] [Whitespace(" ")],
+                                    },
+                                },
+                            },
+                            tail: CssMediaType {
+                                value: ScssInterpolatedIdentifier {
+                                    items: ScssInterpolatedIdentifierPartList [
+                                        CssIdentifier {
+                                            value_token: IDENT@886..893 "and" [] [Comments("/**/")],
+                                        },
+                                        ScssInterpolation {
+                                            hash_token: HASH@893..894 "#" [] [],
+                                            l_curly_token: L_CURLY@894..895 "{" [] [],
+                                            value: ScssExpression {
+                                                items: ScssExpressionItemList [
+                                                    ScssVariable {
+                                                        dollar_token: DOLLAR@895..896 "$" [] [],
+                                                        name: CssIdentifier {
+                                                            value_token: IDENT@896..902 "suffix" [] [],
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                            r_curly_token: R_CURLY@902..904 "}" [] [Whitespace(" ")],
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                    ],
+                },
+                block: CssRuleBlock {
+                    l_curly_token: L_CURLY@904..905 "{" [] [],
+                    rules: CssRuleList [],
+                    r_curly_token: R_CURLY@905..906 "}" [] [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@906..907 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..907
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..906
+    0: SCSS_VARIABLE_DECLARATION@0..33
+      0: SCSS_VARIABLE@0..10
+        0: DOLLAR@0..1 "$" [] []
+        1: CSS_IDENTIFIER@1..10
+          0: IDENT@1..10 "condition" [] []
+      1: COLON@10..12 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@12..32
+        0: SCSS_EXPRESSION_ITEM_LIST@12..32
+          0: CSS_STRING@12..32
+            0: CSS_STRING_LITERAL@12..32 "\"(min-width: 40rem)\"" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@32..32
+      4: SEMICOLON@32..33 ";" [] []
+    1: SCSS_VARIABLE_DECLARATION@33..72
+      0: SCSS_VARIABLE@33..45
+        0: DOLLAR@33..35 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@35..45
+          0: IDENT@35..45 "query-tail" [] []
+      1: COLON@45..47 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@47..71
+        0: SCSS_EXPRESSION_ITEM_LIST@47..71
+          0: CSS_STRING@47..71
+            0: CSS_STRING_LITERAL@47..71 "\"and (min-width: 40rem)\"" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@71..71
+      4: SEMICOLON@71..72 ";" [] []
+    2: SCSS_VARIABLE_DECLARATION@72..89
+      0: SCSS_VARIABLE@72..82
+        0: DOLLAR@72..74 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@74..82
+          0: IDENT@74..82 "modifier" [] []
+      1: COLON@82..84 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@84..88
+        0: SCSS_EXPRESSION_ITEM_LIST@84..88
+          0: CSS_IDENTIFIER@84..88
+            0: IDENT@84..88 "only" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@88..88
+      4: SEMICOLON@88..89 ";" [] []
+    3: SCSS_VARIABLE_DECLARATION@89..104
+      0: SCSS_VARIABLE@89..95
+        0: DOLLAR@89..91 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@91..95
+          0: IDENT@91..95 "type" [] []
+      1: COLON@95..97 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@97..103
+        0: SCSS_EXPRESSION_ITEM_LIST@97..103
+          0: CSS_IDENTIFIER@97..103
+            0: IDENT@97..103 "screen" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@103..103
+      4: SEMICOLON@103..104 ";" [] []
+    4: SCSS_VARIABLE_DECLARATION@104..120
+      0: SCSS_VARIABLE@104..112
+        0: DOLLAR@104..106 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@106..112
+          0: IDENT@106..112 "prefix" [] []
+      1: COLON@112..114 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@114..119
+        0: SCSS_EXPRESSION_ITEM_LIST@114..119
+          0: CSS_IDENTIFIER@114..119
+            0: IDENT@114..119 "print" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@119..119
+      4: SEMICOLON@119..120 ";" [] []
+    5: SCSS_VARIABLE_DECLARATION@120..136
+      0: SCSS_VARIABLE@120..128
+        0: DOLLAR@120..122 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@122..128
+          0: IDENT@122..128 "suffix" [] []
+      1: COLON@128..130 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@130..135
+        0: SCSS_EXPRESSION_ITEM_LIST@130..135
+          0: CSS_IDENTIFIER@130..135
+            0: IDENT@130..135 "color" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@135..135
+      4: SEMICOLON@135..136 ";" [] []
+    6: CSS_AT_RULE@136..161
+      0: AT@136..139 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@139..161
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@139..159
+          0: MEDIA_KW@139..145 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@145..159
+            0: SCSS_MEDIA_QUERY@145..159
+              0: CSS_MEDIA_TYPE_QUERY@145..159
+                0: (empty)
+                1: CSS_MEDIA_TYPE@145..159
+                  0: SCSS_INTERPOLATED_IDENTIFIER@145..159
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@145..159
+                      0: SCSS_INTERPOLATION@145..159
+                        0: HASH@145..146 "#" [] []
+                        1: L_CURLY@146..147 "{" [] []
+                        2: SCSS_EXPRESSION@147..157
+                          0: SCSS_EXPRESSION_ITEM_LIST@147..157
+                            0: SCSS_VARIABLE@147..157
+                              0: DOLLAR@147..148 "$" [] []
+                              1: CSS_IDENTIFIER@148..157
+                                0: IDENT@148..157 "condition" [] []
+                        3: R_CURLY@157..159 "}" [] [Whitespace(" ")]
+              1: (empty)
+        1: CSS_RULE_BLOCK@159..161
+          0: L_CURLY@159..160 "{" [] []
+          1: CSS_RULE_LIST@160..160
+          2: R_CURLY@160..161 "}" [] []
+    7: CSS_AT_RULE@161..180
+      0: AT@161..163 "@" [Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@163..180
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@163..178
+          0: MEDIA_KW@163..169 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@169..178
+            0: SCSS_MEDIA_QUERY@169..178
+              0: CSS_MEDIA_TYPE_QUERY@169..178
+                0: (empty)
+                1: CSS_MEDIA_TYPE@169..178
+                  0: SCSS_INTERPOLATED_IDENTIFIER@169..178
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@169..178
+                      0: CSS_IDENTIFIER@169..172
+                        0: IDENT@169..172 "bar" [] []
+                      1: SCSS_INTERPOLATION@172..178
+                        0: HASH@172..173 "#" [] []
+                        1: L_CURLY@173..174 "{" [] []
+                        2: SCSS_EXPRESSION@174..176
+                          0: SCSS_EXPRESSION_ITEM_LIST@174..176
+                            0: CSS_NUMBER@174..176
+                              0: CSS_NUMBER_LITERAL@174..176 "12" [] []
+                        3: R_CURLY@176..178 "}" [] [Whitespace(" ")]
+              1: (empty)
+        1: CSS_RULE_BLOCK@178..180
+          0: L_CURLY@178..179 "{" [] []
+          1: CSS_RULE_LIST@179..179
+          2: R_CURLY@179..180 "}" [] []
+    8: CSS_AT_RULE@180..208
+      0: AT@180..182 "@" [Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@182..208
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@182..206
+          0: MEDIA_KW@182..188 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@188..206
+            0: SCSS_MEDIA_QUERY@188..206
+              0: CSS_MEDIA_TYPE_QUERY@188..206
+                0: (empty)
+                1: CSS_MEDIA_TYPE@188..206
+                  0: SCSS_INTERPOLATED_IDENTIFIER@188..206
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@188..206
+                      0: SCSS_INTERPOLATION@188..198
+                        0: HASH@188..189 "#" [] []
+                        1: L_CURLY@189..190 "{" [] []
+                        2: SCSS_EXPRESSION@190..197
+                          0: SCSS_EXPRESSION_ITEM_LIST@190..197
+                            0: SCSS_VARIABLE@190..197
+                              0: DOLLAR@190..191 "$" [] []
+                              1: CSS_IDENTIFIER@191..197
+                                0: IDENT@191..197 "prefix" [] []
+                        3: R_CURLY@197..198 "}" [] []
+                      1: CSS_IDENTIFIER@198..206
+                        0: IDENT@198..206 "-screen" [] [Whitespace(" ")]
+              1: (empty)
+        1: CSS_RULE_BLOCK@206..208
+          0: L_CURLY@206..207 "{" [] []
+          1: CSS_RULE_LIST@207..207
+          2: R_CURLY@207..208 "}" [] []
+    9: CSS_AT_RULE@208..230
+      0: AT@208..210 "@" [Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@210..230
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@210..228
+          0: MEDIA_KW@210..216 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@216..228
+            0: SCSS_MEDIA_QUERY@216..228
+              0: CSS_MEDIA_TYPE_QUERY@216..228
+                0: (empty)
+                1: CSS_MEDIA_TYPE@216..228
+                  0: SCSS_INTERPOLATED_IDENTIFIER@216..228
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@216..228
+                      0: CSS_IDENTIFIER@216..219
+                        0: IDENT@216..219 "scr" [] []
+                      1: SCSS_INTERPOLATION@219..226
+                        0: HASH@219..220 "#" [] []
+                        1: L_CURLY@220..221 "{" [] []
+                        2: SCSS_EXPRESSION@221..225
+                          0: SCSS_EXPRESSION_ITEM_LIST@221..225
+                            0: CSS_STRING@221..225
+                              0: CSS_STRING_LITERAL@221..225 "\"ee\"" [] []
+                        3: R_CURLY@225..226 "}" [] []
+                      2: CSS_IDENTIFIER@226..228
+                        0: IDENT@226..228 "n" [] [Whitespace(" ")]
+              1: (empty)
+        1: CSS_RULE_BLOCK@228..230
+          0: L_CURLY@228..229 "{" [] []
+          1: CSS_RULE_LIST@229..229
+          2: R_CURLY@229..230 "}" [] []
+    10: CSS_AT_RULE@230..257
+      0: AT@230..232 "@" [Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@232..257
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@232..255
+          0: MEDIA_KW@232..238 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@238..255
+            0: SCSS_MEDIA_QUERY@238..255
+              0: CSS_MEDIA_TYPE_QUERY@238..255
+                0: (empty)
+                1: CSS_MEDIA_TYPE@238..255
+                  0: SCSS_INTERPOLATED_IDENTIFIER@238..255
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@238..255
+                      0: CSS_IDENTIFIER@238..244
+                        0: IDENT@238..244 "print-" [] []
+                      1: SCSS_INTERPOLATION@244..255
+                        0: HASH@244..245 "#" [] []
+                        1: L_CURLY@245..246 "{" [] []
+                        2: SCSS_EXPRESSION@246..253
+                          0: SCSS_EXPRESSION_ITEM_LIST@246..253
+                            0: SCSS_VARIABLE@246..253
+                              0: DOLLAR@246..247 "$" [] []
+                              1: CSS_IDENTIFIER@247..253
+                                0: IDENT@247..253 "suffix" [] []
+                        3: R_CURLY@253..255 "}" [] [Whitespace(" ")]
+              1: (empty)
+        1: CSS_RULE_BLOCK@255..257
+          0: L_CURLY@255..256 "{" [] []
+          1: CSS_RULE_LIST@256..256
+          2: R_CURLY@256..257 "}" [] []
+    11: CSS_AT_RULE@257..287
+      0: AT@257..260 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@260..287
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@260..285
+          0: MEDIA_KW@260..266 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@266..285
+            0: SCSS_MEDIA_QUERY@266..285
+              0: CSS_MEDIA_TYPE_QUERY@266..270
+                0: (empty)
+                1: CSS_MEDIA_TYPE@266..270
+                  0: CSS_IDENTIFIER@266..270
+                    0: IDENT@266..270 "all" [] [Whitespace(" ")]
+              1: CSS_MEDIA_TYPE@270..285
+                0: SCSS_INTERPOLATED_IDENTIFIER@270..285
+                  0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@270..285
+                    0: SCSS_INTERPOLATION@270..285
+                      0: HASH@270..271 "#" [] []
+                      1: L_CURLY@271..272 "{" [] []
+                      2: SCSS_EXPRESSION@272..283
+                        0: SCSS_EXPRESSION_ITEM_LIST@272..283
+                          0: SCSS_VARIABLE@272..283
+                            0: DOLLAR@272..273 "$" [] []
+                            1: CSS_IDENTIFIER@273..283
+                              0: IDENT@273..283 "query-tail" [] []
+                      3: R_CURLY@283..285 "}" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@285..287
+          0: L_CURLY@285..286 "{" [] []
+          1: CSS_RULE_LIST@286..286
+          2: R_CURLY@286..287 "}" [] []
+    12: CSS_AT_RULE@287..319
+      0: AT@287..289 "@" [Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@289..319
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@289..317
+          0: MEDIA_KW@289..295 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@295..317
+            0: SCSS_MEDIA_QUERY@295..317
+              0: CSS_MEDIA_TYPE_QUERY@295..301
+                0: (empty)
+                1: CSS_MEDIA_TYPE@295..301
+                  0: CSS_IDENTIFIER@295..301
+                    0: IDENT@295..301 "screen" [] []
+              1: CSS_MEDIA_TYPE@301..317
+                0: SCSS_INTERPOLATED_IDENTIFIER@301..317
+                  0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@301..317
+                    0: SCSS_INTERPOLATION@301..317
+                      0: HASH@301..303 "#" [Newline("\n")] []
+                      1: L_CURLY@303..304 "{" [] []
+                      2: SCSS_EXPRESSION@304..315
+                        0: SCSS_EXPRESSION_ITEM_LIST@304..315
+                          0: SCSS_VARIABLE@304..315
+                            0: DOLLAR@304..305 "$" [] []
+                            1: CSS_IDENTIFIER@305..315
+                              0: IDENT@305..315 "query-tail" [] []
+                      3: R_CURLY@315..317 "}" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@317..319
+          0: L_CURLY@317..318 "{" [] []
+          1: CSS_RULE_LIST@318..318
+          2: R_CURLY@318..319 "}" [] []
+    13: CSS_AT_RULE@319..349
+      0: AT@319..321 "@" [Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@321..349
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@321..347
+          0: MEDIA_KW@321..327 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@327..347
+            0: SCSS_MEDIA_QUERY@327..347
+              0: CSS_MEDIA_TYPE_QUERY@327..340
+                0: (empty)
+                1: CSS_MEDIA_TYPE@327..340
+                  0: SCSS_INTERPOLATED_IDENTIFIER@327..340
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@327..340
+                      0: SCSS_INTERPOLATION@327..340
+                        0: HASH@327..328 "#" [] []
+                        1: L_CURLY@328..329 "{" [] []
+                        2: SCSS_EXPRESSION@329..338
+                          0: SCSS_EXPRESSION_ITEM_LIST@329..338
+                            0: SCSS_VARIABLE@329..338
+                              0: DOLLAR@329..330 "$" [] []
+                              1: CSS_IDENTIFIER@330..338
+                                0: IDENT@330..338 "modifier" [] []
+                        3: R_CURLY@338..340 "}" [] [Whitespace(" ")]
+              1: CSS_MEDIA_TYPE@340..347
+                0: CSS_IDENTIFIER@340..347
+                  0: IDENT@340..347 "screen" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@347..349
+          0: L_CURLY@347..348 "{" [] []
+          1: CSS_RULE_LIST@348..348
+          2: R_CURLY@348..349 "}" [] []
+    14: CSS_AT_RULE@349..381
+      0: AT@349..351 "@" [Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@351..381
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@351..379
+          0: MEDIA_KW@351..357 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@357..379
+            0: SCSS_MEDIA_QUERY@357..379
+              0: CSS_MEDIA_TYPE_QUERY@357..370
+                0: (empty)
+                1: CSS_MEDIA_TYPE@357..370
+                  0: SCSS_INTERPOLATED_IDENTIFIER@357..370
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@357..370
+                      0: SCSS_INTERPOLATION@357..370
+                        0: HASH@357..358 "#" [] []
+                        1: L_CURLY@358..359 "{" [] []
+                        2: SCSS_EXPRESSION@359..368
+                          0: SCSS_EXPRESSION_ITEM_LIST@359..368
+                            0: SCSS_VARIABLE@359..368
+                              0: DOLLAR@359..360 "$" [] []
+                              1: CSS_IDENTIFIER@360..368
+                                0: IDENT@360..368 "modifier" [] []
+                        3: R_CURLY@368..370 "}" [] [Whitespace(" ")]
+              1: CSS_MEDIA_TYPE@370..379
+                0: SCSS_INTERPOLATED_IDENTIFIER@370..379
+                  0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@370..379
+                    0: SCSS_INTERPOLATION@370..379
+                      0: HASH@370..371 "#" [] []
+                      1: L_CURLY@371..372 "{" [] []
+                      2: SCSS_EXPRESSION@372..377
+                        0: SCSS_EXPRESSION_ITEM_LIST@372..377
+                          0: SCSS_VARIABLE@372..377
+                            0: DOLLAR@372..373 "$" [] []
+                            1: CSS_IDENTIFIER@373..377
+                              0: IDENT@373..377 "type" [] []
+                      3: R_CURLY@377..379 "}" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@379..381
+          0: L_CURLY@379..380 "{" [] []
+          1: CSS_RULE_LIST@380..380
+          2: R_CURLY@380..381 "}" [] []
+    15: CSS_AT_RULE@381..405
+      0: AT@381..383 "@" [Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@383..405
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@383..403
+          0: MEDIA_KW@383..389 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@389..403
+            0: SCSS_MEDIA_QUERY@389..403
+              0: CSS_MEDIA_TYPE_QUERY@389..403
+                0: ONLY_KW@389..394 "only" [] [Whitespace(" ")]
+                1: CSS_MEDIA_TYPE@394..403
+                  0: SCSS_INTERPOLATED_IDENTIFIER@394..403
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@394..403
+                      0: SCSS_INTERPOLATION@394..403
+                        0: HASH@394..395 "#" [] []
+                        1: L_CURLY@395..396 "{" [] []
+                        2: SCSS_EXPRESSION@396..401
+                          0: SCSS_EXPRESSION_ITEM_LIST@396..401
+                            0: SCSS_VARIABLE@396..401
+                              0: DOLLAR@396..397 "$" [] []
+                              1: CSS_IDENTIFIER@397..401
+                                0: IDENT@397..401 "type" [] []
+                        3: R_CURLY@401..403 "}" [] [Whitespace(" ")]
+              1: (empty)
+        1: CSS_RULE_BLOCK@403..405
+          0: L_CURLY@403..404 "{" [] []
+          1: CSS_RULE_LIST@404..404
+          2: R_CURLY@404..405 "}" [] []
+    16: CSS_AT_RULE@405..428
+      0: AT@405..407 "@" [Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@407..428
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@407..426
+          0: MEDIA_KW@407..413 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@413..426
+            0: SCSS_MEDIA_QUERY@413..426
+              0: CSS_MEDIA_TYPE_QUERY@413..426
+                0: NOT_KW@413..417 "not" [] [Whitespace(" ")]
+                1: CSS_MEDIA_TYPE@417..426
+                  0: SCSS_INTERPOLATED_IDENTIFIER@417..426
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@417..426
+                      0: SCSS_INTERPOLATION@417..426
+                        0: HASH@417..418 "#" [] []
+                        1: L_CURLY@418..419 "{" [] []
+                        2: SCSS_EXPRESSION@419..424
+                          0: SCSS_EXPRESSION_ITEM_LIST@419..424
+                            0: SCSS_VARIABLE@419..424
+                              0: DOLLAR@419..420 "$" [] []
+                              1: CSS_IDENTIFIER@420..424
+                                0: IDENT@420..424 "type" [] []
+                        3: R_CURLY@424..426 "}" [] [Whitespace(" ")]
+              1: (empty)
+        1: CSS_RULE_BLOCK@426..428
+          0: L_CURLY@426..427 "{" [] []
+          1: CSS_RULE_LIST@427..427
+          2: R_CURLY@427..428 "}" [] []
+    17: CSS_AT_RULE@428..460
+      0: AT@428..431 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@431..460
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@431..458
+          0: MEDIA_KW@431..437 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@437..458
+            0: CSS_MEDIA_CONDITION_QUERY@437..458
+              0: CSS_MEDIA_AND_CONDITION@437..458
+                0: SCSS_MEDIA_QUERY@437..446
+                  0: CSS_MEDIA_TYPE_QUERY@437..446
+                    0: (empty)
+                    1: CSS_MEDIA_TYPE@437..446
+                      0: SCSS_INTERPOLATED_IDENTIFIER@437..446
+                        0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@437..446
+                          0: SCSS_INTERPOLATION@437..446
+                            0: HASH@437..438 "#" [] []
+                            1: L_CURLY@438..439 "{" [] []
+                            2: SCSS_EXPRESSION@439..444
+                              0: SCSS_EXPRESSION_ITEM_LIST@439..444
+                                0: SCSS_VARIABLE@439..444
+                                  0: DOLLAR@439..440 "$" [] []
+                                  1: CSS_IDENTIFIER@440..444
+                                    0: IDENT@440..444 "type" [] []
+                            3: R_CURLY@444..446 "}" [] [Whitespace(" ")]
+                  1: (empty)
+                1: AND_KW@446..450 "and" [] [Whitespace(" ")]
+                2: CSS_MEDIA_FEATURE_IN_PARENS@450..458
+                  0: L_PAREN@450..451 "(" [] []
+                  1: CSS_QUERY_FEATURE_BOOLEAN@451..456
+                    0: CSS_IDENTIFIER@451..456
+                      0: IDENT@451..456 "color" [] []
+                  2: R_PAREN@456..458 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@458..460
+          0: L_CURLY@458..459 "{" [] []
+          1: CSS_RULE_LIST@459..459
+          2: R_CURLY@459..460 "}" [] []
+    18: CSS_AT_RULE@460..501
+      0: AT@460..462 "@" [Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@462..501
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@462..499
+          0: MEDIA_KW@462..468 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@468..499
+            0: CSS_MEDIA_CONDITION_QUERY@468..499
+              0: CSS_MEDIA_AND_CONDITION@468..499
+                0: SCSS_MEDIA_QUERY@468..487
+                  0: CSS_MEDIA_TYPE_QUERY@468..472
+                    0: (empty)
+                    1: CSS_MEDIA_TYPE@468..472
+                      0: CSS_IDENTIFIER@468..472
+                        0: IDENT@468..472 "all" [] [Whitespace(" ")]
+                  1: CSS_MEDIA_TYPE@472..487
+                    0: SCSS_INTERPOLATED_IDENTIFIER@472..487
+                      0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@472..487
+                        0: SCSS_INTERPOLATION@472..487
+                          0: HASH@472..473 "#" [] []
+                          1: L_CURLY@473..474 "{" [] []
+                          2: SCSS_EXPRESSION@474..485
+                            0: SCSS_EXPRESSION_ITEM_LIST@474..485
+                              0: SCSS_VARIABLE@474..485
+                                0: DOLLAR@474..475 "$" [] []
+                                1: CSS_IDENTIFIER@475..485
+                                  0: IDENT@475..485 "query-tail" [] []
+                          3: R_CURLY@485..487 "}" [] [Whitespace(" ")]
+                1: AND_KW@487..491 "and" [] [Whitespace(" ")]
+                2: CSS_MEDIA_FEATURE_IN_PARENS@491..499
+                  0: L_PAREN@491..492 "(" [] []
+                  1: CSS_QUERY_FEATURE_BOOLEAN@492..497
+                    0: CSS_IDENTIFIER@492..497
+                      0: IDENT@492..497 "color" [] []
+                  2: R_PAREN@497..499 ")" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@499..501
+          0: L_CURLY@499..500 "{" [] []
+          1: CSS_RULE_LIST@500..500
+          2: R_CURLY@500..501 "}" [] []
+    19: CSS_AT_RULE@501..537
+      0: AT@501..503 "@" [Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@503..537
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@503..535
+          0: MEDIA_KW@503..509 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@509..535
+            0: CSS_MEDIA_CONDITION_QUERY@509..535
+              0: CSS_MEDIA_AND_CONDITION@509..535
+                0: CSS_MEDIA_FEATURE_IN_PARENS@509..517
+                  0: L_PAREN@509..510 "(" [] []
+                  1: CSS_QUERY_FEATURE_BOOLEAN@510..515
+                    0: CSS_IDENTIFIER@510..515
+                      0: IDENT@510..515 "color" [] []
+                  2: R_PAREN@515..517 ")" [] [Whitespace(" ")]
+                1: AND_KW@517..521 "and" [] [Whitespace(" ")]
+                2: SCSS_MEDIA_QUERY@521..535
+                  0: CSS_MEDIA_TYPE_QUERY@521..535
+                    0: (empty)
+                    1: CSS_MEDIA_TYPE@521..535
+                      0: SCSS_INTERPOLATED_IDENTIFIER@521..535
+                        0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@521..535
+                          0: SCSS_INTERPOLATION@521..535
+                            0: HASH@521..522 "#" [] []
+                            1: L_CURLY@522..523 "{" [] []
+                            2: SCSS_EXPRESSION@523..533
+                              0: SCSS_EXPRESSION_ITEM_LIST@523..533
+                                0: SCSS_VARIABLE@523..533
+                                  0: DOLLAR@523..524 "$" [] []
+                                  1: CSS_IDENTIFIER@524..533
+                                    0: IDENT@524..533 "condition" [] []
+                            3: R_CURLY@533..535 "}" [] [Whitespace(" ")]
+                  1: (empty)
+        1: CSS_RULE_BLOCK@535..537
+          0: L_CURLY@535..536 "{" [] []
+          1: CSS_RULE_LIST@536..536
+          2: R_CURLY@536..537 "}" [] []
+    20: CSS_AT_RULE@537..624
+      0: AT@537..539 "@" [Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@539..624
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@539..622
+          0: MEDIA_KW@539..545 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@545..622
+            0: CSS_MEDIA_CONDITION_QUERY@545..622
+              0: CSS_MEDIA_AND_CONDITION@545..622
+                0: SCSS_MEDIA_QUERY@545..562
+                  0: CSS_MEDIA_TYPE_QUERY@545..562
+                    0: (empty)
+                    1: CSS_MEDIA_TYPE@545..562
+                      0: SCSS_INTERPOLATED_IDENTIFIER@545..562
+                        0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@545..562
+                          0: SCSS_INTERPOLATION@545..562
+                            0: HASH@545..546 "#" [] []
+                            1: L_CURLY@546..547 "{" [] []
+                            2: SCSS_EXPRESSION@547..560
+                              0: SCSS_EXPRESSION_ITEM_LIST@547..560
+                                0: CSS_STRING@547..560
+                                  0: CSS_STRING_LITERAL@547..560 "\"only screen\"" [] []
+                            3: R_CURLY@560..562 "}" [] [Whitespace(" ")]
+                  1: (empty)
+                1: AND_KW@562..566 "and" [] [Whitespace(" ")]
+                2: CSS_MEDIA_AND_CONDITION@566..622
+                  0: SCSS_MEDIA_QUERY@566..590
+                    0: CSS_MEDIA_TYPE_QUERY@566..590
+                      0: (empty)
+                      1: CSS_MEDIA_TYPE@566..590
+                        0: SCSS_INTERPOLATED_IDENTIFIER@566..590
+                          0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@566..590
+                            0: SCSS_INTERPOLATION@566..590
+                              0: HASH@566..567 "#" [] []
+                              1: L_CURLY@567..568 "{" [] []
+                              2: SCSS_EXPRESSION@568..588
+                                0: SCSS_EXPRESSION_ITEM_LIST@568..588
+                                  0: CSS_STRING@568..588
+                                    0: CSS_STRING_LITERAL@568..588 "\"(min-width: 700px)\"" [] []
+                              3: R_CURLY@588..590 "}" [] [Whitespace(" ")]
+                    1: (empty)
+                  1: AND_KW@590..594 "and" [] [Whitespace(" ")]
+                  2: SCSS_MEDIA_QUERY@594..622
+                    0: CSS_MEDIA_TYPE_QUERY@594..622
+                      0: (empty)
+                      1: CSS_MEDIA_TYPE@594..622
+                        0: SCSS_INTERPOLATED_IDENTIFIER@594..622
+                          0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@594..622
+                            0: SCSS_INTERPOLATION@594..622
+                              0: HASH@594..595 "#" [] []
+                              1: L_CURLY@595..596 "{" [] []
+                              2: SCSS_EXPRESSION@596..620
+                                0: SCSS_EXPRESSION_ITEM_LIST@596..620
+                                  0: SCSS_BINARY_EXPRESSION@596..620
+                                    0: CSS_STRING@596..610
+                                      0: CSS_STRING_LITERAL@596..610 "\"(max-width: \"" [] []
+                                    1: PLUS@610..611 "+" [] []
+                                    2: CSS_STRING@611..620
+                                      0: CSS_STRING_LITERAL@611..620 "\"1920px)\"" [] []
+                              3: R_CURLY@620..622 "}" [] [Whitespace(" ")]
+                    1: (empty)
+        1: CSS_RULE_BLOCK@622..624
+          0: L_CURLY@622..623 "{" [] []
+          1: CSS_RULE_LIST@623..623
+          2: R_CURLY@623..624 "}" [] []
+    21: CSS_AT_RULE@624..681
+      0: AT@624..626 "@" [Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@626..681
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@626..679
+          0: MEDIA_KW@626..632 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@632..679
+            0: SCSS_MEDIA_QUERY@632..679
+              0: CSS_MEDIA_TYPE_QUERY@632..651
+                0: (empty)
+                1: CSS_MEDIA_TYPE@632..651
+                  0: SCSS_INTERPOLATED_IDENTIFIER@632..651
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@632..651
+                      0: CSS_IDENTIFIER@632..635
+                        0: IDENT@632..635 "scr" [] []
+                      1: SCSS_INTERPOLATION@635..648
+                        0: HASH@635..636 "#" [] []
+                        1: L_CURLY@636..637 "{" [] []
+                        2: SCSS_EXPRESSION@637..647
+                          0: SCSS_EXPRESSION_ITEM_LIST@637..647
+                            0: CSS_STRING@637..647
+                              0: CSS_STRING_LITERAL@637..647 "\"een, pri\"" [] []
+                        3: R_CURLY@647..648 "}" [] []
+                      2: CSS_IDENTIFIER@648..651
+                        0: IDENT@648..651 "nt" [] [Whitespace(" ")]
+              1: CSS_MEDIA_TYPE@651..679
+                0: SCSS_INTERPOLATED_IDENTIFIER@651..679
+                  0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@651..679
+                    0: CSS_IDENTIFIER@651..652
+                      0: IDENT@651..652 "a" [] []
+                    1: SCSS_INTERPOLATION@652..679
+                      0: HASH@652..653 "#" [] []
+                      1: L_CURLY@653..654 "{" [] []
+                      2: SCSS_EXPRESSION@654..677
+                        0: SCSS_EXPRESSION_ITEM_LIST@654..677
+                          0: CSS_STRING@654..677
+                            0: CSS_STRING_LITERAL@654..677 "\"nd (max-width: 300px)\"" [] []
+                      3: R_CURLY@677..679 "}" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@679..681
+          0: L_CURLY@679..680 "{" [] []
+          1: CSS_RULE_LIST@680..680
+          2: R_CURLY@680..681 "}" [] []
+    22: CSS_AT_RULE@681..737
+      0: AT@681..684 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@684..737
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@684..735
+          0: MEDIA_KW@684..690 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@690..735
+            0: CSS_MEDIA_TYPE_QUERY@690..696
+              0: (empty)
+              1: CSS_MEDIA_TYPE@690..696
+                0: CSS_IDENTIFIER@690..696
+                  0: IDENT@690..696 "screen" [] []
+            1: COMMA@696..698 "," [] [Whitespace(" ")]
+            2: SCSS_MEDIA_QUERY@698..716
+              0: CSS_MEDIA_TYPE_QUERY@698..702
+                0: (empty)
+                1: CSS_MEDIA_TYPE@698..702
+                  0: CSS_IDENTIFIER@698..702
+                    0: IDENT@698..702 "all" [] [Whitespace(" ")]
+              1: CSS_MEDIA_TYPE@702..716
+                0: SCSS_INTERPOLATED_IDENTIFIER@702..716
+                  0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@702..716
+                    0: SCSS_INTERPOLATION@702..716
+                      0: HASH@702..703 "#" [] []
+                      1: L_CURLY@703..704 "{" [] []
+                      2: SCSS_EXPRESSION@704..715
+                        0: SCSS_EXPRESSION_ITEM_LIST@704..715
+                          0: SCSS_VARIABLE@704..715
+                            0: DOLLAR@704..705 "$" [] []
+                            1: CSS_IDENTIFIER@705..715
+                              0: IDENT@705..715 "query-tail" [] []
+                      3: R_CURLY@715..716 "}" [] []
+            3: COMMA@716..718 "," [] [Whitespace(" ")]
+            4: SCSS_MEDIA_QUERY@718..735
+              0: CSS_MEDIA_TYPE_QUERY@718..735
+                0: (empty)
+                1: CSS_MEDIA_TYPE@718..735
+                  0: SCSS_INTERPOLATED_IDENTIFIER@718..735
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@718..735
+                      0: CSS_IDENTIFIER@718..724
+                        0: IDENT@718..724 "print-" [] []
+                      1: SCSS_INTERPOLATION@724..735
+                        0: HASH@724..725 "#" [] []
+                        1: L_CURLY@725..726 "{" [] []
+                        2: SCSS_EXPRESSION@726..733
+                          0: SCSS_EXPRESSION_ITEM_LIST@726..733
+                            0: SCSS_VARIABLE@726..733
+                              0: DOLLAR@726..727 "$" [] []
+                              1: CSS_IDENTIFIER@727..733
+                                0: IDENT@727..733 "suffix" [] []
+                        3: R_CURLY@733..735 "}" [] [Whitespace(" ")]
+              1: (empty)
+        1: CSS_RULE_BLOCK@735..737
+          0: L_CURLY@735..736 "{" [] []
+          1: CSS_RULE_LIST@736..736
+          2: R_CURLY@736..737 "}" [] []
+    23: CSS_AT_RULE@737..761
+      0: AT@737..740 "@" [Newline("\n"), Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@740..761
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@740..759
+          0: MEDIA_KW@740..746 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@746..759
+            0: SCSS_MEDIA_QUERY@746..759
+              0: CSS_MEDIA_TYPE_QUERY@746..759
+                0: (empty)
+                1: CSS_MEDIA_TYPE@746..759
+                  0: SCSS_INTERPOLATED_IDENTIFIER@746..759
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@746..759
+                      0: CSS_IDENTIFIER@746..750
+                        0: IDENT@746..750 "only" [] []
+                      1: SCSS_INTERPOLATION@750..759
+                        0: HASH@750..751 "#" [] []
+                        1: L_CURLY@751..752 "{" [] []
+                        2: SCSS_EXPRESSION@752..757
+                          0: SCSS_EXPRESSION_ITEM_LIST@752..757
+                            0: SCSS_VARIABLE@752..757
+                              0: DOLLAR@752..753 "$" [] []
+                              1: CSS_IDENTIFIER@753..757
+                                0: IDENT@753..757 "type" [] []
+                        3: R_CURLY@757..759 "}" [] [Whitespace(" ")]
+              1: (empty)
+        1: CSS_RULE_BLOCK@759..761
+          0: L_CURLY@759..760 "{" [] []
+          1: CSS_RULE_LIST@760..760
+          2: R_CURLY@760..761 "}" [] []
+    24: CSS_AT_RULE@761..783
+      0: AT@761..763 "@" [Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@763..783
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@763..781
+          0: MEDIA_KW@763..769 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@769..781
+            0: SCSS_MEDIA_QUERY@769..781
+              0: CSS_MEDIA_TYPE_QUERY@769..781
+                0: (empty)
+                1: CSS_MEDIA_TYPE@769..781
+                  0: SCSS_INTERPOLATED_IDENTIFIER@769..781
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@769..781
+                      0: CSS_IDENTIFIER@769..772
+                        0: IDENT@769..772 "not" [] []
+                      1: SCSS_INTERPOLATION@772..781
+                        0: HASH@772..773 "#" [] []
+                        1: L_CURLY@773..774 "{" [] []
+                        2: SCSS_EXPRESSION@774..779
+                          0: SCSS_EXPRESSION_ITEM_LIST@774..779
+                            0: SCSS_VARIABLE@774..779
+                              0: DOLLAR@774..775 "$" [] []
+                              1: CSS_IDENTIFIER@775..779
+                                0: IDENT@775..779 "type" [] []
+                        3: R_CURLY@779..781 "}" [] [Whitespace(" ")]
+              1: (empty)
+        1: CSS_RULE_BLOCK@781..783
+          0: L_CURLY@781..782 "{" [] []
+          1: CSS_RULE_LIST@782..782
+          2: R_CURLY@782..783 "}" [] []
+    25: CSS_AT_RULE@783..814
+      0: AT@783..785 "@" [Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@785..814
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@785..812
+          0: MEDIA_KW@785..791 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@791..812
+            0: SCSS_MEDIA_QUERY@791..812
+              0: CSS_MEDIA_TYPE_QUERY@791..798
+                0: (empty)
+                1: CSS_MEDIA_TYPE@791..798
+                  0: CSS_IDENTIFIER@791..798
+                    0: IDENT@791..798 "screen" [] [Whitespace(" ")]
+              1: CSS_MEDIA_TYPE@798..812
+                0: SCSS_INTERPOLATED_IDENTIFIER@798..812
+                  0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@798..812
+                    0: CSS_IDENTIFIER@798..801
+                      0: IDENT@798..801 "and" [] []
+                    1: SCSS_INTERPOLATION@801..812
+                      0: HASH@801..802 "#" [] []
+                      1: L_CURLY@802..803 "{" [] []
+                      2: SCSS_EXPRESSION@803..810
+                        0: SCSS_EXPRESSION_ITEM_LIST@803..810
+                          0: SCSS_VARIABLE@803..810
+                            0: DOLLAR@803..804 "$" [] []
+                            1: CSS_IDENTIFIER@804..810
+                              0: IDENT@804..810 "suffix" [] []
+                      3: R_CURLY@810..812 "}" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@812..814
+          0: L_CURLY@812..813 "{" [] []
+          1: CSS_RULE_LIST@813..813
+          2: R_CURLY@813..814 "}" [] []
+    26: CSS_AT_RULE@814..844
+      0: AT@814..816 "@" [Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@816..844
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@816..842
+          0: MEDIA_KW@816..822 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@822..842
+            0: SCSS_MEDIA_QUERY@822..842
+              0: CSS_MEDIA_TYPE_QUERY@822..829
+                0: (empty)
+                1: CSS_MEDIA_TYPE@822..829
+                  0: CSS_IDENTIFIER@822..829
+                    0: IDENT@822..829 "screen" [] [Whitespace(" ")]
+              1: CSS_MEDIA_TYPE@829..842
+                0: SCSS_INTERPOLATED_IDENTIFIER@829..842
+                  0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@829..842
+                    0: CSS_IDENTIFIER@829..831
+                      0: IDENT@829..831 "or" [] []
+                    1: SCSS_INTERPOLATION@831..842
+                      0: HASH@831..832 "#" [] []
+                      1: L_CURLY@832..833 "{" [] []
+                      2: SCSS_EXPRESSION@833..840
+                        0: SCSS_EXPRESSION_ITEM_LIST@833..840
+                          0: SCSS_VARIABLE@833..840
+                            0: DOLLAR@833..834 "$" [] []
+                            1: CSS_IDENTIFIER@834..840
+                              0: IDENT@834..840 "suffix" [] []
+                      3: R_CURLY@840..842 "}" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@842..844
+          0: L_CURLY@842..843 "{" [] []
+          1: CSS_RULE_LIST@843..843
+          2: R_CURLY@843..844 "}" [] []
+    27: CSS_AT_RULE@844..871
+      0: AT@844..846 "@" [Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@846..871
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@846..869
+          0: MEDIA_KW@846..852 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@852..869
+            0: SCSS_MEDIA_QUERY@852..869
+              0: CSS_MEDIA_TYPE_QUERY@852..869
+                0: (empty)
+                1: CSS_MEDIA_TYPE@852..869
+                  0: SCSS_INTERPOLATED_IDENTIFIER@852..869
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@852..869
+                      0: CSS_IDENTIFIER@852..860
+                        0: IDENT@852..860 "only" [] [Comments("/**/")]
+                      1: SCSS_INTERPOLATION@860..869
+                        0: HASH@860..861 "#" [] []
+                        1: L_CURLY@861..862 "{" [] []
+                        2: SCSS_EXPRESSION@862..867
+                          0: SCSS_EXPRESSION_ITEM_LIST@862..867
+                            0: SCSS_VARIABLE@862..867
+                              0: DOLLAR@862..863 "$" [] []
+                              1: CSS_IDENTIFIER@863..867
+                                0: IDENT@863..867 "type" [] []
+                        3: R_CURLY@867..869 "}" [] [Whitespace(" ")]
+              1: (empty)
+        1: CSS_RULE_BLOCK@869..871
+          0: L_CURLY@869..870 "{" [] []
+          1: CSS_RULE_LIST@870..870
+          2: R_CURLY@870..871 "}" [] []
+    28: CSS_AT_RULE@871..906
+      0: AT@871..873 "@" [Newline("\n")] []
+      1: CSS_MEDIA_AT_RULE@873..906
+        0: CSS_MEDIA_AT_RULE_DECLARATOR@873..904
+          0: MEDIA_KW@873..879 "media" [] [Whitespace(" ")]
+          1: CSS_MEDIA_QUERY_LIST@879..904
+            0: SCSS_MEDIA_QUERY@879..904
+              0: CSS_MEDIA_TYPE_QUERY@879..886
+                0: (empty)
+                1: CSS_MEDIA_TYPE@879..886
+                  0: CSS_IDENTIFIER@879..886
+                    0: IDENT@879..886 "screen" [] [Whitespace(" ")]
+              1: CSS_MEDIA_TYPE@886..904
+                0: SCSS_INTERPOLATED_IDENTIFIER@886..904
+                  0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@886..904
+                    0: CSS_IDENTIFIER@886..893
+                      0: IDENT@886..893 "and" [] [Comments("/**/")]
+                    1: SCSS_INTERPOLATION@893..904
+                      0: HASH@893..894 "#" [] []
+                      1: L_CURLY@894..895 "{" [] []
+                      2: SCSS_EXPRESSION@895..902
+                        0: SCSS_EXPRESSION_ITEM_LIST@895..902
+                          0: SCSS_VARIABLE@895..902
+                            0: DOLLAR@895..896 "$" [] []
+                            1: CSS_IDENTIFIER@896..902
+                              0: IDENT@896..902 "suffix" [] []
+                      3: R_CURLY@902..904 "}" [] [Whitespace(" ")]
+        1: CSS_RULE_BLOCK@904..906
+          0: L_CURLY@904..905 "{" [] []
+          1: CSS_RULE_LIST@905..905
+          2: R_CURLY@905..906 "}" [] []
+  2: EOF@906..907 "" [Newline("\n")] []
+
+```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/media-interpolated-logic.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/media-interpolated-logic.scss.snap
@@ -70,18 +70,28 @@ CssRoot {
                                 },
                                 and_token: AND_KW@11..15 "and" [] [Whitespace(" ")],
                                 right: ScssMediaQuery {
-                                    query: ScssInterpolation {
-                                        hash_token: HASH@15..16 "#" [] [],
-                                        l_curly_token: L_CURLY@16..17 "{" [] [],
-                                        value: ScssExpression {
-                                            items: ScssExpressionItemList [
-                                                CssString {
-                                                    value_token: CSS_STRING_LITERAL@17..30 "\"(b) and (c)\"" [] [],
-                                                },
-                                            ],
+                                    head: CssMediaTypeQuery {
+                                        modifier: missing (optional),
+                                        ty: CssMediaType {
+                                            value: ScssInterpolatedIdentifier {
+                                                items: ScssInterpolatedIdentifierPartList [
+                                                    ScssInterpolation {
+                                                        hash_token: HASH@15..16 "#" [] [],
+                                                        l_curly_token: L_CURLY@16..17 "{" [] [],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                CssString {
+                                                                    value_token: CSS_STRING_LITERAL@17..30 "\"(b) and (c)\"" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                        r_curly_token: R_CURLY@30..32 "}" [] [Whitespace(" ")],
+                                                    },
+                                                ],
+                                            },
                                         },
-                                        r_curly_token: R_CURLY@30..32 "}" [] [Whitespace(" ")],
                                     },
+                                    tail: missing (optional),
                                 },
                             },
                         },
@@ -153,18 +163,28 @@ CssRoot {
                                 },
                                 or_token: OR_KW@68..71 "or" [] [Whitespace(" ")],
                                 right: ScssMediaQuery {
-                                    query: ScssInterpolation {
-                                        hash_token: HASH@71..72 "#" [] [],
-                                        l_curly_token: L_CURLY@72..73 "{" [] [],
-                                        value: ScssExpression {
-                                            items: ScssExpressionItemList [
-                                                CssString {
-                                                    value_token: CSS_STRING_LITERAL@73..85 "\"(b) or (c)\"" [] [],
-                                                },
-                                            ],
+                                    head: CssMediaTypeQuery {
+                                        modifier: missing (optional),
+                                        ty: CssMediaType {
+                                            value: ScssInterpolatedIdentifier {
+                                                items: ScssInterpolatedIdentifierPartList [
+                                                    ScssInterpolation {
+                                                        hash_token: HASH@71..72 "#" [] [],
+                                                        l_curly_token: L_CURLY@72..73 "{" [] [],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                CssString {
+                                                                    value_token: CSS_STRING_LITERAL@73..85 "\"(b) or (c)\"" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                        r_curly_token: R_CURLY@85..87 "}" [] [Whitespace(" ")],
+                                                    },
+                                                ],
+                                            },
                                         },
-                                        r_curly_token: R_CURLY@85..87 "}" [] [Whitespace(" ")],
                                     },
+                                    tail: missing (optional),
                                 },
                             },
                         },
@@ -236,18 +256,28 @@ CssRoot {
                             right: CssMediaNotCondition {
                                 not_token: NOT_KW@125..129 "not" [] [Whitespace(" ")],
                                 condition: ScssMediaQuery {
-                                    query: ScssInterpolation {
-                                        hash_token: HASH@129..130 "#" [] [],
-                                        l_curly_token: L_CURLY@130..131 "{" [] [],
-                                        value: ScssExpression {
-                                            items: ScssExpressionItemList [
-                                                CssString {
-                                                    value_token: CSS_STRING_LITERAL@131..136 "\"(b)\"" [] [],
-                                                },
-                                            ],
+                                    head: CssMediaTypeQuery {
+                                        modifier: missing (optional),
+                                        ty: CssMediaType {
+                                            value: ScssInterpolatedIdentifier {
+                                                items: ScssInterpolatedIdentifierPartList [
+                                                    ScssInterpolation {
+                                                        hash_token: HASH@129..130 "#" [] [],
+                                                        l_curly_token: L_CURLY@130..131 "{" [] [],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                CssString {
+                                                                    value_token: CSS_STRING_LITERAL@131..136 "\"(b)\"" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                        r_curly_token: R_CURLY@136..138 "}" [] [Whitespace(" ")],
+                                                    },
+                                                ],
+                                            },
                                         },
-                                        r_curly_token: R_CURLY@136..138 "}" [] [Whitespace(" ")],
                                     },
+                                    tail: missing (optional),
                                 },
                             },
                         },
@@ -309,18 +339,28 @@ CssRoot {
                         CssMediaConditionQuery {
                             condition: CssMediaAndCondition {
                                 left: ScssMediaQuery {
-                                    query: ScssInterpolation {
-                                        hash_token: HASH@170..171 "#" [] [],
-                                        l_curly_token: L_CURLY@171..172 "{" [] [],
-                                        value: ScssExpression {
-                                            items: ScssExpressionItemList [
-                                                CssIdentifier {
-                                                    value_token: IDENT@172..173 "a" [] [],
-                                                },
-                                            ],
+                                    head: CssMediaTypeQuery {
+                                        modifier: missing (optional),
+                                        ty: CssMediaType {
+                                            value: ScssInterpolatedIdentifier {
+                                                items: ScssInterpolatedIdentifierPartList [
+                                                    ScssInterpolation {
+                                                        hash_token: HASH@170..171 "#" [] [],
+                                                        l_curly_token: L_CURLY@171..172 "{" [] [],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                CssIdentifier {
+                                                                    value_token: IDENT@172..173 "a" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                        r_curly_token: R_CURLY@173..175 "}" [] [Whitespace(" ")],
+                                                    },
+                                                ],
+                                            },
                                         },
-                                        r_curly_token: R_CURLY@173..175 "}" [] [Whitespace(" ")],
                                     },
+                                    tail: missing (optional),
                                 },
                                 and_token: AND_KW@175..179 "and" [] [Whitespace(" ")],
                                 right: CssMediaNotCondition {
@@ -397,21 +437,31 @@ CssRoot {
                                 l_paren_token: L_PAREN@219..220 "(" [] [],
                                 condition: CssMediaAndCondition {
                                     left: ScssMediaQuery {
-                                        query: ScssInterpolation {
-                                            hash_token: HASH@220..221 "#" [] [],
-                                            l_curly_token: L_CURLY@221..222 "{" [] [],
-                                            value: ScssExpression {
-                                                items: ScssExpressionItemList [
-                                                    ScssVariable {
-                                                        dollar_token: DOLLAR@222..223 "$" [] [],
-                                                        name: CssIdentifier {
-                                                            value_token: IDENT@223..228 "query" [] [],
+                                        head: CssMediaTypeQuery {
+                                            modifier: missing (optional),
+                                            ty: CssMediaType {
+                                                value: ScssInterpolatedIdentifier {
+                                                    items: ScssInterpolatedIdentifierPartList [
+                                                        ScssInterpolation {
+                                                            hash_token: HASH@220..221 "#" [] [],
+                                                            l_curly_token: L_CURLY@221..222 "{" [] [],
+                                                            value: ScssExpression {
+                                                                items: ScssExpressionItemList [
+                                                                    ScssVariable {
+                                                                        dollar_token: DOLLAR@222..223 "$" [] [],
+                                                                        name: CssIdentifier {
+                                                                            value_token: IDENT@223..228 "query" [] [],
+                                                                        },
+                                                                    },
+                                                                ],
+                                                            },
+                                                            r_curly_token: R_CURLY@228..230 "}" [] [Whitespace(" ")],
                                                         },
-                                                    },
-                                                ],
+                                                    ],
+                                                },
                                             },
-                                            r_curly_token: R_CURLY@228..230 "}" [] [Whitespace(" ")],
                                         },
+                                        tail: missing (optional),
                                     },
                                     and_token: AND_KW@230..234 "and" [] [Whitespace(" ")],
                                     right: CssMediaNotCondition {
@@ -485,24 +535,29 @@ CssRoot {
                 declarator: CssMediaAtRuleDeclarator {
                     media_token: MEDIA_KW@273..279 "media" [] [Whitespace(" ")],
                     queries: CssMediaQueryList [
-                        CssMediaConditionQuery {
-                            condition: CssMediaNotCondition {
-                                not_token: NOT_KW@279..283 "not" [] [Whitespace(" ")],
-                                condition: ScssMediaQuery {
-                                    query: ScssInterpolation {
-                                        hash_token: HASH@283..284 "#" [] [],
-                                        l_curly_token: L_CURLY@284..285 "{" [] [],
-                                        value: ScssExpression {
-                                            items: ScssExpressionItemList [
-                                                CssString {
-                                                    value_token: CSS_STRING_LITERAL@285..290 "\"(a)\"" [] [],
+                        ScssMediaQuery {
+                            head: CssMediaTypeQuery {
+                                modifier: NOT_KW@279..283 "not" [] [Whitespace(" ")],
+                                ty: CssMediaType {
+                                    value: ScssInterpolatedIdentifier {
+                                        items: ScssInterpolatedIdentifierPartList [
+                                            ScssInterpolation {
+                                                hash_token: HASH@283..284 "#" [] [],
+                                                l_curly_token: L_CURLY@284..285 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        CssString {
+                                                            value_token: CSS_STRING_LITERAL@285..290 "\"(a)\"" [] [],
+                                                        },
+                                                    ],
                                                 },
-                                            ],
-                                        },
-                                        r_curly_token: R_CURLY@290..292 "}" [] [Whitespace(" ")],
+                                                r_curly_token: R_CURLY@290..292 "}" [] [Whitespace(" ")],
+                                            },
+                                        ],
                                     },
                                 },
                             },
+                            tail: missing (optional),
                         },
                     ],
                 },
@@ -580,14 +635,20 @@ CssRoot {
                   2: R_PAREN@9..11 ")" [] [Whitespace(" ")]
                 1: AND_KW@11..15 "and" [] [Whitespace(" ")]
                 2: SCSS_MEDIA_QUERY@15..32
-                  0: SCSS_INTERPOLATION@15..32
-                    0: HASH@15..16 "#" [] []
-                    1: L_CURLY@16..17 "{" [] []
-                    2: SCSS_EXPRESSION@17..30
-                      0: SCSS_EXPRESSION_ITEM_LIST@17..30
-                        0: CSS_STRING@17..30
-                          0: CSS_STRING_LITERAL@17..30 "\"(b) and (c)\"" [] []
-                    3: R_CURLY@30..32 "}" [] [Whitespace(" ")]
+                  0: CSS_MEDIA_TYPE_QUERY@15..32
+                    0: (empty)
+                    1: CSS_MEDIA_TYPE@15..32
+                      0: SCSS_INTERPOLATED_IDENTIFIER@15..32
+                        0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@15..32
+                          0: SCSS_INTERPOLATION@15..32
+                            0: HASH@15..16 "#" [] []
+                            1: L_CURLY@16..17 "{" [] []
+                            2: SCSS_EXPRESSION@17..30
+                              0: SCSS_EXPRESSION_ITEM_LIST@17..30
+                                0: CSS_STRING@17..30
+                                  0: CSS_STRING_LITERAL@17..30 "\"(b) and (c)\"" [] []
+                            3: R_CURLY@30..32 "}" [] [Whitespace(" ")]
+                  1: (empty)
         1: CSS_RULE_BLOCK@32..55
           0: L_CURLY@32..33 "{" [] []
           1: CSS_RULE_LIST@33..53
@@ -633,14 +694,20 @@ CssRoot {
                   2: R_PAREN@66..68 ")" [] [Whitespace(" ")]
                 1: OR_KW@68..71 "or" [] [Whitespace(" ")]
                 2: SCSS_MEDIA_QUERY@71..87
-                  0: SCSS_INTERPOLATION@71..87
-                    0: HASH@71..72 "#" [] []
-                    1: L_CURLY@72..73 "{" [] []
-                    2: SCSS_EXPRESSION@73..85
-                      0: SCSS_EXPRESSION_ITEM_LIST@73..85
-                        0: CSS_STRING@73..85
-                          0: CSS_STRING_LITERAL@73..85 "\"(b) or (c)\"" [] []
-                    3: R_CURLY@85..87 "}" [] [Whitespace(" ")]
+                  0: CSS_MEDIA_TYPE_QUERY@71..87
+                    0: (empty)
+                    1: CSS_MEDIA_TYPE@71..87
+                      0: SCSS_INTERPOLATED_IDENTIFIER@71..87
+                        0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@71..87
+                          0: SCSS_INTERPOLATION@71..87
+                            0: HASH@71..72 "#" [] []
+                            1: L_CURLY@72..73 "{" [] []
+                            2: SCSS_EXPRESSION@73..85
+                              0: SCSS_EXPRESSION_ITEM_LIST@73..85
+                                0: CSS_STRING@73..85
+                                  0: CSS_STRING_LITERAL@73..85 "\"(b) or (c)\"" [] []
+                            3: R_CURLY@85..87 "}" [] [Whitespace(" ")]
+                  1: (empty)
         1: CSS_RULE_BLOCK@87..110
           0: L_CURLY@87..88 "{" [] []
           1: CSS_RULE_LIST@88..108
@@ -686,14 +753,20 @@ CssRoot {
               2: CSS_MEDIA_NOT_CONDITION@125..138
                 0: NOT_KW@125..129 "not" [] [Whitespace(" ")]
                 1: SCSS_MEDIA_QUERY@129..138
-                  0: SCSS_INTERPOLATION@129..138
-                    0: HASH@129..130 "#" [] []
-                    1: L_CURLY@130..131 "{" [] []
-                    2: SCSS_EXPRESSION@131..136
-                      0: SCSS_EXPRESSION_ITEM_LIST@131..136
-                        0: CSS_STRING@131..136
-                          0: CSS_STRING_LITERAL@131..136 "\"(b)\"" [] []
-                    3: R_CURLY@136..138 "}" [] [Whitespace(" ")]
+                  0: CSS_MEDIA_TYPE_QUERY@129..138
+                    0: (empty)
+                    1: CSS_MEDIA_TYPE@129..138
+                      0: SCSS_INTERPOLATED_IDENTIFIER@129..138
+                        0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@129..138
+                          0: SCSS_INTERPOLATION@129..138
+                            0: HASH@129..130 "#" [] []
+                            1: L_CURLY@130..131 "{" [] []
+                            2: SCSS_EXPRESSION@131..136
+                              0: SCSS_EXPRESSION_ITEM_LIST@131..136
+                                0: CSS_STRING@131..136
+                                  0: CSS_STRING_LITERAL@131..136 "\"(b)\"" [] []
+                            3: R_CURLY@136..138 "}" [] [Whitespace(" ")]
+                  1: (empty)
         1: CSS_RULE_BLOCK@138..161
           0: L_CURLY@138..139 "{" [] []
           1: CSS_RULE_LIST@139..159
@@ -732,14 +805,20 @@ CssRoot {
             0: CSS_MEDIA_CONDITION_QUERY@170..187
               0: CSS_MEDIA_AND_CONDITION@170..187
                 0: SCSS_MEDIA_QUERY@170..175
-                  0: SCSS_INTERPOLATION@170..175
-                    0: HASH@170..171 "#" [] []
-                    1: L_CURLY@171..172 "{" [] []
-                    2: SCSS_EXPRESSION@172..173
-                      0: SCSS_EXPRESSION_ITEM_LIST@172..173
-                        0: CSS_IDENTIFIER@172..173
-                          0: IDENT@172..173 "a" [] []
-                    3: R_CURLY@173..175 "}" [] [Whitespace(" ")]
+                  0: CSS_MEDIA_TYPE_QUERY@170..175
+                    0: (empty)
+                    1: CSS_MEDIA_TYPE@170..175
+                      0: SCSS_INTERPOLATED_IDENTIFIER@170..175
+                        0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@170..175
+                          0: SCSS_INTERPOLATION@170..175
+                            0: HASH@170..171 "#" [] []
+                            1: L_CURLY@171..172 "{" [] []
+                            2: SCSS_EXPRESSION@172..173
+                              0: SCSS_EXPRESSION_ITEM_LIST@172..173
+                                0: CSS_IDENTIFIER@172..173
+                                  0: IDENT@172..173 "a" [] []
+                            3: R_CURLY@173..175 "}" [] [Whitespace(" ")]
+                  1: (empty)
                 1: AND_KW@175..179 "and" [] [Whitespace(" ")]
                 2: CSS_MEDIA_NOT_CONDITION@179..187
                   0: NOT_KW@179..183 "not" [] [Whitespace(" ")]
@@ -789,16 +868,22 @@ CssRoot {
                 0: L_PAREN@219..220 "(" [] []
                 1: CSS_MEDIA_AND_CONDITION@220..245
                   0: SCSS_MEDIA_QUERY@220..230
-                    0: SCSS_INTERPOLATION@220..230
-                      0: HASH@220..221 "#" [] []
-                      1: L_CURLY@221..222 "{" [] []
-                      2: SCSS_EXPRESSION@222..228
-                        0: SCSS_EXPRESSION_ITEM_LIST@222..228
-                          0: SCSS_VARIABLE@222..228
-                            0: DOLLAR@222..223 "$" [] []
-                            1: CSS_IDENTIFIER@223..228
-                              0: IDENT@223..228 "query" [] []
-                      3: R_CURLY@228..230 "}" [] [Whitespace(" ")]
+                    0: CSS_MEDIA_TYPE_QUERY@220..230
+                      0: (empty)
+                      1: CSS_MEDIA_TYPE@220..230
+                        0: SCSS_INTERPOLATED_IDENTIFIER@220..230
+                          0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@220..230
+                            0: SCSS_INTERPOLATION@220..230
+                              0: HASH@220..221 "#" [] []
+                              1: L_CURLY@221..222 "{" [] []
+                              2: SCSS_EXPRESSION@222..228
+                                0: SCSS_EXPRESSION_ITEM_LIST@222..228
+                                  0: SCSS_VARIABLE@222..228
+                                    0: DOLLAR@222..223 "$" [] []
+                                    1: CSS_IDENTIFIER@223..228
+                                      0: IDENT@223..228 "query" [] []
+                              3: R_CURLY@228..230 "}" [] [Whitespace(" ")]
+                    1: (empty)
                   1: AND_KW@230..234 "and" [] [Whitespace(" ")]
                   2: CSS_MEDIA_NOT_CONDITION@234..245
                     0: NOT_KW@234..238 "not" [] [Whitespace(" ")]
@@ -844,18 +929,21 @@ CssRoot {
         0: CSS_MEDIA_AT_RULE_DECLARATOR@273..292
           0: MEDIA_KW@273..279 "media" [] [Whitespace(" ")]
           1: CSS_MEDIA_QUERY_LIST@279..292
-            0: CSS_MEDIA_CONDITION_QUERY@279..292
-              0: CSS_MEDIA_NOT_CONDITION@279..292
+            0: SCSS_MEDIA_QUERY@279..292
+              0: CSS_MEDIA_TYPE_QUERY@279..292
                 0: NOT_KW@279..283 "not" [] [Whitespace(" ")]
-                1: SCSS_MEDIA_QUERY@283..292
-                  0: SCSS_INTERPOLATION@283..292
-                    0: HASH@283..284 "#" [] []
-                    1: L_CURLY@284..285 "{" [] []
-                    2: SCSS_EXPRESSION@285..290
-                      0: SCSS_EXPRESSION_ITEM_LIST@285..290
-                        0: CSS_STRING@285..290
-                          0: CSS_STRING_LITERAL@285..290 "\"(a)\"" [] []
-                    3: R_CURLY@290..292 "}" [] [Whitespace(" ")]
+                1: CSS_MEDIA_TYPE@283..292
+                  0: SCSS_INTERPOLATED_IDENTIFIER@283..292
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@283..292
+                      0: SCSS_INTERPOLATION@283..292
+                        0: HASH@283..284 "#" [] []
+                        1: L_CURLY@284..285 "{" [] []
+                        2: SCSS_EXPRESSION@285..290
+                          0: SCSS_EXPRESSION_ITEM_LIST@285..290
+                            0: CSS_STRING@285..290
+                              0: CSS_STRING_LITERAL@285..290 "\"(a)\"" [] []
+                        3: R_CURLY@290..292 "}" [] [Whitespace(" ")]
+              1: (empty)
         1: CSS_RULE_BLOCK@292..315
           0: L_CURLY@292..293 "{" [] []
           1: CSS_RULE_LIST@293..313

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/media-interpolation.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/media-interpolation.scss.snap
@@ -738,21 +738,31 @@ CssRoot {
                     media_token: MEDIA_KW@448..454 "media" [] [Whitespace(" ")],
                     queries: CssMediaQueryList [
                         ScssMediaQuery {
-                            query: ScssInterpolation {
-                                hash_token: HASH@454..455 "#" [] [],
-                                l_curly_token: L_CURLY@455..456 "{" [] [],
-                                value: ScssExpression {
-                                    items: ScssExpressionItemList [
-                                        ScssVariable {
-                                            dollar_token: DOLLAR@456..457 "$" [] [],
-                                            name: CssIdentifier {
-                                                value_token: IDENT@457..462 "query" [] [],
+                            head: CssMediaTypeQuery {
+                                modifier: missing (optional),
+                                ty: CssMediaType {
+                                    value: ScssInterpolatedIdentifier {
+                                        items: ScssInterpolatedIdentifierPartList [
+                                            ScssInterpolation {
+                                                hash_token: HASH@454..455 "#" [] [],
+                                                l_curly_token: L_CURLY@455..456 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@456..457 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@457..462 "query" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                r_curly_token: R_CURLY@462..464 "}" [] [Whitespace(" ")],
                                             },
-                                        },
-                                    ],
+                                        ],
+                                    },
                                 },
-                                r_curly_token: R_CURLY@462..464 "}" [] [Whitespace(" ")],
                             },
+                            tail: missing (optional),
                         },
                     ],
                 },
@@ -812,21 +822,31 @@ CssRoot {
                     media_token: MEDIA_KW@499..505 "media" [] [Whitespace(" ")],
                     queries: CssMediaQueryList [
                         ScssMediaQuery {
-                            query: ScssInterpolation {
-                                hash_token: HASH@505..506 "#" [] [],
-                                l_curly_token: L_CURLY@506..507 "{" [] [],
-                                value: ScssExpression {
-                                    items: ScssExpressionItemList [
-                                        ScssVariable {
-                                            dollar_token: DOLLAR@507..508 "$" [] [],
-                                            name: CssIdentifier {
-                                                value_token: IDENT@508..513 "query" [] [],
+                            head: CssMediaTypeQuery {
+                                modifier: missing (optional),
+                                ty: CssMediaType {
+                                    value: ScssInterpolatedIdentifier {
+                                        items: ScssInterpolatedIdentifierPartList [
+                                            ScssInterpolation {
+                                                hash_token: HASH@505..506 "#" [] [],
+                                                l_curly_token: L_CURLY@506..507 "{" [] [],
+                                                value: ScssExpression {
+                                                    items: ScssExpressionItemList [
+                                                        ScssVariable {
+                                                            dollar_token: DOLLAR@507..508 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@508..513 "query" [] [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                r_curly_token: R_CURLY@513..514 "}" [] [],
                                             },
-                                        },
-                                    ],
+                                        ],
+                                    },
                                 },
-                                r_curly_token: R_CURLY@513..514 "}" [] [],
                             },
+                            tail: missing (optional),
                         },
                         COMMA@514..516 "," [] [Whitespace(" ")],
                         CssMediaTypeQuery {
@@ -1506,16 +1526,22 @@ CssRoot {
           0: MEDIA_KW@448..454 "media" [] [Whitespace(" ")]
           1: CSS_MEDIA_QUERY_LIST@454..464
             0: SCSS_MEDIA_QUERY@454..464
-              0: SCSS_INTERPOLATION@454..464
-                0: HASH@454..455 "#" [] []
-                1: L_CURLY@455..456 "{" [] []
-                2: SCSS_EXPRESSION@456..462
-                  0: SCSS_EXPRESSION_ITEM_LIST@456..462
-                    0: SCSS_VARIABLE@456..462
-                      0: DOLLAR@456..457 "$" [] []
-                      1: CSS_IDENTIFIER@457..462
-                        0: IDENT@457..462 "query" [] []
-                3: R_CURLY@462..464 "}" [] [Whitespace(" ")]
+              0: CSS_MEDIA_TYPE_QUERY@454..464
+                0: (empty)
+                1: CSS_MEDIA_TYPE@454..464
+                  0: SCSS_INTERPOLATED_IDENTIFIER@454..464
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@454..464
+                      0: SCSS_INTERPOLATION@454..464
+                        0: HASH@454..455 "#" [] []
+                        1: L_CURLY@455..456 "{" [] []
+                        2: SCSS_EXPRESSION@456..462
+                          0: SCSS_EXPRESSION_ITEM_LIST@456..462
+                            0: SCSS_VARIABLE@456..462
+                              0: DOLLAR@456..457 "$" [] []
+                              1: CSS_IDENTIFIER@457..462
+                                0: IDENT@457..462 "query" [] []
+                        3: R_CURLY@462..464 "}" [] [Whitespace(" ")]
+              1: (empty)
         1: CSS_RULE_BLOCK@464..496
           0: L_CURLY@464..465 "{" [] []
           1: CSS_RULE_LIST@465..494
@@ -1553,16 +1579,22 @@ CssRoot {
           0: MEDIA_KW@499..505 "media" [] [Whitespace(" ")]
           1: CSS_MEDIA_QUERY_LIST@505..523
             0: SCSS_MEDIA_QUERY@505..514
-              0: SCSS_INTERPOLATION@505..514
-                0: HASH@505..506 "#" [] []
-                1: L_CURLY@506..507 "{" [] []
-                2: SCSS_EXPRESSION@507..513
-                  0: SCSS_EXPRESSION_ITEM_LIST@507..513
-                    0: SCSS_VARIABLE@507..513
-                      0: DOLLAR@507..508 "$" [] []
-                      1: CSS_IDENTIFIER@508..513
-                        0: IDENT@508..513 "query" [] []
-                3: R_CURLY@513..514 "}" [] []
+              0: CSS_MEDIA_TYPE_QUERY@505..514
+                0: (empty)
+                1: CSS_MEDIA_TYPE@505..514
+                  0: SCSS_INTERPOLATED_IDENTIFIER@505..514
+                    0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@505..514
+                      0: SCSS_INTERPOLATION@505..514
+                        0: HASH@505..506 "#" [] []
+                        1: L_CURLY@506..507 "{" [] []
+                        2: SCSS_EXPRESSION@507..513
+                          0: SCSS_EXPRESSION_ITEM_LIST@507..513
+                            0: SCSS_VARIABLE@507..513
+                              0: DOLLAR@507..508 "$" [] []
+                              1: CSS_IDENTIFIER@508..513
+                                0: IDENT@508..513 "query" [] []
+                        3: R_CURLY@513..514 "}" [] []
+              1: (empty)
             1: COMMA@514..516 "," [] [Whitespace(" ")]
             2: CSS_MEDIA_TYPE_QUERY@516..523
               0: (empty)

--- a/crates/biome_css_parser/tests/scss_exclusive_syntax_feature.rs
+++ b/crates/biome_css_parser/tests/scss_exclusive_syntax_feature.rs
@@ -1,10 +1,13 @@
 use biome_css_parser::{CssParserOptions, parse_css};
+use biome_css_syntax::CssSyntaxKind::{CSS_BOGUS_MEDIA_QUERY, SCSS_MEDIA_QUERY};
 use biome_languages::CssFileSource;
 
 const SCSS_VARIABLE_DECLARATION: &str = "$color: red;";
 const SCSS_VARIABLE_VALUE: &str = ".selector { color: $color; }";
 const SCSS_DIMENSION_INTERPOLATED_VALUE: &str = ".selector { width: 10px#{suffix}; }";
 const SCSS_NUMBER_INTERPOLATED_VALUE: &str = ".selector { width: 10#{unit}; }";
+const SCSS_INTERPOLATED_MEDIA_QUERIES: &[&str] =
+    &["@media print-#{$suffix} {}", "@media all #{$query} {}"];
 
 fn diagnostic_text(parse: &biome_css_parser::CssParse) -> String {
     format!("{:?}", parse.diagnostics())
@@ -87,6 +90,27 @@ fn reporting_scss_exclusive_syntax_only_changes_diagnostic_text() {
         assert!(
             reporting_diagnostics.contains("SCSS"),
             "expected reporting parser option to emit SCSS diagnostics, got: {reporting_diagnostics}"
+        );
+    }
+}
+
+#[test]
+fn css_files_recover_interpolated_media_queries_as_bogus() {
+    for source in SCSS_INTERPOLATED_MEDIA_QUERIES {
+        let parse = parse_css(source, CssFileSource::css(), CssParserOptions::default());
+        let syntax = parse.syntax();
+
+        assert!(
+            syntax
+                .descendants()
+                .any(|node| node.kind() == CSS_BOGUS_MEDIA_QUERY),
+            "expected an interpolated media query to be bogus in CSS: {source}"
+        );
+        assert!(
+            !syntax
+                .descendants()
+                .any(|node| node.kind() == SCSS_MEDIA_QUERY),
+            "expected no SCSS media-query node in CSS: {source}"
         );
     }
 }

--- a/crates/biome_css_syntax/src/generated/nodes.rs
+++ b/crates/biome_css_syntax/src/generated/nodes.rs
@@ -5051,7 +5051,7 @@ impl CssMediaType {
             value: self.value(),
         }
     }
-    pub fn value(&self) -> SyntaxResult<CssIdentifier> {
+    pub fn value(&self) -> SyntaxResult<AnyCssMediaTypeName> {
         support::required_node(&self.syntax, 0usize)
     }
 }
@@ -5065,7 +5065,7 @@ impl Serialize for CssMediaType {
 }
 #[derive(Serialize)]
 pub struct CssMediaTypeFields {
-    pub value: SyntaxResult<CssIdentifier>,
+    pub value: SyntaxResult<AnyCssMediaTypeName>,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct CssMediaTypeQuery {
@@ -11471,11 +11471,15 @@ impl ScssMediaQuery {
     }
     pub fn as_fields(&self) -> ScssMediaQueryFields {
         ScssMediaQueryFields {
-            query: self.query(),
+            head: self.head(),
+            tail: self.tail(),
         }
     }
-    pub fn query(&self) -> SyntaxResult<ScssInterpolation> {
+    pub fn head(&self) -> SyntaxResult<CssMediaTypeQuery> {
         support::required_node(&self.syntax, 0usize)
+    }
+    pub fn tail(&self) -> Option<CssMediaType> {
+        support::node(&self.syntax, 1usize)
     }
 }
 impl Serialize for ScssMediaQuery {
@@ -11488,7 +11492,8 @@ impl Serialize for ScssMediaQuery {
 }
 #[derive(Serialize)]
 pub struct ScssMediaQueryFields {
-    pub query: SyntaxResult<ScssInterpolation>,
+    pub head: SyntaxResult<CssMediaTypeQuery>,
+    pub tail: Option<CssMediaType>,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ScssMixinAtRule {
@@ -15751,6 +15756,25 @@ impl AnyCssMediaTypeCondition {
     pub fn as_css_media_not_condition(&self) -> Option<&CssMediaNotCondition> {
         match &self {
             Self::CssMediaNotCondition(item) => Some(item),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, PartialEq, Eq, Hash, Serialize)]
+pub enum AnyCssMediaTypeName {
+    CssIdentifier(CssIdentifier),
+    ScssInterpolatedIdentifier(ScssInterpolatedIdentifier),
+}
+impl AnyCssMediaTypeName {
+    pub fn as_css_identifier(&self) -> Option<&CssIdentifier> {
+        match &self {
+            Self::CssIdentifier(item) => Some(item),
+            _ => None,
+        }
+    }
+    pub fn as_scss_interpolated_identifier(&self) -> Option<&ScssInterpolatedIdentifier> {
+        match &self {
+            Self::ScssInterpolatedIdentifier(item) => Some(item),
             _ => None,
         }
     }
@@ -31862,7 +31886,8 @@ impl std::fmt::Debug for ScssMediaQuery {
         let result = if current_depth < 16 {
             DEPTH.set(current_depth + 1);
             f.debug_struct("ScssMediaQuery")
-                .field("query", &support::DebugSyntaxResult(self.query()))
+                .field("head", &support::DebugSyntaxResult(self.head()))
+                .field("tail", &support::DebugOptionalElement(self.tail()))
                 .finish()
         } else {
             f.debug_struct("ScssMediaQuery").finish()
@@ -40512,6 +40537,68 @@ impl From<AnyCssMediaTypeCondition> for SyntaxElement {
         node.into()
     }
 }
+impl From<CssIdentifier> for AnyCssMediaTypeName {
+    fn from(node: CssIdentifier) -> Self {
+        Self::CssIdentifier(node)
+    }
+}
+impl From<ScssInterpolatedIdentifier> for AnyCssMediaTypeName {
+    fn from(node: ScssInterpolatedIdentifier) -> Self {
+        Self::ScssInterpolatedIdentifier(node)
+    }
+}
+impl AstNode for AnyCssMediaTypeName {
+    type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        CssIdentifier::KIND_SET.union(ScssInterpolatedIdentifier::KIND_SET);
+    fn can_cast(kind: SyntaxKind) -> bool {
+        matches!(kind, CSS_IDENTIFIER | SCSS_INTERPOLATED_IDENTIFIER)
+    }
+    fn cast(syntax: SyntaxNode) -> Option<Self> {
+        let res = match syntax.kind() {
+            CSS_IDENTIFIER => Self::CssIdentifier(CssIdentifier { syntax }),
+            SCSS_INTERPOLATED_IDENTIFIER => {
+                Self::ScssInterpolatedIdentifier(ScssInterpolatedIdentifier { syntax })
+            }
+            _ => return None,
+        };
+        Some(res)
+    }
+    fn syntax(&self) -> &SyntaxNode {
+        match self {
+            Self::CssIdentifier(it) => it.syntax(),
+            Self::ScssInterpolatedIdentifier(it) => it.syntax(),
+        }
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        match self {
+            Self::CssIdentifier(it) => it.into_syntax(),
+            Self::ScssInterpolatedIdentifier(it) => it.into_syntax(),
+        }
+    }
+}
+impl std::fmt::Debug for AnyCssMediaTypeName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CssIdentifier(it) => std::fmt::Debug::fmt(it, f),
+            Self::ScssInterpolatedIdentifier(it) => std::fmt::Debug::fmt(it, f),
+        }
+    }
+}
+impl From<AnyCssMediaTypeName> for SyntaxNode {
+    fn from(n: AnyCssMediaTypeName) -> Self {
+        match n {
+            AnyCssMediaTypeName::CssIdentifier(it) => it.into_syntax(),
+            AnyCssMediaTypeName::ScssInterpolatedIdentifier(it) => it.into_syntax(),
+        }
+    }
+}
+impl From<AnyCssMediaTypeName> for SyntaxElement {
+    fn from(n: AnyCssMediaTypeName) -> Self {
+        let node: SyntaxNode = n.into();
+        node.into()
+    }
+}
 impl From<CssMediaAndTypeQuery> for AnyCssMediaTypeQuery {
     fn from(node: CssMediaAndTypeQuery) -> Self {
         Self::CssMediaAndTypeQuery(node)
@@ -46806,6 +46893,11 @@ impl std::fmt::Display for AnyCssMediaQuery {
     }
 }
 impl std::fmt::Display for AnyCssMediaTypeCondition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl std::fmt::Display for AnyCssMediaTypeName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(self.syntax(), f)
     }

--- a/crates/biome_css_syntax/src/generated/nodes_mut.rs
+++ b/crates/biome_css_syntax/src/generated/nodes_mut.rs
@@ -2044,7 +2044,7 @@ impl CssMediaOrCondition {
     }
 }
 impl CssMediaType {
-    pub fn with_value(self, element: CssIdentifier) -> Self {
+    pub fn with_value(self, element: AnyCssMediaTypeName) -> Self {
         Self::unwrap_cast(
             self.syntax
                 .splice_slots(0usize..=0usize, once(Some(element.into_syntax().into()))),
@@ -4570,11 +4570,17 @@ impl ScssMapExpressionPair {
     }
 }
 impl ScssMediaQuery {
-    pub fn with_query(self, element: ScssInterpolation) -> Self {
+    pub fn with_head(self, element: CssMediaTypeQuery) -> Self {
         Self::unwrap_cast(
             self.syntax
                 .splice_slots(0usize..=0usize, once(Some(element.into_syntax().into()))),
         )
+    }
+    pub fn with_tail(self, element: Option<CssMediaType>) -> Self {
+        Self::unwrap_cast(self.syntax.splice_slots(
+            1usize..=1usize,
+            once(element.map(|element| element.into_syntax().into())),
+        ))
     }
 }
 impl ScssMixinAtRule {

--- a/crates/biome_grit_patterns/src/grit_target_language/css_target_language/generated_mappings.rs
+++ b/crates/biome_grit_patterns/src/grit_target_language/css_target_language/generated_mappings.rs
@@ -704,7 +704,7 @@ pub fn native_slots_for_name(node_name: &str) -> &'static [(&'static str, u32)] 
         "ScssKeywordArgument" => &[("name", 0), ("value", 2)],
         "ScssMapExpression" => &[("pairs", 1)],
         "ScssMapExpressionPair" => &[("key", 0), ("value", 2)],
-        "ScssMediaQuery" => &[("query", 0)],
+        "ScssMediaQuery" => &[("head", 0), ("tail", 1)],
         "ScssMixinAtRule" => &[("name", 1), ("parameters", 2), ("block", 3)],
         "ScssModuleConfiguration" => &[("name", 0), ("value", 2), ("modifier", 3)],
         "ScssModuleMemberAccess" => &[("module", 0), ("member", 2)],

--- a/xtask/codegen/css.ungram
+++ b/xtask/codegen/css.ungram
@@ -1487,10 +1487,16 @@ AnyCssMediaQuery =
 	| CssBogusMediaQuery
 	| CssMetavariable
 
-// @media #{$query} {}
-//        ^^^^^^^^^
+// @media all #{$query} {}
+//        ^^^^^^^^^^^^^
+// Parser-owned invariant: at least one media-type name contains interpolation.
 ScssMediaQuery =
-	query: ScssInterpolation
+	head: CssMediaTypeQuery
+	tail: CssMediaType?
+
+AnyCssMediaTypeName =
+	CssIdentifier
+	| ScssInterpolatedIdentifier
 
 // @media screen, (width > 500px), print {}
 // 				        ^^^^^^^^^^^^^^^
@@ -1520,7 +1526,7 @@ CssMediaTypeQuery =
 // @media not all and not (color)  { }
 //            ^^^
 CssMediaType =
-	value: CssIdentifier
+	value: AnyCssMediaTypeName
 
 AnyCssMediaTypeCondition =
 	CssMediaNotCondition


### PR DESCRIPTION
> This PR was created with AI assistance (Codex).

## Summary

Adds parser and formatter support for SCSS-interpolated media-query fragments, including:

```scss
@media #{$query} {}
@media print-#{$suffix} {}
@media all #{$query} {}
```


## Test Plan

- `cargo test -p biome_css_parser`
- `cargo test -p biome_css_formatter`