### PR TITLE
fix(lsp): reparse open documents after settings load

### DIFF
--- a/.changeset/fix-embedded-lsp-formatting.md
+++ b/.changeset/fix-embedded-lsp-formatting.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11275](https://github.com/biomejs/biome/issues/11275): Fixed a bug that could cause formatting Astro, Vue, and Svelte files in editors to delete markup when full HTML support is enabled in a nested configuration. Changes to embedded snippet settings now also take effect for already-open files.

--- a/crates/biome_lsp/src/handlers/text_document.rs
+++ b/crates/biome_lsp/src/handlers/text_document.rs
@@ -221,8 +221,7 @@ pub(crate) async fn did_change(
         old_text,
         params.content_changes,
     );
-
-    session.insert_document(url.clone(), Document::new(doc.project_key, version, &text));
+    let document = Document::new(doc.project_key, version, &text);
 
     session.workspace().change_file(ChangeFileParams {
         project_key: doc.project_key,
@@ -232,6 +231,8 @@ pub(crate) async fn did_change(
         inline_config: session.inline_config(),
         editor_features: None,
     })?;
+
+    session.insert_document(url.clone(), document);
 
     session.schedule_diagnostics(url, version);
 

--- a/crates/biome_lsp/src/server.tests.rs
+++ b/crates/biome_lsp/src/server.tests.rs
@@ -133,6 +133,34 @@ fn create_document_content_change_event() -> Vec<TextDocumentContentChangeEvent>
     ]
 }
 
