### PR TITLE
fix(format/js): check declared property name suppressions

### DIFF
--- a/.changeset/tall-ghosts-grin.md
+++ b/.changeset/tall-ghosts-grin.md
@@ -5,5 +5,7 @@
 Fixed handling of `biome-ignore format` suppression comments on TypeScript declared class properties with string literal names.
 
 ```ts
-declare /* biome-ignore format: reason */ "role-admin": Array<number>;
+class A {
+	declare /* biome-ignore format: exercise suppression checking */ 'a-b': 0;
+}
 ```

--- a/.changeset/tall-ghosts-grin.md
+++ b/.changeset/tall-ghosts-grin.md
@@ -1,0 +1,9 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed handling of `biome-ignore format` suppression comments on TypeScript declared class properties with string literal names.
+
+```ts
+declare /* biome-ignore format: reason */ "role-admin": Array<number>;
+```

--- a/crates/biome_js_formatter/src/utils/assignment_like.rs
+++ b/crates/biome_js_formatter/src/utils/assignment_like.rs
@@ -476,7 +476,14 @@ impl AnyJsAssignmentLike {
 
                 write!(f, [modifiers.format(), space(),])?;
 
-                let width = write_member_name(&name?.into(), f)?;
+                let name = name?;
+
+                if f.context().comments().is_suppressed(name.syntax()) {
+                    write!(f, [format_suppressed_node(name.syntax())])?;
+                    return Ok(false);
+                }
+
+                let width = write_member_name(&name.into(), f)?;
 
                 write!(f, [property_annotation.format()])?;
                 let text_width_for_break =
@@ -494,7 +501,14 @@ impl AnyJsAssignmentLike {
 
                 write!(f, [modifiers.format(), space(),])?;
 
-                let width = write_member_name(&name?.into(), f)?;
+                let name = name?;
+
+                if f.context().comments().is_suppressed(name.syntax()) {
+                    write!(f, [format_suppressed_node(name.syntax())])?;
+                    return Ok(false);
+                }
+
+                let width = write_member_name(&name.into(), f)?;
 
                 write!(f, [question_mark_token.format()])?;
                 let text_width_for_break =

--- a/crates/biome_js_formatter/tests/specs/ts/declaration/declared_string_property.ts
+++ b/crates/biome_js_formatter/tests/specs/ts/declaration/declared_string_property.ts
@@ -1,0 +1,6 @@
+class A {
+	declare "a-b": 0;
+	declare "c-d" = 1;
+}
+
+class B {declare "e-f":0;declare "g-h"=1;}

--- a/crates/biome_js_formatter/tests/specs/ts/declaration/declared_string_property.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/declaration/declared_string_property.ts.snap
@@ -1,0 +1,32 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: ts/declaration/declared_string_property.ts
+---
+
+# Input
+
+```ts
+class A {
+	declare "a-b": 0;
+	declare "c-d" = 1;
+}
+
+class B {declare "e-f":0;declare "g-h"=1;}
+
+```
+
+
+# Formatted
+
+```ts
+class A {
+	declare "a-b": 0;
+	declare "c-d" = 1;
+}
+
+class B {
+	declare "e-f": 0;
+	declare "g-h" = 1;
+}
+
+```

--- a/crates/biome_js_formatter/tests/specs/ts/declaration/suppressed_declared_string_property.ts
+++ b/crates/biome_js_formatter/tests/specs/ts/declaration/suppressed_declared_string_property.ts
@@ -1,0 +1,3 @@
+class A {
+	declare /* biome-ignore format: exercise suppression checking */ 'a-b': 0;
+}

--- a/crates/biome_js_formatter/tests/specs/ts/declaration/suppressed_declared_string_property.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/declaration/suppressed_declared_string_property.ts.snap
@@ -1,0 +1,23 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: ts/declaration/suppressed_declared_string_property.ts
+---
+
+# Input
+
+```ts
+class A {
+	declare /* biome-ignore format: exercise suppression checking */ 'a-b': 0;
+}
+
+```
+
+
+# Formatted
+
+```ts
+class A {
+	declare /* biome-ignore format: exercise suppression checking */ "a-b": 0;
+}
+
+```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
fixes a panic found by ecosystem ci: https://github.com/biomejs/ecosystem-ci/actions/runs/30797612813/job/91637557181

Previously, we weren't checking the suppression comment in this sample. Now we do.

```ts
class Foo {
    declare /* biome-ignore format: reason */ "role-admin": Array<number>;
}
```

It was specifically triggered by the `"role-admin"` string literal.

fixed by gpt 5.6 sol
<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
added new tests

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
