### PR TITLE
fix(parse/html): stop reading `{{` as an interpolation in Svelte

### DIFF
--- a/.changeset/fix-svelte-double-curly.md
+++ b/.changeset/fix-svelte-double-curly.md
@@ -1,0 +1,10 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed Svelte files failing to parse when an expression begins with an object literal. `{{` was read as the start of an interpolation, as it is in Vue, but Svelte has no such syntax: there the outer brace opens the expression and the inner one opens an object.
+
+```svelte
+<p>{{ a: true }}</p>
+<div class={{ active: isActive }}></div>
+```

--- a/.changeset/fix-svelte-double-curly.md
+++ b/.changeset/fix-svelte-double-curly.md
@@ -2,7 +2,9 @@
 "@biomejs/biome": patch
 ---
 
-Fixed Svelte files failing to parse when an expression begins with an object literal. `{{` was read as the start of an interpolation, as it is in Vue, but Svelte has no such syntax: there the outer brace opens the expression and the inner one opens an object.
+Fixed Svelte files failing to parse when an expression begins with an object literal.
+
+Now the following snippet is correctly parsed:
 
 ```svelte
 <p>{{ a: true }}</p>

--- a/crates/biome_html_formatter/tests/specs/html/svelte/double_curly.svelte
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/double_curly.svelte
@@ -2,3 +2,9 @@
 <p>{{ a: true }}</p>
 <p>{JSON.stringify({ foo: "bar" })}</p>
 <div class={{ active: isActive }}></div>
+
+<section>
+<p>{{ a: true }}</p>
+<p>{JSON.stringify({ foo: "bar" })}</p>
+<div class={{ active: isActive }}></div>
+</section>

--- a/crates/biome_html_formatter/tests/specs/html/svelte/double_curly.svelte
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/double_curly.svelte
@@ -3,8 +3,6 @@
 <p>{JSON.stringify({ foo: "bar" })}</p>
 <div class={{ active: isActive }}></div>
 
-<section>
-<p>{{ a: true }}</p>
-<p>{JSON.stringify({ foo: "bar" })}</p>
-<div class={{ active: isActive }}></div>
-</section>
+<p>{   { a: true }    }</p>
+<p>{JSON.stringify(  { foo: "bar" }  )}</p>
+<div class={   {  active: isActive }   }></div>

--- a/crates/biome_html_formatter/tests/specs/html/svelte/double_curly.svelte
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/double_curly.svelte
@@ -1,0 +1,4 @@
+{{ a: true }}
+<p>{{ a: true }}</p>
+<p>{JSON.stringify({ foo: "bar" })}</p>
+<div class={{ active: isActive }}></div>

--- a/crates/biome_html_formatter/tests/specs/html/svelte/double_curly.svelte.snap
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/double_curly.svelte.snap
@@ -11,6 +11,12 @@ info: svelte/double_curly.svelte
 <p>{JSON.stringify({ foo: "bar" })}</p>
 <div class={{ active: isActive }}></div>
 
+<section>
+<p>{{ a: true }}</p>
+<p>{JSON.stringify({ foo: "bar" })}</p>
+<div class={{ active: isActive }}></div>
+</section>
+
 ```
 
 
@@ -21,5 +27,11 @@ info: svelte/double_curly.svelte
 <p>{{ a: true }}</p>
 <p>{JSON.stringify({ foo: "bar" })}</p>
 <div class={{ active: isActive }}></div>
+
+<section>
+	<p>{{ a: true }}</p>
+	<p>{JSON.stringify({ foo: "bar" })}</p>
+	<div class={{ active: isActive }}></div>
+</section>
 
 ```

--- a/crates/biome_html_formatter/tests/specs/html/svelte/double_curly.svelte.snap
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/double_curly.svelte.snap
@@ -11,11 +11,9 @@ info: svelte/double_curly.svelte
 <p>{JSON.stringify({ foo: "bar" })}</p>
 <div class={{ active: isActive }}></div>
 
-<section>
-<p>{{ a: true }}</p>
-<p>{JSON.stringify({ foo: "bar" })}</p>
-<div class={{ active: isActive }}></div>
-</section>
+<p>{   { a: true }    }</p>
+<p>{JSON.stringify(  { foo: "bar" }  )}</p>
+<div class={   {  active: isActive }   }></div>
 
 ```
 
@@ -28,10 +26,8 @@ info: svelte/double_curly.svelte
 <p>{JSON.stringify({ foo: "bar" })}</p>
 <div class={{ active: isActive }}></div>
 
-<section>
-	<p>{{ a: true }}</p>
-	<p>{JSON.stringify({ foo: "bar" })}</p>
-	<div class={{ active: isActive }}></div>
-</section>
+<p>{{ a: true }}</p>
+<p>{JSON.stringify(  { foo: "bar" }  )}</p>
+<div class={{  active: isActive }}></div>
 
 ```

--- a/crates/biome_html_formatter/tests/specs/html/svelte/double_curly.svelte.snap
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/double_curly.svelte.snap
@@ -1,0 +1,25 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: svelte/double_curly.svelte
+---
+
+# Input
+
+```svelte
+{{ a: true }}
+<p>{{ a: true }}</p>
+<p>{JSON.stringify({ foo: "bar" })}</p>
+<div class={{ active: isActive }}></div>
+
+```
+
+
+# Formatted
+
+```svelte
+{{ a: true }}
+<p>{{ a: true }}</p>
+<p>{JSON.stringify({ foo: "bar" })}</p>
+<div class={{ active: isActive }}></div>
+
+```

--- a/crates/biome_html_formatter/tests/specs/svelte-plugin/formatting/pre-mustache.svelte.snap
+++ b/crates/biome_html_formatter/tests/specs/svelte-plugin/formatting/pre-mustache.svelte.snap
@@ -78,24 +78,6 @@ info: formatting/pre-mustache.svelte
 			this line is intended using tabs which should be preserved</pre>
 ```
 
