### PR TITLE
fix(useAwait): treat await using as an async operation

### DIFF
--- a/.changeset/cuddly-places-bow.md
+++ b/.changeset/cuddly-places-bow.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11250](https://github.com/biomejs/biome/issues/11250): [`useAwait`](https://biomejs.dev/linter/rules/use-await/) no longer reports async functions that contain an `await using` declaration.

--- a/crates/biome_js_analyze/src/lint/suspicious/use_await.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/use_await.rs
@@ -5,8 +5,8 @@ use biome_analyze::{
 use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_syntax::{
-    AnyFunctionLike, JsAwaitExpression, JsForOfStatement, JsLanguage, JsYieldExpression,
-    TextRange, WalkEvent,
+    AnyFunctionLike, JsAwaitExpression, JsForOfStatement, JsForVariableDeclaration, JsLanguage,
+    JsVariableDeclaration, JsYieldExpression, TextRange, WalkEvent,
 };
 use biome_rowan::{AstNode, AstNodeList, Language, SyntaxNode, TextSize};
 use biome_rule_options::use_await::UseAwaitOptions;
@@ -14,11 +14,11 @@ use biome_rule_options::use_await::UseAwaitOptions;
 declare_lint_rule! {
     /// Ensure `async` functions utilize `await`.
     ///
-    /// This rule reports `async` functions that lack an `await` expression. As `async`
-    /// functions return a promise, the use of `await` is often necessary to capture the
-    /// resolved value and handle the asynchronous operation appropriately. Without `await`,
-    /// the function operates synchronously and might not leverage the advantages of async
-    /// functions.
+    /// This rule reports `async` functions that lack an `await` expression or another
+    /// operation that requires async semantics. As `async` functions return a promise, the
+    /// use of `await` is often necessary to capture the resolved value and handle the
+    /// asynchronous operation appropriately. Without `await`, the function operates
+    /// synchronously and might not leverage the advantages of async functions.
     ///
     /// ## Examples
     ///
@@ -51,6 +51,12 @@ declare_lint_rule! {
     /// // Async generators that use `yield*` with an async iterable
     /// async function* delegateToAsyncIterable() {
     ///   yield* otherAsyncIterable();
+    /// }
+    ///
+    /// // `await using` awaits asynchronous resource disposal
+    /// async function consumeResource() {
+    ///   await using resource = acquire();
+    ///   consume(resource);
     /// }
     /// ```
     pub UseAwait {
@@ -93,6 +99,10 @@ impl Visitor for MissingAwaitVisitor {
                         *has_await = true;
                     } else if let Some(for_of) = JsForOfStatement::cast_ref(node) {
                         *has_await = *has_await || for_of.await_token().is_some();
+                    } else if let Some(declaration) = JsVariableDeclaration::cast_ref(node) {
+                        *has_await = *has_await || declaration.await_token().is_some();
+                    } else if let Some(declaration) = JsForVariableDeclaration::cast_ref(node) {
+                        *has_await = *has_await || declaration.await_token().is_some();
                     } else if let Some(yield_expr) = JsYieldExpression::cast_ref(node) {
                         *has_await = *has_await
                             || yield_expr

--- a/crates/biome_js_analyze/tests/specs/suspicious/useAwait/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/suspicious/useAwait/invalid.js
@@ -93,3 +93,8 @@ async function* yieldWithoutStar() {
 	yield 1;
 	yield 2;
 }
+
+async function withUsing() {
+	using resource = acquire();
+	consume(resource);
+}

--- a/crates/biome_js_analyze/tests/specs/suspicious/useAwait/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/useAwait/invalid.js.snap
@@ -100,6 +100,11 @@ async function* yieldWithoutStar() {
 	yield 2;
 }
 
+async function withUsing() {
+	using resource = acquire();
+	consume(resource);
+}
+
 ```
 
 # Diagnostics
@@ -609,6 +614,7 @@ invalid.js:92:1 lint/suspicious/useAwait ━━━━━━━━━━━━━
   > 95 │ }
        │ ^
     96 │ 
+    97 │ async function withUsing() {
   
   i Remove this async modifier, or add an await expression in the function.
   
@@ -621,6 +627,39 @@ invalid.js:92:1 lint/suspicious/useAwait ━━━━━━━━━━━━━
   > 95 │ }
        │ ^
     96 │ 
+    97 │ async function withUsing() {
+  
+  i Async functions without await expressions may not need to be declared async.
+  
+
+```
+
+```
+invalid.js:97:1 lint/suspicious/useAwait ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This async function lacks an await expression.
+  
+     95 │ }
+     96 │ 
+   > 97 │ async function withUsing() {
+        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   > 98 │ 	using resource = acquire();
+   > 99 │ 	consume(resource);
+  > 100 │ }
+        │ ^
+    101 │ 
+  
+  i Remove this async modifier, or add an await expression in the function.
+  
+     95 │ }
+     96 │ 
+   > 97 │ async function withUsing() {
+        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   > 98 │ 	using resource = acquire();
+   > 99 │ 	consume(resource);
+  > 100 │ }
+        │ ^
+    101 │ 
   
   i Async functions without await expressions may not need to be declared async.
   

--- a/crates/biome_js_analyze/tests/specs/suspicious/useAwait/valid.js
+++ b/crates/biome_js_analyze/tests/specs/suspicious/useAwait/valid.js
@@ -76,3 +76,18 @@ async function* yieldStarWithAwait() {
 	yield* processData(data);
 }
 
+async function withAwaitUsing() {
+	await using resource = acquire();
+	consume(resource);
+}
+
+async function* withAwaitUsingGenerator() {
+	await using resource = acquire();
+	yield resource;
+}
+
+async function withAwaitUsingForOf() {
+	for (await using resource of resources) {
+		consume(resource);
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/suspicious/useAwait/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/useAwait/valid.js.snap
@@ -82,5 +82,20 @@ async function* yieldStarWithAwait() {
 	yield* processData(data);
 }
 
+async function withAwaitUsing() {
+	await using resource = acquire();
+	consume(resource);
+}
+
+async function* withAwaitUsingGenerator() {
+	await using resource = acquire();
+	yield resource;
+}
+
+async function withAwaitUsingForOf() {
+	for (await using resource of resources) {
+		consume(resource);
+	}
+}
 
 ```


### PR DESCRIPTION
## Summary

Fixes #11250

`useAwait` now treats `await using` declarations as async operations.

> This PR was primarily implemented with OpenAI Codex, including codebase analysis, code changes, tests, validation, and preparation of this description.

## Test Plan

Added regression coverage for `await using` in async functions, async generators, and `for...of`, plus a control case for plain `using`.

## Docs

Updated the rule documentation with an `await using` example.
