### PR TITLE
fix(lint): handle unused type parameters in overload signatures

### DIFF
--- a/.changeset/ten-years-buy.md
+++ b/.changeset/ten-years-buy.md
@@ -1,0 +1,13 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11214](https://github.com/biomejs/biome/issues/11214): [`noUnusedVariables`](https://biomejs.dev/linter/rules/no-unused-variables/) no longer reports type parameters declared on function overload signatures as unused.
+
+```ts
+function someFn<MyGeneric>();
+function someFn<MyGeneric>() {
+	const a: MyGeneric = returnAny();
+	console.log(a);
+}
+```

--- a/.changeset/ten-years-buy.md
+++ b/.changeset/ten-years-buy.md
@@ -2,7 +2,7 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#11214](https://github.com/biomejs/biome/issues/11214): [`noUnusedVariables`](https://biomejs.dev/linter/rules/no-unused-variables/) no longer reports type parameters declared on function overload signatures as unused.
+Fixed [#11214](https://github.com/biomejs/biome/issues/11214): [`noUnusedVariables`](https://biomejs.dev/linter/rules/no-unused-variables/) no longer reports type parameters declared on function or class method overload signatures that have an implementation.
 
 ```ts
 function someFn<MyGeneric>();
@@ -10,4 +10,13 @@ function someFn<MyGeneric>() {
 	const a: MyGeneric = returnAny();
 	console.log(a);
 }
+
+class C {
+	method<MyGeneric>(): void;
+	method<MyGeneric>(a?: MyGeneric): void {
+		console.log(a);
+	}
+}
 ```
+
+Type parameters on signatures that never get an implementation, such as abstract methods and interface members, are still reported.

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_variables.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_variables.rs
@@ -10,9 +10,8 @@ use biome_js_syntax::binding_ext::{AnyJsBindingDeclaration, AnyJsIdentifierBindi
 use biome_js_syntax::declaration_ext::is_in_ambient_context;
 use biome_js_syntax::modifier_ext::Modifier;
 use biome_js_syntax::{
-    AnyJsBinding, AnyJsExpression, JsCallExpression, JsClassExpression, JsClassMemberList,
-    JsExport, JsExportDefaultDeclarationClause, JsForStatement, JsFunctionDeclaration,
-    JsFunctionExportDefaultDeclaration, JsFunctionExpression, JsIdentifierExpression,
+    AnyJsExpression, JsCallExpression, JsClassExpression, JsClassMemberList, JsExport,
+    JsExportDefaultDeclarationClause, JsForStatement, JsFunctionExpression, JsIdentifierExpression,
     JsModuleItemList, JsSequenceExpression, JsSyntaxKind, JsSyntaxNode, JsVariableDeclarator,
     TsConditionalType, TsDeclarationModule, TsDeclareFunctionDeclaration,
     TsDeclareFunctionExportDefaultDeclaration, TsInferType, TsInterfaceDeclaration,
@@ -260,7 +259,7 @@ fn is_rest_spread_sibling(decl: &AnyJsBindingDeclaration) -> bool {
 /// without an implementation, such as an abstract method, remains subject to
 /// this rule.
 /// See https://github.com/biomejs/biome/issues/11214
-fn is_type_parameter_of_signature(type_parameter: &JsSyntaxNode) -> bool {
+fn is_type_parameter_of_signature(model: &SemanticModel, type_parameter: &JsSyntaxNode) -> bool {
     let Some(owner) = type_parameter
         .ancestors()
         .find_map(TsTypeParameters::cast)
@@ -271,7 +270,7 @@ fn is_type_parameter_of_signature(type_parameter: &JsSyntaxNode) -> bool {
     match owner.kind() {
         JsSyntaxKind::TS_DECLARE_FUNCTION_DECLARATION => {
             TsDeclareFunctionDeclaration::cast(owner)
-                .is_some_and(|signature| declare_function_has_implementation(&signature))
+                .is_some_and(|signature| declare_function_has_implementation(model, &signature))
         }
         JsSyntaxKind::TS_DECLARE_FUNCTION_EXPORT_DEFAULT_DECLARATION => {
             TsDeclareFunctionExportDefaultDeclaration::cast(owner)
@@ -285,56 +284,55 @@ fn is_type_parameter_of_signature(type_parameter: &JsSyntaxNode) -> bool {
     }
 }
 
-/// Returns the identifier name bound by `binding`, if any.
-fn binding_name_text(binding: SyntaxResult<AnyJsBinding>) -> Option<biome_rowan::TokenText> {
-    Some(
-        binding
-            .ok()?
-            .as_js_identifier_binding()?
-            .name_token()
-            .ok()?
-            .token_text_trimmed(),
+/// Returns `true` if `declaration` is a function declaration carrying a body,
+/// meaning it implements an overload set rather than adding a signature to it.
+fn is_function_implementation(declaration: &AnyJsBindingDeclaration) -> bool {
+    matches!(
+        declaration,
+        AnyJsBindingDeclaration::JsFunctionDeclaration(_)
+            | AnyJsBindingDeclaration::JsFunctionExportDefaultDeclaration(_)
     )
 }
 
-/// Returns `true` if a `function` declaration with a body and the same name
-/// as `signature` exists among its siblings. Function declarations may be
-/// wrapped in `export` nodes, so those wrappers are inspected as well.
-fn declare_function_has_implementation(signature: &TsDeclareFunctionDeclaration) -> bool {
-    let Some(name) = binding_name_text(signature.id()) else {
+/// Returns `true` if the name of `signature` is bound in the enclosing scope
+/// to a `function` declaration that TypeScript merges it with.
+///
+/// An overload signature always precedes its implementation, and a scope binds
+/// a name to the last declaration using it, so this lookup lands on the
+/// implementation whenever the overload set has one.
+fn declare_function_has_implementation(
+    model: &SemanticModel,
+    signature: &TsDeclareFunctionDeclaration,
+) -> bool {
+    let Some(name) = signature
+        .id()
+        .ok()
+        .and_then(|id| id.as_js_identifier_binding()?.name_token().ok())
+    else {
         return false;
     };
-    let Some(parent) = signature.syntax().parent() else {
+    let signature = AnyJsBindingDeclaration::from(signature.clone());
+    let Some(statement_list) = containing_statement_list(&signature) else {
         return false;
     };
-    let container = if JsExport::can_cast(parent.kind()) {
-        parent.parent()
-    } else {
-        Some(parent)
-    };
-    let Some(container) = container else {
+    let Some(declaration) = model
+        .scope(&statement_list)
+        .get_binding(name.text_trimmed())
+        .and_then(|binding| binding.tree().declaration())
+    else {
         return false;
     };
-    container.children().any(|item| {
-        let candidate = if JsExport::can_cast(item.kind()) {
-            item.children()
-                .find(|child| JsFunctionDeclaration::can_cast(child.kind()))
-        } else if JsFunctionDeclaration::can_cast(item.kind()) {
-            Some(item)
-        } else {
-            None
-        };
-        candidate
-            .and_then(JsFunctionDeclaration::cast)
-            .and_then(|decl| binding_name_text(decl.id()))
-            .is_some_and(|other_name| other_name.text() == name.text())
-    })
+    is_function_implementation(&declaration) && signature.is_mergeable(&declaration)
 }
 
-/// Returns `true` if a `export default function` declaration with a body
+/// Returns `true` if an `export default function` declaration with a body
 /// exists among the siblings of `signature`. There can only be one default
 /// export per module, so its mere presence identifies it as the
 /// implementation of this signature.
+///
+/// Unlike [`declare_function_has_implementation`], this cannot go through the
+/// semantic model: a default export overload may be anonymous, in which case
+/// it binds no name to look up.
 fn declare_default_function_has_implementation(
     signature: &TsDeclareFunctionExportDefaultDeclaration,
 ) -> bool {
@@ -351,6 +349,7 @@ fn declare_default_function_has_implementation(
     let Some(container) = export.parent() else {
         return false;
     };
+    let signature = AnyJsBindingDeclaration::from(signature.clone());
     container.children().any(|item| {
         JsExport::can_cast(item.kind())
             && item
@@ -360,7 +359,11 @@ fn declare_default_function_has_implementation(
                     clause
                         .syntax()
                         .children()
-                        .any(|decl| JsFunctionExportDefaultDeclaration::can_cast(decl.kind()))
+                        .filter_map(AnyJsBindingDeclaration::cast)
+                        .any(|declaration| {
+                            is_function_implementation(&declaration)
+                                && signature.is_mergeable(&declaration)
+                        })
                 })
     })
 }
@@ -407,6 +410,7 @@ fn suggestion_for_binding(binding: &AnyJsIdentifierBinding) -> Option<SuggestedF
 // It is ok in some Typescripts constructs for a parameter to be unused.
 // Returning None means is ok to be unused
 fn suggested_fix_if_unused(
+    model: &SemanticModel,
     binding: &AnyJsIdentifierBinding,
     options: &NoUnusedVariablesOptions,
 ) -> Option<SuggestedFix> {
@@ -466,7 +470,9 @@ fn suggested_fix_if_unused(
         // Type parameters are never ok to be unused unless they are declared in an
         // ambient context or in an overload signature that has an implementation
         node @ AnyJsBindingDeclaration::TsTypeParameter(_) => {
-            if is_in_ambient_context(node.syntax()) || is_type_parameter_of_signature(node.syntax()) {
+            if is_in_ambient_context(node.syntax())
+                || is_type_parameter_of_signature(model, node.syntax())
+            {
                 None
             } else {
                 Some(SuggestedFix::PrefixUnderscore)
@@ -609,7 +615,7 @@ impl Rule for NoUnusedVariables {
             {
                 return None;
             }
-            suggested_fix_if_unused(binding, ctx.options())
+            suggested_fix_if_unused(model, binding, ctx.options())
         } else {
             None
         }

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_variables.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_variables.rs
@@ -8,18 +8,23 @@ use biome_diagnostics::Severity;
 use biome_js_semantic::{ReferencesExtensions, SemanticModel};
 use biome_js_syntax::binding_ext::{AnyJsBindingDeclaration, AnyJsIdentifierBinding};
 use biome_js_syntax::declaration_ext::is_in_ambient_context;
+use biome_js_syntax::modifier_ext::Modifier;
 use biome_js_syntax::{
-    AnyJsExpression, JsCallExpression, JsClassExpression, JsForStatement, JsFunctionExpression,
-    JsIdentifierExpression, JsModuleItemList, JsSequenceExpression, JsSyntaxKind, JsSyntaxNode,
-    JsVariableDeclarator, TsConditionalType, TsDeclarationModule, TsInferType,
-    TsInterfaceDeclaration, TsTypeAliasDeclaration,
+    AnyJsBinding, AnyJsExpression, JsCallExpression, JsClassExpression, JsClassMemberList,
+    JsExport, JsExportDefaultDeclarationClause, JsForStatement, JsFunctionDeclaration,
+    JsFunctionExportDefaultDeclaration, JsFunctionExpression, JsIdentifierExpression,
+    JsModuleItemList, JsSequenceExpression, JsSyntaxKind, JsSyntaxNode, JsVariableDeclarator,
+    TsConditionalType, TsDeclarationModule, TsDeclareFunctionDeclaration,
+    TsDeclareFunctionExportDefaultDeclaration, TsInferType, TsInterfaceDeclaration,
+    TsMethodSignatureClassMember, TsTypeAliasDeclaration, TsTypeParameters,
 };
 use biome_languages::JsFileSource;
 use biome_languages::javascript::JsEmbeddingKind;
-use biome_rowan::{AstNode, BatchMutationExt, Direction, SyntaxResult};
+use biome_rowan::{AstNode, AstNodeList, BatchMutationExt, Direction, SyntaxResult};
 use biome_rule_options::no_unused_variables::{
     NoUnusedVariablesOptions, NoUnusedVariablesOptionsIgnore,
 };
+use enumflags2::BitFlags;
 
 declare_lint_rule! {
     /// Disallow unused variables.
@@ -245,6 +250,152 @@ fn is_rest_spread_sibling(decl: &AnyJsBindingDeclaration) -> bool {
     }
 }
 
+/// Returns `true` if the type parameter belongs to a function or method
+/// signature (a declaration without a body, such as an overload signature)
+/// that has a body-bearing implementation of the same identity in scope.
+///
+/// TypeScript does not report unused type parameters on overload signatures.
+/// It checks the type parameters of the body-bearing implementation against
+/// references in that declaration's signature and body. A body-less method
+/// without an implementation, such as an abstract method, remains subject to
+/// this rule.
+/// See https://github.com/biomejs/biome/issues/11214
+fn is_type_parameter_of_signature(type_parameter: &JsSyntaxNode) -> bool {
+    let Some(owner) = type_parameter
+        .ancestors()
+        .find_map(TsTypeParameters::cast)
+        .and_then(|type_parameters| type_parameters.syntax().parent())
+    else {
+        return false;
+    };
+    match owner.kind() {
+        JsSyntaxKind::TS_DECLARE_FUNCTION_DECLARATION => {
+            TsDeclareFunctionDeclaration::cast(owner)
+                .is_some_and(|signature| declare_function_has_implementation(&signature))
+        }
+        JsSyntaxKind::TS_DECLARE_FUNCTION_EXPORT_DEFAULT_DECLARATION => {
+            TsDeclareFunctionExportDefaultDeclaration::cast(owner)
+                .is_some_and(|signature| declare_default_function_has_implementation(&signature))
+        }
+        JsSyntaxKind::TS_METHOD_SIGNATURE_CLASS_MEMBER => {
+            TsMethodSignatureClassMember::cast(owner)
+                .is_some_and(|signature| method_signature_has_implementation(&signature))
+        }
+        _ => false,
+    }
+}
+
+/// Returns the identifier name bound by `binding`, if any.
+fn binding_name_text(binding: SyntaxResult<AnyJsBinding>) -> Option<biome_rowan::TokenText> {
+    Some(
+        binding
+            .ok()?
+            .as_js_identifier_binding()?
+            .name_token()
+            .ok()?
+            .token_text_trimmed(),
+    )
+}
+
+/// Returns `true` if a `function` declaration with a body and the same name
+/// as `signature` exists among its siblings. Function declarations may be
+/// wrapped in `export` nodes, so those wrappers are inspected as well.
+fn declare_function_has_implementation(signature: &TsDeclareFunctionDeclaration) -> bool {
+    let Some(name) = binding_name_text(signature.id()) else {
+        return false;
+    };
+    let Some(parent) = signature.syntax().parent() else {
+        return false;
+    };
+    let container = if JsExport::can_cast(parent.kind()) {
+        parent.parent()
+    } else {
+        Some(parent)
+    };
+    let Some(container) = container else {
+        return false;
+    };
+    container.children().any(|item| {
+        let candidate = if JsExport::can_cast(item.kind()) {
+            item.children()
+                .find(|child| JsFunctionDeclaration::can_cast(child.kind()))
+        } else if JsFunctionDeclaration::can_cast(item.kind()) {
+            Some(item)
+        } else {
+            None
+        };
+        candidate
+            .and_then(JsFunctionDeclaration::cast)
+            .and_then(|decl| binding_name_text(decl.id()))
+            .is_some_and(|other_name| other_name.text() == name.text())
+    })
+}
+
+/// Returns `true` if a `export default function` declaration with a body
+/// exists among the siblings of `signature`. There can only be one default
+/// export per module, so its mere presence identifies it as the
+/// implementation of this signature.
+fn declare_default_function_has_implementation(
+    signature: &TsDeclareFunctionExportDefaultDeclaration,
+) -> bool {
+    let Some(export_clause) = signature
+        .syntax()
+        .ancestors()
+        .find_map(JsExportDefaultDeclarationClause::cast)
+    else {
+        return false;
+    };
+    let Some(export) = export_clause.syntax().parent() else {
+        return false;
+    };
+    let Some(container) = export.parent() else {
+        return false;
+    };
+    container.children().any(|item| {
+        JsExport::can_cast(item.kind())
+            && item
+                .children()
+                .find_map(JsExportDefaultDeclarationClause::cast)
+                .is_some_and(|clause| {
+                    clause
+                        .syntax()
+                        .children()
+                        .any(|decl| JsFunctionExportDefaultDeclaration::can_cast(decl.kind()))
+                })
+    })
+}
+
+/// Returns `true` if a class method with a body, the same name, and the same
+/// static-ness as `signature` exists among the members of the enclosing
+/// class. An abstract method never gets one, so its signature is left out of
+/// the exemption and is checked like any other declaration.
+fn method_signature_has_implementation(signature: &TsMethodSignatureClassMember) -> bool {
+    let Some(name) = signature.name().ok().and_then(|name| name.name()) else {
+        return false;
+    };
+    let is_static = BitFlags::<Modifier>::from(&signature.modifiers()).contains(Modifier::Static);
+    let Some(member_list) = signature
+        .syntax()
+        .ancestors()
+        .find_map(JsClassMemberList::cast)
+    else {
+        return false;
+    };
+    member_list.iter().any(|member| {
+        let Some(method) = member.as_js_method_class_member() else {
+            return false;
+        };
+        let other_is_static =
+            BitFlags::<Modifier>::from(&method.modifiers()).contains(Modifier::Static);
+        other_is_static == is_static
+            && method
+                .name()
+                .ok()
+                .and_then(|other_name| other_name.name())
+                .is_some_and(|other_name| other_name.text() == name.text())
+    })
+}
+
 fn suggestion_for_binding(binding: &AnyJsIdentifierBinding) -> Option<SuggestedFix> {
     if binding.is_under_object_pattern_binding()? {
         Some(SuggestedFix::NoSuggestion)
@@ -312,9 +463,10 @@ fn suggested_fix_if_unused(
         // Bindings under catch are never ok to be unused
         AnyJsBindingDeclaration::JsCatchDeclaration(_) => Some(SuggestedFix::PrefixUnderscore),
 
-        // Type parameters are never ok to be unused unless they are declared in an ambient context
+        // Type parameters are never ok to be unused unless they are declared in an
+        // ambient context or in an overload signature that has an implementation
         node @ AnyJsBindingDeclaration::TsTypeParameter(_) => {
-            if is_in_ambient_context(node.syntax()) {
+            if is_in_ambient_context(node.syntax()) || is_type_parameter_of_signature(node.syntax()) {
                 None
             } else {
                 Some(SuggestedFix::PrefixUnderscore)

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidTypeParam.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidTypeParam.ts
@@ -12,3 +12,13 @@ export interface I {
 export abstract class AbstractClass {
 	abstract method<T>(): void;
 }
+// A method with a body only implements a signature of the same static-ness.
+export class MismatchedStaticness {
+	static onlyInstanceImplementation<T>(): void;
+	onlyInstanceImplementation(): void {}
+
+	onlyStaticImplementation<T>(): void;
+	static onlyStaticImplementation(): void {}
+}
+// An overload signature left without any implementation is not exempt.
+export function orphanSignature<T>();

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidTypeParam.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidTypeParam.ts
@@ -3,3 +3,12 @@ export class C<T> {}
 export type Alias<T> = number
 export type Inferred<T> = T extends (infer I)[] ? number : never;
 export type TestUnionType<T> = T extends (infer B)[] | infer B ? number : never;
+// Only function/method signatures with a body-bearing implementation are exempt;
+// interface members and abstract methods, which never get one, still report.
+// See https://github.com/biomejs/biome/issues/11214
+export interface I {
+	m<T>(): void;
+}
+export abstract class AbstractClass {
+	abstract method<T>(): void;
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidTypeParam.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidTypeParam.ts.snap
@@ -18,6 +18,16 @@ export interface I {
 export abstract class AbstractClass {
 	abstract method<T>(): void;
 }
+// A method with a body only implements a signature of the same static-ness.
+export class MismatchedStaticness {
+	static onlyInstanceImplementation<T>(): void;
+	onlyInstanceImplementation(): void {}
+
+	onlyStaticImplementation<T>(): void;
+	static onlyStaticImplementation(): void {}
+}
+// An overload signature left without any implementation is not exempt.
+export function orphanSignature<T>();
 ```
 
 # Diagnostics
@@ -163,6 +173,7 @@ invalidTypeParam.ts:13:18 lint/correctness/noUnusedVariables  FIXABLE  ━━━
   > 13 │ 	abstract method<T>(): void;
        │ 	                ^
     14 │ }
+    15 │ // A method with a body only implements a signature of the same static-ness.
   
   i Unused variables are often the result of typos, incomplete refactors, or other sources of bugs.
   
@@ -173,6 +184,81 @@ invalidTypeParam.ts:13:18 lint/correctness/noUnusedVariables  FIXABLE  ━━━
     13    │ - → abstract·method<T>():·void;
        13 │ + → abstract·method<_T>():·void;
     14 14 │   }
+    15 15 │   // A method with a body only implements a signature of the same static-ness.
+  
+
+```
+
+```
+invalidTypeParam.ts:17:36 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This type parameter T is unused.
+  
+    15 │ // A method with a body only implements a signature of the same static-ness.
+    16 │ export class MismatchedStaticness {
+  > 17 │ 	static onlyInstanceImplementation<T>(): void;
+       │ 	                                  ^
+    18 │ 	onlyInstanceImplementation(): void {}
+    19 │ 
+  
+  i Unused variables are often the result of typos, incomplete refactors, or other sources of bugs.
+  
+  i Unsafe fix: If this is intentional, prepend T with an underscore.
+  
+    15 15 │   // A method with a body only implements a signature of the same static-ness.
+    16 16 │   export class MismatchedStaticness {
+    17    │ - → static·onlyInstanceImplementation<T>():·void;
+       17 │ + → static·onlyInstanceImplementation<_T>():·void;
+    18 18 │     onlyInstanceImplementation(): void {}
+    19 19 │   
+  
+
+```
+
+```
+invalidTypeParam.ts:20:27 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This type parameter T is unused.
+  
+    18 │ 	onlyInstanceImplementation(): void {}
+    19 │ 
+  > 20 │ 	onlyStaticImplementation<T>(): void;
+       │ 	                         ^
+    21 │ 	static onlyStaticImplementation(): void {}
+    22 │ }
+  
+  i Unused variables are often the result of typos, incomplete refactors, or other sources of bugs.
+  
+  i Unsafe fix: If this is intentional, prepend T with an underscore.
+  
+    18 18 │     onlyInstanceImplementation(): void {}
+    19 19 │   
+    20    │ - → onlyStaticImplementation<T>():·void;
+       20 │ + → onlyStaticImplementation<_T>():·void;
+    21 21 │     static onlyStaticImplementation(): void {}
+    22 22 │   }
+  
+
+```
+
+```
+invalidTypeParam.ts:24:33 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This type parameter T is unused.
+  
+    22 │ }
+    23 │ // An overload signature left without any implementation is not exempt.
+  > 24 │ export function orphanSignature<T>();
+       │                                 ^
+  
+  i Unused variables are often the result of typos, incomplete refactors, or other sources of bugs.
+  
+  i Unsafe fix: If this is intentional, prepend T with an underscore.
+  
+    22 22 │   }
+    23 23 │   // An overload signature left without any implementation is not exempt.
+    24    │ - export·function·orphanSignature<T>();
+       24 │ + export·function·orphanSignature<_T>();
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidTypeParam.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidTypeParam.ts.snap
@@ -9,6 +9,15 @@ export class C<T> {}
 export type Alias<T> = number
 export type Inferred<T> = T extends (infer I)[] ? number : never;
 export type TestUnionType<T> = T extends (infer B)[] | infer B ? number : never;
+// Only function/method signatures with a body-bearing implementation are exempt;
+// interface members and abstract methods, which never get one, still report.
+// See https://github.com/biomejs/biome/issues/11214
+export interface I {
+	m<T>(): void;
+}
+export abstract class AbstractClass {
+	abstract method<T>(): void;
+}
 ```
 
 # Diagnostics
@@ -26,10 +35,10 @@ invalidTypeParam.ts:1:19 lint/correctness/noUnusedVariables  FIXABLE  ━━━�
   
   i Unsafe fix: If this is intentional, prepend T with an underscore.
   
-    1   │ - export·function·f<T>()·{}
-      1 │ + export·function·f<_T>()·{}
-    2 2 │   export class C<T> {}
-    3 3 │   export type Alias<T> = number
+     1    │ - export·function·f<T>()·{}
+        1 │ + export·function·f<_T>()·{}
+     2  2 │   export class C<T> {}
+     3  3 │   export type Alias<T> = number
   
 
 ```
@@ -49,11 +58,11 @@ invalidTypeParam.ts:2:16 lint/correctness/noUnusedVariables  FIXABLE  ━━━�
   
   i Unsafe fix: If this is intentional, prepend T with an underscore.
   
-    1 1 │   export function f<T>() {}
-    2   │ - export·class·C<T>·{}
-      2 │ + export·class·C<_T>·{}
-    3 3 │   export type Alias<T> = number
-    4 4 │   export type Inferred<T> = T extends (infer I)[] ? number : never;
+     1  1 │   export function f<T>() {}
+     2    │ - export·class·C<T>·{}
+        2 │ + export·class·C<_T>·{}
+     3  3 │   export type Alias<T> = number
+     4  4 │   export type Inferred<T> = T extends (infer I)[] ? number : never;
   
 
 ```
@@ -74,12 +83,12 @@ invalidTypeParam.ts:3:19 lint/correctness/noUnusedVariables  FIXABLE  ━━━�
   
   i Unsafe fix: If this is intentional, prepend T with an underscore.
   
-    1 1 │   export function f<T>() {}
-    2 2 │   export class C<T> {}
-    3   │ - export·type·Alias<T>·=·number
-      3 │ + export·type·Alias<_T>·=·number
-    4 4 │   export type Inferred<T> = T extends (infer I)[] ? number : never;
-    5 5 │   export type TestUnionType<T> = T extends (infer B)[] | infer B ? number : never;
+     1  1 │   export function f<T>() {}
+     2  2 │   export class C<T> {}
+     3    │ - export·type·Alias<T>·=·number
+        3 │ + export·type·Alias<_T>·=·number
+     4  4 │   export type Inferred<T> = T extends (infer I)[] ? number : never;
+     5  5 │   export type TestUnionType<T> = T extends (infer B)[] | infer B ? number : never;
   
 
 ```
@@ -94,6 +103,7 @@ invalidTypeParam.ts:4:44 lint/correctness/noUnusedVariables ━━━━━━�
   > 4 │ export type Inferred<T> = T extends (infer I)[] ? number : never;
       │                                            ^
     5 │ export type TestUnionType<T> = T extends (infer B)[] | infer B ? number : never;
+    6 │ // Only function/method signatures with a body-bearing implementation are exempt;
   
   i Unused variables are often the result of typos, incomplete refactors, or other sources of bugs.
   
@@ -109,8 +119,60 @@ invalidTypeParam.ts:5:62 lint/correctness/noUnusedVariables ━━━━━━�
     4 │ export type Inferred<T> = T extends (infer I)[] ? number : never;
   > 5 │ export type TestUnionType<T> = T extends (infer B)[] | infer B ? number : never;
       │                                                              ^
+    6 │ // Only function/method signatures with a body-bearing implementation are exempt;
+    7 │ // interface members and abstract methods, which never get one, still report.
   
   i Unused variables are often the result of typos, incomplete refactors, or other sources of bugs.
+  
+
+```
+
+```
+invalidTypeParam.ts:10:4 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This type parameter T is unused.
+  
+     8 │ // See https://github.com/biomejs/biome/issues/11214
+     9 │ export interface I {
+  > 10 │ 	m<T>(): void;
+       │ 	  ^
+    11 │ }
+    12 │ export abstract class AbstractClass {
+  
+  i Unused variables are often the result of typos, incomplete refactors, or other sources of bugs.
+  
+  i Unsafe fix: If this is intentional, prepend T with an underscore.
+  
+     8  8 │   // See https://github.com/biomejs/biome/issues/11214
+     9  9 │   export interface I {
+    10    │ - → m<T>():·void;
+       10 │ + → m<_T>():·void;
+    11 11 │   }
+    12 12 │   export abstract class AbstractClass {
+  
+
+```
+
+```
+invalidTypeParam.ts:13:18 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This type parameter T is unused.
+  
+    11 │ }
+    12 │ export abstract class AbstractClass {
+  > 13 │ 	abstract method<T>(): void;
+       │ 	                ^
+    14 │ }
+  
+  i Unused variables are often the result of typos, incomplete refactors, or other sources of bugs.
+  
+  i Unsafe fix: If this is intentional, prepend T with an underscore.
+  
+    11 11 │   }
+    12 12 │   export abstract class AbstractClass {
+    13    │ - → abstract·method<T>():·void;
+       13 │ + → abstract·method<_T>():·void;
+    14 14 │   }
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validOverloadTypeParam.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validOverloadTypeParam.ts
@@ -17,5 +17,11 @@ class C {
 	m<T>(x?: T): void {
 		console.log(x);
 	}
+
+	static s<T>(): void;
+	static s<T>(x?: T): void {
+		console.log(x);
+	}
 }
 new C().m();
+C.s();

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validOverloadTypeParam.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validOverloadTypeParam.ts
@@ -1,0 +1,21 @@
+/* should not generate diagnostics */
+
+async function returnAny() {
+	return "" as any;
+}
+
+// See https://github.com/biomejs/biome/issues/11214
+function someFn<MyGeneric>();
+function someFn<MyGeneric>() {
+	const a: MyGeneric = returnAny();
+	console.log(a);
+}
+someFn();
+
+class C {
+	m<T>(): void;
+	m<T>(x?: T): void {
+		console.log(x);
+	}
+}
+new C().m();

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validOverloadTypeParam.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validOverloadTypeParam.ts.snap
@@ -1,0 +1,29 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validOverloadTypeParam.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+async function returnAny() {
+	return "" as any;
+}
+
+// See https://github.com/biomejs/biome/issues/11214
+function someFn<MyGeneric>();
+function someFn<MyGeneric>() {
+	const a: MyGeneric = returnAny();
+	console.log(a);
+}
+someFn();
+
+class C {
+	m<T>(): void;
+	m<T>(x?: T): void {
+		console.log(x);
+	}
+}
+new C().m();
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validOverloadTypeParam.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validOverloadTypeParam.ts.snap
@@ -23,7 +23,13 @@ class C {
 	m<T>(x?: T): void {
 		console.log(x);
 	}
+
+	static s<T>(): void;
+	static s<T>(x?: T): void {
+		console.log(x);
+	}
 }
 new C().m();
+C.s();
 
 ```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validOverloadTypeParamAnonymousDefaultExport.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validOverloadTypeParamAnonymousDefaultExport.ts
@@ -1,0 +1,8 @@
+/* should not generate diagnostics */
+
+// An overloaded default export may be anonymous, so it binds no name.
+// See https://github.com/biomejs/biome/issues/11214
+export default function <T>(): void;
+export default function <T>(value?: T): void {
+	console.log(value);
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validOverloadTypeParamAnonymousDefaultExport.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validOverloadTypeParamAnonymousDefaultExport.ts.snap
@@ -1,0 +1,16 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validOverloadTypeParamAnonymousDefaultExport.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+// An overloaded default export may be anonymous, so it binds no name.
+// See https://github.com/biomejs/biome/issues/11214
+export default function <T>(): void;
+export default function <T>(value?: T): void {
+	console.log(value);
+}
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validOverloadTypeParamDefaultExport.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validOverloadTypeParamDefaultExport.ts
@@ -1,0 +1,7 @@
+/* should not generate diagnostics */
+
+// See https://github.com/biomejs/biome/issues/11214
+export default function overloaded<T>(): void;
+export default function overloaded<T>(value?: T): void {
+	console.log(value);
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validOverloadTypeParamDefaultExport.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validOverloadTypeParamDefaultExport.ts.snap
@@ -1,0 +1,15 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validOverloadTypeParamDefaultExport.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+// See https://github.com/biomejs/biome/issues/11214
+export default function overloaded<T>(): void;
+export default function overloaded<T>(value?: T): void {
+	console.log(value);
+}
+
+```


### PR DESCRIPTION
## Summary

Fixes #11214

`noUnusedVariables` incorrectly reports generic type parameters on overload signatures as unused when the implementation uses them. The analyzer now exempts only signatures with a matching body-bearing implementation while continuing to report unused parameters on abstract methods and interface members.

A patch changeset is included.

This PR was implemented with the help of Codex.

## Test Plan

- Added regression coverage for function and method overloads.
- Added coverage ensuring abstract and interface method type parameters remain diagnosed.
- `cargo test -p biome_js_analyze --test spec_tests correctness::no_unused_variables`
- `cargo fmt --all -- --check`

## Docs

N/A