+fn apply_ascii_text_edits(source: &str, edits: Vec<TextEdit>) -> String {
+    let position_to_offset = |position: Position| {
+        source
+            .split_inclusive('\n')
+            .take(position.line as usize)
+            .map(str::len)
+            .sum::<usize>()
+            + position.character as usize
+    };
+    let mut edits = edits
+        .into_iter()
+        .map(|edit| {
+            (
+                position_to_offset(edit.range.start),
+                position_to_offset(edit.range.end),
+                edit.new_text,
+            )
+        })
+        .collect::<Vec<_>>();
+    edits.sort_unstable_by_key(|(start, _, _)| std::cmp::Reverse(*start));
+
+    let mut output = source.to_string();
+    for (start, end, new_text) in edits {
+        output.replace_range(start..end, &new_text);
+    }
+    output
+}
+
 fn full_document_change(text: impl Into<String>) -> Vec<TextDocumentContentChangeEvent> {
     vec![TextDocumentContentChangeEvent {
         range: None,
@@ -4702,6 +4730,115 @@ async fn should_acknowledge_changes_in_settings_in_formatting() -> Result<()> {
 
     server.close_document().await?;
 
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn should_reparse_open_embedded_language_files_after_loading_settings() -> Result<()> {
+    let documents = [
+        (
+            uri!("document.astro"),
+            "astro",
+            "---\nconst foo= 1;\n---\n<p>{foo}</p>\n",
+            "<p>{foo}</p>",
+        ),
+        (
+            uri!("document.vue"),
+            "vue",
+            "<script setup>const foo= 1;</script><template><p>{{ foo }}</p></template>\n",
+            "<template",
+        ),
+        (
+            uri!("document.svelte"),
+            "svelte",
+            "<script>const foo= 1;</script><p>{foo}</p>\n",
+            "<p>{foo}</p>",
+        ),
+        (
+            uri!("document.html"),
+            "html",
+            "<script>const foo= 1;</script><p>foo</p>\n",
+            "<p>foo</p>",
+        ),
+        (
+            uri!("document.svg"),
+            "xml",
+            "<svg><style>circle{fill:red}</style><script>const foo= 1;</script><circle /></svg>\n",
+            "<circle />",
+        ),
+    ];
+
+    let fs = Arc::new(MemoryFileSystem::default());
+    fs.insert(to_utf8_file_path_buf(uri!("biome.json")), "{}");
+
+    let factory = ServerFactory::new_with_fs(fs.clone());
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+    server.load_configuration().await?;
+
+    for (uri, language_id, source, _) in &documents {
+        server
+            .open_named_document(source, uri.clone(), language_id)
+            .await?;
+    }
+
+    fs.insert(
+        to_utf8_file_path_buf(uri!("biome.json")),
+        r#"{
+  "html": {
+    "experimentalFullSupportEnabled": true,
+    "formatter": {
+      "enabled": true
+    }
+  }
+}"#,
+    );
+    server.load_configuration().await?;
+
+    for (uri, _, source, expected_markup) in &documents {
+        let edits: Option<Vec<TextEdit>> = server
+            .request(
+                "textDocument/formatting",
+                "formatting",
+                DocumentFormattingParams {
+                    text_document: TextDocumentIdentifier { uri: uri.clone() },
+                    options: FormattingOptions::default(),
+                    work_done_progress_params: WorkDoneProgressParams {
+                        work_done_token: None,
+                    },
+                },
+            )
+            .await?
+            .context("formatting returned None")?;
+        let output = apply_ascii_text_edits(
+            source,
+            edits.context("formatting did not return an edit list")?,
+        );
+
+        assert!(output.contains("const foo = 1;"), "{output}");
+        assert!(output.contains(expected_markup), "{output}");
+    }
+
+    for (uri, _, _, _) in documents {
+        server
+            .notify(
+                "textDocument/didClose",
+                DidCloseTextDocumentParams {
+                    text_document: TextDocumentIdentifier { uri },
+                },
+            )
+            .await?;
+    }
     server.shutdown().await?;
     reader.abort();
 

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -23,7 +23,7 @@ use biome_service::projects::ProjectKey;
 use biome_service::settings::{EditorFeature, ModuleGraphResolutionKind};
 use biome_service::workspace::db::DbState;
 use biome_service::workspace::{
-    FeaturesBuilder, GetFileContentParams, OpenProjectParams, OpenProjectResult,
+    ChangeFileParams, FeaturesBuilder, GetFileContentParams, OpenProjectParams, OpenProjectResult,
     PullDiagnosticsParams, RetryingWorkspace, SupportsFeatureParams,
 };
 use biome_service::workspace::{FileFeaturesResult, ServiceNotification};
@@ -1059,6 +1059,60 @@ impl Session {
             let config_file_path = base_path.to_path_buf();
             let status = self.load_biome_configuration_file(base_path, reload).await;
             self.record_configuration_status(config_file_path.as_deref(), status);
+        }
+
+        self.reparse_open_documents().await;
+    }
+
+    async fn reparse_open_documents(self: &Arc<Self>) {
+        let documents = self
+            .documents
+            .pin()
+            .iter()
+            .map(|(url, document)| (url.clone(), document.clone()))
+            .collect::<Vec<_>>();
+        let session = self.clone();
+        let inline_config = self.inline_config();
+        let editor_features = self.extension_settings.read().editor_features();
+
+        if let Err(error) = spawn_blocking(move || {
+            for (url, document) in documents {
+                let path = match session.file_path(&url) {
+                    Ok(path) => path,
+                    Err(error) => {
+                        error!(
+                            "Failed to resolve the path of open document {}: {error}",
+                            url.as_str()
+                        );
+                        continue;
+                    }
+                };
+                let content = match session.workspace().get_file_content(GetFileContentParams {
+                    project_key: document.project_key,
+                    path: path.clone(),
+                }) {
+                    Ok(content) => content,
+                    Err(error) => {
+                        error!("Failed to read open document {}: {error}", url.as_str());
+                        continue;
+                    }
+                };
+
+                if let Err(error) = session.workspace().change_file(ChangeFileParams {
+                    project_key: document.project_key,
+                    path,
+                    content,
+                    version: document.version,
+                    inline_config: inline_config.clone(),
+                    editor_features: Some(editor_features),
+                }) {
+                    error!("Failed to reparse open document {}: {error}", url.as_str());
+                }
+            }
+        })
+        .await
+        {
+            error!("Failed to reparse open documents: {error}");
         }
     }
 

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -1098,10 +1098,7 @@ impl WorkspaceServerWithDb<'_> {
         node_cache: &mut NodeCache,
         settings: &SettingsWithEditor,
     ) -> Result<Vec<(AnyParse, EmbedContent, DocumentFileSource)>, WorkspaceError> {
-        let capabilities = self.get_file_capabilities(
-            path,
-            settings.as_ref().experimental_full_html_support_enabled(),
-        );
+        let capabilities = self.features.get_deprecated_capabilities(*file_source);
         let Some(parse_embedded_nodes) = capabilities.parser.parse_embedded_nodes else {
             return Ok(Default::default());
         };
@@ -2970,15 +2967,6 @@ impl Workspace for WorkspaceServerWithDb<'_> {
             });
         }
 
-        if existing_version == Some(version) {
-            let parsed = {
-                let db = self.get_db();
-                db.get_file(path.as_path())
-                    .ok_or_else(|| WorkspaceError::not_found(path.to_string()))?
-            };
-            return self.finish_change_file(project_key, &path, parsed);
-        }
-
         let settings = self
             .projects
             .get_settings_based_on_path(project_key, &path)
