### PR TITLE
fix(css_formatter): preserve block comment indentation

### DIFF
--- a/.changeset/every-chefs-hunt.md
+++ b/.changeset/every-chefs-hunt.md
@@ -1,0 +1,14 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11228](https://github.com/biomejs/biome/issues/11228): CSS block comments between a declaration colon and value now preserve their source indentation.
+
+```diff
+ :root {
+   --font-stack:
+-/* comment */
++    /* comment */
+     system-ui;
+ }
+```

--- a/crates/biome_css_formatter/src/css/properties/generic_property.rs
+++ b/crates/biome_css_formatter/src/css/properties/generic_property.rs
@@ -248,23 +248,20 @@ impl<'a> CssPropertyColonComments<'a> {
         let formatted = format_dangling_comment(comment);
 
         if comment.lines_before() > 0 {
-            if comment.kind().is_line() {
-                if let Some(source_indent) = source_indent_before_comment(comment) {
-                    return write!(
-                        f,
-                        [dedent_to_root(&align(
-                            source_indent,
-                            &format_args![hard_line_break(), formatted]
-                        ))]
-                    );
-                }
+            if let Some(source_indent) = source_indent_before_comment(comment) {
+                return write!(
+                    f,
+                    [dedent_to_root(&align(
+                        source_indent,
+                        &format_args![hard_line_break(), formatted]
+                    ))]
+                );
+            }
 
+            if comment.kind().is_line() {
                 return write!(f, [hard_line_break(), formatted]);
             }
 
-            // Keep the block comment at its raw column:
-            // a { color:
-            // /* note */ red; }
             return write!(
                 f,
                 [dedent_to_root(&format_args![hard_line_break(), formatted])]

--- a/crates/biome_css_formatter/tests/specs/css/comments/custom-property-value-comment-indentation.css
+++ b/crates/biome_css_formatter/tests/specs/css/comments/custom-property-value-comment-indentation.css
@@ -1,0 +1,13 @@
+:root {
+	--main-font-stack:
+		/* Why does this comment get placed without indentation? */
+		system-ui,
+		/* Comment 1 */
+		-apple-system,
+		BlinkMacSystemFont,
+		/* Comment 2 */
+		"Segoe UI",
+		Roboto, Ubuntu,
+		/* Comment 3 */
+		sans-serif;
+}

--- a/crates/biome_css_formatter/tests/specs/css/comments/custom-property-value-comment-indentation.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/comments/custom-property-value-comment-indentation.css.snap
@@ -1,0 +1,36 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/comments/custom-property-value-comment-indentation.css
+---
+
+# Input
+
+```css
+:root {
+	--main-font-stack:
+		/* Why does this comment get placed without indentation? */
+		system-ui,
+		/* Comment 1 */
+		-apple-system,
+		BlinkMacSystemFont,
+		/* Comment 2 */
+		"Segoe UI",
+		Roboto, Ubuntu,
+		/* Comment 3 */
+		sans-serif;
+}
+
+```
+
+
+# Formatted
+
+```css
+:root {
+	--main-font-stack:
+		/* Why does this comment get placed without indentation? */
+		system-ui, /* Comment 1 */ -apple-system, BlinkMacSystemFont,
+		/* Comment 2 */ "Segoe UI", Roboto, Ubuntu, /* Comment 3 */ sans-serif;
+}
+
+```

--- a/crates/biome_css_formatter/tests/specs/prettier/css/comments/declaration.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/comments/declaration.css.snap
@@ -133,36 +133,31 @@ body
    /* comment 45 */
 -  /* comment 46 */
 -  color/* comment 47 */
--    /* comment 48 */
--    /* comment 49 */ :  /* comment 50 */
--    /* comment 51 */
--    /* comment 52 */ blue
--    /* comment 53 */ /* comment 54 */ /* comment 55 */; /* comment 56 */
 +  /* comment 46 */ color/* comment 47 */
 +:
-+/* comment 48 */
-+/* comment 49 */ /* comment 50 */
-+/* comment 51 */
-+/* comment 52 */ blue /* comment 53 */; /* comment 56 */
+     /* comment 48 */
+-    /* comment 49 */ :  /* comment 50 */
++    /* comment 49 */ /* comment 50 */
+     /* comment 51 */
+-    /* comment 52 */ blue
+-    /* comment 53 */ /* comment 54 */ /* comment 55 */; /* comment 56 */
++    /* comment 52 */ blue /* comment 53 */; /* comment 56 */
 +  /* comment 54 */
 +  /* comment 55 */
    /* comment 57 */
 -  /* comment 58 */
 -  transform/* comment 59 */
--    /* comment 60 */
++  /* comment 58 */ transform/* comment 59 */
++:
+     /* comment 60 */
 -    /* comment 61 */ : /* comment 62 */
--    /* comment 63 */
--    /* comment 64 */ translate(
++    /* comment 61 */ /* comment 62 */
+     /* comment 63 */
+     /* comment 64 */ translate(
 -      /* comment 65 */ /* comment 66 */ /* comment 67 */ 10px /* comment 68 */
 -        /* comment 69 */ /* comment 70 */
 -    )
 -    /* comment 71 */ /* comment 72 */ /* comment 73 */; /* comment 74 */
-+  /* comment 58 */ transform/* comment 59 */
-+:
-+/* comment 60 */
-+/* comment 61 */ /* comment 62 */
-+/* comment 63 */
-+/* comment 64 */ translate(
 +    /* comment 65 */
 +    /* comment 66 */
 +    /* comment 67 */ 10px /* comment 68 */
@@ -212,19 +207,19 @@ a {
   /* comment 45 */
   /* comment 46 */ color/* comment 47 */
 :
-/* comment 48 */
-/* comment 49 */ /* comment 50 */
-/* comment 51 */
-/* comment 52 */ blue /* comment 53 */; /* comment 56 */
+    /* comment 48 */
+    /* comment 49 */ /* comment 50 */
+    /* comment 51 */
+    /* comment 52 */ blue /* comment 53 */; /* comment 56 */
   /* comment 54 */
   /* comment 55 */
   /* comment 57 */
   /* comment 58 */ transform/* comment 59 */
 :
-/* comment 60 */
-/* comment 61 */ /* comment 62 */
-/* comment 63 */
-/* comment 64 */ translate(
+    /* comment 60 */
+    /* comment 61 */ /* comment 62 */
+    /* comment 63 */
+    /* comment 64 */ translate(
     /* comment 65 */
     /* comment 66 */
     /* comment 67 */ 10px /* comment 68 */


### PR DESCRIPTION
## Summary

Fixes #11228.

Fixes an issue where a standalone block comment (`/* ... */`) immediately following the colon in a multiline custom property was incorrectly indented to column 0 due to `dedent_to_root`.

Restoring original indentation via `source_indent_before_comment` in `fmt_value_boundary_comment` was previously restricted to line comments (`//`). This check is now moved outside the line-comment branch so block comments also retain their source column.

```diff
 :root {
   --font-stack:
-/* comment */
+    /* comment */
     system-ui;
 } 
```
 
 ## Test Plan
- `cargo test -p biome_css_formatter --test spec_tests css::comments::custom_property_value_comment_indentation` — passed.
  - `cargo test -p biome_css_formatter --no-fail-fast` — passed.
  - `just f` — passed.
  - `cargo clippy -p biome_css_formatter --lib --all-features -- --deny warnings` — passed.
  - `git diff --check` — passed.
## Docs
N/A — This is an internal formatter bug fix with no public configuration or API changes.