-# Errors
-```
-pre-mustache.svelte:4:99 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Text expressions aren't supported.
-  
-    2 │   world!   {JSON.stringify({   foo:'bar'},null,
-    3 │   2)}Goodbye.
-  > 4 │   this text goes waaaaaaaaaaaaaaaaaaaaaaaaaaaaaayyyyyyyyyyyyyyyyyyyyyyyyyyy above the print width {{a: true}} and the mustache should split it
-      │                                                                                                   ^^^^^^^^^^^
-    5 │   <code>const asd = {
-    6 │     variable };</code>
-  
-  i Remove it or enable the parsing using the html.parser.interpolation option.
-  
-
-```
-
 # Lines exceeding max width of 80 characters
 ```
     4:   this text goes waaaaaaaaaaaaaaaaaaaaaaaaaaaaaayyyyyyyyyyyyyyyyyyyyyyyyyyy above the print width {{a: true}} and the mustache should split it

--- a/crates/biome_html_parser/src/lexer/mod.rs
+++ b/crates/biome_html_parser/src/lexer/mod.rs
@@ -98,7 +98,12 @@ impl<'src> HtmlLexer<'src> {
     }
 
     /// Consume a token in the [HtmlLexContext::InsideTag] context.
-    fn consume_token_inside_tag(&mut self, current: u8, mode: TagNameMode) -> HtmlSyntaxKind {
+    fn consume_token_inside_tag(
+        &mut self,
+        current: u8,
+        mode: TagNameMode,
+        double_text_expressions: bool,
+    ) -> HtmlSyntaxKind {
         let dispatched = lookup_byte(current);
 
         match dispatched {
@@ -111,7 +116,7 @@ impl<'src> HtmlLexer<'src> {
             EXL => self.consume_byte(T![!]),
             BEO if self.at_svelte_opening_block() => self.consume_svelte_opening_block(),
             BEO => {
-                if self.at_opening_double_text_expression() {
+                if double_text_expressions && self.at_opening_double_text_expression() {
                     self.consume_l_double_text_expression()
                 } else {
                     self.consume_byte(T!['{'])
@@ -301,7 +306,7 @@ impl<'src> HtmlLexer<'src> {
             EQL => self.consume_byte(T![=]),
             EXL => self.consume_byte(T![!]),
             BEO => {
-                if self.at_opening_double_text_expression() {
+                if !svelte && self.at_opening_double_text_expression() {
                     self.consume_l_double_text_expression()
                 } else {
                     self.consume_byte(T!['{'])
@@ -396,7 +401,7 @@ impl<'src> HtmlLexer<'src> {
             PRD => return self.consume_byte(T![.]),
             _ => {}
         }
-        self.consume_token_inside_tag(current, mode)
+        self.consume_token_inside_tag(current, mode, false)
     }
 
     fn consume_token_vue_v_for_value(&mut self, current: u8) -> HtmlSyntaxKind {
@@ -445,7 +450,7 @@ impl<'src> HtmlLexer<'src> {
     }
 
     /// Consume a token in the [HtmlLexContext::Regular] context.
-    fn consume_token(&mut self, current: u8) -> HtmlSyntaxKind {
+    fn consume_token(&mut self, current: u8, double_text_expressions: bool) -> HtmlSyntaxKind {
         let dispatched = lookup_byte(current);
 
         match dispatched {
@@ -458,7 +463,7 @@ impl<'src> HtmlLexer<'src> {
             }
             BEO if self.at_svelte_opening_block() => self.consume_svelte_opening_block(),
             BEO => {
-                if self.at_opening_double_text_expression() {
+                if double_text_expressions && self.at_opening_double_text_expression() {
                     self.consume_l_double_text_expression()
                 } else {
                     self.consume_byte(T!['{'])
@@ -491,7 +496,7 @@ impl<'src> HtmlLexer<'src> {
             }
             IDT => self
                 .consume_language_identifier(current)
-                .unwrap_or_else(|| self.consume_html_text(current)),
+                .unwrap_or_else(|| self.consume_html_text(current, double_text_expressions)),
             _ => {
                 if self.position == 0
                     && let Some((bom, bom_size)) = self.consume_potential_bom(UNICODE_BOM)
@@ -499,7 +504,7 @@ impl<'src> HtmlLexer<'src> {
                     self.unicode_bom_length = bom_size;
                     return bom;
                 }
-                self.consume_html_text(current)
+                self.consume_html_text(current, double_text_expressions)
             }
         }
     }
@@ -1543,7 +1548,7 @@ impl<'src> HtmlLexer<'src> {
     ///
     /// - See: <https://html.spec.whatwg.org/#space-separated-tokens>
     /// - See: <https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace>
-    fn consume_html_text(&mut self, current: u8) -> HtmlSyntaxKind {
+    fn consume_html_text(&mut self, current: u8, double_text_expressions: bool) -> HtmlSyntaxKind {
         let mut whitespace_started = None;
         let mut seen_newlines = 0;
 
@@ -1554,7 +1559,7 @@ impl<'src> HtmlLexer<'src> {
 
         match dispatched {
             BEO => {
-                if self.at_opening_double_text_expression() {
+                if double_text_expressions && self.at_opening_double_text_expression() {
                     self.consume_l_double_text_expression()
                 } else {
                     self.consume_byte(T!['{'])
@@ -1670,11 +1675,15 @@ impl<'src> Lexer<'src> for HtmlLexer<'src> {
         } else {
             match self.current_byte() {
                 Some(current) => match context {
-                    HtmlLexContext::Regular => self.consume_token(current),
+                    HtmlLexContext::Regular { framework } => {
+                        self.consume_token(current, framework != HtmlFramework::Svelte)
+                    }
                     HtmlLexContext::InsideTag { framework } => {
                         let mode = TagNameMode::for_inside_tag(framework);
                         match framework {
-                            HtmlFramework::Plain => self.consume_token_inside_tag(current, mode),
+                            HtmlFramework::Plain => {
+                                self.consume_token_inside_tag(current, mode, true)
+                            }
                             HtmlFramework::Vue => {
                                 self.consume_token_inside_tag_directives(current, false, mode)
                             }
@@ -1804,11 +1813,13 @@ impl<'src> ReLexer<'src> for HtmlLexer<'src> {
         let re_lexed_kind = match self.current_byte() {
             Some(current) => match context {
                 HtmlReLexContext::Svelte => self.consume_svelte(current),
-                HtmlReLexContext::HtmlText => self.consume_html_text(current),
+                HtmlReLexContext::HtmlText { framework } => {
+                    self.consume_html_text(current, framework != HtmlFramework::Svelte)
+                }
                 // Re-lexing is only used mid-tag (e.g. to split `:`/`.`), never at the
                 // tag-name position, so the classification mode is irrelevant here.
                 HtmlReLexContext::InsideTag => {
-                    self.consume_token_inside_tag(current, TagNameMode::Html)
+                    self.consume_token_inside_tag(current, TagNameMode::Html, true)
                 }
                 HtmlReLexContext::InsideTagAstro => {
                     self.consume_token_inside_tag_astro(current, TagNameMode::Html)

--- a/crates/biome_html_parser/src/lexer/tests.rs
+++ b/crates/biome_html_parser/src/lexer/tests.rs
@@ -302,7 +302,7 @@ fn long_text() {
 #[test]
 fn text_trailing_whitespace() {
     assert_lex! {
-        HtmlLexContext::Regular,
+        HtmlLexContext::default(),
         "Lorem ipsum dolor <a",
         HTML_LITERAL: 17,
         WHITESPACE: 1,
@@ -314,7 +314,7 @@ fn text_trailing_whitespace() {
 #[test]
 fn text_trailing_whitespace_multiple() {
     assert_lex! {
-        HtmlLexContext::Regular,
+        HtmlLexContext::default(),
         "Lorem ipsum dolor  <a",
         HTML_LITERAL: 17,
         WHITESPACE: 2,
@@ -372,7 +372,7 @@ fn cdata_full() {
 #[test]
 fn svelte_openings() {
     assert_lex! {
-        HtmlLexContext::Regular,
+        HtmlLexContext::default(),
         "{@debug}",
         SV_CURLY_AT: 2,
         DEBUG_KW: 5,
@@ -380,7 +380,7 @@ fn svelte_openings() {
     }
 
     assert_lex! {
-        HtmlLexContext::Regular,
+        HtmlLexContext::default(),
         "{/debug}",
         SV_CURLY_SLASH: 2,
         DEBUG_KW: 5,
@@ -388,7 +388,7 @@ fn svelte_openings() {
     }
 
     assert_lex! {
-        HtmlLexContext::Regular,
+        HtmlLexContext::default(),
         "{:debug}",
         SV_CURLY_COLON: 2,
         DEBUG_KW: 5,
@@ -396,11 +396,27 @@ fn svelte_openings() {
     }
 
     assert_lex! {
-        HtmlLexContext::Regular,
+        HtmlLexContext::default(),
         "{#debug}",
         SV_CURLY_HASH: 2,
         DEBUG_KW: 5,
         R_CURLY: 1
+    }
+}
+
+#[test]
+fn double_curly_depends_on_regular_context() {
+    assert_lex! {
+        HtmlLexContext::Regular { framework: HtmlFramework::Plain },
+        "{{",
+        L_DOUBLE_CURLY: 2,
+    }
+
+    assert_lex! {
+        HtmlLexContext::Regular { framework: HtmlFramework::Svelte },
+        "{{",
+        L_CURLY: 1,
+        L_CURLY: 1,
     }
 }
 

--- a/crates/biome_html_parser/src/parser.rs
+++ b/crates/biome_html_parser/src/parser.rs
@@ -1,5 +1,5 @@
 use crate::token_source::{
-    HtmlLexContext, HtmlReLexContext, HtmlTokenSource, HtmlTokenSourceCheckpoint,
+    HtmlFramework, HtmlLexContext, HtmlReLexContext, HtmlTokenSource, HtmlTokenSourceCheckpoint,
     TextExpressionKind,
 };
 use biome_html_factory::HtmlSyntaxFactory;
@@ -23,9 +23,10 @@ pub(crate) struct HtmlParser<'source> {
 
 impl<'source> HtmlParser<'source> {
     pub fn new(source: &'source str, options: HtmlParserOptions) -> Self {
+        let framework = options.framework();
         Self {
             context: ParserContext::default(),
-            source: HtmlTokenSource::from_str(source),
+            source: HtmlTokenSource::from_str(source, HtmlLexContext::Regular { framework }),
             options,
         }
     }
@@ -149,6 +150,20 @@ pub struct HtmlParserOptions {
 }
 
 impl HtmlParserOptions {
+    pub(crate) fn framework(&self) -> HtmlFramework {
+        if self.vue {
+            HtmlFramework::Vue
+        } else if self.svelte {
+            HtmlFramework::Svelte
+        } else if self.frontmatter {
+            HtmlFramework::Astro
+        } else if self.angular {
+            HtmlFramework::Angular
+        } else {
+            HtmlFramework::Plain
+        }
+    }
+
     pub fn with_single_text_expression(mut self) -> Self {
         self.text_expression = Some(TextExpressionKind::Single);
         self

--- a/crates/biome_html_parser/src/syntax/mod.rs
+++ b/crates/biome_html_parser/src/syntax/mod.rs
@@ -591,10 +591,7 @@ impl ParseNodeList for ElementList {
     }
 
     fn is_at_list_end(&self, p: &mut Self::Parser<'_>) -> bool {
-        let at_l_angle0 = p.at(T![<]);
-        let at_slash1 = p.nth_at(1, T![/]);
-        let at_eof = p.at(EOF);
-        at_l_angle0 && at_slash1 || at_eof
+        p.at(EOF) || p.at(T![<]) && p.nth_at(1, T![/])
     }
 
     fn recover(

--- a/crates/biome_html_parser/src/syntax/mod.rs
+++ b/crates/biome_html_parser/src/syntax/mod.rs
@@ -189,17 +189,7 @@ fn parse_doc_type(p: &mut HtmlParser) -> ParsedSyntax {
 /// The framework flavor of the file currently being parsed.
 #[inline(always)]
 fn html_framework(p: &HtmlParser) -> HtmlFramework {
-    if Vue.is_supported(p) {
-        HtmlFramework::Vue
-    } else if Svelte.is_supported(p) {
-        HtmlFramework::Svelte
-    } else if Astro.is_supported(p) {
-        HtmlFramework::Astro
-    } else if Angular.is_supported(p) {
-        HtmlFramework::Angular
-    } else {
-        HtmlFramework::Plain
-    }
+    p.options().framework()
 }
 
 /// The lexer context to use inside a `<...>` tag. `framework` selects the directive
@@ -213,6 +203,20 @@ fn html_framework(p: &HtmlParser) -> HtmlFramework {
 #[inline(always)]
 fn inside_tag_context(p: &HtmlParser) -> HtmlLexContext {
     HtmlLexContext::InsideTag {
+        framework: html_framework(p),
+    }
+}
+
+#[inline(always)]
+fn regular_context(p: &HtmlParser) -> HtmlLexContext {
+    HtmlLexContext::Regular {
+        framework: html_framework(p),
+    }
+}
+
+#[inline(always)]
+fn html_text_re_lex_context(p: &HtmlParser) -> HtmlReLexContext {
+    HtmlReLexContext::HtmlText {
         framework: html_framework(p),
     }
 }
@@ -391,14 +395,14 @@ fn parse_element_allowing_sfc_blocks(p: &mut HtmlParser, sfc_blocks: bool) -> Pa
 
     if p.at(T![/]) {
         p.bump_with_context(T![/], inside_tag_context(p));
-        p.expect_with_context(T![>], HtmlLexContext::Regular);
+        p.expect_with_context(T![>], regular_context(p));
         Present(m.complete(p, HTML_SELF_CLOSING_ELEMENT))
     } else {
         if should_be_self_closing {
             if p.at(T![/]) {
                 p.bump_with_context(T![/], inside_tag_context(p));
             }
-            p.expect_with_context(T![>], HtmlLexContext::Regular);
+            p.expect_with_context(T![>], regular_context(p));
             return Present(m.complete(p, HTML_SELF_CLOSING_ELEMENT));
         }
         p.expect_with_context(
@@ -422,7 +426,7 @@ fn parse_element_allowing_sfc_blocks(p: &mut HtmlParser, sfc_blocks: bool) -> Pa
                     _ => unreachable!(),
                 })
             } else {
-                HtmlLexContext::Regular
+                regular_context(p)
             },
         );
 
@@ -430,7 +434,7 @@ fn parse_element_allowing_sfc_blocks(p: &mut HtmlParser, sfc_blocks: bool) -> Pa
 
         // if the lexer found a keyword, rewind and lex as text
         if is_at_keyword(p) {
-            p.re_lex(HtmlReLexContext::HtmlText);
+            p.re_lex(html_text_re_lex_context(p));
         }
 
         if is_raw_text {
@@ -534,7 +538,7 @@ pub(crate) fn parse_html_element(p: &mut HtmlParser, at_vue_sfc_top_level: bool)
         T![<] => parse_element(p, at_vue_sfc_top_level),
         T!["{{"] => HtmlSyntaxFeatures::DoubleTextExpressions.parse_exclusive_syntax(
             p,
-            |p| parse_double_text_expression(p, HtmlLexContext::Regular),
+            |p| parse_double_text_expression(p, regular_context(p)),
             |p, m| disabled_interpolation(p, m.range(p)),
         ),
         T!["{@"] => parse_svelte_at_block(p),
@@ -556,13 +560,13 @@ pub(crate) fn parse_html_element(p: &mut HtmlParser, at_vue_sfc_top_level: bool)
         // handled them first.
         _ if is_at_keyword(p) => {
             let m = p.start();
-            p.re_lex(HtmlReLexContext::HtmlText);
-            p.bump_with_context(HTML_LITERAL, HtmlLexContext::Regular);
+            p.re_lex(html_text_re_lex_context(p));
+            p.bump_with_context(HTML_LITERAL, regular_context(p));
             Present(m.complete(p, HTML_CONTENT))
         }
         HTML_LITERAL => {
             let m = p.start();
-            p.bump_with_context(HTML_LITERAL, HtmlLexContext::Regular);
+            p.bump_with_context(HTML_LITERAL, regular_context(p));
             Present(m.complete(p, HTML_CONTENT))
         }
         _ => Absent,
@@ -798,14 +802,14 @@ fn parse_literal(p: &mut HtmlParser, kind: HtmlSyntaxKind) -> ParsedSyntax {
 
     if p.at(T!["{{"]) {
         if HtmlSyntaxFeatures::DoubleTextExpressions.is_supported(p) {
-            parse_double_text_expression(p, HtmlLexContext::Regular).ok();
+            parse_double_text_expression(p, regular_context(p)).ok();
         } else {
             p.bump_remap_with_context(
                 HTML_LITERAL,
                 match kind {
                     HTML_TAG_NAME | HTML_ATTRIBUTE_NAME | HTML_COMPONENT_NAME
                     | HTML_MEMBER_NAME => inside_tag_context(p),
-                    _ => HtmlLexContext::Regular,
+                    _ => regular_context(p),
                 },
             )
         }
@@ -816,7 +820,7 @@ fn parse_literal(p: &mut HtmlParser, kind: HtmlSyntaxKind) -> ParsedSyntax {
                 HTML_TAG_NAME | HTML_ATTRIBUTE_NAME | HTML_COMPONENT_NAME | HTML_MEMBER_NAME => {
                     inside_tag_context(p)
                 }
-                _ => HtmlLexContext::Regular,
+                _ => regular_context(p),
             },
         );
     } else {
@@ -826,7 +830,7 @@ fn parse_literal(p: &mut HtmlParser, kind: HtmlSyntaxKind) -> ParsedSyntax {
                 HTML_TAG_NAME | HTML_ATTRIBUTE_NAME | HTML_COMPONENT_NAME | HTML_MEMBER_NAME => {
                     inside_tag_context(p)
                 }
-                _ => HtmlLexContext::Regular,
+                _ => regular_context(p),
             },
         );
     }

--- a/crates/biome_html_parser/src/syntax/svelte.rs
+++ b/crates/biome_html_parser/src/syntax/svelte.rs
@@ -1126,11 +1126,8 @@ impl ParseNodeList for SvelteElementList {
     }
 
     fn is_at_list_end(&self, p: &mut Self::Parser<'_>) -> bool {
-        let at_l_angle0 = p.at(T![<]);
-        let at_slash1 = p.nth_at(1, T![/]);
-        let at_eof = p.at(EOF);
-        at_l_angle0 && at_slash1
-            || at_eof
+        p.at(EOF)
+            || p.at(T![<]) && p.nth_at(1, T![/])
             || p.at(T!["{/"])
             || (self.stop_at_curly_colon && p.at(T!["{:"]))
     }

--- a/crates/biome_html_parser/src/syntax/svelte.rs
+++ b/crates/biome_html_parser/src/syntax/svelte.rs
@@ -46,7 +46,7 @@ pub(crate) fn parse_svelte_hash_block(p: &mut HtmlParser) -> ParsedSyntax {
                 let _ = ParseRecoveryTokenSet::new(HTML_BOGUS, token_set![T!['}']]).recover(p);
             }
 
-            p.expect(T!['}']);
+            p.expect_with_context(T!['}'], super::regular_context(p));
             Present(m.complete(p, SVELTE_BOGUS_BLOCK))
         }
     }
@@ -102,7 +102,7 @@ fn parse_if_opening_block(p: &mut HtmlParser, parent_marker: Marker) -> ParsedSy
         expected_expression(p, range.sub_start(parent_marker.start()))
     });
 
-    p.expect(T!['}']);
+    p.expect_with_context(T!['}'], super::regular_context(p));
 
     SvelteElementList::new()
         .with_stop_at_curly_colon()
@@ -135,7 +135,7 @@ pub(crate) fn parse_else_if_clause(p: &mut HtmlParser) -> ParsedSyntax {
         expected_expression(p, range.sub_start(m.start()))
     });
 
-    p.expect(T!['}']);
+    p.expect_with_context(T!['}'], super::regular_context(p));
 
     SvelteElementList::new()
         .with_stop_at_curly_colon()
@@ -151,8 +151,8 @@ pub(crate) fn parse_else_clause(p: &mut HtmlParser) -> ParsedSyntax {
     }
     let m = p.start();
     p.bump_with_context(T!["{:"], HtmlLexContext::Svelte);
-    p.expect(T![else]);
-    p.expect(T!['}']);
+    p.expect_with_context(T![else], HtmlLexContext::Svelte);
+    p.expect_with_context(T!['}'], super::regular_context(p));
     SvelteElementList::new().parse_list(p);
     Present(m.complete(p, SVELTE_ELSE_CLAUSE))
 }
@@ -253,7 +253,7 @@ fn parse_each_key(p: &mut HtmlParser) -> ParsedSyntax {
     // Re-lex to Svelte context to recognize ',) and other tokens
     p.re_lex(HtmlReLexContext::Svelte);
 
-    p.expect(T![')']);
+    p.expect_with_context(T![')'], HtmlLexContext::Svelte);
 
     Present(m.complete(p, SVELTE_EACH_KEY))
 }
@@ -366,7 +366,7 @@ fn parse_each_opening_block(p: &mut HtmlParser, parent_marker: Marker) -> (Parse
         parse_svelte_block_item(p).ok();
     }
 
-    p.expect(T!['}']);
+    p.expect_with_context(T!['}'], super::regular_context(p));
 
     (
         Present(parent_marker.complete(p, SVELTE_EACH_OPENING_BLOCK)),
@@ -411,7 +411,7 @@ pub(crate) fn parse_svelte_spread_or_expression(p: &mut HtmlParser) -> ParsedSyn
 
 pub(crate) fn parse_svelte_declaration_or_expression(p: &mut HtmlParser) -> ParsedSyntax {
     if !Svelte.is_supported(p) || !p.at(T!['{']) {
-        return parse_single_text_expression(p, HtmlLexContext::Regular);
+        return parse_single_text_expression(p, super::regular_context(p));
     }
 
     let checkpoint = p.checkpoint();
@@ -439,12 +439,12 @@ pub(crate) fn parse_svelte_declaration_or_expression(p: &mut HtmlParser) -> Pars
 
     if is_declaration {
         parse_single_text_expression_content(p).or_add_diagnostic(p, expected_text_expression);
-        p.expect_with_context(T!['}'], HtmlLexContext::Regular);
+        p.expect_with_context(T!['}'], super::regular_context(p));
         Present(m.complete(p, SVELTE_DECLARATION_BLOCK))
     } else {
         parse_single_text_expression_after_opening(
             p,
-            HtmlLexContext::Regular,
+            super::regular_context(p),
             checkpoint,
             m,
             opening_range,
@@ -531,7 +531,7 @@ fn parse_await_opening_block(p: &mut HtmlParser, parent_marker: Marker) -> Parse
         has_catch_clause = Some(m.range(p));
     }
 
-    p.expect(T!['}']);
+    p.expect_with_context(T!['}'], super::regular_context(p));
 
     SvelteElementList::new()
         .with_stop_at_curly_colon()
@@ -668,7 +668,7 @@ fn parse_await_then_or_catch_block(
         return (Absent, BlockParsed::None);
     }
     let m = p.start();
-    p.bump(T!["{:"]);
+    p.bump_with_context(T!["{:"], HtmlLexContext::Svelte);
 
     if p.at(T![then]) {
         (
@@ -699,7 +699,7 @@ fn parse_await_then_block(
 
     parse_single_text_expression_content(p).ok();
 
-    p.expect(T!['}']);
+    p.expect_with_context(T!['}'], super::regular_context(p));
 
     SvelteElementList::new()
         .with_stop_at_curly_colon()
@@ -731,7 +731,7 @@ fn parse_await_catch_block(
 
     parse_single_text_expression_content(p).ok();
 
-    p.expect(T!['}']);
+    p.expect_with_context(T!['}'], super::regular_context(p));
 
     SvelteElementList::new()
         .with_stop_at_curly_colon()
@@ -788,7 +788,7 @@ fn parse_snippet_opening_block(p: &mut HtmlParser, parent_marker: Marker) -> Par
         p.error(p.err_builder("Expected an expression after 'snippet'", p.cur_range()));
     }
 
-    p.expect(T!['}']);
+    p.expect_with_context(T!['}'], super::regular_context(p));
 
     SvelteElementList::new()
         .with_stop_at_curly_colon()
@@ -807,7 +807,7 @@ fn parse_curly_destructured_name(p: &mut HtmlParser) -> ParsedSyntax {
 
     SvelteBindingAssignmentBindingList.parse_list(p);
 
-    p.expect(T!['}']);
+    p.expect_with_context(T!['}'], HtmlLexContext::Svelte);
 
     Present(m.complete(p, SVELTE_CURLY_DESTRUCTURED_NAME))
 }
@@ -847,7 +847,7 @@ pub(crate) fn parse_opening_block(
         expected_expression(p, range.sub_start(m.start()))
     });
 
-    p.expect(T!['}']);
+    p.expect_with_context(T!['}'], super::regular_context(p));
 
     Present(m.complete(p, node))
 }
@@ -868,7 +868,7 @@ pub(crate) fn parse_closing_block(
 
     p.expect_with_context(keyword, HtmlLexContext::Svelte);
 
-    p.expect(T!['}']);
+    p.expect_with_context(T!['}'], super::regular_context(p));
 
     Present(m.complete(p, node))
 }
@@ -895,7 +895,7 @@ pub(crate) fn parse_svelte_at_block(p: &mut HtmlParser) -> ParsedSyntax {
                 let _ = ParseRecoveryTokenSet::new(HTML_BOGUS, token_set![T!['}']]).recover(p);
             }
 
-            p.expect(T!['}']);
+            p.expect_with_context(T!['}'], super::regular_context(p));
             Present(m.complete(p, SVELTE_BOGUS_BLOCK))
         }
     }
@@ -908,7 +908,7 @@ pub(crate) fn parse_debug_block(p: &mut HtmlParser, marker: Marker) -> ParsedSyn
 
     BindingList.parse_list(p);
 
-    p.expect(T!['}']);
+    p.expect_with_context(T!['}'], super::regular_context(p));
 
     Present(marker.complete(p, SVELTE_DEBUG_BLOCK))
 }
@@ -921,7 +921,7 @@ pub(crate) fn parse_html_block(p: &mut HtmlParser, marker: Marker) -> ParsedSynt
 
     parse_single_text_expression_content(p).or_add_diagnostic(p, expected_text_expression);
 
-    p.expect(T!['}']);
+    p.expect_with_context(T!['}'], super::regular_context(p));
 
     Present(marker.complete(p, SVELTE_HTML_BLOCK))
 }
@@ -934,7 +934,7 @@ pub(crate) fn parse_render_block(p: &mut HtmlParser, marker: Marker) -> ParsedSy
 
     parse_single_text_expression_content(p).or_add_diagnostic(p, expected_text_expression);
 
-    p.expect(T!['}']);
+    p.expect_with_context(T!['}'], super::regular_context(p));
 
     Present(marker.complete(p, SVELTE_RENDER_BLOCK))
 }
@@ -962,7 +962,7 @@ pub(crate) fn parse_const_block(p: &mut HtmlParser, marker: Marker) -> ParsedSyn
 
     parse_single_text_expression_content(p).or_add_diagnostic(p, expected_text_expression);
 
-    p.expect(T!['}']);
+    p.expect_with_context(T!['}'], super::regular_context(p));
 
     Present(marker.complete(p, SVELTE_CONST_BLOCK))
 }

--- a/crates/biome_html_parser/src/token_source.rs
+++ b/crates/biome_html_parser/src/token_source.rs
@@ -16,15 +16,14 @@ pub(crate) struct HtmlTokenSource<'source> {
     pub(super) trivia_list: Vec<Trivia>,
 }
 
-#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum HtmlLexContext {
     /// The default state. This state is used for lexing outside of tags.
     ///
     /// When the lexer is outside of a tag, special characters are lexed as text.
     ///
     /// The exceptions being `<` which indicates the start of a tag, and `>` which is invalid syntax if not preceded with a `<`.
-    #[default]
-    Regular,
+    Regular { framework: HtmlFramework },
     /// When the lexer is inside a tag, special characters are lexed as tag tokens.
     ///
     /// This single context covers plain HTML as well as the Vue/Svelte/Astro
@@ -222,7 +221,15 @@ impl HtmlEmbeddedLanguage {
 
 impl LexContext for HtmlLexContext {
     fn is_regular(&self) -> bool {
-        matches!(self, Self::Regular)
+        matches!(self, Self::Regular { .. })
+    }
+}
+
+impl Default for HtmlLexContext {
+    fn default() -> Self {
+        Self::Regular {
+            framework: HtmlFramework::Plain,
+        }
     }
 }
 
@@ -230,8 +237,8 @@ impl LexContext for HtmlLexContext {
 pub(crate) enum HtmlReLexContext {
     /// Specialised relex that manages certain characters such as commas, etc.
     Svelte,
-    /// Relex tokens using `HtmlLexer::consume_html_text`
-    HtmlText,
+    /// Relex tokens using `HtmlLexer::consume_html_text`.
+    HtmlText { framework: HtmlFramework },
     /// Relex tokens as if the parser was inside a tag.
     InsideTag,
     /// Relex tokens as if the parser was inside a tag in an Astro file.
@@ -249,13 +256,12 @@ pub(crate) type HtmlTokenSourceCheckpoint = TokenSourceCheckpoint<HtmlSyntaxKind
 
 impl<'source> HtmlTokenSource<'source> {
     /// Creates a new token source for the given string
-    pub fn from_str(source: &'source str) -> Self {
+    pub fn from_str(source: &'source str, initial_context: HtmlLexContext) -> Self {
         let lexer = HtmlLexer::from_str(source);
-
         let buffered = BufferedLexer::new(lexer);
         let mut source = Self::new(buffered);
 
-        source.next_non_trivia_token(HtmlLexContext::Regular, true);
+        source.next_non_trivia_token(initial_context, true);
         source
     }
 
@@ -339,11 +345,11 @@ impl TokenSource for HtmlTokenSource<'_> {
     }
 
     fn bump(&mut self) {
-        self.bump_with_context(HtmlLexContext::Regular)
+        self.bump_with_context(HtmlLexContext::default())
     }
 
     fn skip_as_trivia(&mut self) {
-        self.skip_as_trivia_with_context(HtmlLexContext::Regular)
+        self.skip_as_trivia_with_context(HtmlLexContext::default())
     }
 
     fn finish(self) -> (Vec<Trivia>, Vec<ParseDiagnostic>) {

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/double_curly.svelte
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/double_curly.svelte
@@ -1,4 +1,6 @@
 {{ a: true }}
 <p>{{ a: true }}</p>
+<p>text {{ a: true }}</p>
+{#if condition}text {{ a: true }}{/if}
 <p>{JSON.stringify({ foo: "bar" })}</p>
 <div class={{ active: isActive }}></div>

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/double_curly.svelte
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/double_curly.svelte
@@ -1,0 +1,4 @@
+{{ a: true }}
+<p>{{ a: true }}</p>
+<p>{JSON.stringify({ foo: "bar" })}</p>
+<div class={{ active: isActive }}></div>

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/double_curly.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/double_curly.svelte.snap
@@ -1,0 +1,203 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```svelte
+{{ a: true }}
+<p>{{ a: true }}</p>
+<p>{JSON.stringify({ foo: "bar" })}</p>
+<div class={{ active: isActive }}></div>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlSingleTextExpression {
+            l_curly_token: L_CURLY@0..1 "{" [] [],
+            expression: HtmlTextExpression {
+                html_literal_token: HTML_LITERAL@1..12 "{ a: true }" [] [],
+            },
+            r_curly_token: R_CURLY@12..13 "}" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@13..15 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: P_KW@15..16 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@16..17 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlSingleTextExpression {
+                    l_curly_token: L_CURLY@17..18 "{" [] [],
+                    expression: HtmlTextExpression {
+                        html_literal_token: HTML_LITERAL@18..29 "{ a: true }" [] [],
+                    },
+                    r_curly_token: R_CURLY@29..30 "}" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@30..31 "<" [] [],
+                slash_token: SLASH@31..32 "/" [] [],
+                name: HtmlTagName {
+                    value_token: P_KW@32..33 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@33..34 ">" [] [],
+            },
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@34..36 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: P_KW@36..37 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@37..38 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlSingleTextExpression {
+                    l_curly_token: L_CURLY@38..39 "{" [] [],
+                    expression: HtmlTextExpression {
+                        html_literal_token: HTML_LITERAL@39..69 "JSON.stringify({ foo: \"bar\" })" [] [],
+                    },
+                    r_curly_token: R_CURLY@69..70 "}" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@70..71 "<" [] [],
+                slash_token: SLASH@71..72 "/" [] [],
+                name: HtmlTagName {
+                    value_token: P_KW@72..73 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@73..74 ">" [] [],
+            },
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@74..76 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: DIV_KW@76..80 "div" [] [Whitespace(" ")],
+                },
+                attributes: HtmlAttributeList [
+                    HtmlAttribute {
+                        name: HtmlAttributeName {
+                            value_token: HTML_LITERAL@80..85 "class" [] [],
+                        },
+                        initializer: HtmlAttributeInitializerClause {
+                            eq_token: EQ@85..86 "=" [] [],
+                            value: HtmlAttributeSingleTextExpression {
+                                l_curly_token: L_CURLY@86..87 "{" [] [],
+                                expression: HtmlTextExpression {
+                                    html_literal_token: HTML_LITERAL@87..107 "{ active: isActive }" [] [],
+                                },
+                                r_curly_token: R_CURLY@107..108 "}" [] [],
+                            },
+                        },
+                    },
+                ],
+                r_angle_token: R_ANGLE@108..109 ">" [] [],
+            },
+            children: HtmlElementList [],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@109..110 "<" [] [],
+                slash_token: SLASH@110..111 "/" [] [],
+                name: HtmlTagName {
+                    value_token: DIV_KW@111..114 "div" [] [],
+                },
+                r_angle_token: R_ANGLE@114..115 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@115..116 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..116
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..115
+    0: HTML_SINGLE_TEXT_EXPRESSION@0..13
+      0: L_CURLY@0..1 "{" [] []
+      1: HTML_TEXT_EXPRESSION@1..12
+        0: HTML_LITERAL@1..12 "{ a: true }" [] []
+      2: R_CURLY@12..13 "}" [] []
+    1: HTML_ELEMENT@13..34
+      0: HTML_OPENING_ELEMENT@13..17
+        0: L_ANGLE@13..15 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@15..16
+          0: P_KW@15..16 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@16..16
+        3: R_ANGLE@16..17 ">" [] []
+      1: HTML_ELEMENT_LIST@17..30
+        0: HTML_SINGLE_TEXT_EXPRESSION@17..30
+          0: L_CURLY@17..18 "{" [] []
+          1: HTML_TEXT_EXPRESSION@18..29
+            0: HTML_LITERAL@18..29 "{ a: true }" [] []
+          2: R_CURLY@29..30 "}" [] []
+      2: HTML_CLOSING_ELEMENT@30..34
+        0: L_ANGLE@30..31 "<" [] []
+        1: SLASH@31..32 "/" [] []
+        2: HTML_TAG_NAME@32..33
+          0: P_KW@32..33 "p" [] []
+        3: R_ANGLE@33..34 ">" [] []
+    2: HTML_ELEMENT@34..74
+      0: HTML_OPENING_ELEMENT@34..38
+        0: L_ANGLE@34..36 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@36..37
+          0: P_KW@36..37 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@37..37
+        3: R_ANGLE@37..38 ">" [] []
+      1: HTML_ELEMENT_LIST@38..70
+        0: HTML_SINGLE_TEXT_EXPRESSION@38..70
+          0: L_CURLY@38..39 "{" [] []
+          1: HTML_TEXT_EXPRESSION@39..69
+            0: HTML_LITERAL@39..69 "JSON.stringify({ foo: \"bar\" })" [] []
+          2: R_CURLY@69..70 "}" [] []
+      2: HTML_CLOSING_ELEMENT@70..74
+        0: L_ANGLE@70..71 "<" [] []
+        1: SLASH@71..72 "/" [] []
+        2: HTML_TAG_NAME@72..73
+          0: P_KW@72..73 "p" [] []
+        3: R_ANGLE@73..74 ">" [] []
+    3: HTML_ELEMENT@74..115
+      0: HTML_OPENING_ELEMENT@74..109
+        0: L_ANGLE@74..76 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@76..80
+          0: DIV_KW@76..80 "div" [] [Whitespace(" ")]
+        2: HTML_ATTRIBUTE_LIST@80..108
+          0: HTML_ATTRIBUTE@80..108
+            0: HTML_ATTRIBUTE_NAME@80..85
+              0: HTML_LITERAL@80..85 "class" [] []
+            1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@85..108
+              0: EQ@85..86 "=" [] []
+              1: HTML_ATTRIBUTE_SINGLE_TEXT_EXPRESSION@86..108
+                0: L_CURLY@86..87 "{" [] []
+                1: HTML_TEXT_EXPRESSION@87..107
+                  0: HTML_LITERAL@87..107 "{ active: isActive }" [] []
+                2: R_CURLY@107..108 "}" [] []
+        3: R_ANGLE@108..109 ">" [] []
+      1: HTML_ELEMENT_LIST@109..109
+      2: HTML_CLOSING_ELEMENT@109..115
+        0: L_ANGLE@109..110 "<" [] []
+        1: SLASH@110..111 "/" [] []
+        2: HTML_TAG_NAME@111..114
+          0: DIV_KW@111..114 "div" [] []
+        3: R_ANGLE@114..115 ">" [] []
+  4: EOF@115..116 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/double_curly.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/double_curly.svelte.snap
@@ -8,6 +8,8 @@ expression: snapshot
 ```svelte
 {{ a: true }}
 <p>{{ a: true }}</p>
+<p>text {{ a: true }}</p>
+{#if condition}text {{ a: true }}{/if}
 <p>{JSON.stringify({ foo: "bar" })}</p>
 <div class={{ active: isActive }}></div>
 
@@ -66,71 +68,130 @@ HtmlRoot {
                 r_angle_token: R_ANGLE@37..38 ">" [] [],
             },
             children: HtmlElementList [
+                HtmlContent {
+                    value_token: HTML_LITERAL@38..43 "text" [] [Whitespace(" ")],
+                },
                 HtmlSingleTextExpression {
-                    l_curly_token: L_CURLY@38..39 "{" [] [],
+                    l_curly_token: L_CURLY@43..44 "{" [] [],
                     expression: HtmlTextExpression {
-                        html_literal_token: HTML_LITERAL@39..69 "JSON.stringify({ foo: \"bar\" })" [] [],
+                        html_literal_token: HTML_LITERAL@44..55 "{ a: true }" [] [],
                     },
-                    r_curly_token: R_CURLY@69..70 "}" [] [],
+                    r_curly_token: R_CURLY@55..56 "}" [] [],
                 },
             ],
             closing_element: HtmlClosingElement {
-                l_angle_token: L_ANGLE@70..71 "<" [] [],
-                slash_token: SLASH@71..72 "/" [] [],
+                l_angle_token: L_ANGLE@56..57 "<" [] [],
+                slash_token: SLASH@57..58 "/" [] [],
                 name: HtmlTagName {
-                    value_token: P_KW@72..73 "p" [] [],
+                    value_token: P_KW@58..59 "p" [] [],
                 },
-                r_angle_token: R_ANGLE@73..74 ">" [] [],
+                r_angle_token: R_ANGLE@59..60 ">" [] [],
+            },
+        },
+        SvelteIfBlock {
+            opening_block: SvelteIfOpeningBlock {
+                sv_curly_hash_token: SV_CURLY_HASH@60..63 "{#" [Newline("\n")] [],
+                if_token: IF_KW@63..66 "if" [] [Whitespace(" ")],
+                expression: HtmlTextExpression {
+                    html_literal_token: HTML_LITERAL@66..75 "condition" [] [],
+                },
+                r_curly_token: R_CURLY@75..76 "}" [] [],
+                children: HtmlElementList [
+                    HtmlContent {
+                        value_token: HTML_LITERAL@76..81 "text" [] [Whitespace(" ")],
+                    },
+                    HtmlSingleTextExpression {
+                        l_curly_token: L_CURLY@81..82 "{" [] [],
+                        expression: HtmlTextExpression {
+                            html_literal_token: HTML_LITERAL@82..93 "{ a: true }" [] [],
+                        },
+                        r_curly_token: R_CURLY@93..94 "}" [] [],
+                    },
+                ],
+            },
+            else_if_clauses: SvelteElseIfClauseList [],
+            else_clause: missing (optional),
+            closing_block: SvelteIfClosingBlock {
+                sv_curly_slash_token: SV_CURLY_SLASH@94..96 "{/" [] [],
+                if_token: IF_KW@96..98 "if" [] [],
+                r_curly_token: R_CURLY@98..99 "}" [] [],
             },
         },
         HtmlElement {
             opening_element: HtmlOpeningElement {
-                l_angle_token: L_ANGLE@74..76 "<" [Newline("\n")] [],
+                l_angle_token: L_ANGLE@99..101 "<" [Newline("\n")] [],
                 name: HtmlTagName {
-                    value_token: DIV_KW@76..80 "div" [] [Whitespace(" ")],
+                    value_token: P_KW@101..102 "p" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@102..103 ">" [] [],
+            },
+            children: HtmlElementList [
+                HtmlSingleTextExpression {
+                    l_curly_token: L_CURLY@103..104 "{" [] [],
+                    expression: HtmlTextExpression {
+                        html_literal_token: HTML_LITERAL@104..134 "JSON.stringify({ foo: \"bar\" })" [] [],
+                    },
+                    r_curly_token: R_CURLY@134..135 "}" [] [],
+                },
+            ],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@135..136 "<" [] [],
+                slash_token: SLASH@136..137 "/" [] [],
+                name: HtmlTagName {
+                    value_token: P_KW@137..138 "p" [] [],
+                },
+                r_angle_token: R_ANGLE@138..139 ">" [] [],
+            },
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@139..141 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: DIV_KW@141..145 "div" [] [Whitespace(" ")],
                 },
                 attributes: HtmlAttributeList [
                     HtmlAttribute {
                         name: HtmlAttributeName {
-                            value_token: HTML_LITERAL@80..85 "class" [] [],
+                            value_token: HTML_LITERAL@145..150 "class" [] [],
                         },
                         initializer: HtmlAttributeInitializerClause {
-                            eq_token: EQ@85..86 "=" [] [],
+                            eq_token: EQ@150..151 "=" [] [],
                             value: HtmlAttributeSingleTextExpression {
-                                l_curly_token: L_CURLY@86..87 "{" [] [],
+                                l_curly_token: L_CURLY@151..152 "{" [] [],
                                 expression: HtmlTextExpression {
-                                    html_literal_token: HTML_LITERAL@87..107 "{ active: isActive }" [] [],
+                                    html_literal_token: HTML_LITERAL@152..172 "{ active: isActive }" [] [],
                                 },
-                                r_curly_token: R_CURLY@107..108 "}" [] [],
+                                r_curly_token: R_CURLY@172..173 "}" [] [],
                             },
                         },
                     },
                 ],
-                r_angle_token: R_ANGLE@108..109 ">" [] [],
+                r_angle_token: R_ANGLE@173..174 ">" [] [],
             },
             children: HtmlElementList [],
             closing_element: HtmlClosingElement {
-                l_angle_token: L_ANGLE@109..110 "<" [] [],
-                slash_token: SLASH@110..111 "/" [] [],
+                l_angle_token: L_ANGLE@174..175 "<" [] [],
+                slash_token: SLASH@175..176 "/" [] [],
                 name: HtmlTagName {
-                    value_token: DIV_KW@111..114 "div" [] [],
+                    value_token: DIV_KW@176..179 "div" [] [],
                 },
-                r_angle_token: R_ANGLE@114..115 ">" [] [],
+                r_angle_token: R_ANGLE@179..180 ">" [] [],
             },
         },
     ],
-    eof_token: EOF@115..116 "" [Newline("\n")] [],
+    eof_token: EOF@180..181 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: HTML_ROOT@0..116
+0: HTML_ROOT@0..181
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..115
+  3: HTML_ELEMENT_LIST@0..180
     0: HTML_SINGLE_TEXT_EXPRESSION@0..13
       0: L_CURLY@0..1 "{" [] []
       1: HTML_TEXT_EXPRESSION@1..12
@@ -155,49 +216,91 @@ HtmlRoot {
         2: HTML_TAG_NAME@32..33
           0: P_KW@32..33 "p" [] []
         3: R_ANGLE@33..34 ">" [] []
-    2: HTML_ELEMENT@34..74
+    2: HTML_ELEMENT@34..60
       0: HTML_OPENING_ELEMENT@34..38
         0: L_ANGLE@34..36 "<" [Newline("\n")] []
         1: HTML_TAG_NAME@36..37
           0: P_KW@36..37 "p" [] []
         2: HTML_ATTRIBUTE_LIST@37..37
         3: R_ANGLE@37..38 ">" [] []
-      1: HTML_ELEMENT_LIST@38..70
-        0: HTML_SINGLE_TEXT_EXPRESSION@38..70
-          0: L_CURLY@38..39 "{" [] []
-          1: HTML_TEXT_EXPRESSION@39..69
-            0: HTML_LITERAL@39..69 "JSON.stringify({ foo: \"bar\" })" [] []
-          2: R_CURLY@69..70 "}" [] []
-      2: HTML_CLOSING_ELEMENT@70..74
-        0: L_ANGLE@70..71 "<" [] []
-        1: SLASH@71..72 "/" [] []
-        2: HTML_TAG_NAME@72..73
-          0: P_KW@72..73 "p" [] []
-        3: R_ANGLE@73..74 ">" [] []
-    3: HTML_ELEMENT@74..115
-      0: HTML_OPENING_ELEMENT@74..109
-        0: L_ANGLE@74..76 "<" [Newline("\n")] []
-        1: HTML_TAG_NAME@76..80
-          0: DIV_KW@76..80 "div" [] [Whitespace(" ")]
-        2: HTML_ATTRIBUTE_LIST@80..108
-          0: HTML_ATTRIBUTE@80..108
-            0: HTML_ATTRIBUTE_NAME@80..85
-              0: HTML_LITERAL@80..85 "class" [] []
-            1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@85..108
-              0: EQ@85..86 "=" [] []
-              1: HTML_ATTRIBUTE_SINGLE_TEXT_EXPRESSION@86..108
-                0: L_CURLY@86..87 "{" [] []
-                1: HTML_TEXT_EXPRESSION@87..107
-                  0: HTML_LITERAL@87..107 "{ active: isActive }" [] []
-                2: R_CURLY@107..108 "}" [] []
-        3: R_ANGLE@108..109 ">" [] []
-      1: HTML_ELEMENT_LIST@109..109
-      2: HTML_CLOSING_ELEMENT@109..115
-        0: L_ANGLE@109..110 "<" [] []
-        1: SLASH@110..111 "/" [] []
-        2: HTML_TAG_NAME@111..114
-          0: DIV_KW@111..114 "div" [] []
-        3: R_ANGLE@114..115 ">" [] []
-  4: EOF@115..116 "" [Newline("\n")] []
+      1: HTML_ELEMENT_LIST@38..56
+        0: HTML_CONTENT@38..43
+          0: HTML_LITERAL@38..43 "text" [] [Whitespace(" ")]
+        1: HTML_SINGLE_TEXT_EXPRESSION@43..56
+          0: L_CURLY@43..44 "{" [] []
+          1: HTML_TEXT_EXPRESSION@44..55
+            0: HTML_LITERAL@44..55 "{ a: true }" [] []
+          2: R_CURLY@55..56 "}" [] []
+      2: HTML_CLOSING_ELEMENT@56..60
+        0: L_ANGLE@56..57 "<" [] []
+        1: SLASH@57..58 "/" [] []
+        2: HTML_TAG_NAME@58..59
+          0: P_KW@58..59 "p" [] []
+        3: R_ANGLE@59..60 ">" [] []
+    3: SVELTE_IF_BLOCK@60..99
+      0: SVELTE_IF_OPENING_BLOCK@60..94
+        0: SV_CURLY_HASH@60..63 "{#" [Newline("\n")] []
+        1: IF_KW@63..66 "if" [] [Whitespace(" ")]
+        2: HTML_TEXT_EXPRESSION@66..75
+          0: HTML_LITERAL@66..75 "condition" [] []
+        3: R_CURLY@75..76 "}" [] []
+        4: HTML_ELEMENT_LIST@76..94
+          0: HTML_CONTENT@76..81
+            0: HTML_LITERAL@76..81 "text" [] [Whitespace(" ")]
+          1: HTML_SINGLE_TEXT_EXPRESSION@81..94
+            0: L_CURLY@81..82 "{" [] []
+            1: HTML_TEXT_EXPRESSION@82..93
+              0: HTML_LITERAL@82..93 "{ a: true }" [] []
+            2: R_CURLY@93..94 "}" [] []
+      1: SVELTE_ELSE_IF_CLAUSE_LIST@94..94
+      2: (empty)
+      3: SVELTE_IF_CLOSING_BLOCK@94..99
+        0: SV_CURLY_SLASH@94..96 "{/" [] []
+        1: IF_KW@96..98 "if" [] []
+        2: R_CURLY@98..99 "}" [] []
+    4: HTML_ELEMENT@99..139
+      0: HTML_OPENING_ELEMENT@99..103
+        0: L_ANGLE@99..101 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@101..102
+          0: P_KW@101..102 "p" [] []
+        2: HTML_ATTRIBUTE_LIST@102..102
+        3: R_ANGLE@102..103 ">" [] []
+      1: HTML_ELEMENT_LIST@103..135
+        0: HTML_SINGLE_TEXT_EXPRESSION@103..135
+          0: L_CURLY@103..104 "{" [] []
+          1: HTML_TEXT_EXPRESSION@104..134
+            0: HTML_LITERAL@104..134 "JSON.stringify({ foo: \"bar\" })" [] []
+          2: R_CURLY@134..135 "}" [] []
+      2: HTML_CLOSING_ELEMENT@135..139
+        0: L_ANGLE@135..136 "<" [] []
+        1: SLASH@136..137 "/" [] []
+        2: HTML_TAG_NAME@137..138
+          0: P_KW@137..138 "p" [] []
+        3: R_ANGLE@138..139 ">" [] []
+    5: HTML_ELEMENT@139..180
+      0: HTML_OPENING_ELEMENT@139..174
+        0: L_ANGLE@139..141 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@141..145
+          0: DIV_KW@141..145 "div" [] [Whitespace(" ")]
+        2: HTML_ATTRIBUTE_LIST@145..173
+          0: HTML_ATTRIBUTE@145..173
+            0: HTML_ATTRIBUTE_NAME@145..150
+              0: HTML_LITERAL@145..150 "class" [] []
+            1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@150..173
+              0: EQ@150..151 "=" [] []
+              1: HTML_ATTRIBUTE_SINGLE_TEXT_EXPRESSION@151..173
+                0: L_CURLY@151..152 "{" [] []
+                1: HTML_TEXT_EXPRESSION@152..172
+                  0: HTML_LITERAL@152..172 "{ active: isActive }" [] []
+                2: R_CURLY@172..173 "}" [] []
+        3: R_ANGLE@173..174 ">" [] []
+      1: HTML_ELEMENT_LIST@174..174
+      2: HTML_CLOSING_ELEMENT@174..180
+        0: L_ANGLE@174..175 "<" [] []
+        1: SLASH@175..176 "/" [] []
+        2: HTML_TAG_NAME@176..179
+          0: DIV_KW@176..179 "div" [] []
+        3: R_ANGLE@179..180 ">" [] []
+  4: EOF@180..181 "" [Newline("\n")] []
 
 ```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
    Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
    Please provide enough information so that others can review your PR.
    Once created, your PR will be automatically labeled according to changed files.
    Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Fixes the parsing of `{{` in svelte files. It's a bit of a larger refactor than I'd like, but it makes the most sense to me.

implemented by opus 5 initially, gpt 5.6 sol fixed it up
<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>