### PR TITLE
fix(analyze): recognize references in Svelte attachments

### DIFF
--- a/.changeset/huge-adults-beg.md
+++ b/.changeset/huge-adults-beg.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11171](https://github.com/biomejs/biome/issues/11171): variables referenced only inside a Svelte attachment (`{@attach ...}`) are no longer reported as unused by [`noUnusedVariables`](https://biomejs.dev/linter/rules/no-unused-variables/) and [`noUnusedImports`](https://biomejs.dev/linter/rules/no-unused-imports/).

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/valid-svelte-attach.svelte
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/valid-svelte-attach.svelte
@@ -1,0 +1,6 @@
+<!-- should not generate diagnostics -->
+<script>
+import { myAttachment } from "./attachments.js";
+</script>
+
+<div {@attach myAttachment}>...</div>

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/valid-svelte-attach.svelte.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/valid-svelte-attach.svelte.snap
@@ -1,0 +1,14 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid-svelte-attach.svelte
+---
+# Input
+```svelte
+<!-- should not generate diagnostics -->
+<script>
+import { myAttachment } from "./attachments.js";
+</script>
+
+<div {@attach myAttachment}>...</div>
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/valid-svelte-attach.svelte
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/valid-svelte-attach.svelte
@@ -1,0 +1,30 @@
+<!-- should not generate diagnostics -->
+<script lang="ts">
+function myAttachment(node: HTMLElement) {
+  console.log(node);
+}
+
+function tooltip(content: string) {
+  return (node: HTMLElement) => {
+    console.log(content, node);
+  };
+}
+
+let content = "hello";
+let color = "red";
+</script>
+
+<div {@attach myAttachment}>...</div>
+<button {@attach tooltip(content)}>Hover me</button>
+<canvas
+	width={32}
+	height={32}
+	{@attach (canvas: HTMLCanvasElement) => {
+		const context = canvas.getContext('2d');
+
+		$effect(() => {
+			context.fillStyle = color;
+			context.fillRect(0, 0, canvas.width, canvas.height);
+		});
+	}}
+></canvas>

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/valid-svelte-attach.svelte.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/valid-svelte-attach.svelte.snap
@@ -1,0 +1,38 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid-svelte-attach.svelte
+---
+# Input
+```svelte
+<!-- should not generate diagnostics -->
+<script lang="ts">
+function myAttachment(node: HTMLElement) {
+  console.log(node);
+}
+
+function tooltip(content: string) {
+  return (node: HTMLElement) => {
+    console.log(content, node);
+  };
+}
+
+let content = "hello";
+let color = "red";
+</script>
+
+<div {@attach myAttachment}>...</div>
+<button {@attach tooltip(content)}>Hover me</button>
+<canvas
+	width={32}
+	height={32}
+	{@attach (canvas: HTMLCanvasElement) => {
+		const context = canvas.getContext('2d');
+
+		$effect(() => {
+			context.fillStyle = color;
+			context.fillRect(0, 0, canvas.width, canvas.height);
+		});
+	}}
+></canvas>
+
+```

--- a/crates/biome_service/src/file_handlers/html/parse_embedded_nodes.rs
+++ b/crates/biome_service/src/file_handlers/html/parse_embedded_nodes.rs
@@ -366,7 +366,6 @@ pub(crate) fn parse_embedded_nodes(params: ParseEmbeddedParams) -> ParseEmbedRes
                     );
                 }
 
-                // Attachments: <div {@attach myAttachment}>
                 if let Some(attach) = SvelteAttachAttribute::cast_ref(&element)
                     && let Ok(expression) = attach.expression()
                     && let Some(candidate) = build_text_expression_candidate(&expression)

--- a/crates/biome_service/src/file_handlers/html/parse_embedded_nodes.rs
+++ b/crates/biome_service/src/file_handlers/html/parse_embedded_nodes.rs
@@ -12,8 +12,8 @@ use biome_html_syntax::{
     AnySvelteDirectiveInitializerClause, AstroEmbeddedContent, HtmlAttribute,
     HtmlAttributeInitializerClause, HtmlAttributeSingleTextExpression, HtmlDoubleTextExpression,
     HtmlElement, HtmlRoot, HtmlSingleTextExpression, HtmlSpreadAttribute, HtmlTextExpression,
-    SvelteName, VueDirective, VueVBindShorthandDirective, VueVForValue, VueVOnShorthandDirective,
-    VueVSlotShorthandDirective,
+    SvelteAttachAttribute, SvelteName, VueDirective, VueVBindShorthandDirective, VueVForValue,
+    VueVOnShorthandDirective, VueVSlotShorthandDirective,
 };
 use biome_js_parser::parse_js_with_offset_and_cache;
 use biome_js_syntax::JsLanguage;
@@ -356,6 +356,19 @@ pub(crate) fn parse_embedded_nodes(params: ParseEmbeddedParams) -> ParseEmbedRes
                         HtmlAttributeInitializerClause::can_cast(parent.kind())
                     })
                     && let Ok(expression) = attr.expression()
+                    && let Some(candidate) = build_text_expression_candidate(&expression)
+                {
+                    ctx.parse_and_push(
+                        &candidate,
+                        &doc_file_source,
+                        Some(embedded_file_source),
+                        &mut nodes,
+                    );
+                }
+
+                // Attachments: <div {@attach myAttachment}>
+                if let Some(attach) = SvelteAttachAttribute::cast_ref(&element)
+                    && let Ok(expression) = attach.expression()
                     && let Some(candidate) = build_text_expression_candidate(&expression)
                 {
                     ctx.parse_and_push(


### PR DESCRIPTION
## Summary

Closes #11171

Svelte `{@attach ...}` expressions were not parsed as embedded JavaScript, causing false `noUnusedVariables` and `noUnusedImports` diagnostics. This change extracts attachment expressions and adds regression fixtures covering direct, factory-call, and inline attachments.

A changeset is included in `.changeset/huge-adults-beg.md`.

This PR was implemented with the assistance of Codex

## Test Plan

- `just test-lintrule noUnusedVariables`
- `just test-lintrule noUnusedImports`
- `cargo fmt --all -- --check`
- `git diff --check`

## Docs

No documentation changes are required for this parser/analyzer bug fix.