### PR TITLE
fix: add 'math' to generic font family keywords (fixes #11229) 🤖🤖🤖

### DIFF
--- a/.changeset/fix-math-generic-font.md
+++ b/.changeset/fix-math-generic-font.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11229](https://github.com/biomejs/biome/issues/11229): `math` is now recognized as a valid generic font family keyword.

--- a/crates/biome_css_analyze/src/keywords.rs
+++ b/crates/biome_css_analyze/src/keywords.rs
@@ -10,9 +10,10 @@ pub const SYSTEM_FAMILY_NAME_KEYWORDS: [&str; 6] = [
     "status-bar",
 ];
 
-pub const FONT_FAMILY_KEYWORDS: [&str; 10] = [
+pub const FONT_FAMILY_KEYWORDS: [&str; 11] = [
     "cursive",
     "fantasy",
+    "math",
     "monospace",
     "sans-serif",
     "serif",

--- a/crates/biome_css_analyze/tests/specs/a11y/useGenericFontNames/valid.css
+++ b/crates/biome_css_analyze/tests/specs/a11y/useGenericFontNames/valid.css
@@ -32,4 +32,4 @@ a { font-family: revert-layer }
 /* @supports feature declarations (the condition part) should not trigger the rule */
 @supports (font: -apple-system-body) {
   /* styles inside @supports block will be checked separately */
-}
+}a { font-family: math; }


### PR DESCRIPTION
## Summary

Fixes [#11229](https://github.com/biomejs/biome/issues/11229): `math` is now recognized as a valid generic font family keyword.

## What Changed

- Added `"math"` to `FONT_FAMILY_KEYWORDS` array in `crates/biome_css_analyze/src/keywords.rs`
- Added test case in `valid.css`

## Test Plan

- `cargo test -p biome_css_analyze -- use_generic_font_names`
- Verified `math` is no longer flagged as missing generic font family