### PR TITLE
fix(format/html): stop printing a document's last comment twice

### DIFF
--- a/.changeset/fix-html-duplicated-trailing-comment.md
+++ b/.changeset/fix-html-duplicated-trailing-comment.md
@@ -1,0 +1,10 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed the HTML formatter printing a comment twice when it ended the line of the last element in a document:
+
+```diff
+- text<!-- a --><!-- a -->
++ text<!-- a -->
+```

--- a/crates/biome_html_formatter/src/comments.rs
+++ b/crates/biome_html_formatter/src/comments.rs
@@ -84,8 +84,14 @@ impl CommentStyle for HtmlCommentStyle {
             //
             // <!-- This comment gets assigned to the text node, despite it being actually attached to the EOF token. -->
             // ```
+            //
+            // Only a comment that sits on its own line is moved. One that ends
+            // the line of the element before it is already printed by the
+            // element list, which reads it out of that element's trailing
+            // trivia; moving it here as well would print it twice.
             if let Some(token) = comment.following_token()
                 && token.kind() == HtmlSyntaxKind::EOF
+                && !comment.text_position().is_end_of_line()
             {
                 return CommentPlacement::trailing(comment.enclosing_node().clone(), comment);
             }

--- a/crates/biome_html_formatter/tests/specs/html/comments/ends-line-of-last-element.html
+++ b/crates/biome_html_formatter/tests/specs/html/comments/ends-line-of-last-element.html
@@ -1,0 +1,3 @@
+text<!-- ends the line of the text before it -->
+<div></div><!-- ends the line of the element before it -->
+<span>a</span><!-- a --><!-- b -->

--- a/crates/biome_html_formatter/tests/specs/html/comments/ends-line-of-last-element.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/comments/ends-line-of-last-element.html.snap
@@ -1,0 +1,24 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: comments/ends-line-of-last-element.html
+---
+
+# Input
+
+```html
+text<!-- ends the line of the text before it -->
+<div></div><!-- ends the line of the element before it -->
+<span>a</span><!-- a --><!-- b -->
+
+```
+
+
+# Formatted
+
+```html
+text<!-- ends the line of the text before it -->
+<div></div>
+<!-- ends the line of the element before it -->
+<span>a</span><!-- a --><!-- b -->
+
+```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Prevent trailing comments at the end of an html document from being double printed.

implemented by opus 5
<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
added tests

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
