### PR TITLE
test(format/html): enable `html_embeds` feature for tests

### DIFF
--- a/crates/biome_html_formatter/Cargo.toml
+++ b/crates/biome_html_formatter/Cargo.toml
@@ -38,7 +38,7 @@ biome_formatter_test = { path = "../biome_formatter_test", features = ["lang_htm
 biome_fs             = { path = "../biome_fs" }
 biome_html_parser    = { path = "../biome_html_parser" }
 biome_parser         = { path = "../biome_parser" }
-biome_service        = { path = "../biome_service", features = ["lang_html", "html_embeds"] }
+biome_service        = { path = "../biome_service", features = ["html_embeds", "lang_html"] }
 biome_test_utils     = { path = "../biome_test_utils", features = ["lang_html"] }
 camino               = { workspace = true }
 countme              = { workspace = true, features = ["enable"] }

--- a/crates/biome_html_formatter/Cargo.toml
+++ b/crates/biome_html_formatter/Cargo.toml
@@ -38,7 +38,7 @@ biome_formatter_test = { path = "../biome_formatter_test", features = ["lang_htm
 biome_fs             = { path = "../biome_fs" }
 biome_html_parser    = { path = "../biome_html_parser" }
 biome_parser         = { path = "../biome_parser" }
-biome_service        = { path = "../biome_service", features = ["lang_html"] }
+biome_service        = { path = "../biome_service", features = ["lang_html", "html_embeds"] }
 biome_test_utils     = { path = "../biome_test_utils", features = ["lang_html"] }
 camino               = { workspace = true }
 countme              = { workspace = true, features = ["enable"] }


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Simply enables the `html_embeds` feature for the html formatter tests to prevent false positives when running focused tests.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
green ci, `cargo test -p biome_html_formatter` should also pass on it's own with no snapshot changes

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
