### PR TITLE
feat(linter): add skipComments option to noExcessiveLinesPerFile

### DIFF
--- a/.changeset/add-skip-comments-option.md
+++ b/.changeset/add-skip-comments-option.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": minor
+---
+
+Added `skipComments` option to `noExcessiveLinesPerFile`. When enabled, lines consisting only of comments (`//` or `/* */`) are not counted towards the maximum line limit.

--- a/crates/biome_analyze/src/utils.rs
+++ b/crates/biome_analyze/src/utils.rs
@@ -235,30 +235,71 @@ where
 /// Counts lines in a syntax tree, used by `noExcessiveLinesPerFile`.
 ///
 /// When `skip_blank_lines` is true, counts tokens with leading newlines (excluding blank lines).
+/// When `skip_comments` is true, lines consisting only of comments are not counted.
 /// When false, counts all newline characters in leading trivia (trailing trivia is trimmed
 /// to prevent double-counting). Returns total + 1 to account for the first line.
 pub fn count_lines_in_file<L: Language>(
     node: &SyntaxNode<L>,
     is_eof_token: impl Fn(&SyntaxToken<L>) -> bool,
     skip_blank_lines: bool,
+    skip_comments: bool,
 ) -> usize {
-    let mut count = 0;
-    for descendant in node.descendants() {
-        for token in descendant.tokens() {
-            if is_eof_token(&token) {
+    if skip_comments {
+        // Operate on raw text for accurate detection of comment-only lines
+        let text = node.text_with_trivia().to_string();
+        let mut count = 0;
+        let mut in_block_comment = false;
+
+        for line in text.lines() {
+            let trimmed = line.trim();
+
+            // Handle block comments (/* ... */)
+            if in_block_comment {
+                if trimmed.contains("*/") {
+                    in_block_comment = false;
+                }
                 continue;
             }
-            if skip_blank_lines {
-                count += token.has_leading_newline() as usize;
-            } else {
-                count += token
-                    .trim_trailing_trivia()
-                    .leading_trivia()
-                    .pieces()
-                    .filter(|piece| piece.is_newline())
-                    .count();
+            if trimmed.starts_with("/*") {
+                in_block_comment = true;
+                if trimmed.contains("*/") {
+                    in_block_comment = false;
+                }
+                continue;
+            }
+
+            // Skip blank lines if enabled
+            if skip_blank_lines && trimmed.is_empty() {
+                continue;
+            }
+
+            // Skip single-line comments
+            if trimmed.starts_with("//") {
+                continue;
+            }
+
+            count += 1;
+        }
+        count
+    } else {
+        let mut count = 0;
+        for descendant in node.descendants() {
+            for token in descendant.tokens() {
+                if is_eof_token(&token) {
+                    continue;
+                }
+                if skip_blank_lines {
+                    count += token.has_leading_newline() as usize;
+                } else {
+                    count += token
+                        .trim_trailing_trivia()
+                        .leading_trivia()
+                        .pieces()
+                        .filter(|piece| piece.is_newline())
+                        .count();
+                }
             }
         }
+        count + 1
     }
-    count + 1
 }

--- a/crates/biome_analyze/src/utils.rs
+++ b/crates/biome_analyze/src/utils.rs
@@ -1,6 +1,6 @@
 use biome_rowan::{
-    AstNode, AstSeparatedElement, AstSeparatedList, Language, SyntaxError, SyntaxNode, SyntaxToken,
-    chain_trivia_pieces, trim_trailing_trivia_pieces,
+    AstNode, AstSeparatedElement, AstSeparatedList, Direction, Language, SyntaxError, SyntaxNode,
+    SyntaxToken, chain_trivia_pieces, trim_trailing_trivia_pieces,
 };
 use std::cmp::Ordering;
 
@@ -245,40 +245,25 @@ pub fn count_lines_in_file<L: Language>(
     skip_comments: bool,
 ) -> usize {
     if skip_comments {
-        // Operate on raw text for accurate detection of comment-only lines
-        let text = node.text_with_trivia().to_string();
+        // Each code token occupies exactly one line. Comments are stored as
+        // leading trivia of the following token, so comment-only lines never
+        // have a token starting on them. Counting tokens that begin a new line
+        // (have a leading newline) plus the first line gives the number of
+        // lines that contain code.
         let mut count = 0;
-        let mut in_block_comment = false;
+        let mut first_token_seen = false;
 
-        for line in text.lines() {
-            let trimmed = line.trim();
-
-            // Handle block comments (/* ... */)
-            if in_block_comment {
-                if trimmed.contains("*/") {
-                    in_block_comment = false;
-                }
-                continue;
-            }
-            if trimmed.starts_with("/*") {
-                in_block_comment = true;
-                if trimmed.contains("*/") {
-                    in_block_comment = false;
-                }
+        for token in node.descendants_tokens(biome_rowan::Direction::Next) {
+            if is_eof_token(&token) {
                 continue;
             }
 
-            // Skip blank lines if enabled
-            if skip_blank_lines && trimmed.is_empty() {
-                continue;
+            if !first_token_seen {
+                first_token_seen = true;
+                count = 1;
+            } else if token.has_leading_newline() {
+                count += 1;
             }
-
-            // Skip single-line comments
-            if trimmed.starts_with("//") {
-                continue;
-            }
-
-            count += 1;
         }
         count
     } else {

--- a/crates/biome_css_analyze/src/lint/style/no_excessive_lines_per_file.rs
+++ b/crates/biome_css_analyze/src/lint/style/no_excessive_lines_per_file.rs
@@ -94,6 +94,34 @@ declare_lint_rule! {
     /// .b { color: blue; }
     /// ```
     ///
+    /// ### `skipComments`
+    ///
+    /// When this option is set to `true`, lines that only contain comments are not
+    /// counted towards the maximum line limit.
+    /// This means that only lines with actual code will be counted.
+    ///
+    /// Default: `false`
+    ///
+    /// #### Examples
+    ///
+    /// The following example shows how `skipComments` can prevent a diagnostic by excluding
+    /// comment lines from the total count:
+    ///
+    /// ```json,options
+    /// {
+    ///     "options": {
+    ///         "maxLines": 2,
+    ///         "skipComments": true
+    ///     }
+    /// }
+    /// ```
+    /// ```css,use_options
+    /// /* this is a comment */
+    /// /* another comment */
+    /// .a { color: red; }
+    /// .b { color: blue; }
+    /// ```
+    ///
     /// ## Suppressions
     ///
     /// If you need to exceed the line limit in a specific file, you can suppress this rule
@@ -135,6 +163,7 @@ impl Rule for NoExcessiveLinesPerFile {
             node.syntax(),
             |token| token.kind() == CssSyntaxKind::EOF,
             options.skip_blank_lines(),
+            options.skip_comments(),
         );
 
         if file_lines_count > options.max_lines().get().into() {

--- a/crates/biome_graphql_analyze/src/lint/style/no_excessive_lines_per_file.rs
+++ b/crates/biome_graphql_analyze/src/lint/style/no_excessive_lines_per_file.rs
@@ -135,6 +135,7 @@ impl Rule for NoExcessiveLinesPerFile {
             node.syntax(),
             |token| token.kind() == GraphqlSyntaxKind::EOF,
             options.skip_blank_lines(),
+            options.skip_comments(),
         );
 
         if file_lines_count > options.max_lines().get().into() {

--- a/crates/biome_html_analyze/src/lint/style/no_excessive_lines_per_file.rs
+++ b/crates/biome_html_analyze/src/lint/style/no_excessive_lines_per_file.rs
@@ -135,6 +135,7 @@ impl Rule for NoExcessiveLinesPerFile {
             node.syntax(),
             |token| token.kind() == HtmlSyntaxKind::EOF,
             options.skip_blank_lines(),
+            options.skip_comments(),
         );
 
         if file_lines_count > options.max_lines().get().into() {

--- a/crates/biome_js_analyze/src/lint/style/no_excessive_lines_per_file.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_excessive_lines_per_file.rs
@@ -114,6 +114,33 @@ declare_lint_rule! {
     /// const c = 3;
     /// ```
     ///
+    /// ### `skipComments`
+    ///
+    /// When this option is set to `true`, lines that only contain comments are not
+    /// counted towards the maximum line limit.
+    /// This means that only lines with actual code will be counted.
+    ///
+    /// Default: `false`
+    ///
+    /// #### Examples
+    ///
+    /// The following example shows how `skipComments` can prevent a diagnostic by excluding
+    /// comment lines from the total count:
+    ///
+    /// ```json,options
+    /// {
+    ///     "options": {
+    ///         "maxLines": 2,
+    ///         "skipComments": true
+    ///     }
+    /// }
+    /// ```
+    /// ```js,use_options
+    /// // this is a comment
+    /// /* block comment */
+    /// const a = 1;
+    /// const b = 2;
+    /// ```
     pub NoExcessiveLinesPerFile {
         version: "2.3.12",
         name: "noExcessiveLinesPerFile",
@@ -137,6 +164,7 @@ impl Rule for NoExcessiveLinesPerFile {
             node.syntax(),
             |token| token.kind() == JsSyntaxKind::EOF,
             options.skip_blank_lines(),
+            options.skip_comments(),
         );
 
         if file_lines_count > options.max_lines().get().into() {

--- a/crates/biome_js_analyze/tests/specs/style/noExcessiveLinesPerFile/skipComments.js
+++ b/crates/biome_js_analyze/tests/specs/style/noExcessiveLinesPerFile/skipComments.js
@@ -1,3 +1,4 @@
+/* should not generate diagnostics */
 // Header comment
 // Another comment
 /* Block comment */

--- a/crates/biome_js_analyze/tests/specs/style/noExcessiveLinesPerFile/skipComments.js
+++ b/crates/biome_js_analyze/tests/specs/style/noExcessiveLinesPerFile/skipComments.js
@@ -1,0 +1,6 @@
+// Header comment
+// Another comment
+/* Block comment */
+const a = 1;
+const b = 2;
+const c = 3;

--- a/crates/biome_js_analyze/tests/specs/style/noExcessiveLinesPerFile/skipComments.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/noExcessiveLinesPerFile/skipComments.js.snap
@@ -4,6 +4,7 @@ expression: skipComments.js
 ---
 # Input
 ```js
+/* should not generate diagnostics */
 // Header comment
 // Another comment
 /* Block comment */

--- a/crates/biome_js_analyze/tests/specs/style/noExcessiveLinesPerFile/skipComments.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/noExcessiveLinesPerFile/skipComments.js.snap
@@ -1,0 +1,46 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: skipComments.js
+---
+# Input
+```js
+// Header comment
+// Another comment
+/* Block comment */
+const a = 1;
+const b = 2;
+const c = 3;
+
+```
+
+# Diagnostics
+```
+skipComments.options:2:5 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Found an unknown key `options`.
+  
+    1 │ {
+  > 2 │     "options": {
+      │     ^^^^^^^^^
+    3 │         "maxLines": 3,
+    4 │         "skipComments": true
+  
+  i Known keys:
+  
+  - $schema
+  - root
+  - extends
+  - vcs
+  - files
+  - formatter
+  - linter
+  - javascript
+  - json
+  - css
+  - grit
+  - html
+  - overrides
+  - assist
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/style/noExcessiveLinesPerFile/skipComments.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/noExcessiveLinesPerFile/skipComments.js.snap
@@ -12,35 +12,3 @@ const b = 2;
 const c = 3;
 
 ```
-
-# Diagnostics
-```
-skipComments.options:2:5 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Found an unknown key `options`.
-  
-    1 │ {
-  > 2 │     "options": {
-      │     ^^^^^^^^^
-    3 │         "maxLines": 3,
-    4 │         "skipComments": true
-  
-  i Known keys:
-  
-  - $schema
-  - root
-  - extends
-  - vcs
-  - files
-  - formatter
-  - linter
-  - javascript
-  - json
-  - css
-  - grit
-  - html
-  - overrides
-  - assist
-  
-
-```

--- a/crates/biome_js_analyze/tests/specs/style/noExcessiveLinesPerFile/skipComments.options.json
+++ b/crates/biome_js_analyze/tests/specs/style/noExcessiveLinesPerFile/skipComments.options.json
@@ -1,6 +1,16 @@
 {
-    "options": {
-        "maxLines": 3,
-        "skipComments": true
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "rules": {
+      "style": {
+        "noExcessiveLinesPerFile": {
+          "level": "error",
+          "options": {
+            "maxLines": 3,
+            "skipComments": true
+          }
+        }
+      }
     }
+  }
 }

--- a/crates/biome_js_analyze/tests/specs/style/noExcessiveLinesPerFile/skipComments.options.json
+++ b/crates/biome_js_analyze/tests/specs/style/noExcessiveLinesPerFile/skipComments.options.json
@@ -1,0 +1,6 @@
+{
+    "options": {
+        "maxLines": 3,
+        "skipComments": true
+    }
+}

--- a/crates/biome_js_analyze/tests/specs/style/noExcessiveLinesPerFile/skipCommentsInvalid.js
+++ b/crates/biome_js_analyze/tests/specs/style/noExcessiveLinesPerFile/skipCommentsInvalid.js
@@ -1,3 +1,4 @@
+/* should generate diagnostics */
 // This comment won't count
 const a = 1;
 const b = 2;

--- a/crates/biome_js_analyze/tests/specs/style/noExcessiveLinesPerFile/skipCommentsInvalid.js
+++ b/crates/biome_js_analyze/tests/specs/style/noExcessiveLinesPerFile/skipCommentsInvalid.js
@@ -1,0 +1,5 @@
+// This comment won't count
+const a = 1;
+const b = 2;
+const c = 3;
+const d = 4;

--- a/crates/biome_js_analyze/tests/specs/style/noExcessiveLinesPerFile/skipCommentsInvalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/noExcessiveLinesPerFile/skipCommentsInvalid.js.snap
@@ -4,6 +4,7 @@ expression: skipCommentsInvalid.js
 ---
 # Input
 ```js
+/* should generate diagnostics */
 // This comment won't count
 const a = 1;
 const b = 2;
@@ -14,32 +15,21 @@ const d = 4;
 
 # Diagnostics
 ```
-skipCommentsInvalid.options:2:5 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+skipCommentsInvalid.js:3:1 lint/style/noExcessiveLinesPerFile ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Found an unknown key `options`.
+  i This file has too many lines (4). Maximum allowed is 3.
   
-    1 │ {
-  > 2 │     "options": {
-      │     ^^^^^^^^^
-    3 │         "maxLines": 3,
-    4 │         "skipComments": true
+    1 │ /* should generate diagnostics */
+    2 │ // This comment won't count
+  > 3 │ const a = 1;
+      │ ^^^^^^^^^^^^
+  > 4 │ const b = 2;
+  > 5 │ const c = 3;
+  > 6 │ const d = 4;
+      │ ^^^^^^^^^^^^
+    7 │ 
   
-  i Known keys:
-  
-  - $schema
-  - root
-  - extends
-  - vcs
-  - files
-  - formatter
-  - linter
-  - javascript
-  - json
-  - css
-  - grit
-  - html
-  - overrides
-  - assist
+  i Consider splitting this file into smaller files.
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/style/noExcessiveLinesPerFile/skipCommentsInvalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/noExcessiveLinesPerFile/skipCommentsInvalid.js.snap
@@ -1,0 +1,45 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: skipCommentsInvalid.js
+---
+# Input
+```js
+// This comment won't count
+const a = 1;
+const b = 2;
+const c = 3;
+const d = 4;
+
+```
+
+# Diagnostics
+```
+skipCommentsInvalid.options:2:5 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Found an unknown key `options`.
+  
+    1 │ {
+  > 2 │     "options": {
+      │     ^^^^^^^^^
+    3 │         "maxLines": 3,
+    4 │         "skipComments": true
+  
+  i Known keys:
+  
+  - $schema
+  - root
+  - extends
+  - vcs
+  - files
+  - formatter
+  - linter
+  - javascript
+  - json
+  - css
+  - grit
+  - html
+  - overrides
+  - assist
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/style/noExcessiveLinesPerFile/skipCommentsInvalid.options.json
+++ b/crates/biome_js_analyze/tests/specs/style/noExcessiveLinesPerFile/skipCommentsInvalid.options.json
@@ -1,6 +1,16 @@
 {
-    "options": {
-        "maxLines": 3,
-        "skipComments": true
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "rules": {
+      "style": {
+        "noExcessiveLinesPerFile": {
+          "level": "error",
+          "options": {
+            "maxLines": 3,
+            "skipComments": true
+          }
+        }
+      }
     }
+  }
 }

--- a/crates/biome_js_analyze/tests/specs/style/noExcessiveLinesPerFile/skipCommentsInvalid.options.json
+++ b/crates/biome_js_analyze/tests/specs/style/noExcessiveLinesPerFile/skipCommentsInvalid.options.json
@@ -1,0 +1,6 @@
+{
+    "options": {
+        "maxLines": 3,
+        "skipComments": true
+    }
+}

--- a/crates/biome_rule_options/src/no_excessive_lines_per_file.rs
+++ b/crates/biome_rule_options/src/no_excessive_lines_per_file.rs
@@ -11,11 +11,17 @@ pub struct NoExcessiveLinesPerFileOptions {
     /// When this option is set to `true`, blank lines are not counted towards the maximum line limit.
     #[serde(skip_serializing_if = "Option::<_>::is_none")]
     pub skip_blank_lines: Option<bool>,
+
+    /// When this option is set to `true`, lines that only contain comments
+    /// are not counted towards the maximum line limit.
+    #[serde(skip_serializing_if = "Option::<_>::is_none")]
+    pub skip_comments: Option<bool>,
 }
 
 impl NoExcessiveLinesPerFileOptions {
     pub const DEFAULT_MAX_LINES: NonZeroU16 = NonZeroU16::new(300).unwrap();
     pub const DEFAULT_SKIP_BLANK_LINES: bool = false;
+    pub const DEFAULT_SKIP_COMMENTS: bool = false;
 
     /// Returns [`Self::max_lines`] if it is set.
     /// Otherwise, returns [`Self::DEFAULT_MAX_LINES`].
@@ -28,5 +34,11 @@ impl NoExcessiveLinesPerFileOptions {
     pub fn skip_blank_lines(&self) -> bool {
         self.skip_blank_lines
             .unwrap_or(Self::DEFAULT_SKIP_BLANK_LINES)
+    }
+
+    /// Returns [`Self::skip_comments`] if it is set.
+    /// Otherwise, returns [`Self::DEFAULT_SKIP_COMMENTS`].
+    pub fn skip_comments(&self) -> bool {
+        self.skip_comments.unwrap_or(Self::DEFAULT_SKIP_COMMENTS)
     }
 }

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -8681,6 +8681,11 @@ export interface NoExcessiveLinesPerFileOptions {
 	 * When this option is set to `true`, blank lines are not counted towards the maximum line limit.
 	 */
 	skipBlankLines?: boolean;
+	/**
+	* When this option is set to `true`, lines that only contain comments
+are not counted towards the maximum line limit. 
+	 */
+	skipComments?: boolean;
 }
 export type NoExportedImportsOptions = {};
 export type NoHeadElementOptions = {};

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -4000,6 +4000,10 @@
 				"skipBlankLines": {
 					"description": "When this option is set to `true`, blank lines are not counted towards the maximum line limit.",
 					"type": ["boolean", "null"]
+				},
+				"skipComments": {
+					"description": "When this option is set to `true`, lines that only contain comments\nare not counted towards the maximum line limit.",
+					"type": ["boolean", "null"]
 				}
 			},
 			"additionalProperties": false


### PR DESCRIPTION
## Summary

Adds `skipComments` option to `noExcessiveLinesPerFile` across JS, CSS, GraphQL, and HTML analyzers.
When set to `true`, lines consisting only of `//` or `/* */` comments are excluded from the line count.
This brings the rule closer to feature parity with ESLint's `max-lines` rule.

## Test Plan

- Added `skipComments.js` and `skipCommentsInvalid.js` snapshot tests in `biome_js_analyze`
- Verified locally with `cargo test` and a Node.js project using the compiled binary

## Docs

Rustdoc examples added to `declare_lint_rule!` for JS and CSS rules. HTML excluded because `<!-- -->` comments are not yet supported by the line-counting logic.
