### PR TITLE
fix(analyzer): support suppressions on multiline HTML tags

### DIFF
--- a/.changeset/silly-clocks-enter.md
+++ b/.changeset/silly-clocks-enter.md
@@ -1,0 +1,15 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11182](https://github.com/biomejs/biome/issues/11182): a `biome-ignore` comment now suppresses diagnostics reported on attributes of an HTML element whose start tag spans multiple lines. Previously, the comment only suppressed diagnostics on the tag's first line.
+
+```html
+<!-- biome-ignore lint/a11y/noPositiveTabindex: third-party markup -->
+<slot
+  name="icon"
+  tabindex="2"
+></slot>
+```
+
+Additionally, the "Suppress rule" code action for such elements no longer inserts the suppression comment inside the start tag, which produced invalid HTML.

--- a/crates/biome_analyze/src/lib.rs
+++ b/crates/biome_analyze/src/lib.rs
@@ -65,7 +65,7 @@ pub use crate::visitor::{NodeVisitor, Visitor, VisitorContext, VisitorFinishCont
 use biome_diagnostics::{Diagnostic, DiagnosticExt, category};
 use biome_rowan::{
     AstNode, BatchMutation, Direction, Language, SyntaxKind as _, SyntaxToken, TextRange, TextSize,
-    TokenAtOffset, TriviaPieceKind,
+    TokenAtOffset, TriviaPieceKind, WalkEvent,
 };
 use biome_suppression::{Suppression, SuppressionKind};
 pub use suppression_action::{ApplySuppression, SuppressionAction};
@@ -301,6 +301,12 @@ where
         // Iterate for syntax rules after we've established suppressions
         let iter = self.root.syntax().preorder();
         for event in iter {
+            if let WalkEvent::Enter(node) = &event
+                && node.kind().extends_line_suppression()
+            {
+                self.suppressions.expand_to_node(node.text_trimmed_range());
+            }
+
             // If this is a node event pass it to the visitors for this phase
             for visitor in self.visitors.iter_mut() {
                 let ctx = VisitorContext {

--- a/crates/biome_analyze/src/suppressions.rs
+++ b/crates/biome_analyze/src/suppressions.rs
@@ -592,6 +592,20 @@ impl<'analyzer> Suppressions<'analyzer> {
         found
     }
 
+    /// Extends every line suppression that covers `node_range`'s start so that it covers the
+    /// whole node. See [`biome_rowan::SyntaxKind::extends_line_suppression`].
+    pub(crate) fn expand_to_node(&mut self, node_range: TextRange) {
+        let start = node_range.start();
+        for suppression in self.line_suppressions.iter_mut().rev() {
+            if suppression.text_range.end() < start {
+                break;
+            }
+            if suppression.text_range.contains(start) {
+                suppression.text_range = suppression.text_range.cover(node_range);
+            }
+        }
+    }
+
     pub(crate) fn bump_line_index(&mut self, line_index: usize) {
         self.line_index = line_index;
     }

--- a/crates/biome_html_analyze/src/suppression_action.rs
+++ b/crates/biome_html_analyze/src/suppression_action.rs
@@ -1,5 +1,5 @@
 use biome_analyze::{ApplySuppression, SuppressionAction};
-use biome_html_syntax::{HtmlLanguage, HtmlSyntaxToken};
+use biome_html_syntax::{HtmlLanguage, HtmlSyntaxKind, HtmlSyntaxToken};
 use biome_rowan::{BatchMutation, TriviaPieceKind};
 
 pub(crate) struct HtmlSuppressionAction;
@@ -17,8 +17,24 @@ impl SuppressionAction for HtmlSuppressionAction {
             should_insert_leading_newline: false,
         };
 
+        // If the token is part of a (possibly multi-line) start tag, hoist it to the
+        // tag's first token so the suppression comment is placed above the whole
+        // element instead of inside the tag, where a comment isn't valid HTML.
+        let start_token = token
+            .ancestors()
+            .find(|node| {
+                matches!(
+                    node.kind(),
+                    HtmlSyntaxKind::HTML_OPENING_ELEMENT
+                        | HtmlSyntaxKind::HTML_SELF_CLOSING_ELEMENT
+                        | HtmlSyntaxKind::HTML_BOGUS_ELEMENT
+                )
+            })
+            .and_then(|node| node.first_token())
+            .unwrap_or(token);
+
         // Find the token at the start of suppressed token's line
-        let mut current_token = token;
+        let mut current_token = start_token;
         loop {
             let trivia = current_token.leading_trivia();
             if trivia.pieces().any(|trivia| trivia.kind().is_newline()) {

--- a/crates/biome_html_analyze/tests/specs/a11y/noPositiveTabindex/html/suppressionMultiline.html
+++ b/crates/biome_html_analyze/tests/specs/a11y/noPositiveTabindex/html/suppressionMultiline.html
@@ -1,0 +1,11 @@
+<!-- should generate diagnostics -->
+<!-- biome-ignore lint/a11y/noPositiveTabindex: suppressed -->
+<slot
+  name="icon"
+  tabindex="2"
+></slot>
+
+<!-- biome-ignore lint/a11y/noPositiveTabindex: does not reach children -->
+<div>
+  <span tabindex="2"></span>
+</div>

--- a/crates/biome_html_analyze/tests/specs/a11y/noPositiveTabindex/html/suppressionMultiline.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noPositiveTabindex/html/suppressionMultiline.html.snap
@@ -1,0 +1,43 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: suppressionMultiline.html
+---
+# Input
+```html
+<!-- should generate diagnostics -->
+<!-- biome-ignore lint/a11y/noPositiveTabindex: suppressed -->
+<slot
+  name="icon"
+  tabindex="2"
+></slot>
+
+<!-- biome-ignore lint/a11y/noPositiveTabindex: does not reach children -->
+<div>
+  <span tabindex="2"></span>
+</div>
+
+```
+
+# Diagnostics
+```
+suppressionMultiline.html:10:18 lint/a11y/noPositiveTabindex  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Avoid positive values for the tabindex attribute.
+  
+     8 │ <!-- biome-ignore lint/a11y/noPositiveTabindex: does not reach children -->
+     9 │ <div>
+  > 10 │   <span tabindex="2"></span>
+       │                  ^^^
+    11 │ </div>
+    12 │ 
+  
+  i Elements with a positive tabindex override natural page content order. This causes elements without a positive tab index to come last when navigating using a keyboard.
+  
+  i Use only 0 and -1 as tabindex values. Avoid using tabindex values greater than 0 and CSS properties that can change the order of focusable HTML elements.
+  
+  i Unsafe fix: Remove the tabindex attribute.
+  
+    10 │ ··<span·tabindex="2"></span>
+       │         ------------        
+
+```

--- a/crates/biome_html_analyze/tests/suppression/a11y/noPositiveTabindex/noPositiveTabindex.html
+++ b/crates/biome_html_analyze/tests/suppression/a11y/noPositiveTabindex/noPositiveTabindex.html
@@ -1,0 +1,4 @@
+<slot
+  name="icon"
+  tabindex="2"
+></slot>

--- a/crates/biome_html_analyze/tests/suppression/a11y/noPositiveTabindex/noPositiveTabindex.html.snap
+++ b/crates/biome_html_analyze/tests/suppression/a11y/noPositiveTabindex/noPositiveTabindex.html.snap
@@ -1,0 +1,48 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: noPositiveTabindex.html
+---
+# Input
+```html
+<slot
+  name="icon"
+  tabindex="2"
+></slot>
+
+```
+
+# Diagnostics
+```
+noPositiveTabindex.html:3:12 lint/a11y/noPositiveTabindex  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Avoid positive values for the tabindex attribute.
+  
+    1 │ <slot
+    2 │   name="icon"
+  > 3 │   tabindex="2"
+      │            ^^^
+    4 │ ></slot>
+    5 │ 
+  
+  i Elements with a positive tabindex override natural page content order. This causes elements without a positive tab index to come last when navigating using a keyboard.
+  
+  i Use only 0 and -1 as tabindex values. Avoid using tabindex values greater than 0 and CSS properties that can change the order of focusable HTML elements.
+  
+  i Safe fix: Suppress rule lint/a11y/noPositiveTabindex for this line.
+  
+    1   │ - <slot
+      1 │ + <!--·biome-ignore·lint/a11y/noPositiveTabindex:·<explanation>·-->
+      2 │ + <slot
+    2 3 │     name="icon"
+    3 4 │     tabindex="2"
+  
+  i Safe fix: Suppress rule lint/a11y/noPositiveTabindex for the whole file.
+  
+    1   │ - <slot
+      1 │ + <!--·biome-ignore-all·lint/a11y/noPositiveTabindex:·<explanation>·-->
+      2 │ + <slot
+    2 3 │     name="icon"
+    3 4 │     tabindex="2"
+  
+
+```

--- a/crates/biome_html_syntax/src/lib.rs
+++ b/crates/biome_html_syntax/src/lib.rs
@@ -99,6 +99,13 @@ impl biome_rowan::SyntaxKind for HtmlSyntaxKind {
     fn to_string(&self) -> Option<&'static str> {
         Self::to_string(self)
     }
+
+    fn extends_line_suppression(&self) -> bool {
+        matches!(
+            self,
+            Self::HTML_OPENING_ELEMENT | Self::HTML_SELF_CLOSING_ELEMENT | Self::HTML_BOGUS_ELEMENT
+        )
+    }
 }
 
 impl TryFrom<HtmlSyntaxKind> for TriviaPieceKind {

--- a/crates/biome_rowan/src/syntax.rs
+++ b/crates/biome_rowan/src/syntax.rs
@@ -56,6 +56,16 @@ pub trait SyntaxKind: fmt::Debug + PartialEq + Copy {
     fn is_allowed_before_suppressions(&self) -> bool {
         false
     }
+
+    /// Returns `true` if a line suppression that covers the start of this node should extend
+    /// over the node's whole range.
+    ///
+    /// Constructs like an HTML start tag are conceptually a single unit but may be written
+    /// across several lines. Without this, a `biome-ignore` above the tag would only cover the
+    /// tag's first line.
+    fn extends_line_suppression(&self) -> bool {
+        false
+    }
 }
 
 pub trait Language: Sized + Clone + Copy + fmt::Debug + Eq + Ord + std::hash::Hash {


### PR DESCRIPTION
## Summary

Fixes #11182

Line suppressions now cover multiline HTML opening, self-closing, and recovery elements. The HTML suppression action also places generated comments before the full start tag, keeping the resulting markup valid.

Regression fixtures and a changeset are included.

This PR was implemented with help from Codex AI assistant. 

## Test Plan

- `cargo test -p biome_analyze`
- `cargo test -p biome_html_analyze --test spec_tests`
- `cargo fmt --all -- --check`
- Focused Clippy checks with warnings denied

## Docs

A changeset was added. No website documentation changes are required for this bug fix.