### PR TITLE
fix(cli): preserve Unicode in stdin output

### DIFF
--- a/.changeset/common-toes-grow.md
+++ b/.changeset/common-toes-grow.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10395](https://github.com/biomejs/biome/issues/10395): Formatting standard input now preserves Unicode characters in non-terminal output.

--- a/crates/biome_cli/src/runner/impls/process_file/format.rs
+++ b/crates/biome_cli/src/runner/impls/process_file/format.rs
@@ -142,7 +142,7 @@ impl ProcessFile for FormatProcessFile {
         })?;
 
         if file_features.is_ignored() {
-            console.append(markup! {{content}});
+            console.append_raw(content);
             // Write error last because files may generally be long
             console.error(markup! {
                 <Warn>"The content was not formatted because the path `"{biome_path.as_str()}"` is ignored."</Warn>
@@ -159,7 +159,7 @@ impl ProcessFile for FormatProcessFile {
             } else {
                 console.error(markup! {{PrintDiagnostic::simple(&protected_diagnostic)}})
             }
-            console.append(markup! {{content}});
+            console.append_raw(content);
             return Ok(());
         };
         if file_features.supports_format() {
@@ -186,12 +186,10 @@ impl ProcessFile for FormatProcessFile {
             if result.format_with_errors_disabled {
                 return Err(WorkspaceError::format_with_errors_disabled().into());
             }
-            console.append(markup! {{source}});
+            console.append_raw(source);
             Ok(())
         } else {
-            console.append(markup! {
-                {content}
-            });
+            console.append_raw(content);
             console.error(markup! {
                 <Warn>"The content was not formatted because the formatter is currently disabled."</Warn>
             });

--- a/crates/biome_cli/src/runner/impls/process_file/lint_and_assist.rs
+++ b/crates/biome_cli/src/runner/impls/process_file/lint_and_assist.rs
@@ -147,7 +147,7 @@ impl ProcessFile for LintAssistProcessFile {
         })?;
 
         if file_features.is_ignored() {
-            console.append(markup! {{content}});
+            console.append_raw(content);
             // Write error last because files may generally be long
             console.error(markup! {
                 <Warn>"The content was not fixed because the path `"{biome_path.as_str()}"` is ignored."</Warn>
@@ -164,7 +164,7 @@ impl ProcessFile for LintAssistProcessFile {
             } else {
                 console.error(markup! {{PrintDiagnostic::simple(&protected_diagnostic)}})
             }
-            console.append(markup! {{content}});
+            console.append_raw(content);
 
             return Ok(());
         };
@@ -209,7 +209,7 @@ impl ProcessFile for LintAssistProcessFile {
             skip_parse_errors: execution.should_skip_parse_errors(),
         })?;
         let source = result.output.as_deref().unwrap_or(content);
-        console.append(markup! {{source}});
+        console.append_raw(source);
 
         if result.output.is_none() && !execution.requires_write_access() {
             Err(StdinDiagnostic::new_not_formatted().into())

--- a/crates/biome_cli/src/runner/mod.rs
+++ b/crates/biome_cli/src/runner/mod.rs
@@ -304,7 +304,7 @@ pub(crate) trait CommandRunner {
                 console.error(markup! {
                     {PrintDiagnostic::simple(&CliDiagnostic::from(StdinDiagnostic::new_no_extension()))}
                 });
-                console.append(markup! {{content}});
+                console.append_raw(&content);
                 return Ok(());
             }
 

--- a/crates/biome_cli/tests/commands/mod.rs
+++ b/crates/biome_cli/tests/commands/mod.rs
@@ -9,4 +9,5 @@ mod migrate_eslint;
 mod migrate_prettier;
 mod rage;
 mod search;
+mod stdin_output;
 mod version;

--- a/crates/biome_cli/tests/commands/stdin_output.rs
+++ b/crates/biome_cli/tests/commands/stdin_output.rs
@@ -1,0 +1,112 @@
+use crate::run_cli;
+use biome_console::{Console, LogLevel, Markup};
+use biome_fs::MemoryFileSystem;
+use bpaf::Args;
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+const SOURCE: &str = "const warning = `\u{26a0}`;\nconst success = `\u{2714}`;\n";
+
+#[derive(Default)]
+struct SanitizingConsole {
+    stdout: String,
+    stderr: String,
+    stdin: Option<String>,
+}
+
+impl SanitizingConsole {
+    fn with_stdin(content: &str) -> Self {
+        Self {
+            stdin: Some(content.to_string()),
+            ..Self::default()
+        }
+    }
+
+    fn push(&mut self, level: LogLevel, content: &str) {
+        match level {
+            LogLevel::Error => self.stderr.push_str(content),
+            LogLevel::Log => self.stdout.push_str(content),
+        }
+    }
+
+    fn render(args: Markup) -> String {
+        args.to_owned()
+            .0
+            .into_iter()
+            .map(|node| node.content)
+            .collect::<String>()
+            .replace('\u{26a0}', "!")
+            .replace('\u{2714}', "\u{221a}")
+    }
+}
+
+impl Console for SanitizingConsole {
+    fn println(&mut self, level: LogLevel, args: Markup) {
+        let mut content = Self::render(args);
+        content.push('\n');
+        self.push(level, &content);
+    }
+
+    fn print(&mut self, level: LogLevel, args: Markup) {
+        self.push(level, &Self::render(args));
+    }
+
+    fn print_raw(&mut self, level: LogLevel, content: &str) {
+        self.push(level, content);
+    }
+
+    fn read(&mut self) -> Option<String> {
+        self.stdin.take()
+    }
+}
+
+fn assert_stdin_output(args: &[&str]) {
+    let mut console = SanitizingConsole::with_stdin(SOURCE);
+    let (_, result) = run_cli(MemoryFileSystem::default(), &mut console, Args::from(args));
+
+    assert!(result.is_ok(), "CLI returned {result:?}");
+    assert_eq!(console.stdout, SOURCE);
+}
+
+#[test]
+fn format_stdin_preserves_unicode_source() {
+    assert_stdin_output(&["format", "--stdin-file-path=probe.ts"]);
+}
+
+#[test]
+fn check_write_stdin_preserves_unicode_source() {
+    assert_stdin_output(&["check", "--write", "--stdin-file-path=probe.ts"]);
+}
+
+#[test]
+fn extension_error_preserves_unicode_source() {
+    assert_stdin_output(&["format", "--stdin-file-path=probe"]);
+}
+
+#[test]
+fn env_console_preserves_unicode_source() {
+    for colors in ["--colors=off", "--colors=force"] {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_biome"))
+            .args(["format", colors, "--stdin-file-path=probe.ts"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("failed to run biome");
+
+        child
+            .stdin
+            .take()
+            .expect("missing stdin")
+            .write_all(SOURCE.as_bytes())
+            .expect("failed to write stdin");
+
+        let output = child.wait_with_output().expect("failed to read output");
+        assert!(
+            output.status.success(),
+            "biome failed with {colors}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(output.stdout, SOURCE.as_bytes(), "colors: {colors}");
+    }
+}

--- a/crates/biome_console/src/lib.rs
+++ b/crates/biome_console/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(clippy::use_self)]
 
+use crate as biome_console;
 use std::io;
 use std::io::{IsTerminal, Read, Write};
 use std::panic::RefUnwindSafe;
@@ -37,6 +38,14 @@ pub trait Console: Send + Sync + RefUnwindSafe {
     /// Prints a message (formatted using [markup!]) to the console.
     fn print(&mut self, level: LogLevel, args: Markup);
 
+    /// Prints text without applying markup formatting or terminal sanitization.
+    ///
+    /// Console implementations that transform text in [Console::print] should override this
+    /// method when they can preserve the original bytes.
+    fn print_raw(&mut self, level: LogLevel, content: &str) {
+        self.print(level, markup! {{content}});
+    }
+
     /// It reads from a source, and if this source contains something, it's converted into a [String]
     fn read(&mut self) -> Option<String>;
 
@@ -63,6 +72,9 @@ pub trait ConsoleExt: Console {
     ///
     /// It doesn't add any line
     fn append(&mut self, args: Markup);
+
+    /// Prints text unchanged with level [LogLevel::Log].
+    fn append_raw(&mut self, content: &str);
 }
 
 impl<T: Console + ?Sized> ConsoleExt for T {
@@ -76,6 +88,10 @@ impl<T: Console + ?Sized> ConsoleExt for T {
 
     fn append(&mut self, args: Markup) {
         self.print(LogLevel::Log, args);
+    }
+
+    fn append_raw(&mut self, content: &str) {
+        self.print_raw(LogLevel::Log, content);
     }
 }
 
@@ -172,6 +188,15 @@ impl Console for EnvConsole {
             .unwrap();
 
         write!(out, "").unwrap();
+    }
+
+    fn print_raw(&mut self, level: LogLevel, content: &str) {
+        let mut out = match level {
+            LogLevel::Error => self.err.lock(),
+            LogLevel::Log => self.out.lock(),
+        };
+
+        out.write_all(content.as_bytes()).unwrap();
     }
 
     fn read(&mut self) -> Option<String> {


### PR DESCRIPTION
## Summary

  Fixes #10395.

  Formatting source code from stdin reused the diagnostic markup output path. The terminal renderer intentionally replaces some Unicode characters with ASCII-safe alternatiives, which is appropriate for
  diagnostics but caused redirected source output to change characters such as ⚠ and ✔.

  This adds a raw console output path that writes UTF-8 text directly without markup rendering or Unicode sanitization. All stdin source-output paths now use it, including format, check --write, ignored or
  protected files, disabled formatting, and the missing-extension fallback. Diagnostic messages continue to use the existing renderer.

  ## Test Plan

  - Console tests: 17 unit tests 3 macro tests and 1 doctest passed.
  - CLI tests: 907 passed 3 ignored.
  - Added routing tests using a sanitizing console
  - Added a real CLI subprocess test that verifies exact stdout bytes with both --colors=off and --colors=force.
  - Scoped Clippy checks for biome_console and biome_cli passed
  - Rust and TOML formatting check passed
  - git diff --check passed
  - Full workspace Clippy was started but did not complete locally

  ## Docs

  This change does not add a configuration option or new public API. A patch changeset is included