### PR TITLE
perf(lint): reduce trigger of rules

### DIFF
--- a/.changeset/free-carpets-add.md
+++ b/.changeset/free-carpets-add.md
@@ -1,0 +1,13 @@
+---
+"@biomejs/biome": patch
+---
+
+Improved the performance of the following lint rules:
+
+- [`noArguments`](https://biomejs.dev/linter/rules/no-arguments/).
+- [`noGlobalAssign`](https://biomejs.dev/linter/rules/no-global-assign/).
+- [`noUndeclaredVariables`](https://biomejs.dev/linter/rules/no-undeclared-variables/).
+- [`noRestrictedGlobals`](https://biomejs.dev/linter/rules/no-restricted-globals/).
+- [`noInvalidUseBeforeDeclaration`](https://biomejs.dev/linter/rules/no-invalid-use-before-declaration/).
+- [`noShadow`](https://biomejs.dev/linter/rules/no-shadow/).
+- [`noRedeclare`](https://biomejs.dev/linter/rules/no-redeclare/).

--- a/crates/biome_cli/tests/snapshots/main_cases_linter_groups_plain/enables_all_rules_when_group_is_on_with_default_severity.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_linter_groups_plain/enables_all_rules_when_group_is_on_with_default_severity.snap
@@ -24,20 +24,6 @@ function f() { console.log(arguments); }
 # Emitted Messages
 
 ```block
-test1.js:1:28 lint/complexity/noArguments ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Use the rest parameters instead of arguments.
-  
-  > 1 │ function f() { console.log(arguments); }
-      │                            ^^^^^^^^^
-    2 │ 
-  
-  i arguments does not have Array.prototype methods and can be inconvenient to use.
-  
-
-```
-
-```block
 test1.js:1:10 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This function f is unused.
@@ -53,6 +39,20 @@ test1.js:1:10 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━
     1   │ - function·f()·{·console.log(arguments);·}
       1 │ + function·_f()·{·console.log(arguments);·}
     2 2 │   
+  
+
+```
+
+```block
+test1.js:1:28 lint/complexity/noArguments ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use the rest parameters instead of arguments.
+  
+  > 1 │ function f() { console.log(arguments); }
+      │                            ^^^^^^^^^
+    2 │ 
+  
+  i arguments does not have Array.prototype methods and can be inconvenient to use.
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/takes_last_linter_enabled_into_account.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_linter/takes_last_linter_enabled_into_account.snap
@@ -60,20 +60,6 @@ test.js:1:10 lint/correctness/noUndeclaredVariables ━━━━━━━━━�
 ```
 
 ```block
-test.js:1:10 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × The GLOBAL_VAR variable is undeclared.
-  
-  > 1 │ export { GLOBAL_VAR };
-      │          ^^^^^^^^^^
-  
-  i By default, Biome recognizes browser and Node.js globals.
-    You can ignore more globals using the javascript.globals configuration.
-  
-
-```
-
-```block
 Checked 2 files in <TIME>. No fixes applied.
-Found 2 errors.
+Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_check_command.snap
@@ -277,7 +277,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     "location": {
       "path": "index.ts",
       "lines": {
-        "begin": 17
+        "begin": 16
       }
     }
   },
@@ -289,7 +289,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     "location": {
       "path": "index.ts",
       "lines": {
-        "begin": 18
+        "begin": 17
       }
     }
   },
@@ -297,6 +297,18 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     "description": "'f' is redeclared in the same scope.",
     "check_name": "lint/suspicious/noRedeclare",
     "fingerprint": "7842353260163629265",
+    "severity": "critical",
+    "location": {
+      "path": "index.ts",
+      "lines": {
+        "begin": 18
+      }
+    }
+  },
+  {
+    "description": "'f' is redeclared in the same scope.",
+    "check_name": "lint/suspicious/noRedeclare",
+    "fingerprint": "4835254919265693190",
     "severity": "critical",
     "location": {
       "path": "index.ts",
@@ -313,18 +325,6 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     "location": {
       "path": "index.ts",
       "lines": {
-        "begin": 5
-      }
-    }
-  },
-  {
-    "description": "Using == may be unsafe if you are relying on type coercion.",
-    "check_name": "lint/suspicious/noDoubleEquals",
-    "fingerprint": "9497329216962766751",
-    "severity": "critical",
-    "location": {
-      "path": "index.ts",
-      "lines": {
         "begin": 6
       }
     }
@@ -332,7 +332,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
   {
     "description": "Using == may be unsafe if you are relying on type coercion.",
     "check_name": "lint/suspicious/noDoubleEquals",
-    "fingerprint": "18366180239442454213",
+    "fingerprint": "9497329216962766751",
     "severity": "critical",
     "location": {
       "path": "index.ts",
@@ -474,6 +474,18 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     }
   },
   {
+    "description": "Using == may be unsafe if you are relying on type coercion.",
+    "check_name": "lint/suspicious/noDoubleEquals",
+    "fingerprint": "18366180239442454213",
+    "severity": "critical",
+    "location": {
+      "path": "index.ts",
+      "lines": {
+        "begin": 5
+      }
+    }
+  },
+  {
     "description": "'z' is redeclared in the same scope.",
     "check_name": "lint/suspicious/noRedeclare",
     "fingerprint": "8595162422023295635",
@@ -488,24 +500,12 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
   {
     "description": "'f' is redeclared in the same scope.",
     "check_name": "lint/suspicious/noRedeclare",
-    "fingerprint": "4835254919265693190",
-    "severity": "critical",
-    "location": {
-      "path": "index.ts",
-      "lines": {
-        "begin": 15
-      }
-    }
-  },
-  {
-    "description": "'f' is redeclared in the same scope.",
-    "check_name": "lint/suspicious/noRedeclare",
     "fingerprint": "3103625193263367010",
     "severity": "critical",
     "location": {
       "path": "index.ts",
       "lines": {
-        "begin": 16
+        "begin": 15
       }
     }
   },
@@ -606,6 +606,18 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     }
   },
   {
+    "description": "Sort these imports.",
+    "check_name": "assist/source/organizeImports",
+    "fingerprint": "15695086553598122883",
+    "severity": "critical",
+    "location": {
+      "path": "main.ts",
+      "lines": {
+        "begin": 1
+      }
+    }
+  },
+  {
     "description": "'z' is redeclared in the same scope.",
     "check_name": "lint/suspicious/noRedeclare",
     "fingerprint": "4177467054814594004",
@@ -674,18 +686,6 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
       "path": "main.ts",
       "lines": {
         "begin": 19
-      }
-    }
-  },
-  {
-    "description": "Sort these imports.",
-    "check_name": "assist/source/organizeImports",
-    "fingerprint": "15695086553598122883",
-    "severity": "critical",
-    "location": {
-      "path": "main.ts",
-      "lines": {
-        "begin": 1
       }
     }
   },

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_ci_command.snap
@@ -277,7 +277,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     "location": {
       "path": "index.ts",
       "lines": {
-        "begin": 17
+        "begin": 16
       }
     }
   },
@@ -289,7 +289,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     "location": {
       "path": "index.ts",
       "lines": {
-        "begin": 18
+        "begin": 17
       }
     }
   },
@@ -297,6 +297,18 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     "description": "'f' is redeclared in the same scope.",
     "check_name": "lint/suspicious/noRedeclare",
     "fingerprint": "7842353260163629265",
+    "severity": "critical",
+    "location": {
+      "path": "index.ts",
+      "lines": {
+        "begin": 18
+      }
+    }
+  },
+  {
+    "description": "'f' is redeclared in the same scope.",
+    "check_name": "lint/suspicious/noRedeclare",
+    "fingerprint": "4835254919265693190",
     "severity": "critical",
     "location": {
       "path": "index.ts",
@@ -313,18 +325,6 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     "location": {
       "path": "index.ts",
       "lines": {
-        "begin": 5
-      }
-    }
-  },
-  {
-    "description": "Using == may be unsafe if you are relying on type coercion.",
-    "check_name": "lint/suspicious/noDoubleEquals",
-    "fingerprint": "9497329216962766751",
-    "severity": "critical",
-    "location": {
-      "path": "index.ts",
-      "lines": {
         "begin": 6
       }
     }
@@ -332,7 +332,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
   {
     "description": "Using == may be unsafe if you are relying on type coercion.",
     "check_name": "lint/suspicious/noDoubleEquals",
-    "fingerprint": "18366180239442454213",
+    "fingerprint": "9497329216962766751",
     "severity": "critical",
     "location": {
       "path": "index.ts",
@@ -474,6 +474,18 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     }
   },
   {
+    "description": "Using == may be unsafe if you are relying on type coercion.",
+    "check_name": "lint/suspicious/noDoubleEquals",
+    "fingerprint": "18366180239442454213",
+    "severity": "critical",
+    "location": {
+      "path": "index.ts",
+      "lines": {
+        "begin": 5
+      }
+    }
+  },
+  {
     "description": "'z' is redeclared in the same scope.",
     "check_name": "lint/suspicious/noRedeclare",
     "fingerprint": "8595162422023295635",
@@ -488,24 +500,12 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
   {
     "description": "'f' is redeclared in the same scope.",
     "check_name": "lint/suspicious/noRedeclare",
-    "fingerprint": "4835254919265693190",
-    "severity": "critical",
-    "location": {
-      "path": "index.ts",
-      "lines": {
-        "begin": 15
-      }
-    }
-  },
-  {
-    "description": "'f' is redeclared in the same scope.",
-    "check_name": "lint/suspicious/noRedeclare",
     "fingerprint": "3103625193263367010",
     "severity": "critical",
     "location": {
       "path": "index.ts",
       "lines": {
-        "begin": 16
+        "begin": 15
       }
     }
   },
@@ -606,6 +606,18 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     }
   },
   {
+    "description": "Sort these imports.",
+    "check_name": "assist/source/organizeImports",
+    "fingerprint": "15695086553598122883",
+    "severity": "critical",
+    "location": {
+      "path": "main.ts",
+      "lines": {
+        "begin": 1
+      }
+    }
+  },
+  {
     "description": "'z' is redeclared in the same scope.",
     "check_name": "lint/suspicious/noRedeclare",
     "fingerprint": "4177467054814594004",
@@ -674,18 +686,6 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
       "path": "main.ts",
       "lines": {
         "begin": 19
-      }
-    }
-  },
-  {
-    "description": "Sort these imports.",
-    "check_name": "assist/source/organizeImports",
-    "fingerprint": "15695086553598122883",
-    "severity": "critical",
-    "location": {
-      "path": "main.ts",
-      "lines": {
-        "begin": 1
       }
     }
   },

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_lint_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_lint_command.snap
@@ -277,7 +277,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
     "location": {
       "path": "index.ts",
       "lines": {
-        "begin": 18
+        "begin": 17
       }
     }
   },
@@ -285,6 +285,18 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
     "description": "'f' is redeclared in the same scope.",
     "check_name": "lint/suspicious/noRedeclare",
     "fingerprint": "8601445511714044637",
+    "severity": "critical",
+    "location": {
+      "path": "index.ts",
+      "lines": {
+        "begin": 18
+      }
+    }
+  },
+  {
+    "description": "'f' is redeclared in the same scope.",
+    "check_name": "lint/suspicious/noRedeclare",
+    "fingerprint": "7842353260163629265",
     "severity": "critical",
     "location": {
       "path": "index.ts",
@@ -297,18 +309,6 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
     "description": "Using == may be unsafe if you are relying on type coercion.",
     "check_name": "lint/suspicious/noDoubleEquals",
     "fingerprint": "9497329216962766751",
-    "severity": "critical",
-    "location": {
-      "path": "index.ts",
-      "lines": {
-        "begin": 6
-      }
-    }
-  },
-  {
-    "description": "Using == may be unsafe if you are relying on type coercion.",
-    "check_name": "lint/suspicious/noDoubleEquals",
-    "fingerprint": "18366180239442454213",
     "severity": "critical",
     "location": {
       "path": "index.ts",
@@ -390,18 +390,6 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
     }
   },
   {
-    "description": "Using == may be unsafe if you are relying on type coercion.",
-    "check_name": "lint/suspicious/noDoubleEquals",
-    "fingerprint": "17264185503232320851",
-    "severity": "critical",
-    "location": {
-      "path": "index.ts",
-      "lines": {
-        "begin": 5
-      }
-    }
-  },
-  {
     "description": "This variable implicitly has the any type.",
     "check_name": "lint/suspicious/noImplicitAnyLet",
     "fingerprint": "18285621777301161439",
@@ -410,6 +398,18 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
       "path": "index.ts",
       "lines": {
         "begin": 16
+      }
+    }
+  },
+  {
+    "description": "Using == may be unsafe if you are relying on type coercion.",
+    "check_name": "lint/suspicious/noDoubleEquals",
+    "fingerprint": "18366180239442454213",
+    "severity": "critical",
+    "location": {
+      "path": "index.ts",
+      "lines": {
+        "begin": 5
       }
     }
   },
@@ -450,6 +450,18 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
     }
   },
   {
+    "description": "Using == may be unsafe if you are relying on type coercion.",
+    "check_name": "lint/suspicious/noDoubleEquals",
+    "fingerprint": "17264185503232320851",
+    "severity": "critical",
+    "location": {
+      "path": "index.ts",
+      "lines": {
+        "begin": 6
+      }
+    }
+  },
+  {
     "description": "'z' is redeclared in the same scope.",
     "check_name": "lint/suspicious/noRedeclare",
     "fingerprint": "8595162422023295635",
@@ -464,7 +476,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
   {
     "description": "'f' is redeclared in the same scope.",
     "check_name": "lint/suspicious/noRedeclare",
-    "fingerprint": "7842353260163629265",
+    "fingerprint": "4835254919265693190",
     "severity": "critical",
     "location": {
       "path": "index.ts",
@@ -476,7 +488,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
   {
     "description": "'f' is redeclared in the same scope.",
     "check_name": "lint/suspicious/noRedeclare",
-    "fingerprint": "4835254919265693190",
+    "fingerprint": "3103625193263367010",
     "severity": "critical",
     "location": {
       "path": "index.ts",
@@ -488,24 +500,12 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
   {
     "description": "'f' is redeclared in the same scope.",
     "check_name": "lint/suspicious/noRedeclare",
-    "fingerprint": "3103625193263367010",
-    "severity": "critical",
-    "location": {
-      "path": "index.ts",
-      "lines": {
-        "begin": 17
-      }
-    }
-  },
-  {
-    "description": "'f' is redeclared in the same scope.",
-    "check_name": "lint/suspicious/noRedeclare",
     "fingerprint": "710662920264236176",
     "severity": "critical",
     "location": {
       "path": "main.ts",
       "lines": {
-        "begin": 17
+        "begin": 16
       }
     }
   },
@@ -570,6 +570,18 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
     }
   },
   {
+    "description": "Using == may be unsafe if you are relying on type coercion.",
+    "check_name": "lint/suspicious/noDoubleEquals",
+    "fingerprint": "6143155163249580709",
+    "severity": "critical",
+    "location": {
+      "path": "main.ts",
+      "lines": {
+        "begin": 4
+      }
+    }
+  },
+  {
     "description": "'z' is redeclared in the same scope.",
     "check_name": "lint/suspicious/noRedeclare",
     "fingerprint": "4177467054814594004",
@@ -594,6 +606,18 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
     }
   },
   {
+    "description": "Using == may be unsafe if you are relying on type coercion.",
+    "check_name": "lint/suspicious/noDoubleEquals",
+    "fingerprint": "16004470298861036684",
+    "severity": "critical",
+    "location": {
+      "path": "main.ts",
+      "lines": {
+        "begin": 5
+      }
+    }
+  },
+  {
     "description": "'f' is redeclared in the same scope.",
     "check_name": "lint/suspicious/noRedeclare",
     "fingerprint": "14476601875768703957",
@@ -601,19 +625,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
     "location": {
       "path": "main.ts",
       "lines": {
-        "begin": 16
-      }
-    }
-  },
-  {
-    "description": "Using == may be unsafe if you are relying on type coercion.",
-    "check_name": "lint/suspicious/noDoubleEquals",
-    "fingerprint": "6143155163249580709",
-    "severity": "critical",
-    "location": {
-      "path": "main.ts",
-      "lines": {
-        "begin": 4
+        "begin": 17
       }
     }
   },
@@ -638,18 +650,6 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
       "path": "main.ts",
       "lines": {
         "begin": 19
-      }
-    }
-  },
-  {
-    "description": "Using == may be unsafe if you are relying on type coercion.",
-    "check_name": "lint/suspicious/noDoubleEquals",
-    "fingerprint": "16004470298861036684",
-    "severity": "critical",
-    "location": {
-      "path": "main.ts",
-      "lines": {
-        "begin": 5
       }
     }
   },

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_lint_verbose_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_lint_verbose_command.snap
@@ -277,7 +277,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
     "location": {
       "path": "index.ts",
       "lines": {
-        "begin": 18
+        "begin": 17
       }
     }
   },
@@ -285,6 +285,18 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
     "description": "'f' is redeclared in the same scope.",
     "check_name": "lint/suspicious/noRedeclare",
     "fingerprint": "8601445511714044637",
+    "severity": "critical",
+    "location": {
+      "path": "index.ts",
+      "lines": {
+        "begin": 18
+      }
+    }
+  },
+  {
+    "description": "'f' is redeclared in the same scope.",
+    "check_name": "lint/suspicious/noRedeclare",
+    "fingerprint": "7842353260163629265",
     "severity": "critical",
     "location": {
       "path": "index.ts",
@@ -297,18 +309,6 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
     "description": "Using == may be unsafe if you are relying on type coercion.",
     "check_name": "lint/suspicious/noDoubleEquals",
     "fingerprint": "9497329216962766751",
-    "severity": "critical",
-    "location": {
-      "path": "index.ts",
-      "lines": {
-        "begin": 6
-      }
-    }
-  },
-  {
-    "description": "Using == may be unsafe if you are relying on type coercion.",
-    "check_name": "lint/suspicious/noDoubleEquals",
-    "fingerprint": "18366180239442454213",
     "severity": "critical",
     "location": {
       "path": "index.ts",
@@ -390,18 +390,6 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
     }
   },
   {
-    "description": "Using == may be unsafe if you are relying on type coercion.",
-    "check_name": "lint/suspicious/noDoubleEquals",
-    "fingerprint": "17264185503232320851",
-    "severity": "critical",
-    "location": {
-      "path": "index.ts",
-      "lines": {
-        "begin": 5
-      }
-    }
-  },
-  {
     "description": "This variable implicitly has the any type.",
     "check_name": "lint/suspicious/noImplicitAnyLet",
     "fingerprint": "18285621777301161439",
@@ -410,6 +398,18 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
       "path": "index.ts",
       "lines": {
         "begin": 16
+      }
+    }
+  },
+  {
+    "description": "Using == may be unsafe if you are relying on type coercion.",
+    "check_name": "lint/suspicious/noDoubleEquals",
+    "fingerprint": "18366180239442454213",
+    "severity": "critical",
+    "location": {
+      "path": "index.ts",
+      "lines": {
+        "begin": 5
       }
     }
   },
@@ -450,6 +450,18 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
     }
   },
   {
+    "description": "Using == may be unsafe if you are relying on type coercion.",
+    "check_name": "lint/suspicious/noDoubleEquals",
+    "fingerprint": "17264185503232320851",
+    "severity": "critical",
+    "location": {
+      "path": "index.ts",
+      "lines": {
+        "begin": 6
+      }
+    }
+  },
+  {
     "description": "'z' is redeclared in the same scope.",
     "check_name": "lint/suspicious/noRedeclare",
     "fingerprint": "8595162422023295635",
@@ -464,7 +476,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
   {
     "description": "'f' is redeclared in the same scope.",
     "check_name": "lint/suspicious/noRedeclare",
-    "fingerprint": "7842353260163629265",
+    "fingerprint": "4835254919265693190",
     "severity": "critical",
     "location": {
       "path": "index.ts",
@@ -476,7 +488,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
   {
     "description": "'f' is redeclared in the same scope.",
     "check_name": "lint/suspicious/noRedeclare",
-    "fingerprint": "4835254919265693190",
+    "fingerprint": "3103625193263367010",
     "severity": "critical",
     "location": {
       "path": "index.ts",
@@ -488,24 +500,12 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
   {
     "description": "'f' is redeclared in the same scope.",
     "check_name": "lint/suspicious/noRedeclare",
-    "fingerprint": "3103625193263367010",
-    "severity": "critical",
-    "location": {
-      "path": "index.ts",
-      "lines": {
-        "begin": 17
-      }
-    }
-  },
-  {
-    "description": "'f' is redeclared in the same scope.",
-    "check_name": "lint/suspicious/noRedeclare",
     "fingerprint": "710662920264236176",
     "severity": "critical",
     "location": {
       "path": "main.ts",
       "lines": {
-        "begin": 17
+        "begin": 16
       }
     }
   },
@@ -570,6 +570,18 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
     }
   },
   {
+    "description": "Using == may be unsafe if you are relying on type coercion.",
+    "check_name": "lint/suspicious/noDoubleEquals",
+    "fingerprint": "6143155163249580709",
+    "severity": "critical",
+    "location": {
+      "path": "main.ts",
+      "lines": {
+        "begin": 4
+      }
+    }
+  },
+  {
     "description": "'z' is redeclared in the same scope.",
     "check_name": "lint/suspicious/noRedeclare",
     "fingerprint": "4177467054814594004",
@@ -594,6 +606,18 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
     }
   },
   {
+    "description": "Using == may be unsafe if you are relying on type coercion.",
+    "check_name": "lint/suspicious/noDoubleEquals",
+    "fingerprint": "16004470298861036684",
+    "severity": "critical",
+    "location": {
+      "path": "main.ts",
+      "lines": {
+        "begin": 5
+      }
+    }
+  },
+  {
     "description": "'f' is redeclared in the same scope.",
     "check_name": "lint/suspicious/noRedeclare",
     "fingerprint": "14476601875768703957",
@@ -601,19 +625,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
     "location": {
       "path": "main.ts",
       "lines": {
-        "begin": 16
-      }
-    }
-  },
-  {
-    "description": "Using == may be unsafe if you are relying on type coercion.",
-    "check_name": "lint/suspicious/noDoubleEquals",
-    "fingerprint": "6143155163249580709",
-    "severity": "critical",
-    "location": {
-      "path": "main.ts",
-      "lines": {
-        "begin": 4
+        "begin": 17
       }
     }
   },
@@ -638,18 +650,6 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
       "path": "main.ts",
       "lines": {
         "begin": 19
-      }
-    }
-  },
-  {
-    "description": "Using == may be unsafe if you are relying on type coercion.",
-    "check_name": "lint/suspicious/noDoubleEquals",
-    "fingerprint": "16004470298861036684",
-    "severity": "critical",
-    "location": {
-      "path": "main.ts",
-      "lines": {
-        "begin": 5
       }
     }
   },

--- a/crates/biome_css_analyze/src/services/semantic.rs
+++ b/crates/biome_css_analyze/src/services/semantic.rs
@@ -9,6 +9,12 @@ use biome_css_semantic::model::SemanticModel;
 use biome_css_syntax::{AnyCssRoot, CssLanguage, CssSyntaxNode, TextRange};
 use biome_rowan::{AstNode, WalkEvent};
 
+/// ## Warning
+///
+/// Using this type as a [biome_analyze::Rule] `Query` is discouraged, because it enforces the inspections of an entire
+/// document, even when the document doesn't contain the nodes that needs to be inspected.
+///
+/// Prefer the use of `Semantic<Node>` to trigger the rule only for those nodes that might trigger the rule.
 pub struct SemanticServices {
     model: SemanticModel,
 }

--- a/crates/biome_js_analyze/src/lint/complexity/no_arguments.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_arguments.rs
@@ -1,8 +1,8 @@
-use crate::services::semantic::SemanticServices;
+use crate::services::semantic::Semantic;
 use biome_analyze::{Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule};
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_js_syntax::TextRange;
+use biome_js_syntax::{AnyJsIdentifierReference, TextRange};
 use biome_rule_options::no_arguments::NoArgumentsOptions;
 
 declare_lint_rule! {
@@ -37,23 +37,18 @@ declare_lint_rule! {
 }
 
 impl Rule for NoArguments {
-    type Query = SemanticServices;
+    type Query = Semantic<AnyJsIdentifierReference>;
     type State = TextRange;
-    type Signals = Box<[Self::State]>;
+    type Signals = Option<Self::State>;
     type Options = NoArgumentsOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
-        let model = ctx.query();
-        let mut found_arguments = vec![];
-
-        for unresolved_reference in model.all_unresolved_references() {
-            let name = unresolved_reference.syntax().text_trimmed();
-            if name == "arguments" {
-                found_arguments.push(unresolved_reference.range());
-            }
+        let reference = ctx.query();
+        if !ctx.model().is_unresolved_reference(reference) {
+            return None;
         }
-
-        found_arguments.into_boxed_slice()
+        let token = reference.value_token().ok()?;
+        (token.text_trimmed() == "arguments").then(|| token.text_trimmed_range())
     }
 
     fn diagnostic(_: &RuleContext<Self>, range: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/src/lint/correctness/no_invalid_use_before_declaration.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_invalid_use_before_declaration.rs
@@ -1,9 +1,9 @@
-use crate::services::semantic::SemanticServices;
+use crate::services::semantic::Semantic;
 use biome_analyze::{Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule};
 use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_syntax::{
-    AnyJsExportNamedSpecifier, AnyJsFunction, AnyJsIdentifierUsage, JsClassDeclaration,
+    AnyJsExportNamedSpecifier, AnyJsFunction, AnyJsIdentifierReference, JsClassDeclaration,
     JsConstructorClassMember, JsGetterClassMember, JsGetterObjectMember, JsMethodClassMember,
     JsMethodObjectMember, JsModule, JsScript, JsSetterClassMember, JsSetterObjectMember,
     JsStaticInitializationBlockClassMember, JsVariableDeclarationClause, TsDeclareStatement,
@@ -89,7 +89,7 @@ declare_lint_rule! {
 }
 
 impl Rule for NoInvalidUseBeforeDeclaration {
-    type Query = SemanticServices;
+    type Query = Semantic<AnyJsIdentifierBinding>;
     type State = InvalidUseBeforeDeclaration;
     type Signals = Box<[Self::State]>;
     type Options = NoInvalidUseBeforeDeclarationOptions;
@@ -104,49 +104,49 @@ impl Rule for NoInvalidUseBeforeDeclaration {
         if is_declaration_file {
             return Box::default();
         }
-        for binding in model.all_bindings() {
-            let id = binding.tree();
-            if matches!(
-                id,
-                AnyJsIdentifierBinding::TsIdentifierBinding(_)
-                    | AnyJsIdentifierBinding::TsTypeParameterName(_)
-            ) {
-                // Ignore type declarations (interfaces, type-aliases, ...)
-                continue;
-            };
-            let Some(declaration) = id.declaration() else {
-                continue;
-            };
-            let Ok(declaration_kind) = DeclarationKind::try_from(&declaration) else {
-                continue;
-            };
-            let declaration_end = if matches!(
-                declaration_kind,
-                DeclarationKind::Class | DeclarationKind::Enum
-            ) {
-                // A class can be instantiated by its properties.
-                // Enum members can be qualified by the enum name.
-                id.range().end()
-            } else {
-                declaration.range().end()
-            };
-            let declaration_scope = declaration
-                .syntax()
-                .ancestors()
-                .skip(1)
-                .find(|ancestor| AnyJsVariableScope::can_cast(ancestor.kind()));
-            for reference in binding.all_references() {
-                if reference.range_start() < declaration_end {
-                    let reference_syntax = reference.syntax();
-                    // References that are exports, such as `export { a }` are always valid,
-                    // even when they appear before the declaration.
-                    // For example:
-                    //
-                    // ```js
-                    // export { X };
-                    // const X = 0;
-                    // ```
-                    if reference_syntax
+        let id = ctx.query();
+        if matches!(
+            id,
+            AnyJsIdentifierBinding::TsIdentifierBinding(_)
+                | AnyJsIdentifierBinding::TsTypeParameterName(_)
+        ) {
+            // Ignore type declarations (interfaces, type-aliases, ...)
+            return Box::default();
+        };
+        let Some(declaration) = id.declaration() else {
+            return Box::default();
+        };
+        let Ok(declaration_kind) = DeclarationKind::try_from(&declaration) else {
+            return Box::default();
+        };
+        let declaration_end = if matches!(
+            declaration_kind,
+            DeclarationKind::Class | DeclarationKind::Enum
+        ) {
+            // A class can be instantiated by its properties.
+            // Enum members can be qualified by the enum name.
+            id.range().end()
+        } else {
+            declaration.range().end()
+        };
+        let declaration_scope = declaration
+            .syntax()
+            .ancestors()
+            .skip(1)
+            .find(|ancestor| AnyJsVariableScope::can_cast(ancestor.kind()));
+        let binding = model.as_binding(id);
+        for reference in binding.all_references() {
+            if reference.range_start() < declaration_end {
+                let reference_syntax = reference.syntax();
+                // References that are exports, such as `export { a }` are always valid,
+                // even when they appear before the declaration.
+                // For example:
+                //
+                // ```js
+                // export { X };
+                // const X = 0;
+                // ```
+                if reference_syntax
                         .parent()
                         .kind().as_ref().is_none_or(|parent_kind| !AnyJsExportNamedSpecifier::can_cast(*parent_kind))
                         // Don't report variables used in another control flow root (function, classes, ...)
@@ -168,15 +168,14 @@ impl Rule for NoInvalidUseBeforeDeclaration {
                         // type Y = typeof X;
                         // const X = 0;
                         // ```
-                        && !AnyJsIdentifierUsage::cast_ref(&reference_syntax)
-                            .is_some_and(|usage| usage.is_only_type())
-                    {
-                        result.push(InvalidUseBeforeDeclaration {
-                            declaration_kind,
-                            reference_range: reference_syntax.text_trimmed_range(),
-                            binding_range: id.range(),
-                        });
-                    }
+                    && !AnyJsIdentifierReference::cast_ref(&reference_syntax)
+                        .is_some_and(|reference| reference.is_only_type())
+                {
+                    result.push(InvalidUseBeforeDeclaration {
+                        declaration_kind,
+                        reference_range: reference_syntax.text_trimmed_range(),
+                        binding_range: id.range(),
+                    });
                 }
             }
         }

--- a/crates/biome_js_analyze/src/lint/correctness/no_undeclared_variables.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_undeclared_variables.rs
@@ -1,11 +1,13 @@
 use crate::globals::{is_js_global, is_ts_global};
 use crate::services::embedded::EmbeddedService;
-use crate::services::semantic::SemanticServices;
+use crate::services::semantic::Semantic;
 use biome_analyze::context::RuleContext;
 use biome_analyze::{Rule, RuleDiagnostic, RuleSource, declare_lint_rule};
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_js_syntax::{AnyJsFunction, JsSyntaxToken, TsAsExpression, TsReferenceType};
+use biome_js_syntax::{
+    AnyJsFunction, AnyJsIdentifierReference, JsSyntaxToken, TsAsExpression, TsReferenceType,
+};
 use biome_languages::JsFileSource;
 use biome_languages::javascript::Language;
 use biome_rowan::AstNode;
@@ -63,79 +65,73 @@ declare_lint_rule! {
 }
 
 impl Rule for NoUndeclaredVariables {
-    type Query = SemanticServices;
+    type Query = Semantic<AnyJsIdentifierReference>;
     type State = JsSyntaxToken;
-    type Signals = Box<[Self::State]>;
+    type Signals = Option<Self::State>;
     type Options = NoUndeclaredVariablesOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
-        let model = ctx.query();
+        let model = ctx.model();
+        let identifier = ctx.query();
+        if !model.is_unresolved_reference(identifier) {
+            return None;
+        }
         let source_type = ctx.source_type::<JsFileSource>();
         let embedded = ctx
             .get_service::<EmbeddedService>()
             .expect("embedded service");
         let flavor = model.flavor();
 
-        model
-            .all_unresolved_references()
-            .filter_map(|reference| {
-                let identifier = reference.tree();
-                let under_as_expression = identifier
-                    .parent::<TsReferenceType>()
-                    .and_then(|ty| ty.parent::<TsAsExpression>())
-                    .is_some();
+        let under_as_expression = identifier
+            .parent::<TsReferenceType>()
+            .and_then(|ty| ty.parent::<TsAsExpression>())
+            .is_some();
 
-                let token = identifier.value_token().ok()?;
-                let text = token.text_trimmed();
-                let token_text = token.token_text_trimmed();
-                // Semantic resolution handles declared `$store` bindings; this fallback keeps
-                // configured globals and embedded bindings aligned on `store`.
-                let store_name = flavor.store_reference_name(text);
+        let token = identifier.value_token().ok()?;
+        let text = token.text_trimmed();
+        let token_text = token.token_text_trimmed();
+        // Semantic resolution handles declared `$store` bindings; this fallback keeps
+        // configured globals and embedded bindings aligned on `store`.
+        let store_name = flavor.store_reference_name(text);
 
-                if ctx.is_global(text)
-                    || store_name.is_some_and(|store_name| ctx.is_global(store_name))
-                {
-                    return None;
-                }
+        if ctx.is_global(text) || store_name.is_some_and(|store_name| ctx.is_global(store_name)) {
+            return None;
+        }
 
-                if embedded.contains_binding(token_text)
-                    || store_name
-                        .is_some_and(|store_name| embedded.contains_binding_text(store_name))
-                {
-                    return None;
-                }
+        if embedded.contains_binding(token_text)
+            || store_name.is_some_and(|store_name| embedded.contains_binding_text(store_name))
+        {
+            return None;
+        }
 
-                // Typescript Const Assertion
-                if text == "const" && under_as_expression {
-                    return None;
-                }
+        // Typescript Const Assertion
+        if text == "const" && under_as_expression {
+            return None;
+        }
 
-                // arguments object within non-arrow functions
-                if text == "arguments" {
-                    let is_in_non_arrow_function =
-                        identifier.syntax().ancestors().skip(1).any(|ancestor| {
-                            !matches!(
-                                AnyJsFunction::cast(ancestor),
-                                None | Some(AnyJsFunction::JsArrowFunctionExpression(_))
-                            )
-                        });
-                    if is_in_non_arrow_function {
-                        return None;
-                    }
-                }
+        // arguments object within non-arrow functions
+        if text == "arguments" {
+            let is_in_non_arrow_function =
+                identifier.syntax().ancestors().skip(1).any(|ancestor| {
+                    !matches!(
+                        AnyJsFunction::cast(ancestor),
+                        None | Some(AnyJsFunction::JsArrowFunctionExpression(_))
+                    )
+                });
+            if is_in_non_arrow_function {
+                return None;
+            }
+        }
 
-                if is_global(text, source_type) {
-                    return None;
-                }
+        if is_global(text, source_type) {
+            return None;
+        }
 
-                if !ctx.options().check_types() && identifier.is_only_type() {
-                    return None;
-                }
+        if !ctx.options().check_types() && identifier.is_only_type() {
+            return None;
+        }
 
-                Some(token)
-            })
-            .collect::<Vec<_>>()
-            .into_boxed_slice()
+        Some(token)
     }
 
     fn diagnostic(_ctx: &RuleContext<Self>, token: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/src/lint/style/no_restricted_globals.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_restricted_globals.rs
@@ -1,11 +1,10 @@
-use crate::services::semantic::SemanticServices;
+use crate::services::semantic::Semantic;
 use biome_analyze::context::RuleContext;
 use biome_analyze::{Rule, RuleDiagnostic, RuleSource, declare_lint_rule};
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_js_semantic::{Binding, BindingExtensions};
-use biome_js_syntax::{AnyJsIdentifierUsage, JsSyntaxToken};
-use biome_rowan::AstNode;
+use biome_js_semantic::Binding;
+use biome_js_syntax::{AnyJsIdentifierReference, JsSyntaxToken};
 use biome_rule_options::no_restricted_globals::NoRestrictedGlobalsOptions;
 use rustc_hash::FxHashMap;
 
@@ -63,48 +62,27 @@ declare_lint_rule! {
 const RESTRICTED_GLOBALS: [&str; 2] = ["event", "error"];
 
 impl Rule for NoRestrictedGlobals {
-    type Query = SemanticServices;
+    type Query = Semantic<AnyJsIdentifierReference>;
     type State = JsSyntaxToken;
-    type Signals = Box<[Self::State]>;
+    type Signals = Option<Self::State>;
     type Options = NoRestrictedGlobalsOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let model = ctx.model();
+        let reference = ctx.query();
         let options = ctx.options();
 
-        let unresolved_reference_nodes = model
-            .all_unresolved_references()
-            .map(|reference| reference.syntax().clone());
-        let global_references_nodes = model
-            .all_global_references()
-            .map(|reference| reference.syntax().clone());
-
-        unresolved_reference_nodes
-            .chain(global_references_nodes)
-            .filter_map(|node| {
-                let node = AnyJsIdentifierUsage::unwrap_cast(node);
-                let (token, binding) = match node {
-                    AnyJsIdentifierUsage::JsReferenceIdentifier(node) => {
-                        (node.value_token(), node.binding(model))
-                    }
-                    AnyJsIdentifierUsage::JsxReferenceIdentifier(node) => {
-                        (node.value_token(), node.binding(model))
-                    }
-                    AnyJsIdentifierUsage::JsIdentifierAssignment(node) => {
-                        (node.name_token(), node.binding(model))
-                    }
-                };
-                let token = token.ok()?;
-                let text = token.text_trimmed();
-
-                if is_restricted(text, &binding, options.denied_globals.as_ref()) {
-                    Some(token)
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>()
-            .into_boxed_slice()
+        if !model.is_unresolved_reference(reference) && !model.is_global_reference(reference) {
+            return None;
+        }
+        let token = reference.value_token().ok()?;
+        let binding = model.binding(reference);
+        is_restricted(
+            token.text_trimmed(),
+            &binding,
+            options.denied_globals.as_ref(),
+        )
+        .then_some(token)
     }
 
     fn diagnostic(_ctx: &RuleContext<Self>, token: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/src/lint/style/use_filenaming_convention.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_filenaming_convention.rs
@@ -3,7 +3,7 @@ use biome_analyze::{Rule, RuleDiagnostic, RuleSource, context::RuleContext, decl
 use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_syntax::{
-    AnyJsIdentifierUsage, JsExportNamedSpecifier, binding_ext::AnyJsIdentifierBinding,
+    AnyJsIdentifierReference, JsExportNamedSpecifier, binding_ext::AnyJsIdentifierBinding,
 };
 use biome_rowan::{AstNode, TextRange};
 use biome_rule_options::use_filenaming_convention::UseFilenamingConventionOptions;
@@ -262,7 +262,7 @@ impl Rule for UseFilenamingConvention {
                             Ok(id) => id.name_token().ok(),
                             Err(export) => match JsExportNamedSpecifier::cast(export.parent()?) {
                                 Some(specifier) => specifier.exported_name().ok()?.value().ok(),
-                                None => AnyJsIdentifierUsage::cast(export)?.value_token().ok(),
+                                None => AnyJsIdentifierReference::cast(export)?.value_token().ok(),
                             },
                         })
                         .all(|exported_name_token| exported_name_token.text_trimmed() != name)

--- a/crates/biome_js_analyze/src/lint/style/use_import_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_import_type.rs
@@ -14,7 +14,7 @@ use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_semantic::{ReferencesExtensions, SemanticModel};
 use biome_js_syntax::{
-    AnyJsCombinedSpecifier, AnyJsIdentifierUsage, AnyJsImportClause, AnyJsModuleItem,
+    AnyJsCombinedSpecifier, AnyJsIdentifierReference, AnyJsImportClause, AnyJsModuleItem,
     AnyJsModuleSource, AnyJsNamedImportSpecifier, AnyJsRoot, JsIdentifierBinding, JsImport,
     JsImportCombinedClause, JsImportDefaultClause, JsLanguage, JsModuleItemList,
     JsNamedImportSpecifierList, JsNamedImportSpecifiers, JsSyntaxNode, JsSyntaxToken, T,
@@ -838,7 +838,7 @@ fn is_only_used_as_type(
     let mut all_type_only = true;
     for reference in binding.all_references(model) {
         has_reference = true;
-        if let Some(reference) = AnyJsIdentifierUsage::cast_ref(&reference.syntax())
+        if let Some(reference) = AnyJsIdentifierReference::cast_ref(&reference.syntax())
             && !reference.is_only_type()
         {
             all_type_only = false;

--- a/crates/biome_js_analyze/src/lint/suspicious/no_global_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_global_assign.rs
@@ -1,11 +1,11 @@
 use crate::globals::is_js_global;
 
-use crate::services::semantic::SemanticServices;
+use crate::services::semantic::Semantic;
 use biome_analyze::RuleSource;
 use biome_analyze::{Rule, RuleDiagnostic, context::RuleContext, declare_lint_rule};
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_js_syntax::{JsSyntaxKind, TextRange};
+use biome_js_syntax::{JsIdentifierAssignment, TextRange};
 use biome_rule_options::no_global_assign::NoGlobalAssignOptions;
 
 declare_lint_rule! {
@@ -51,25 +51,18 @@ declare_lint_rule! {
 }
 
 impl Rule for NoGlobalAssign {
-    type Query = SemanticServices;
+    type Query = Semantic<JsIdentifierAssignment>;
     type State = TextRange;
-    type Signals = Box<[Self::State]>;
+    type Signals = Option<Self::State>;
     type Options = NoGlobalAssignOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
-        let global_refs = ctx.query().all_unresolved_references();
-        let mut result = Vec::new();
-        for global_ref in global_refs {
-            let is_write = global_ref.syntax().kind() == JsSyntaxKind::JS_IDENTIFIER_ASSIGNMENT;
-            if is_write {
-                let identifier = global_ref.syntax().text_trimmed();
-                let is_global_var = is_js_global(identifier.into_text().text());
-                if is_global_var {
-                    result.push(global_ref.range());
-                }
-            }
+        let assignment = ctx.query();
+        if !ctx.model().is_unresolved_reference(assignment) {
+            return None;
         }
-        result.into_boxed_slice()
+        let token = assignment.name_token().ok()?;
+        is_js_global(token.text_trimmed()).then(|| token.text_trimmed_range())
     }
 
     fn diagnostic(_ctx: &RuleContext<Self>, range: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/src/lint/suspicious/no_redeclare.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_redeclare.rs
@@ -1,10 +1,10 @@
-use crate::services::semantic::SemanticServices;
+use crate::services::semantic::Semantic;
 use biome_analyze::{Rule, RuleDiagnostic, context::RuleContext};
 use biome_analyze::{RuleSource, declare_lint_rule};
 use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_semantic::Scope;
-use biome_js_syntax::binding_ext::AnyJsBindingDeclaration;
+use biome_js_syntax::binding_ext::{AnyJsBindingDeclaration, AnyJsIdentifierBinding};
 use biome_js_syntax::{JsSyntaxKind, TextRange};
 use biome_rowan::{AstNode, TokenText};
 use biome_rule_options::no_redeclare::NoRedeclareOptions;
@@ -81,16 +81,26 @@ pub struct Redeclaration {
 }
 
 impl Rule for NoRedeclare {
-    type Query = SemanticServices;
+    type Query = Semantic<AnyJsIdentifierBinding>;
     type State = Redeclaration;
     type Signals = Box<[Redeclaration]>;
     type Options = NoRedeclareOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
-        let mut redeclarations = Vec::default();
-        for scope in ctx.query().scopes() {
-            check_redeclarations_in_single_scope(&scope, &mut redeclarations);
+        let model = ctx.model();
+        let binding = model.as_binding(ctx.query());
+        let scope = model
+            .scope_hoisted_to(&binding.syntax())
+            .unwrap_or_else(|| binding.scope());
+        if scope
+            .bindings()
+            .next()
+            .is_none_or(|first| first.syntax() != binding.syntax())
+        {
+            return Box::default();
         }
+        let mut redeclarations = Vec::default();
+        check_redeclarations_in_single_scope(&scope, &mut redeclarations);
         redeclarations.into_boxed_slice()
     }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_shadow.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_shadow.rs
@@ -7,13 +7,14 @@ use biome_js_semantic::{Binding, SemanticModel};
 use biome_js_syntax::{
     JsClassExpression, JsFormalParameter, JsFunctionExpression, JsIdentifierBinding,
     JsParameterList, JsRestParameter, TsIdentifierBinding, TsPropertySignatureTypeMember,
-    TsTypeParameter, TsTypeParameterName, binding_ext::AnyJsBindingDeclaration,
+    TsTypeParameter, TsTypeParameterName,
+    binding_ext::{AnyJsBindingDeclaration, AnyJsIdentifierBinding},
     binding_ext::AnyJsParameterParentFunction,
 };
 use biome_rowan::{AstNode, SyntaxNodeCast, TokenText, declare_node_union};
 use biome_rule_options::no_shadow::NoShadowOptions;
 
-use crate::services::semantic::SemanticServices;
+use crate::services::semantic::Semantic;
 
 declare_lint_rule! {
     /// Disallow variable declarations from shadowing variables declared in the outer scope.
@@ -127,23 +128,14 @@ pub struct ShadowedBinding {
 }
 
 impl Rule for NoShadow {
-    type Query = SemanticServices;
+    type Query = Semantic<AnyJsIdentifierBinding>;
     type State = ShadowedBinding;
-    type Signals = Box<[Self::State]>;
+    type Signals = Option<Self::State>;
     type Options = NoShadowOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
-        let mut shadowed_bindings = Vec::new();
-        let model = ctx.query();
-        let options = ctx.options();
-
-        for binding in ctx.query().all_bindings() {
-            if let Some(shadowed_binding) = check_shadowing(model, binding, options) {
-                shadowed_bindings.push(shadowed_binding);
-            }
-        }
-
-        shadowed_bindings.into_boxed_slice()
+        let model = ctx.model();
+        check_shadowing(model, model.as_binding(ctx.query()), ctx.options())
     }
 
     fn diagnostic(_ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/src/services/semantic.rs
+++ b/crates/biome_js_analyze/src/services/semantic.rs
@@ -8,6 +8,12 @@ use biome_js_syntax::{AnyJsRoot, JsLanguage, JsSyntaxNode, TextRange, WalkEvent}
 use biome_languages::JsFileSource;
 use biome_rowan::AstNode;
 
+/// ## Warning
+///
+/// Using this type as a [biome_analyze::Rule] `Query` is discouraged, because it enforces the inspections of an entire
+/// document, even when the document doesn't contain the nodes that needs to be inspected.
+///
+/// Prefer the use of `Semantic<Node>` to trigger the rule only for those nodes that might trigger the rule.
 pub struct SemanticServices {
     model: SemanticModel,
 }

--- a/crates/biome_js_analyze/src/utils/rename.rs
+++ b/crates/biome_js_analyze/src/utils/rename.rs
@@ -253,8 +253,7 @@ impl RenameSymbolExtensions for BatchMutation<JsLanguage> {
             }
 
             let reference_syntax = reference.syntax();
-            let Some(identifier_reference) =
-                AnyJsIdentifierReference::cast_ref(&reference_syntax)
+            let Some(identifier_reference) = AnyJsIdentifierReference::cast_ref(&reference_syntax)
             else {
                 continue;
             };

--- a/crates/biome_js_analyze/src/utils/rename.rs
+++ b/crates/biome_js_analyze/src/utils/rename.rs
@@ -4,7 +4,7 @@ use biome_diagnostics::{Diagnostic, Location, Severity};
 use biome_js_factory::make;
 use biome_js_semantic::{ReferencesExtensions, SemanticModel};
 use biome_js_syntax::{
-    AnyJsIdentifierUsage, JsIdentifierAssignment, JsIdentifierBinding, JsLanguage,
+    AnyJsIdentifierReference, JsIdentifierAssignment, JsIdentifierBinding, JsLanguage,
     JsReferenceIdentifier, JsSyntaxKind, JsSyntaxNode, T, TextRange, TsIdentifierBinding,
     binding_ext::AnyJsIdentifierBinding,
 };
@@ -253,10 +253,12 @@ impl RenameSymbolExtensions for BatchMutation<JsLanguage> {
             }
 
             let reference_syntax = reference.syntax();
-            let Some(id_usage) = AnyJsIdentifierUsage::cast_ref(&reference_syntax) else {
+            let Some(identifier_reference) =
+                AnyJsIdentifierReference::cast_ref(&reference_syntax)
+            else {
                 continue;
             };
-            let Ok(prev_ref_token) = id_usage.value_token() else {
+            let Ok(prev_ref_token) = identifier_reference.value_token() else {
                 continue;
             };
 

--- a/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noRedeclare/invalid.ts.snap
@@ -27,6 +27,59 @@ namespace Ns2 {}
 
 # Diagnostics
 ```
+invalid.ts:15:11 lint/suspicious/noRedeclare ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × 'Ns1' is redeclared in the same scope.
+  
+    14 │ import * as Ns1 from ""
+  > 15 │ namespace Ns1 {}
+       │           ^^^
+    16 │ 
+    17 │ import type * as Ns2 from ""
+  
+  i 'Ns1' is defined here:
+  
+    12 │ }
+    13 │ 
+  > 14 │ import * as Ns1 from ""
+       │             ^^^
+    15 │ namespace Ns1 {}
+    16 │ 
+  
+  i Redeclarations make it unclear which variable a reference points to and can hide earlier declarations.
+  
+  i Remove the duplicate declaration or rename one of the variables.
+  
+
+```
+
+```
+invalid.ts:18:11 lint/suspicious/noRedeclare ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × 'Ns2' is redeclared in the same scope.
+  
+    17 │ import type * as Ns2 from ""
+  > 18 │ namespace Ns2 {}
+       │           ^^^
+    19 │ 
+  
+  i 'Ns2' is defined here:
+  
+    15 │ namespace Ns1 {}
+    16 │ 
+  > 17 │ import type * as Ns2 from ""
+       │                  ^^^
+    18 │ namespace Ns2 {}
+    19 │ 
+  
+  i Redeclarations make it unclear which variable a reference points to and can hide earlier declarations.
+  
+  i Remove the duplicate declaration or rename one of the variables.
+  
+
+```
+
+```
 invalid.ts:4:7 lint/suspicious/noRedeclare ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × 'a' is redeclared in the same scope.
@@ -101,59 +154,6 @@ invalid.ts:11:10 lint/suspicious/noRedeclare ━━━━━━━━━━━�
        │            ^
     11 │     type T = number;
     12 │ }
-  
-  i Redeclarations make it unclear which variable a reference points to and can hide earlier declarations.
-  
-  i Remove the duplicate declaration or rename one of the variables.
-  
-
-```
-
-```
-invalid.ts:15:11 lint/suspicious/noRedeclare ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × 'Ns1' is redeclared in the same scope.
-  
-    14 │ import * as Ns1 from ""
-  > 15 │ namespace Ns1 {}
-       │           ^^^
-    16 │ 
-    17 │ import type * as Ns2 from ""
-  
-  i 'Ns1' is defined here:
-  
-    12 │ }
-    13 │ 
-  > 14 │ import * as Ns1 from ""
-       │             ^^^
-    15 │ namespace Ns1 {}
-    16 │ 
-  
-  i Redeclarations make it unclear which variable a reference points to and can hide earlier declarations.
-  
-  i Remove the duplicate declaration or rename one of the variables.
-  
-
-```
-
-```
-invalid.ts:18:11 lint/suspicious/noRedeclare ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × 'Ns2' is redeclared in the same scope.
-  
-    17 │ import type * as Ns2 from ""
-  > 18 │ namespace Ns2 {}
-       │           ^^^
-    19 │ 
-  
-  i 'Ns2' is defined here:
-  
-    15 │ namespace Ns1 {}
-    16 │ 
-  > 17 │ import type * as Ns2 from ""
-       │                  ^^^
-    18 │ namespace Ns2 {}
-    19 │ 
   
   i Redeclarations make it unclear which variable a reference points to and can hide earlier declarations.
   

--- a/crates/biome_js_semantic/src/events.rs
+++ b/crates/biome_js_semantic/src/events.rs
@@ -3,7 +3,7 @@
 use JsSyntaxKind::*;
 use biome_js_syntax::binding_ext::{AnyJsBindingDeclaration, AnyJsIdentifierBinding};
 use biome_js_syntax::{
-    AnyJsIdentifierUsage, JsDirective, JsLanguage, JsSyntaxKind, JsSyntaxNode, TextRange,
+    AnyJsIdentifierReference, JsDirective, JsLanguage, JsSyntaxKind, JsSyntaxNode, TextRange,
     TsTypeParameterName, inner_string_text,
 };
 use biome_js_syntax::{AnyJsImportClause, AnyJsNamedImportSpecifier, AnyTsType};
@@ -320,7 +320,7 @@ impl SemanticEventExtractor {
             }
 
             JS_REFERENCE_IDENTIFIER | JSX_REFERENCE_IDENTIFIER | JS_IDENTIFIER_ASSIGNMENT => {
-                self.enter_identifier_usage(AnyJsIdentifierUsage::unwrap_cast(node.clone()));
+                self.enter_identifier_reference(AnyJsIdentifierReference::unwrap_cast(node.clone()));
             }
 
             JS_MODULE => {
@@ -807,14 +807,14 @@ impl SemanticEventExtractor {
         }
     }
 
-    fn enter_identifier_usage(&mut self, node: AnyJsIdentifierUsage) {
+    fn enter_identifier_reference(&mut self, node: AnyJsIdentifierReference) {
         let range = node.syntax().text_trimmed_range();
         let Ok(name_token) = node.value_token() else {
             return;
         };
         let name = name_token.token_text_trimmed();
         match node {
-            AnyJsIdentifierUsage::JsReferenceIdentifier(node) => {
+            AnyJsIdentifierReference::JsReferenceIdentifier(node) => {
                 let Some(parent) = node.syntax().parent() else {
                     self.push_reference(
                         BindingName::Value(name),
@@ -913,14 +913,14 @@ impl SemanticEventExtractor {
                     }
                 }
             }
-            AnyJsIdentifierUsage::JsxReferenceIdentifier(_) => {
+            AnyJsIdentifierReference::JsxReferenceIdentifier(_) => {
                 if name.text() == "this" {
                     // Ignore `this` in JSX. e.g. `<this.foo />`.
                     return;
                 }
                 self.push_reference(BindingName::Value(name), Reference::Read(range));
             }
-            AnyJsIdentifierUsage::JsIdentifierAssignment(_) => {
+            AnyJsIdentifierReference::JsIdentifierAssignment(_) => {
                 self.push_reference(BindingName::Value(name), Reference::Write(range));
             }
         }

--- a/crates/biome_js_semantic/src/events.rs
+++ b/crates/biome_js_semantic/src/events.rs
@@ -320,7 +320,9 @@ impl SemanticEventExtractor {
             }
 
             JS_REFERENCE_IDENTIFIER | JSX_REFERENCE_IDENTIFIER | JS_IDENTIFIER_ASSIGNMENT => {
-                self.enter_identifier_reference(AnyJsIdentifierReference::unwrap_cast(node.clone()));
+                self.enter_identifier_reference(AnyJsIdentifierReference::unwrap_cast(
+                    node.clone(),
+                ));
             }
 
             JS_MODULE => {

--- a/crates/biome_js_semantic/src/semantic_model/binding.rs
+++ b/crates/biome_js_semantic/src/semantic_model/binding.rs
@@ -604,7 +604,7 @@ impl Binding {
     /// Returns all exports of the binding.
     ///
     /// The node kind is either an identifier binding (if the declaration is
-    /// itself an `export` statement) or an identifier usage.
+    /// itself an `export` statement) or an identifier reference.
     pub fn exports(&self) -> impl Iterator<Item = JsSyntaxNode> + '_ {
         let binding = self.data.binding(self.id);
         binding.export_ranges.iter().filter_map(|export_start| {

--- a/crates/biome_js_semantic/src/semantic_model/builder.rs
+++ b/crates/biome_js_semantic/src/semantic_model/builder.rs
@@ -31,6 +31,8 @@ pub struct SemanticModelBuilder {
     declared_at_by_start: FxHashMap<TextSize, BindingId>,
     exported: FxHashSet<BindingId>,
     unresolved_references: Vec<SemanticModelUnresolvedReference>,
+    unresolved_references_by_start: FxHashSet<TextSize>,
+    global_references_by_start: FxHashSet<TextSize>,
     flavor: SemanticFlavor,
     pub(crate) export_jsdoc_by_range: FxHashMap<TextRange, JsdocComment>,
 }
@@ -51,6 +53,8 @@ impl SemanticModelBuilder {
             declared_at_by_start: FxHashMap::default(),
             exported: FxHashSet::default(),
             unresolved_references: Vec::new(),
+            unresolved_references_by_start: FxHashSet::default(),
+            global_references_by_start: FxHashSet::default(),
             flavor: SemanticFlavor::default(),
             export_jsdoc_by_range: FxHashMap::default(),
         }
@@ -368,6 +372,7 @@ impl SemanticModelBuilder {
                 let unresolved_name = node.text_trimmed().to_string();
 
                 if let Some(global_name) = self.resolve_global_name(&unresolved_name) {
+                    self.global_references_by_start.insert(range.start());
                     if let Some(index) = self.globals_by_name[global_name] {
                         self.globals[index as usize].references.push(
                             SemanticModelGlobalReferenceData {
@@ -390,6 +395,7 @@ impl SemanticModelBuilder {
                             Some(id);
                     }
                 } else {
+                    self.unresolved_references_by_start.insert(range.start());
                     self.unresolved_references
                         .push(SemanticModelUnresolvedReference { range });
                 }
@@ -435,6 +441,8 @@ impl SemanticModelBuilder {
             declared_at_by_start: self.declared_at_by_start,
             exported: self.exported,
             unresolved_references: self.unresolved_references,
+            unresolved_references_by_start: self.unresolved_references_by_start,
+            global_references_by_start: self.global_references_by_start,
             globals: self.globals,
             export_jsdoc_by_range: self.export_jsdoc_by_range,
         };

--- a/crates/biome_js_semantic/src/semantic_model/model.rs
+++ b/crates/biome_js_semantic/src/semantic_model/model.rs
@@ -93,8 +93,10 @@ pub(crate) struct SemanticModelData {
     pub(crate) exported: FxHashSet<BindingId>,
     /// All references that could not be resolved
     pub(crate) unresolved_references: Vec<SemanticModelUnresolvedReference>,
+    pub(crate) unresolved_references_by_start: FxHashSet<TextSize>,
     /// All globals references
     pub(crate) globals: Vec<SemanticModelGlobalBindingData>,
+    pub(crate) global_references_by_start: FxHashSet<TextSize>,
     /// JSDoc comments attached to export statements (keyed by the JsExport node's range).
     pub(crate) export_jsdoc_by_range: FxHashMap<TextRange, JsdocComment>,
 }
@@ -436,6 +438,13 @@ impl SemanticModel {
         std::iter::successors(first, succ)
     }
 
+    /// Returns whether `reference` resolves to a configured global.
+    pub fn is_global_reference(&self, reference: &impl HasDeclarationAstNode) -> bool {
+        self.data
+            .global_references_by_start
+            .contains(&reference.syntax().text_trimmed_range().start())
+    }
+
     /// Returns an iterator of all the unresolved references in the program
     pub fn all_unresolved_references(
         &self,
@@ -463,6 +472,13 @@ impl SemanticModel {
                 })
         }
         std::iter::successors(first, succ)
+    }
+
+    /// Returns whether `reference` could not be resolved to a binding or configured global.
+    pub fn is_unresolved_reference(&self, reference: &impl HasDeclarationAstNode) -> bool {
+        self.data
+            .unresolved_references_by_start
+            .contains(&reference.syntax().text_trimmed_range().start())
     }
 
     /// Returns if the node is exported or is a reference to a binding

--- a/crates/biome_js_semantic/src/semantic_model/reference.rs
+++ b/crates/biome_js_semantic/src/semantic_model/reference.rs
@@ -1,4 +1,4 @@
-use biome_js_syntax::{AnyJsFunction, AnyJsIdentifierUsage, JsCallExpression};
+use biome_js_syntax::{AnyJsFunction, AnyJsIdentifierReference, JsCallExpression};
 
 use super::*;
 use std::sync::Arc;
@@ -193,8 +193,8 @@ impl UnresolvedReference {
             .to_node(self.data.to_root().syntax())
     }
 
-    pub fn tree(&self) -> AnyJsIdentifierUsage {
-        AnyJsIdentifierUsage::unwrap_cast(self.syntax().clone())
+    pub fn tree(&self) -> AnyJsIdentifierReference {
+        AnyJsIdentifierReference::unwrap_cast(self.syntax().clone())
     }
 
     pub fn range(&self) -> TextRange {
@@ -213,6 +213,7 @@ pub trait HasDeclarationAstNode: AstNode<Language = JsLanguage> {
 impl HasDeclarationAstNode for JsReferenceIdentifier {}
 impl HasDeclarationAstNode for JsIdentifierAssignment {}
 impl HasDeclarationAstNode for JsxReferenceIdentifier {}
+impl HasDeclarationAstNode for AnyJsIdentifierReference {}
 
 /// Extension method to allow any node that is a declaration to easily
 /// get all of its references.

--- a/crates/biome_js_semantic/src/semantic_model/tests.rs
+++ b/crates/biome_js_semantic/src/semantic_model/tests.rs
@@ -6,8 +6,8 @@ mod test {
     };
     use biome_js_parser::JsParserOptions;
     use biome_js_syntax::{
-        AnyJsIdentifierReference, JsIdentifierAssignment, JsIdentifierBinding,
-        JsReferenceIdentifier, JsSyntaxKind, TsIdentifierBinding,
+        JsIdentifierAssignment, JsIdentifierBinding, JsReferenceIdentifier, JsSyntaxKind,
+        TsIdentifierBinding,
     };
     use biome_languages::JsFileSource;
     use biome_rowan::{AstNode, SyntaxNodeCast};
@@ -324,9 +324,6 @@ mod test {
         assert_eq!(globals.len(), 1);
         assert!(globals[0].is_read());
         assert_eq!(globals[0].syntax().text_trimmed(), "console");
-        let reference = AnyJsIdentifierReference::unwrap_cast(globals[0].syntax());
-        assert!(model.is_global_reference(&reference));
-        assert!(!model.is_unresolved_reference(&reference));
     }
 
     #[test]
@@ -410,8 +407,6 @@ declare module "jsoneditor" {
         let unresolved_reference = unresolved_references
             .next()
             .expect("expected one unresolved reference");
-        assert!(model.is_unresolved_reference(&unresolved_reference.tree()));
-        assert!(!model.is_global_reference(&unresolved_reference.tree()));
         assert_eq!(
             unresolved_reference.tree().syntax().text_trimmed(),
             "Namespace"

--- a/crates/biome_js_semantic/src/semantic_model/tests.rs
+++ b/crates/biome_js_semantic/src/semantic_model/tests.rs
@@ -6,8 +6,8 @@ mod test {
     };
     use biome_js_parser::JsParserOptions;
     use biome_js_syntax::{
-        JsIdentifierAssignment, JsIdentifierBinding, JsReferenceIdentifier, JsSyntaxKind,
-        TsIdentifierBinding,
+        AnyJsIdentifierReference, JsIdentifierAssignment, JsIdentifierBinding,
+        JsReferenceIdentifier, JsSyntaxKind, TsIdentifierBinding,
     };
     use biome_languages::JsFileSource;
     use biome_rowan::{AstNode, SyntaxNodeCast};
@@ -324,6 +324,9 @@ mod test {
         assert_eq!(globals.len(), 1);
         assert!(globals[0].is_read());
         assert_eq!(globals[0].syntax().text_trimmed(), "console");
+        let reference = AnyJsIdentifierReference::unwrap_cast(globals[0].syntax());
+        assert!(model.is_global_reference(&reference));
+        assert!(!model.is_unresolved_reference(&reference));
     }
 
     #[test]
@@ -386,7 +389,7 @@ declare module "jsoneditor" {
     }
 
     #[test]
-    pub fn ok_semantic_model_namespace_import_type_unqualified_reference_is_unresolved_and_tracked_for_usage()
+    pub fn ok_semantic_model_namespace_import_type_unqualified_reference_is_unresolved_and_tracked()
      {
         let r = biome_js_parser::parse(
             "import type * as Namespace from \"mod\"; type T = Namespace;",
@@ -407,6 +410,8 @@ declare module "jsoneditor" {
         let unresolved_reference = unresolved_references
             .next()
             .expect("expected one unresolved reference");
+        assert!(model.is_unresolved_reference(&unresolved_reference.tree()));
+        assert!(!model.is_global_reference(&unresolved_reference.tree()));
         assert_eq!(
             unresolved_reference.tree().syntax().text_trimmed(),
             "Namespace"

--- a/crates/biome_js_semantic/src/tests/references.rs
+++ b/crates/biome_js_semantic/src/tests/references.rs
@@ -1,4 +1,9 @@
 use crate::assert_semantics;
+use crate::{SemanticModelOptions, semantic_model};
+use biome_js_parser::JsParserOptions;
+use biome_js_syntax::AnyJsIdentifierReference;
+use biome_languages::JsFileSource;
+use biome_rowan::AstNode;
 
 // Reads
 
@@ -32,6 +37,29 @@ f(1);"#,
         console.log(5, a/*READ A1*/);",
     ok_reference_recursive,
         "const fn/*#A*/ = (callback) => { callback(fn/*READ A*/) };",
+}
+
+#[test]
+fn classifies_global_and_unresolved_references() {
+    let parse = biome_js_parser::parse(
+        "configured; missing;",
+        JsFileSource::js_module(),
+        JsParserOptions::default(),
+    );
+    let mut options = SemanticModelOptions::default();
+    options.globals.insert("configured".into());
+    let model = semantic_model(&parse.tree(), options);
+    let mut references = parse
+        .syntax()
+        .descendants()
+        .filter_map(AnyJsIdentifierReference::cast);
+    let configured = references.next().expect("configured reference");
+    let missing = references.next().expect("unresolved reference");
+
+    assert!(model.is_global_reference(&configured));
+    assert!(!model.is_unresolved_reference(&configured));
+    assert!(model.is_unresolved_reference(&missing));
+    assert!(!model.is_global_reference(&missing));
 }
 
 // Read Hoisting

--- a/crates/biome_js_syntax/src/identifier_ext.rs
+++ b/crates/biome_js_syntax/src/identifier_ext.rs
@@ -8,10 +8,10 @@ use biome_rowan::{
 };
 
 declare_node_union! {
-    pub AnyJsIdentifierUsage = JsReferenceIdentifier | JsIdentifierAssignment | JsxReferenceIdentifier
+    pub AnyJsIdentifierReference = JsReferenceIdentifier | JsIdentifierAssignment | JsxReferenceIdentifier
 }
 
-impl AnyJsIdentifierUsage {
+impl AnyJsIdentifierReference {
     pub fn value_token(&self) -> SyntaxResult<JsSyntaxToken> {
         match self {
             Self::JsReferenceIdentifier(node) => node.value_token(),
@@ -40,7 +40,7 @@ impl AnyJsIdentifierUsage {
     }
 }
 
-pub enum IdentifierUsageKind {
+pub enum IdentifierReferenceKind {
     TypeValue,
     Type,
     Value,

--- a/crates/biome_workspace_db/src/embedded/visitor.rs
+++ b/crates/biome_workspace_db/src/embedded/visitor.rs
@@ -11,7 +11,7 @@ use biome_html_syntax::{
 use biome_js_syntax::{
     AnyJsArrayAssignmentPatternElement, AnyJsArrayBindingPatternElement, AnyJsArrayElement,
     AnyJsAssignmentPattern, AnyJsBindingPattern, AnyJsCallArgument, AnyJsExpression,
-    AnyJsIdentifierUsage, AnyJsModuleItem, AnyJsObjectAssignmentPatternMember,
+    AnyJsIdentifierReference, AnyJsModuleItem, AnyJsObjectAssignmentPatternMember,
     AnyJsObjectBindingPatternMember, AnyJsObjectMember, AnyJsRoot, AnyJsStatement,
     AnyTsIdentifierBinding, AnyTsType, JsAssignmentExpression, JsCallExpression, JsExport,
     JsIdentifierAssignment, JsImport, JsModuleItemList, JsReferenceIdentifier,
@@ -1285,9 +1285,9 @@ impl EmbeddedReferencesBuilder {
     }
 
     fn visit_reference_identifier(&mut self, reference: JsReferenceIdentifier) -> Option<()> {
-        let usage = AnyJsIdentifierUsage::from(reference.clone());
+        let reference = AnyJsIdentifierReference::from(reference.clone());
         let name_token = reference.value_token().ok()?;
-        if usage.is_only_type() {
+        if reference.is_only_type() {
             self.register_type_reference(
                 name_token.text_trimmed_range(),
                 name_token.token_text_trimmed(),


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

The use of `SemanticServices` is a hazard because it forces the inspection of a document even when it doesn't have any of the nodes we need to analyse.

This PR removes most of its usage from rules, and it's replaced with the simpler `Semantic<N>`. Only few cases are left, which are genuine.

Designed by me, implemented with a coding agent.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Green CI. The change in snapshot is just an order of the diagnostics. 

<!-- What demonstrates that your implementation is correct? -->

## Docs

N/A

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