@@ -3001,10 +2989,23 @@ impl Workspace for WorkspaceServerWithDb<'_> {
         let persist_node_cache = node_cache.is_some();
         let mut node_cache = node_cache.unwrap_or_default();
 
-        let document_source = self.get_file_source(
+        let document_source = self
+            .db_get_source(index)
+            .ok_or_else(|| WorkspaceError::not_found(path.to_string()))?;
+        let path_source = DocumentFileSource::from_path(
             &path,
             settings.as_ref().experimental_full_html_support_enabled(),
         );
+        let source_changed = Self::should_prefer_path_source(document_source, path_source)
+            || Self::should_prefer_path_source(path_source, document_source);
+        let (index, document_source) = if source_changed {
+            (self.db_add_source(path_source), path_source)
+        } else {
+            (index, document_source)
+        };
+        if source_changed {
+            node_cache = NodeCache::default();
+        }
 
         let ParseResult {
             any_parse,

--- a/crates/biome_service/src/workspace/server.tests.rs
+++ b/crates/biome_service/src/workspace/server.tests.rs
@@ -153,6 +153,71 @@ fn process_file_preserves_embedded_content_after_formatting() {
 }
 
 #[test]
+fn change_file_reparses_javascript_embeds_with_current_settings() {
+    const PATH: &str = "/project/index.tsx";
+    const SOURCE: &str = r#"const styles = css`color:red`;
+const component = styled.div`color:red`;
+const wrapped = styled(Component)`color:red`;
+const query = gql`query { version }`;
+const other_query = graphql`query { version }`;
+const called_query = graphql(`query { version }`);
+"#;
+
+    let fs = MemoryFileSystem::default();
+    fs.insert(Utf8PathBuf::from(PATH), SOURCE);
+    let (workspace, project_key) = setup_workspace_and_open_project(fs, "/project");
+
+    workspace
+        .open_file(OpenFileParams {
+            project_key,
+            path: BiomePath::new(PATH),
+            content: FileContent::FromClient {
+                content: SOURCE.into(),
+                version: 0,
+            },
+            document_file_source: Some(DocumentFileSource::from_language_id(
+                "typescriptreact",
+                Some("tsx"),
+            )),
+            persist_node_cache: false,
+            inline_config: None,
+            editor_features: None,
+        })
+        .unwrap();
+
+    assert!(workspace.get_snippets(Utf8Path::new(PATH)).is_empty());
+
+    workspace
+        .update_settings(UpdateSettingsParams {
+            project_key,
+            workspace_directory: Some(BiomePath::new("/project")),
+            configuration: Configuration {
+                javascript: Some(JsConfiguration {
+                    experimental_embedded_snippets_enabled: Some(true.into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            extended_configurations: vec![],
+            module_graph_resolution_kind: ModuleGraphResolutionKind::None,
+        })
+        .unwrap();
+
+    workspace
+        .change_file(ChangeFileParams {
+            project_key,
+            path: BiomePath::new(PATH),
+            content: SOURCE.into(),
+            version: 0,
+            inline_config: None,
+            editor_features: None,
+        })
+        .unwrap();
+
+    assert_eq!(workspace.get_snippets(Utf8Path::new(PATH)).len(), 6);
+}
+
+#[test]
 fn change_file_resumes_module_update_after_cancellation() {
     const BASE_PATH: &str = "/project/base.ts";
     const INDEX_PATH: &str = "/project/index.ts";


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
implemented by gpt 5.6 sol

fixes #11275

This is the class of bug that salsa will hopefully help us avoid (when/if we integrate it more).

Here's my clanker's abbreviated explanation of the bug:

The bug required this sequence:

1. The editor opened an Astro, Vue, or Svelte file.
2. Biome had not yet discovered or applied the nested biome.json enabling full HTML support.
3. Biome therefore parsed the document using the legacy JavaScript source.
4. Project scanning later discovered the nested configuration and enabled full HTML support.
5. Biome updated its settings, but did not reparse documents that were already open.
6. A formatting request then combined the new settings with the old parsed document.

The central problem was that configuration and parsed state could disagree:

Current settings: full HTML support enabled
Stored source:    legacy JavaScript/Astro
Stored tree:      script/frontmatter only

Before the fix, `update_settings` installed the new settings and invalidated the analyzer cache, but left the parsed document untouched. The updated method now reparses affected documents at `crates/biome_service/src/workspace/server.rs:2584`.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
added tests

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
