### PR TITLE
fix(analyzer): scope Vue template globals correctly

### DIFF
--- a/.changeset/sweet-horses-write.md
+++ b/.changeset/sweet-horses-write.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11178](https://github.com/biomejs/biome/issues/11178): [`noUndeclaredVariables`](https://biomejs.dev/linter/rules/no-undeclared-variables/) no longer reports Vue's built-in instance properties, such as `$slots` and `$attrs`, in template expressions or `$event` in inline event-handler expressions. The instance properties are still reported inside `<script setup>`, where they are not defined.

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/invalid-vue-object-v-on-dollar-event.vue
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/invalid-vue-object-v-on-dollar-event.vue
@@ -1,0 +1,4 @@
+<!-- should generate diagnostics -->
+<template>
+  <button v-on="{ click: () => $event }"></button>
+</template>

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/invalid-vue-object-v-on-dollar-event.vue.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/invalid-vue-object-v-on-dollar-event.vue.snap
@@ -1,0 +1,31 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid-vue-object-v-on-dollar-event.vue
+---
+# Input
+```vue
+<!-- should generate diagnostics -->
+<template>
+  <button v-on="{ click: () => $event }"></button>
+</template>
+
+```
+
+# Diagnostics
+```
+invalid-vue-object-v-on-dollar-event.vue:3:32 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━
+
+  × The $event variable is undeclared.
+  
+    1 │ <!-- should generate diagnostics -->
+    2 │ <template>
+  > 3 │   <button v-on="{ click: () => $event }"></button>
+      │                                ^^^^^^
+    4 │ </template>
+    5 │ 
+  
+  i By default, Biome recognizes browser and Node.js globals.
+    You can ignore more globals using the javascript.globals configuration.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/invalid-vue-script-setup-instance-properties.vue
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/invalid-vue-script-setup-instance-properties.vue
@@ -1,0 +1,8 @@
+<!-- should generate diagnostics -->
+<script setup>
+const s = $slots;
+</script>
+
+<template>
+  <div>{{ s }}</div>
+</template>

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/invalid-vue-script-setup-instance-properties.vue.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/invalid-vue-script-setup-instance-properties.vue.snap
@@ -1,0 +1,35 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid-vue-script-setup-instance-properties.vue
+---
+# Input
+```vue
+<!-- should generate diagnostics -->
+<script setup>
+const s = $slots;
+</script>
+
+<template>
+  <div>{{ s }}</div>
+</template>
+
+```
+
+# Diagnostics
+```
+invalid-vue-script-setup-instance-properties.vue:3:11 lint/correctness/noUndeclaredVariables ━━━━━━━━━━
+
+  × The $slots variable is undeclared.
+  
+    1 │ <!-- should generate diagnostics -->
+    2 │ <script setup>
+  > 3 │ const s = $slots;
+      │           ^^^^^^
+    4 │ </script>
+    5 │ 
+  
+  i By default, Biome recognizes browser and Node.js globals.
+    You can ignore more globals using the javascript.globals configuration.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/valid-vue-event-handler-dollar-event.vue
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/valid-vue-event-handler-dollar-event.vue
@@ -1,4 +1,5 @@
 <!-- should not generate diagnostics -->
 <template>
   <button @click="$emit('custom', $event)">Click</button>
+  <button v-on:click="$emit('custom', $event)">Click</button>
 </template>

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/valid-vue-event-handler-dollar-event.vue
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/valid-vue-event-handler-dollar-event.vue
@@ -1,0 +1,4 @@
+<!-- should not generate diagnostics -->
+<template>
+  <button @click="$emit('custom', $event)">Click</button>
+</template>

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/valid-vue-event-handler-dollar-event.vue.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/valid-vue-event-handler-dollar-event.vue.snap
@@ -1,0 +1,12 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid-vue-event-handler-dollar-event.vue
+---
+# Input
+```vue
+<!-- should not generate diagnostics -->
+<template>
+  <button @click="$emit('custom', $event)">Click</button>
+</template>
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/valid-vue-event-handler-dollar-event.vue.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/valid-vue-event-handler-dollar-event.vue.snap
@@ -7,6 +7,7 @@ expression: valid-vue-event-handler-dollar-event.vue
 <!-- should not generate diagnostics -->
 <template>
   <button @click="$emit('custom', $event)">Click</button>
+  <button v-on:click="$emit('custom', $event)">Click</button>
 </template>
 
 ```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/valid-vue-object-v-on.vue
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/valid-vue-object-v-on.vue
@@ -1,0 +1,4 @@
+<!-- should not generate diagnostics -->
+<template>
+  <button v-on="{ click: () => console.log('clicked') }"></button>
+</template>

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/valid-vue-object-v-on.vue.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/valid-vue-object-v-on.vue.snap
@@ -1,0 +1,12 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid-vue-object-v-on.vue
+---
+# Input
+```vue
+<!-- should not generate diagnostics -->
+<template>
+  <button v-on="{ click: () => console.log('clicked') }"></button>
+</template>
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/valid-vue-template-instance-properties.vue
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/valid-vue-template-instance-properties.vue
@@ -1,0 +1,14 @@
+<!-- should not generate diagnostics -->
+<script setup>
+const items = [{ id: 1, name: "alpha" }];
+</script>
+
+<template>
+  <button v-if="$slots['icon']">
+    <slot name="icon"></slot>
+  </button>
+  <p>{{ $attrs.class }} {{ $props }} {{ $refs.foo }} {{ $el }} {{ $root }}</p>
+  <p v-for="item in items" :key="item.id" @click="$emit('select', item)">
+    {{ item.name }}
+  </p>
+</template>

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/valid-vue-template-instance-properties.vue.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/valid-vue-template-instance-properties.vue.snap
@@ -1,0 +1,22 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid-vue-template-instance-properties.vue
+---
+# Input
+```vue
+<!-- should not generate diagnostics -->
+<script setup>
+const items = [{ id: 1, name: "alpha" }];
+</script>
+
+<template>
+  <button v-if="$slots['icon']">
+    <slot name="icon"></slot>
+  </button>
+  <p>{{ $attrs.class }} {{ $props }} {{ $refs.foo }} {{ $el }} {{ $root }}</p>
+  <p v-for="item in items" :key="item.id" @click="$emit('select', item)">
+    {{ item.name }}
+  </p>
+</template>
+
+```

--- a/crates/biome_service/src/file_handlers/html/parse_embedded_nodes.rs
+++ b/crates/biome_service/src/file_handlers/html/parse_embedded_nodes.rs
@@ -256,7 +256,7 @@ pub(crate) fn parse_embedded_nodes(params: ParseEmbeddedParams) -> ParseEmbedRes
                 {
                     let is_v_on = directive
                         .name_token()
-                        .is_ok_and(|t| t.text_trimmed() == "v-on");
+                        .is_ok_and(|t| t.text_trimmed() == "v-on" && directive.arg().is_some());
                     if let Some(candidate) = build_vue_directive_candidate(&initializer, is_v_on) {
                         ctx.parse_and_push(
                             &candidate,

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -228,6 +228,29 @@ impl From<JsxRuntime> for JsEnvironmentSettings {
     }
 }
 
+/// Public properties of the Vue component instance. Vue's compiler exposes them to every
+/// template expression, so they are never declared in user code.
+///
+/// Vue 2-only members (`$children`, `$listeners`, `$scopedSlots`, `$set`, `$delete`, `$on`,
+/// `$off`, `$once`, `$destroy`) are intentionally excluded.
+///
+/// See <https://vuejs.org/api/component-instance.html>
+const VUE_TEMPLATE_INSTANCE_PROPERTIES: [&str; 13] = [
+    "$attrs",
+    "$data",
+    "$el",
+    "$emit",
+    "$forceUpdate",
+    "$nextTick",
+    "$options",
+    "$parent",
+    "$props",
+    "$refs",
+    "$root",
+    "$slots",
+    "$watch",
+];
+
 impl ServiceLanguage for JsLanguage {
     type FormatterSettings = JsFormatterSettings;
     type LinterSettings = JsLinterSettings;
@@ -349,7 +372,7 @@ impl ServiceLanguage for JsLanguage {
         _language: &Self::LinterSettings,
         environment: Option<&Self::EnvironmentSettings>,
         path: &BiomePath,
-        _file_source: &DocumentFileSource,
+        file_source: &DocumentFileSource,
         suppression_reason: Option<&str>,
     ) -> AnalyzerOptions {
         let preferred_quote = global
@@ -425,6 +448,26 @@ impl ServiceLanguage for JsLanguage {
                     ]
                     .map(Into::into),
                 );
+
+                // Vue's public instance properties are exposed to every template
+                // expression by the compiler, but are never declared in user code.
+                // Inside `<script setup>` they are genuinely undeclared: Vue requires
+                // `useSlots()`, `defineProps()`, etc. instead.
+                if let Some(snippet_source) = file_source.to_js_file_source()
+                    && snippet_source.as_embedding_kind().is_vue()
+                    && !snippet_source.is_embedded_source()
+                {
+                    globals.extend(
+                        VUE_TEMPLATE_INSTANCE_PROPERTIES
+                            .iter()
+                            .copied()
+                            .map(Into::into),
+                    );
+
+                    if snippet_source.as_embedding_kind().is_vue_event_handler() {
+                        globals.push("$event".into());
+                    }
+                }
             } else if source_type.as_embedding_kind().is_astro() {
                 globals.extend(["Astro"].map(Into::into));
             } else if source_type.as_embedding_kind().is_svelte() {

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -232,7 +232,7 @@ impl From<JsxRuntime> for JsEnvironmentSettings {
 /// template expression, so they are never declared in user code.
 ///
 /// Vue 2-only members (`$children`, `$listeners`, `$scopedSlots`, `$set`, `$delete`, `$on`,
-/// `$off`, `$once`, `$destroy`) are intentionally excluded.
+/// `$off`, `$once`, `$destroy`) are intentionally excluded, because Vue 2 is end of life.
 ///
 /// See <https://vuejs.org/api/component-instance.html>
 const VUE_TEMPLATE_INSTANCE_PROPERTIES: [&str; 13] = [

--- a/crates/biome_service/src/settings.tests.rs
+++ b/crates/biome_service/src/settings.tests.rs
@@ -94,6 +94,83 @@ fn correctly_computes_analyzer_options() {
 }
 
 #[test]
+fn vue_template_expressions_get_instance_properties() {
+    use biome_languages::JsFileSource;
+    use biome_languages::javascript::JsEmbeddingKind;
+
+    let settings = Settings::default();
+    let language = JsLanguage::lookup_settings(&settings.languages);
+    let environment = JsLanguage::resolve_environment(&settings);
+
+    let template_source = JsFileSource::js_module().with_embedding_kind(JsEmbeddingKind::Vue {
+        setup: false,
+        is_source: false,
+        event_handler: false,
+        allow_statements: false,
+    });
+    let options = JsLanguage::resolve_analyzer_options(
+        &settings,
+        &language.linter,
+        environment,
+        &BiomePath::new(Utf8PathBuf::from("/test.vue")),
+        &DocumentFileSource::from(template_source),
+        None,
+    );
+
+    assert!(options.globals().contains(&"$slots".into()));
+    assert!(!options.globals().contains(&"$event".into()));
+}
+
+#[test]
+fn vue_event_handlers_get_dollar_event() {
+    use biome_languages::JsFileSource;
+    use biome_languages::javascript::JsEmbeddingKind;
+
+    let settings = Settings::default();
+    let language = JsLanguage::lookup_settings(&settings.languages);
+    let environment = JsLanguage::resolve_environment(&settings);
+
+    let event_handler_source =
+        JsFileSource::js_module().with_embedding_kind(JsEmbeddingKind::Vue {
+            setup: false,
+            is_source: false,
+            event_handler: true,
+            allow_statements: false,
+        });
+    let options = JsLanguage::resolve_analyzer_options(
+        &settings,
+        &language.linter,
+        environment,
+        &BiomePath::new(Utf8PathBuf::from("/test.vue")),
+        &DocumentFileSource::from(event_handler_source),
+        None,
+    );
+
+    assert!(options.globals().contains(&"$event".into()));
+    assert!(options.globals().contains(&"$slots".into()));
+}
+
+#[test]
+fn vue_script_setup_does_not_get_instance_properties() {
+    let settings = Settings::default();
+    let language = JsLanguage::lookup_settings(&settings.languages);
+    let environment = JsLanguage::resolve_environment(&settings);
+
+    let options = JsLanguage::resolve_analyzer_options(
+        &settings,
+        &language.linter,
+        environment,
+        &BiomePath::new(Utf8PathBuf::from("/test.vue")),
+        &DocumentFileSource::from(biome_languages::JsFileSource::vue_setup()),
+        None,
+    );
+
+    assert!(options.globals().contains(&"defineProps".into()));
+    assert!(!options.globals().contains(&"$slots".into()));
+    assert!(!options.globals().contains(&"$event".into()));
+}
+
+#[test]
 fn javascript_resolver_experimental_pnpm_catalogs_is_opt_in() {
     let mut default_settings = Settings::default();
     default_settings


### PR DESCRIPTION
## Summary

Closes #11178.

`noUndeclaredVariables` now recognizes Vue component instance properties in template expressions without suppressing diagnostics in `<script setup>`. `$event` is provided only for argumented event-handler directives; argumentless `v-on` object syntax remains checked. Added regression fixtures and a patch changeset.

This PR was implemented with help from Codex AI assistant.

## Test Plan

- `cargo test -p biome_js_analyze -- no_undeclared_variables --show-output`
- `cargo test -p biome_service --all-features vue_ -- --show-output`
- `cargo fmt --all -- --check`
- `cargo clippy -p biome_service --all-targets --all-features -- -D warnings`

## Docs

No documentation changes are needed; this fixes existing rule behavior. The user-facing change is documented in a changeset