### PR TITLE
fix(cli): include formatter diagnostics in JUnit reports 🤖🤖🤖

### DIFF
--- a/.changeset/bright-poets-clap.md
+++ b/.changeset/bright-poets-clap.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#5172](https://github.com/biomejs/biome/issues/5172): The JUnit reporter now emits test cases for formatter diagnostics.

--- a/crates/biome_cli/src/reporter/junit.rs
+++ b/crates/biome_cli/src/reporter/junit.rs
@@ -6,6 +6,7 @@ use biome_diagnostics::display::SourceFile;
 use biome_diagnostics::{Error, Resource};
 use camino::{Utf8Path, Utf8PathBuf};
 use quick_junit::{NonSuccessKind, Report, TestCase, TestCaseStatus, TestSuite};
+use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter};
 use std::io;
 
@@ -85,6 +86,9 @@ impl ReporterVisitor for JunitReporterVisitor {
             }
         });
 
+        // One JUnit <testsuite> per file path; multiple diagnostics accumulate as <testcase>s.
+        let mut suites: BTreeMap<&str, TestSuite> = BTreeMap::new();
+
         for diagnostic in diagnostics {
             let mut status = TestCaseStatus::non_success(NonSuccessKind::Failure);
             let message = format!("{}", JunitDiagnostic { diagnostic });
@@ -123,13 +127,17 @@ impl ReporterVisitor for JunitReporterVisitor {
                     );
                 }
 
-                let mut test_suite = TestSuite::new(path);
-                test_suite
-                    .extra
-                    .insert("package".into(), "org.biome".into());
-                test_suite.add_test_case(case);
-                self.0.add_test_suite(test_suite);
+                let suite = suites.entry(path).or_insert_with(|| {
+                    let mut suite = TestSuite::new(path);
+                    suite.extra.insert("package".into(), "org.biome".into());
+                    suite
+                });
+                suite.add_test_case(case);
             }
+        }
+
+        for suite in suites.into_values() {
+            self.0.add_test_suite(suite);
         }
 
         writer.log(markup! {

--- a/crates/biome_cli/src/reporter/junit.rs
+++ b/crates/biome_cli/src/reporter/junit.rs
@@ -92,18 +92,7 @@ impl ReporterVisitor for JunitReporterVisitor {
 
             let location = diagnostic.location();
 
-            if let (Some(span), Some(source_code), Some(resource)) =
-                (location.span, location.source_code, location.resource)
-            {
-                let source = SourceFile::new(source_code);
-                let start = source.location(span.start())?;
-
-                status.set_description(format!(
-                    "line {row:?}, col {col:?}, {body}",
-                    row = start.line_number.get(),
-                    col = start.column_number.get(),
-                    body = message
-                ));
+            if let Some(Resource::File(path)) = location.resource {
                 let mut case = TestCase::new(
                     format!(
                         "org.biome.{}",
@@ -116,20 +105,30 @@ impl ReporterVisitor for JunitReporterVisitor {
                     status,
                 );
 
-                if let Resource::File(path) = resource {
-                    let mut test_suite = TestSuite::new(path);
+                if let (Some(span), Some(source_code)) = (location.span, location.source_code) {
+                    let source = SourceFile::new(source_code);
+                    let start = source.location(span.start())?;
+
+                    case.status.set_description(format!(
+                        "line {row:?}, col {col:?}, {body}",
+                        row = start.line_number.get(),
+                        col = start.column_number.get(),
+                        body = message
+                    ));
                     case.extra
                         .insert("line".into(), start.line_number.get().to_string().into());
                     case.extra.insert(
                         "column".into(),
                         start.column_number.get().to_string().into(),
                     );
-                    test_suite
-                        .extra
-                        .insert("package".into(), "org.biome".into());
-                    test_suite.add_test_case(case);
-                    self.0.add_test_suite(test_suite);
                 }
+
+                let mut test_suite = TestSuite::new(path);
+                test_suite
+                    .extra
+                    .insert("package".into(), "org.biome".into());
+                test_suite.add_test_case(case);
+                self.0.add_test_suite(test_suite);
             }
         }
 

--- a/crates/biome_cli/src/reporter/junit.rs
+++ b/crates/biome_cli/src/reporter/junit.rs
@@ -86,7 +86,7 @@ impl ReporterVisitor for JunitReporterVisitor {
             }
         });
 
-        // One JUnit <testsuite> per file path; multiple diagnostics accumulate as <testcase>s.
+        // `Report::add_test_suite` does not merge suites with the same path.
         let mut suites: BTreeMap<&str, TestSuite> = BTreeMap::new();
 
         for diagnostic in diagnostics {
@@ -125,6 +125,9 @@ impl ReporterVisitor for JunitReporterVisitor {
                         "column".into(),
                         start.column_number.get().to_string().into(),
                     );
+                } else {
+                    // Formatter diagnostics often omit span/source; still emit failure text.
+                    case.status.set_description(message);
                 }
 
                 let suite = suites.entry(path).or_insert_with(|| {

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_check_command.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-assertion_line: 577
 expression: redactor(content)
 ---
 ## `index.ts`
@@ -47,122 +46,78 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 ```block
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="Biome" tests="24" failures="24" errors="16" time="<TIME>">
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
+    <testsuite name="index.ts" tests="12" disabled="0" errors="0" failures="12" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedImports" line="1" column="8">
             <failure message="This import is unused.">line 1, col 8, This import is unused.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedImports" line="2" column="10">
             <failure message="Several of these imports are unused.">line 2, col 10, Several of these imports are unused.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedVariables" line="8" column="5">
             <failure message="This variable f is unused.">line 8, col 5, This variable f is unused.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedVariables" line="9" column="7">
             <failure message="This variable f is unused.">line 9, col 7, This variable f is unused.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
-        <testcase name="org.biome.lint.correctness.noUnusedImports" line="1" column="8">
-            <failure message="This import is unused.">line 1, col 8, This import is unused.</failure>
-        </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
-        <testcase name="org.biome.lint.correctness.noUnusedImports" line="2" column="10">
-            <failure message="Several of these imports are unused.">line 2, col 10, Several of these imports are unused.</failure>
-        </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
-        <testcase name="org.biome.lint.correctness.noUnusedVariables" line="8" column="5">
-            <failure message="This variable f is unused.">line 8, col 5, This variable f is unused.</failure>
-        </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
-        <testcase name="org.biome.lint.correctness.noUnusedVariables" line="9" column="7">
-            <failure message="This variable f is unused.">line 9, col 7, This variable f is unused.</failure>
-        </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.assist.source.organizeImports" line="1" column="1">
             <failure message="Sort these imports.">line 1, col 1, Sort these imports.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noDoubleEquals" line="4" column="3">
             <failure message="Using == may be unsafe if you are relying on type coercion.">line 4, col 3, Using == may be unsafe if you are relying on type coercion.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noDebugger" line="6" column="1">
             <failure message="This is an unexpected use of the debugger statement.">line 6, col 1, This is an unexpected use of the debugger statement.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noImplicitAnyLet" line="8" column="5">
             <failure message="This variable implicitly has the any type.">line 8, col 5, This variable implicitly has the any type.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noImplicitAnyLet" line="9" column="7">
             <failure message="This variable implicitly has the any type.">line 9, col 7, This variable implicitly has the any type.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noRedeclare" line="2" column="10">
             <failure message="&apos;z&apos; is redeclared in the same scope.">line 2, col 10, &apos;z&apos; is redeclared in the same scope.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noRedeclare" line="9" column="7">
             <failure message="&apos;f&apos; is redeclared in the same scope.">line 9, col 7, &apos;f&apos; is redeclared in the same scope.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.format">
             <failure message="Formatter would have printed the following content:"/>
         </testcase>
     </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
+    <testsuite name="main.ts" tests="12" disabled="0" errors="0" failures="12" package="org.biome">
+        <testcase name="org.biome.lint.correctness.noUnusedImports" line="1" column="8">
+            <failure message="This import is unused.">line 1, col 8, This import is unused.</failure>
+        </testcase>
+        <testcase name="org.biome.lint.correctness.noUnusedImports" line="2" column="10">
+            <failure message="Several of these imports are unused.">line 2, col 10, Several of these imports are unused.</failure>
+        </testcase>
+        <testcase name="org.biome.lint.correctness.noUnusedVariables" line="8" column="5">
+            <failure message="This variable f is unused.">line 8, col 5, This variable f is unused.</failure>
+        </testcase>
+        <testcase name="org.biome.lint.correctness.noUnusedVariables" line="9" column="7">
+            <failure message="This variable f is unused.">line 9, col 7, This variable f is unused.</failure>
+        </testcase>
         <testcase name="org.biome.assist.source.organizeImports" line="1" column="1">
             <failure message="Sort these imports.">line 1, col 1, Sort these imports.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noDoubleEquals" line="4" column="3">
             <failure message="Using == may be unsafe if you are relying on type coercion.">line 4, col 3, Using == may be unsafe if you are relying on type coercion.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noDebugger" line="6" column="1">
             <failure message="This is an unexpected use of the debugger statement.">line 6, col 1, This is an unexpected use of the debugger statement.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noImplicitAnyLet" line="8" column="5">
             <failure message="This variable implicitly has the any type.">line 8, col 5, This variable implicitly has the any type.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noImplicitAnyLet" line="9" column="7">
             <failure message="This variable implicitly has the any type.">line 9, col 7, This variable implicitly has the any type.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noRedeclare" line="2" column="10">
             <failure message="&apos;z&apos; is redeclared in the same scope.">line 2, col 10, &apos;z&apos; is redeclared in the same scope.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noRedeclare" line="9" column="7">
             <failure message="&apos;f&apos; is redeclared in the same scope.">line 9, col 7, &apos;f&apos; is redeclared in the same scope.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.format">
             <failure message="Formatter would have printed the following content:"/>
         </testcase>

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_check_command.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
+assertion_line: 577
 expression: redactor(content)
 ---
 ## `index.ts`
@@ -45,7 +46,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="Biome" tests="22" failures="22" errors="16" time="<TIME>">
+<testsuites name="Biome" tests="24" failures="24" errors="16" time="<TIME>">
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedImports" line="1" column="8">
             <failure message="This import is unused.">line 1, col 8, This import is unused.</failure>
@@ -121,6 +122,11 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
             <failure message="&apos;f&apos; is redeclared in the same scope.">line 9, col 7, &apos;f&apos; is redeclared in the same scope.</failure>
         </testcase>
     </testsuite>
+    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
+        <testcase name="org.biome.format">
+            <failure message="Formatter would have printed the following content:"/>
+        </testcase>
+    </testsuite>
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.assist.source.organizeImports" line="1" column="1">
             <failure message="Sort these imports.">line 1, col 1, Sort these imports.</failure>
@@ -154,6 +160,11 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noRedeclare" line="9" column="7">
             <failure message="&apos;f&apos; is redeclared in the same scope.">line 9, col 7, &apos;f&apos; is redeclared in the same scope.</failure>
+        </testcase>
+    </testsuite>
+    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
+        <testcase name="org.biome.format">
+            <failure message="Formatter would have printed the following content:"/>
         </testcase>
     </testsuite>
 </testsuites>

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_check_command.snap
@@ -81,7 +81,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
             <failure message="&apos;f&apos; is redeclared in the same scope.">line 9, col 7, &apos;f&apos; is redeclared in the same scope.</failure>
         </testcase>
         <testcase name="org.biome.format">
-            <failure message="Formatter would have printed the following content:"/>
+            <failure message="Formatter would have printed the following content:">Formatter would have printed the following content:</failure>
         </testcase>
     </testsuite>
     <testsuite name="main.ts" tests="12" disabled="0" errors="0" failures="12" package="org.biome">
@@ -119,7 +119,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
             <failure message="&apos;f&apos; is redeclared in the same scope.">line 9, col 7, &apos;f&apos; is redeclared in the same scope.</failure>
         </testcase>
         <testcase name="org.biome.format">
-            <failure message="Formatter would have printed the following content:"/>
+            <failure message="Formatter would have printed the following content:">Formatter would have printed the following content:</failure>
         </testcase>
     </testsuite>
 </testsuites>

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_check_command_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_check_command_file.snap
@@ -42,7 +42,7 @@ expression: redactor(content)
             <failure message="&apos;f&apos; is redeclared in the same scope.">line 9, col 7, &apos;f&apos; is redeclared in the same scope.</failure>
         </testcase>
         <testcase name="org.biome.format">
-            <failure message="Formatter would have printed the following content:"/>
+            <failure message="Formatter would have printed the following content:">Formatter would have printed the following content:</failure>
         </testcase>
     </testsuite>
     <testsuite name="main.ts" tests="12" disabled="0" errors="0" failures="12" package="org.biome">
@@ -80,7 +80,7 @@ expression: redactor(content)
             <failure message="&apos;f&apos; is redeclared in the same scope.">line 9, col 7, &apos;f&apos; is redeclared in the same scope.</failure>
         </testcase>
         <testcase name="org.biome.format">
-            <failure message="Formatter would have printed the following content:"/>
+            <failure message="Formatter would have printed the following content:">Formatter would have printed the following content:</failure>
         </testcase>
     </testsuite>
 </testsuites>

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_check_command_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_check_command_file.snap
@@ -1,12 +1,13 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
+assertion_line: 577
 expression: redactor(content)
 ---
 ## `file.xml`
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="Biome" tests="22" failures="22" errors="16" time="<TIME>">
+<testsuites name="Biome" tests="24" failures="24" errors="16" time="<TIME>">
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedImports" line="1" column="8">
             <failure message="This import is unused.">line 1, col 8, This import is unused.</failure>
@@ -82,6 +83,11 @@ expression: redactor(content)
             <failure message="&apos;f&apos; is redeclared in the same scope.">line 9, col 7, &apos;f&apos; is redeclared in the same scope.</failure>
         </testcase>
     </testsuite>
+    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
+        <testcase name="org.biome.format">
+            <failure message="Formatter would have printed the following content:"/>
+        </testcase>
+    </testsuite>
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.assist.source.organizeImports" line="1" column="1">
             <failure message="Sort these imports.">line 1, col 1, Sort these imports.</failure>
@@ -115,6 +121,11 @@ expression: redactor(content)
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noRedeclare" line="9" column="7">
             <failure message="&apos;f&apos; is redeclared in the same scope.">line 9, col 7, &apos;f&apos; is redeclared in the same scope.</failure>
+        </testcase>
+    </testsuite>
+    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
+        <testcase name="org.biome.format">
+            <failure message="Formatter would have printed the following content:"/>
         </testcase>
     </testsuite>
 </testsuites>

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_check_command_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_check_command_file.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-assertion_line: 577
 expression: redactor(content)
 ---
 ## `file.xml`
@@ -8,122 +7,78 @@ expression: redactor(content)
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="Biome" tests="24" failures="24" errors="16" time="<TIME>">
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
+    <testsuite name="index.ts" tests="12" disabled="0" errors="0" failures="12" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedImports" line="1" column="8">
             <failure message="This import is unused.">line 1, col 8, This import is unused.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedImports" line="2" column="10">
             <failure message="Several of these imports are unused.">line 2, col 10, Several of these imports are unused.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedVariables" line="8" column="5">
             <failure message="This variable f is unused.">line 8, col 5, This variable f is unused.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedVariables" line="9" column="7">
             <failure message="This variable f is unused.">line 9, col 7, This variable f is unused.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
-        <testcase name="org.biome.lint.correctness.noUnusedImports" line="1" column="8">
-            <failure message="This import is unused.">line 1, col 8, This import is unused.</failure>
-        </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
-        <testcase name="org.biome.lint.correctness.noUnusedImports" line="2" column="10">
-            <failure message="Several of these imports are unused.">line 2, col 10, Several of these imports are unused.</failure>
-        </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
-        <testcase name="org.biome.lint.correctness.noUnusedVariables" line="8" column="5">
-            <failure message="This variable f is unused.">line 8, col 5, This variable f is unused.</failure>
-        </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
-        <testcase name="org.biome.lint.correctness.noUnusedVariables" line="9" column="7">
-            <failure message="This variable f is unused.">line 9, col 7, This variable f is unused.</failure>
-        </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.assist.source.organizeImports" line="1" column="1">
             <failure message="Sort these imports.">line 1, col 1, Sort these imports.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noDoubleEquals" line="4" column="3">
             <failure message="Using == may be unsafe if you are relying on type coercion.">line 4, col 3, Using == may be unsafe if you are relying on type coercion.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noDebugger" line="6" column="1">
             <failure message="This is an unexpected use of the debugger statement.">line 6, col 1, This is an unexpected use of the debugger statement.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noImplicitAnyLet" line="8" column="5">
             <failure message="This variable implicitly has the any type.">line 8, col 5, This variable implicitly has the any type.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noImplicitAnyLet" line="9" column="7">
             <failure message="This variable implicitly has the any type.">line 9, col 7, This variable implicitly has the any type.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noRedeclare" line="2" column="10">
             <failure message="&apos;z&apos; is redeclared in the same scope.">line 2, col 10, &apos;z&apos; is redeclared in the same scope.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noRedeclare" line="9" column="7">
             <failure message="&apos;f&apos; is redeclared in the same scope.">line 9, col 7, &apos;f&apos; is redeclared in the same scope.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.format">
             <failure message="Formatter would have printed the following content:"/>
         </testcase>
     </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
+    <testsuite name="main.ts" tests="12" disabled="0" errors="0" failures="12" package="org.biome">
+        <testcase name="org.biome.lint.correctness.noUnusedImports" line="1" column="8">
+            <failure message="This import is unused.">line 1, col 8, This import is unused.</failure>
+        </testcase>
+        <testcase name="org.biome.lint.correctness.noUnusedImports" line="2" column="10">
+            <failure message="Several of these imports are unused.">line 2, col 10, Several of these imports are unused.</failure>
+        </testcase>
+        <testcase name="org.biome.lint.correctness.noUnusedVariables" line="8" column="5">
+            <failure message="This variable f is unused.">line 8, col 5, This variable f is unused.</failure>
+        </testcase>
+        <testcase name="org.biome.lint.correctness.noUnusedVariables" line="9" column="7">
+            <failure message="This variable f is unused.">line 9, col 7, This variable f is unused.</failure>
+        </testcase>
         <testcase name="org.biome.assist.source.organizeImports" line="1" column="1">
             <failure message="Sort these imports.">line 1, col 1, Sort these imports.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noDoubleEquals" line="4" column="3">
             <failure message="Using == may be unsafe if you are relying on type coercion.">line 4, col 3, Using == may be unsafe if you are relying on type coercion.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noDebugger" line="6" column="1">
             <failure message="This is an unexpected use of the debugger statement.">line 6, col 1, This is an unexpected use of the debugger statement.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noImplicitAnyLet" line="8" column="5">
             <failure message="This variable implicitly has the any type.">line 8, col 5, This variable implicitly has the any type.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noImplicitAnyLet" line="9" column="7">
             <failure message="This variable implicitly has the any type.">line 9, col 7, This variable implicitly has the any type.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noRedeclare" line="2" column="10">
             <failure message="&apos;z&apos; is redeclared in the same scope.">line 2, col 10, &apos;z&apos; is redeclared in the same scope.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noRedeclare" line="9" column="7">
             <failure message="&apos;f&apos; is redeclared in the same scope.">line 9, col 7, &apos;f&apos; is redeclared in the same scope.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.format">
             <failure message="Formatter would have printed the following content:"/>
         </testcase>

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_ci_command.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
+assertion_line: 577
 expression: redactor(content)
 ---
 ## `index.ts`
@@ -45,7 +46,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="Biome" tests="22" failures="22" errors="16" time="<TIME>">
+<testsuites name="Biome" tests="24" failures="24" errors="16" time="<TIME>">
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedImports" line="1" column="8">
             <failure message="This import is unused.">line 1, col 8, This import is unused.</failure>
@@ -121,6 +122,11 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
             <failure message="&apos;f&apos; is redeclared in the same scope.">line 9, col 7, &apos;f&apos; is redeclared in the same scope.</failure>
         </testcase>
     </testsuite>
+    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
+        <testcase name="org.biome.format">
+            <failure message="File content differs from formatting output"/>
+        </testcase>
+    </testsuite>
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.assist.source.organizeImports" line="1" column="1">
             <failure message="Sort these imports.">line 1, col 1, Sort these imports.</failure>
@@ -154,6 +160,11 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noRedeclare" line="9" column="7">
             <failure message="&apos;f&apos; is redeclared in the same scope.">line 9, col 7, &apos;f&apos; is redeclared in the same scope.</failure>
+        </testcase>
+    </testsuite>
+    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
+        <testcase name="org.biome.format">
+            <failure message="File content differs from formatting output"/>
         </testcase>
     </testsuite>
 </testsuites>

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_ci_command.snap
@@ -81,7 +81,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
             <failure message="&apos;f&apos; is redeclared in the same scope.">line 9, col 7, &apos;f&apos; is redeclared in the same scope.</failure>
         </testcase>
         <testcase name="org.biome.format">
-            <failure message="File content differs from formatting output"/>
+            <failure message="File content differs from formatting output">File content differs from formatting output</failure>
         </testcase>
     </testsuite>
     <testsuite name="main.ts" tests="12" disabled="0" errors="0" failures="12" package="org.biome">
@@ -119,7 +119,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
             <failure message="&apos;f&apos; is redeclared in the same scope.">line 9, col 7, &apos;f&apos; is redeclared in the same scope.</failure>
         </testcase>
         <testcase name="org.biome.format">
-            <failure message="File content differs from formatting output"/>
+            <failure message="File content differs from formatting output">File content differs from formatting output</failure>
         </testcase>
     </testsuite>
 </testsuites>

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_ci_command.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-assertion_line: 577
 expression: redactor(content)
 ---
 ## `index.ts`
@@ -47,122 +46,78 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 ```block
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="Biome" tests="24" failures="24" errors="16" time="<TIME>">
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
+    <testsuite name="index.ts" tests="12" disabled="0" errors="0" failures="12" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedImports" line="1" column="8">
             <failure message="This import is unused.">line 1, col 8, This import is unused.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedImports" line="2" column="10">
             <failure message="Several of these imports are unused.">line 2, col 10, Several of these imports are unused.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedVariables" line="8" column="5">
             <failure message="This variable f is unused.">line 8, col 5, This variable f is unused.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedVariables" line="9" column="7">
             <failure message="This variable f is unused.">line 9, col 7, This variable f is unused.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
-        <testcase name="org.biome.lint.correctness.noUnusedImports" line="1" column="8">
-            <failure message="This import is unused.">line 1, col 8, This import is unused.</failure>
-        </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
-        <testcase name="org.biome.lint.correctness.noUnusedImports" line="2" column="10">
-            <failure message="Several of these imports are unused.">line 2, col 10, Several of these imports are unused.</failure>
-        </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
-        <testcase name="org.biome.lint.correctness.noUnusedVariables" line="8" column="5">
-            <failure message="This variable f is unused.">line 8, col 5, This variable f is unused.</failure>
-        </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
-        <testcase name="org.biome.lint.correctness.noUnusedVariables" line="9" column="7">
-            <failure message="This variable f is unused.">line 9, col 7, This variable f is unused.</failure>
-        </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.assist.source.organizeImports" line="1" column="1">
             <failure message="Sort these imports.">line 1, col 1, Sort these imports.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noDoubleEquals" line="4" column="3">
             <failure message="Using == may be unsafe if you are relying on type coercion.">line 4, col 3, Using == may be unsafe if you are relying on type coercion.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noDebugger" line="6" column="1">
             <failure message="This is an unexpected use of the debugger statement.">line 6, col 1, This is an unexpected use of the debugger statement.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noImplicitAnyLet" line="8" column="5">
             <failure message="This variable implicitly has the any type.">line 8, col 5, This variable implicitly has the any type.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noImplicitAnyLet" line="9" column="7">
             <failure message="This variable implicitly has the any type.">line 9, col 7, This variable implicitly has the any type.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noRedeclare" line="2" column="10">
             <failure message="&apos;z&apos; is redeclared in the same scope.">line 2, col 10, &apos;z&apos; is redeclared in the same scope.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noRedeclare" line="9" column="7">
             <failure message="&apos;f&apos; is redeclared in the same scope.">line 9, col 7, &apos;f&apos; is redeclared in the same scope.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.format">
             <failure message="File content differs from formatting output"/>
         </testcase>
     </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
+    <testsuite name="main.ts" tests="12" disabled="0" errors="0" failures="12" package="org.biome">
+        <testcase name="org.biome.lint.correctness.noUnusedImports" line="1" column="8">
+            <failure message="This import is unused.">line 1, col 8, This import is unused.</failure>
+        </testcase>
+        <testcase name="org.biome.lint.correctness.noUnusedImports" line="2" column="10">
+            <failure message="Several of these imports are unused.">line 2, col 10, Several of these imports are unused.</failure>
+        </testcase>
+        <testcase name="org.biome.lint.correctness.noUnusedVariables" line="8" column="5">
+            <failure message="This variable f is unused.">line 8, col 5, This variable f is unused.</failure>
+        </testcase>
+        <testcase name="org.biome.lint.correctness.noUnusedVariables" line="9" column="7">
+            <failure message="This variable f is unused.">line 9, col 7, This variable f is unused.</failure>
+        </testcase>
         <testcase name="org.biome.assist.source.organizeImports" line="1" column="1">
             <failure message="Sort these imports.">line 1, col 1, Sort these imports.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noDoubleEquals" line="4" column="3">
             <failure message="Using == may be unsafe if you are relying on type coercion.">line 4, col 3, Using == may be unsafe if you are relying on type coercion.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noDebugger" line="6" column="1">
             <failure message="This is an unexpected use of the debugger statement.">line 6, col 1, This is an unexpected use of the debugger statement.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noImplicitAnyLet" line="8" column="5">
             <failure message="This variable implicitly has the any type.">line 8, col 5, This variable implicitly has the any type.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noImplicitAnyLet" line="9" column="7">
             <failure message="This variable implicitly has the any type.">line 9, col 7, This variable implicitly has the any type.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noRedeclare" line="2" column="10">
             <failure message="&apos;z&apos; is redeclared in the same scope.">line 2, col 10, &apos;z&apos; is redeclared in the same scope.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noRedeclare" line="9" column="7">
             <failure message="&apos;f&apos; is redeclared in the same scope.">line 9, col 7, &apos;f&apos; is redeclared in the same scope.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.format">
             <failure message="File content differs from formatting output"/>
         </testcase>

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_format_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_format_command.snap
@@ -45,7 +45,17 @@ format ━━━━━━━━━━━━━━━━━━━━━━━━�
 
 ```block
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="Biome" tests="0" failures="0" errors="2" time="<TIME>">
+<testsuites name="Biome" tests="2" failures="2" errors="2" time="<TIME>">
+    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
+        <testcase name="org.biome.format">
+            <failure message="Formatter would have printed the following content:"/>
+        </testcase>
+    </testsuite>
+    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
+        <testcase name="org.biome.format">
+            <failure message="Formatter would have printed the following content:"/>
+        </testcase>
+    </testsuite>
 </testsuites>
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_format_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_format_command.snap
@@ -48,12 +48,12 @@ format ━━━━━━━━━━━━━━━━━━━━━━━━�
 <testsuites name="Biome" tests="2" failures="2" errors="2" time="<TIME>">
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.format">
-            <failure message="Formatter would have printed the following content:"/>
+            <failure message="Formatter would have printed the following content:">Formatter would have printed the following content:</failure>
         </testcase>
     </testsuite>
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.format">
-            <failure message="Formatter would have printed the following content:"/>
+            <failure message="Formatter would have printed the following content:">Formatter would have printed the following content:</failure>
         </testcase>
     </testsuite>
 </testsuites>

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_lint_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_lint_command.snap
@@ -46,102 +46,66 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 ```block
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="Biome" tests="20" failures="20" errors="12" time="<TIME>">
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
+    <testsuite name="index.ts" tests="10" disabled="0" errors="0" failures="10" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedImports" line="1" column="8">
             <failure message="This import is unused.">line 1, col 8, This import is unused.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedImports" line="2" column="10">
             <failure message="Several of these imports are unused.">line 2, col 10, Several of these imports are unused.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedVariables" line="8" column="5">
             <failure message="This variable f is unused.">line 8, col 5, This variable f is unused.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.correctness.noUnusedVariables" line="9" column="7">
             <failure message="This variable f is unused.">line 9, col 7, This variable f is unused.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
-        <testcase name="org.biome.lint.correctness.noUnusedImports" line="1" column="8">
-            <failure message="This import is unused.">line 1, col 8, This import is unused.</failure>
-        </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
-        <testcase name="org.biome.lint.correctness.noUnusedImports" line="2" column="10">
-            <failure message="Several of these imports are unused.">line 2, col 10, Several of these imports are unused.</failure>
-        </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
-        <testcase name="org.biome.lint.correctness.noUnusedVariables" line="8" column="5">
-            <failure message="This variable f is unused.">line 8, col 5, This variable f is unused.</failure>
-        </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
-        <testcase name="org.biome.lint.correctness.noUnusedVariables" line="9" column="7">
-            <failure message="This variable f is unused.">line 9, col 7, This variable f is unused.</failure>
-        </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noDoubleEquals" line="4" column="3">
             <failure message="Using == may be unsafe if you are relying on type coercion.">line 4, col 3, Using == may be unsafe if you are relying on type coercion.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noDebugger" line="6" column="1">
             <failure message="This is an unexpected use of the debugger statement.">line 6, col 1, This is an unexpected use of the debugger statement.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noImplicitAnyLet" line="8" column="5">
             <failure message="This variable implicitly has the any type.">line 8, col 5, This variable implicitly has the any type.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noImplicitAnyLet" line="9" column="7">
             <failure message="This variable implicitly has the any type.">line 9, col 7, This variable implicitly has the any type.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noRedeclare" line="2" column="10">
             <failure message="&apos;z&apos; is redeclared in the same scope.">line 2, col 10, &apos;z&apos; is redeclared in the same scope.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noRedeclare" line="9" column="7">
             <failure message="&apos;f&apos; is redeclared in the same scope.">line 9, col 7, &apos;f&apos; is redeclared in the same scope.</failure>
         </testcase>
     </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
+    <testsuite name="main.ts" tests="10" disabled="0" errors="0" failures="10" package="org.biome">
+        <testcase name="org.biome.lint.correctness.noUnusedImports" line="1" column="8">
+            <failure message="This import is unused.">line 1, col 8, This import is unused.</failure>
+        </testcase>
+        <testcase name="org.biome.lint.correctness.noUnusedImports" line="2" column="10">
+            <failure message="Several of these imports are unused.">line 2, col 10, Several of these imports are unused.</failure>
+        </testcase>
+        <testcase name="org.biome.lint.correctness.noUnusedVariables" line="8" column="5">
+            <failure message="This variable f is unused.">line 8, col 5, This variable f is unused.</failure>
+        </testcase>
+        <testcase name="org.biome.lint.correctness.noUnusedVariables" line="9" column="7">
+            <failure message="This variable f is unused.">line 9, col 7, This variable f is unused.</failure>
+        </testcase>
         <testcase name="org.biome.lint.suspicious.noDoubleEquals" line="4" column="3">
             <failure message="Using == may be unsafe if you are relying on type coercion.">line 4, col 3, Using == may be unsafe if you are relying on type coercion.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noDebugger" line="6" column="1">
             <failure message="This is an unexpected use of the debugger statement.">line 6, col 1, This is an unexpected use of the debugger statement.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noImplicitAnyLet" line="8" column="5">
             <failure message="This variable implicitly has the any type.">line 8, col 5, This variable implicitly has the any type.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noImplicitAnyLet" line="9" column="7">
             <failure message="This variable implicitly has the any type.">line 9, col 7, This variable implicitly has the any type.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noRedeclare" line="2" column="10">
             <failure message="&apos;z&apos; is redeclared in the same scope.">line 2, col 10, &apos;z&apos; is redeclared in the same scope.</failure>
         </testcase>
-    </testsuite>
-    <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noRedeclare" line="9" column="7">
             <failure message="&apos;f&apos; is redeclared in the same scope.">line 9, col 7, &apos;f&apos; is redeclared in the same scope.</failure>
         </testcase>


### PR DESCRIPTION
## Summary

Fixes #5172

JUnit reports now include file-scoped failing test cases for formatter diagnostics that do not have source spans.

## Test Plan

- `cargo test -p biome_cli reporter_junit --no-fail-fast`
- `cargo fmt --all -- --check`
- `cargo clippy -p biome_cli --tests -- -D warnings`

## Docs

Not applicable. The reporter behavior and changeset are covered by regression snapshots.

> This PR was written and validated primarily by OpenAI Codex. The implementation, tests, changeset, and this disclosure were AI-assisted.
