### PR TITLE
fix(css_formatter): preserve pseudo function comments

### DIFF
--- a/.changeset/fast-boxes-bow.md
+++ b/.changeset/fast-boxes-bow.md
@@ -1,0 +1,10 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11280](https://github.com/biomejs/biome/issues/11280): CSS formatting keeps comments inside functional pseudo-classes and pseudo-elements instead of moving them before the function name.
+
+```diff
+-:/* comment */ where(div) {}
++:where(/* comment */ div) {}
+```

--- a/crates/biome_css_formatter/src/comments.rs
+++ b/crates/biome_css_formatter/src/comments.rs
@@ -10,12 +10,14 @@ use crate::utils::scss_include_comments::{
     place_separated_list_comment,
 };
 use biome_css_syntax::{
-    AnyCssDeclarationName, AnyCssMediaQuery, AnyCssProperty, AnyCssRoot, AnyCssSelector,
-    CssComplexSelector, CssDeclaration, CssDeclarationImportant, CssDeclarationOrRuleBlock,
-    CssFunction, CssGenericComponentValueList, CssGenericProperty, CssIdentifier, CssLanguage,
-    CssMediaQueryList, CssNestedQualifiedRule, CssQualifiedRule, CssSyntaxKind, CssSyntaxNode,
-    CssSyntaxToken, ScssAtRootAtRule, ScssAtRootSelector, ScssEachHeader, ScssEachValueList,
-    ScssExpression, ScssExpressionItemList, ScssIfAtRule, ScssListExpression,
+    AnyCssDeclarationName, AnyCssMediaQuery, AnyCssProperty, AnyCssPseudoClass,
+    AnyCssPseudoElement, AnyCssRoot, AnyCssSelector, AnyCssSelectorIdentifier, CssComplexSelector,
+    CssDeclaration, CssDeclarationImportant, CssDeclarationOrRuleBlock, CssFunction,
+    CssGenericComponentValueList, CssGenericProperty, CssIdentifier, CssLanguage,
+    CssMediaQueryList, CssNestedQualifiedRule, CssPseudoElementFunction, CssQualifiedRule,
+    CssSyntaxKind, CssSyntaxNode, CssSyntaxToken, ScssAtRootAtRule, ScssAtRootSelector,
+    ScssEachHeader, ScssEachValueList, ScssExpression, ScssExpressionItemList, ScssIfAtRule,
+    ScssInterpolatedPseudoClassFunction, ScssInterpolatedPseudoElementFunction, ScssListExpression,
     ScssListExpressionElement, ScssMapExpression, ScssMapExpressionPair, ScssVariableDeclaration,
     T, TextLen, TextSize, is_in_scss_include_arguments,
 };
@@ -125,6 +127,7 @@ impl CommentStyle for CssCommentStyle {
             .or_else(handle_scss_else_clause_comment)
             .or_else(handle_empty_custom_property_container_comment)
             .or_else(handle_function_comment)
+            .or_else(handle_pseudo_function_boundary_comment)
             .or_else(handle_media_separator_comment)
             // Handle SCSS variable name/colon comments before generic properties.
             .or_else(handle_scss_variable_declaration_comment)
@@ -341,6 +344,76 @@ fn handle_function_comment(
         CommentPlacement::leading(following_node.clone(), comment)
     } else {
         CommentPlacement::Default(comment)
+    }
+}
+
+fn handle_pseudo_function_boundary_comment(
+    comment: DecoratedComment<CssLanguage>,
+) -> CommentPlacement<CssLanguage> {
+    let Some(name) = comment
+        .preceding_node()
+        .and_then(AnyCssSelectorIdentifier::cast_ref)
+    else {
+        return CommentPlacement::Default(comment);
+    };
+    let Some(function) = name.syntax().parent() else {
+        return CommentPlacement::Default(comment);
+    };
+
+    let is_functional_pseudo_class =
+        AnyCssPseudoClass::cast_ref(&function).is_some_and(|pseudo_class| {
+            !matches!(
+                pseudo_class,
+                AnyCssPseudoClass::CssBogusPseudoClass(_)
+                    | AnyCssPseudoClass::CssPseudoClassIdentifier(_)
+            )
+        });
+    let is_functional_pseudo_element =
+        AnyCssPseudoElement::cast_ref(&function).is_some_and(|pseudo_element| {
+            !matches!(
+                pseudo_element,
+                AnyCssPseudoElement::CssBogusPseudoElement(_)
+                    | AnyCssPseudoElement::CssPseudoElementIdentifier(_)
+            )
+        });
+    if !is_functional_pseudo_class && !is_functional_pseudo_element {
+        return CommentPlacement::Default(comment);
+    }
+
+    let Some(l_paren) = name
+        .syntax()
+        .next_sibling_or_token()
+        .and_then(|element| element.into_token())
+        .filter(|token| token.kind() == T!['('])
+    else {
+        return CommentPlacement::Default(comment);
+    };
+
+    // Comments before `(` are not part of the function contents.
+    if comment.piece().text_range().start() < l_paren.text_trimmed_range().end() {
+        return CommentPlacement::leading(name.into_syntax(), comment);
+    }
+
+    // Empty functions can expose a following node outside this function.
+    let following_argument = comment
+        .following_node()
+        .filter(|following| following.ancestors().any(|ancestor| ancestor == function));
+    if let Some(following_argument) = following_argument {
+        return CommentPlacement::leading(following_argument.clone(), comment);
+    }
+
+    // Empty functions have no argument node that can own the comment.
+    let is_empty_function = ScssInterpolatedPseudoClassFunction::cast_ref(&function)
+        .is_some_and(|function| function.arguments().is_none())
+        || ScssInterpolatedPseudoElementFunction::cast_ref(&function)
+            .is_some_and(|function| function.arguments().is_none())
+        || CssPseudoElementFunction::cast_ref(&function)
+            .is_some_and(|function| function.items().is_empty());
+
+    if is_empty_function {
+        CommentPlacement::dangling(function, comment)
+    } else {
+        CommentPlacement::leading(name.into_syntax(), comment)
     }
 }
 

--- a/crates/biome_css_formatter/src/css/pseudo/pseudo_element_function.rs
+++ b/crates/biome_css_formatter/src/css/pseudo/pseudo_element_function.rs
@@ -20,6 +20,13 @@ impl FormatNodeRule<CssPseudoElementFunction> for FormatCssPseudoElementFunction
 
         let should_insert_space = f.options().delimiter_spacing().value();
         let name = name?;
+        let content = format_with(|f| {
+            if items.is_empty() {
+                format_dangling_comments(node.syntax()).fmt(f)
+            } else {
+                items.format().fmt(f)
+            }
+        });
 
         write!(
             f,
@@ -27,10 +34,24 @@ impl FormatNodeRule<CssPseudoElementFunction> for FormatCssPseudoElementFunction
                 name.format().with_text_case(pseudo_identifier_case(&name)),
                 group(&format_args![
                     l_paren_token.format(),
-                    soft_block_indent_with_maybe_space(&items.format(), should_insert_space),
+                    soft_block_indent_with_maybe_space(&content, should_insert_space),
                     r_paren_token.format()
                 ])
             ]
         )
+    }
+
+    fn fmt_dangling_comments(
+        &self,
+        node: &CssPseudoElementFunction,
+        f: &mut CssFormatter,
+    ) -> FormatResult<()> {
+        if node.items().is_empty() {
+            Ok(())
+        } else {
+            format_dangling_comments(node.syntax())
+                .with_soft_block_indent()
+                .fmt(f)
+        }
     }
 }

--- a/crates/biome_css_formatter/src/scss/auxiliary/interpolated_string.rs
+++ b/crates/biome_css_formatter/src/scss/auxiliary/interpolated_string.rs
@@ -1,13 +1,10 @@
-mod quotes;
-mod raw_interpolation;
-
-use self::raw_interpolation::FormatRawScssStringInterpolation;
 use crate::prelude::*;
+use crate::utils::scss_interpolated_string::{
+    FormatRawScssStringInterpolation, ScssInterpolatedStringQuotes,
+};
 use biome_css_syntax::{
     AnyScssInterpolatedStringPart, ScssInterpolatedString, ScssInterpolatedStringFields,
 };
-
-pub(crate) use self::quotes::ScssInterpolatedStringQuotes;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatScssInterpolatedString;

--- a/crates/biome_css_formatter/src/scss/auxiliary/string_text.rs
+++ b/crates/biome_css_formatter/src/scss/auxiliary/string_text.rs
@@ -1,5 +1,5 @@
-use super::interpolated_string::ScssInterpolatedStringQuotes;
 use crate::prelude::*;
+use crate::utils::scss_interpolated_string::ScssInterpolatedStringQuotes;
 use biome_css_syntax::{ScssStringText, ScssStringTextFields};
 use biome_formatter::{FormatRuleWithOptions, prelude::text, token::string::normalize_string};
 

--- a/crates/biome_css_formatter/src/scss/pseudo/interpolated_pseudo_class_function.rs
+++ b/crates/biome_css_formatter/src/scss/pseudo/interpolated_pseudo_class_function.rs
@@ -20,6 +20,13 @@ impl FormatNodeRule<ScssInterpolatedPseudoClassFunction>
             arguments,
             r_paren_token,
         } = node.as_fields();
+        let content = format_with(|f| {
+            if arguments.is_some() {
+                arguments.format().fmt(f)
+            } else {
+                format_dangling_comments(node.syntax()).fmt(f)
+            }
+        });
 
         write!(
             f,
@@ -27,10 +34,24 @@ impl FormatNodeRule<ScssInterpolatedPseudoClassFunction>
                 name.format(),
                 group(&format_args![
                     l_paren_token.format(),
-                    soft_block_indent(&arguments.format()),
+                    soft_block_indent(&content),
                     r_paren_token.format()
                 ])
             ]
         )
+    }
+
+    fn fmt_dangling_comments(
+        &self,
+        node: &ScssInterpolatedPseudoClassFunction,
+        f: &mut CssFormatter,
+    ) -> FormatResult<()> {
+        if node.arguments().is_none() {
+            Ok(())
+        } else {
+            format_dangling_comments(node.syntax())
+                .with_soft_block_indent()
+                .fmt(f)
+        }
     }
 }

--- a/crates/biome_css_formatter/src/scss/pseudo/interpolated_pseudo_element_function.rs
+++ b/crates/biome_css_formatter/src/scss/pseudo/interpolated_pseudo_element_function.rs
@@ -20,6 +20,13 @@ impl FormatNodeRule<ScssInterpolatedPseudoElementFunction>
             arguments,
             r_paren_token,
         } = node.as_fields();
+        let content = format_with(|f| {
+            if arguments.is_some() {
+                arguments.format().fmt(f)
+            } else {
+                format_dangling_comments(node.syntax()).fmt(f)
+            }
+        });
 
         write!(
             f,
@@ -27,10 +34,24 @@ impl FormatNodeRule<ScssInterpolatedPseudoElementFunction>
                 name.format(),
                 group(&format_args![
                     l_paren_token.format(),
-                    soft_block_indent(&arguments.format()),
+                    soft_block_indent(&content),
                     r_paren_token.format()
                 ])
             ]
         )
+    }
+
+    fn fmt_dangling_comments(
+        &self,
+        node: &ScssInterpolatedPseudoElementFunction,
+        f: &mut CssFormatter,
+    ) -> FormatResult<()> {
+        if node.arguments().is_none() {
+            Ok(())
+        } else {
+            format_dangling_comments(node.syntax())
+                .with_soft_block_indent()
+                .fmt(f)
+        }
     }
 }

--- a/crates/biome_css_formatter/src/utils/mod.rs
+++ b/crates/biome_css_formatter/src/utils/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod scss_each;
 pub(crate) mod scss_expression;
 pub(crate) mod scss_include_comments;
 pub(crate) mod scss_include_keyword_value;
+pub(crate) mod scss_interpolated_string;
 pub(crate) mod scss_keyword_argument_layout;
 pub(crate) mod scss_list_layout;
 pub(crate) mod scss_map_layout;

--- a/crates/biome_css_formatter/src/utils/scss_interpolated_string.rs
+++ b/crates/biome_css_formatter/src/utils/scss_interpolated_string.rs
@@ -1,0 +1,5 @@
+mod quotes;
+mod raw_interpolation;
+
+pub(crate) use quotes::ScssInterpolatedStringQuotes;
+pub(crate) use raw_interpolation::FormatRawScssStringInterpolation;

--- a/crates/biome_css_formatter/src/utils/scss_interpolated_string/quotes.rs
+++ b/crates/biome_css_formatter/src/utils/scss_interpolated_string/quotes.rs
@@ -70,7 +70,7 @@ impl ScssInterpolatedStringQuotes {
     /// Replaces only the quote token.
     ///
     /// `ScssStringText` normalizes the content separately with `normalize_string`.
-    pub(super) fn write_quote_token(
+    pub(crate) fn write_quote_token(
         self,
         token: &CssSyntaxToken,
         f: &mut CssFormatter,

--- a/crates/biome_css_formatter/src/utils/scss_interpolated_string/raw_interpolation.rs
+++ b/crates/biome_css_formatter/src/utils/scss_interpolated_string/raw_interpolation.rs
@@ -26,13 +26,13 @@ use std::borrow::Cow;
 /// The raw body delegates token tracking, suppression checks, and comment
 /// marking to the verbatim range formatter because child [`FormatNodeRule`]s
 /// do not run for preserved source text.
-pub(super) struct FormatRawScssStringInterpolation<'a> {
+pub(crate) struct FormatRawScssStringInterpolation<'a> {
     interpolation: &'a ScssInterpolation,
     quotes: ScssInterpolatedStringQuotes,
 }
 
 impl<'a> FormatRawScssStringInterpolation<'a> {
-    pub(super) fn new(
+    pub(crate) fn new(
         interpolation: &'a ScssInterpolation,
         quotes: ScssInterpolatedStringQuotes,
     ) -> Self {

--- a/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_element_selector.css
+++ b/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_element_selector.css
@@ -23,3 +23,26 @@ video::cue-region(#scroll
   active active
  active active active
  active ) {}
+
+::part(
+	/* inside function */
+	active
+) {}
+
+::part(
+  /* inside function */
+  active) {}
+
+::cue(/* selector */ b) {}
+
+::highlight(/* identifier */ sample) {}
+
+::part(/* inside empty function */) {}
+
+::part(
+  /* inside empty function */
+) {}
+
+::/* before opening parenthesis */ part(active) {}
+
+::part/* before opening parenthesis */(active) {}

--- a/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_element_selector.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/pseudo/pseudo_element_selector.css.snap
@@ -32,6 +32,29 @@ video::cue-region(#scroll
  active active active
  active ) {}
 
+::part(
+	/* inside function */
+	active
+) {}
+
+::part(
+  /* inside function */
+  active) {}
+
+::cue(/* selector */ b) {}
+
+::highlight(/* identifier */ sample) {}
+
+::part(/* inside empty function */) {}
+
+::part(
+  /* inside empty function */
+) {}
+
+::/* before opening parenthesis */ part(active) {}
+
+::part/* before opening parenthesis */(active) {}
+
 ```
 
 
@@ -69,6 +92,36 @@ video::cue-region(#scroll > .div) {
 	active
 	active
 ) {
+}
+
+::part(
+	/* inside function */
+	active
+) {
+}
+
+::part(
+	/* inside function */
+	active
+) {
+}
+
+::cue(/* selector */ b) {
+}
+
+::highlight(/* identifier */ sample) {
+}
+
+::part(/* inside empty function */) {
+}
+
+::part(/* inside empty function */) {
+}
+
+::/* before opening parenthesis */ part(active) {
+}
+
+::/* before opening parenthesis */ part(active) {
 }
 
 ```

--- a/crates/biome_css_formatter/tests/specs/css/selectors/pseudo_class/pseudo_class_function_comments.css
+++ b/crates/biome_css_formatter/tests/specs/css/selectors/pseudo_class/pseudo_class_function_comments.css
@@ -1,0 +1,32 @@
+:where(
+	/*  */
+	div
+) {
+	color: red;
+}
+
+:where(
+  /*  */
+  div) {
+  color: red;
+}
+
+:where/* before opening parenthesis */(div) {}
+
+:host(/* compound selector */ span:focus) {}
+
+:global(/* selector */ .class) {}
+
+:has(/* relative selector list */ > .child) {}
+
+:lang(/* value list */ en) {}
+
+:nth-child(/* nth */ 2n + 1) {}
+
+html:active-view-transition-type(/* custom identifier list */ forwards) {}
+
+:dir(/* identifier */ ltr) {}
+
+:state(/* identifier */ checked) {}
+
+:current(/* selector */ div) {}

--- a/crates/biome_css_formatter/tests/specs/css/selectors/pseudo_class/pseudo_class_function_comments.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/selectors/pseudo_class/pseudo_class_function_comments.css.snap
@@ -1,0 +1,92 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/selectors/pseudo_class/pseudo_class_function_comments.css
+---
+
+# Input
+
+```css
+:where(
+	/*  */
+	div
+) {
+	color: red;
+}
+
+:where(
+  /*  */
+  div) {
+  color: red;
+}
+
+:where/* before opening parenthesis */(div) {}
+
+:host(/* compound selector */ span:focus) {}
+
+:global(/* selector */ .class) {}
+
+:has(/* relative selector list */ > .child) {}
+
+:lang(/* value list */ en) {}
+
+:nth-child(/* nth */ 2n + 1) {}
+
+html:active-view-transition-type(/* custom identifier list */ forwards) {}
+
+:dir(/* identifier */ ltr) {}
+
+:state(/* identifier */ checked) {}
+
+:current(/* selector */ div) {}
+
+```
+
+
+# Formatted
+
+```css
+:where(
+	/*  */
+	div
+) {
+	color: red;
+}
+
+:where(
+	/*  */
+	div
+) {
+	color: red;
+}
+
+:/* before opening parenthesis */ where(div) {
+}
+
+:host(/* compound selector */ span:focus) {
+}
+
+:global(/* selector */ .class) {
+}
+
+:has(/* relative selector list */ > .child) {
+}
+
+:lang(/* value list */ en) {
+}
+
+:nth-child(/* nth */ 2n + 1) {
+}
+
+html:active-view-transition-type(/* custom identifier list */ forwards) {
+}
+
+:dir(/* identifier */ ltr) {
+}
+
+:state(/* identifier */ checked) {
+}
+
+:current(/* selector */ div) {
+}
+
+```

--- a/crates/biome_css_formatter/tests/specs/prettier/css/comments/selectors.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/comments/selectors.css.snap
@@ -303,12 +303,12 @@ input:not(/* comment 125 */[/* comment 126 */disabled/* comment 127 */]/* commen
  }
  
 -p:lang(/* comment 104 */it/* comment 105 */) {
-+p:/* comment 104 */ lang(/* comment 105 */ it) {
++p:lang(/* comment 104 */ /* comment 105 */ it) {
  }
  
 -span:nth-child(/* comment 106 */2n/* comment 107 */+/* comment 108 */1/* comment 109 */) {
-+span:/* comment 106 */ nth-child(
-+  2n /* comment 107 */ + /* comment 108 */ 1 /* comment 109 */
++span:nth-child(
++  /* comment 106 */ 2n /* comment 107 */ + /* comment 108 */ 1 /* comment 109 */
 +) {
  }
  
@@ -319,8 +319,8 @@ input:not(/* comment 125 */[/* comment 126 */disabled/* comment 127 */]/* commen
  
 -/* comment 111 */
 -:matches(/* comment 112 */section/* comment 113 */,/* comment 114 */ article/* comment 115 */) /* comment 116 */ h1 {
-+/* comment 111 */ :/* comment 112 */ matches(
-+  section /* comment 113 */,
++/* comment 111 */ :matches(
++  /* comment 112 */ section /* comment 113 */,
 +  /* comment 114 */ article /* comment 115 */
 +) /* comment 116 */ h1 {
  }
@@ -346,8 +346,8 @@ input:not(/* comment 125 */[/* comment 126 */disabled/* comment 127 */]/* commen
  }
  
 -input:not(/* comment 125 */[/* comment 126 */disabled/* comment 127 */]/* comment 128 */) {
-+input:/* comment 125 */ not(
-+  [/* comment 126 */ disabled /* comment 127 */] /* comment 128 */
++input:not(
++  /* comment 125 */ [/* comment 126 */ disabled /* comment 127 */] /* comment 128 */
 +) {
  }
  
@@ -412,8 +412,8 @@ input:not(/* comment 125 */[/* comment 126 */disabled/* comment 127 */]/* commen
  }
 -/* comment 176 */
 -.foo /* comment 177 */ :global(/* comment 178 */.bar/* comment 179 */) /* comment 180 */ .baz /* comment 181 */ {
-+/* comment 176 */ .foo /* comment 177 */ :/* comment 178 */ global(
-+  .bar /* comment 179 */
++/* comment 176 */ .foo /* comment 177 */ :global(
++  /* comment 178 */ .bar /* comment 179 */
 +) /* comment 180 */ .baz /* comment 181 */ {
  }
  
@@ -423,8 +423,8 @@ input:not(/* comment 125 */[/* comment 126 */disabled/* comment 127 */]/* commen
  }
 -/* comment 186 */
 -.foo /* comment 187 */ :local(/* comment 188 */.foo/* comment 189 */) /* comment 190 */ .bar /* comment 191 */ {
-+/* comment 186 */ .foo /* comment 187 */ :/* comment 188 */ local(
-+  .foo /* comment 189 */
++/* comment 186 */ .foo /* comment 187 */ :local(
++  /* comment 188 */ .foo /* comment 189 */
 +) /* comment 190 */ .bar /* comment 191 */ {
  }
  
@@ -564,19 +564,19 @@ a /* comment 100 */:/* comment 101 */ active {
 a /* comment 102 */::/* comment 103 */ after {
 }
 
-p:/* comment 104 */ lang(/* comment 105 */ it) {
+p:lang(/* comment 104 */ /* comment 105 */ it) {
 }
 
-span:/* comment 106 */ nth-child(
-  2n /* comment 107 */ + /* comment 108 */ 1 /* comment 109 */
+span:nth-child(
+  /* comment 106 */ 2n /* comment 107 */ + /* comment 108 */ 1 /* comment 109 */
 ) {
 }
 
 /* comment 110 */ ::-webkit-progress-bar {
 }
 
-/* comment 111 */ :/* comment 112 */ matches(
-  section /* comment 113 */,
+/* comment 111 */ :matches(
+  /* comment 112 */ section /* comment 113 */,
   /* comment 114 */ article /* comment 115 */
 ) /* comment 116 */ h1 {
 }
@@ -593,8 +593,8 @@ span:/* comment 106 */ nth-child(
 /* comment 123 */ a /* comment 124 */ {
 }
 
-input:/* comment 125 */ not(
-  [/* comment 126 */ disabled /* comment 127 */] /* comment 128 */
+input:not(
+  /* comment 125 */ [/* comment 126 */ disabled /* comment 127 */] /* comment 128 */
 ) {
 }
 
@@ -640,15 +640,15 @@ input:/* comment 125 */ not(
 
 /* comment 172 */ .foo /* comment 173 */ :global /* comment 174 */ .bar /* comment 175 */ {
 }
-/* comment 176 */ .foo /* comment 177 */ :/* comment 178 */ global(
-  .bar /* comment 179 */
+/* comment 176 */ .foo /* comment 177 */ :global(
+  /* comment 178 */ .bar /* comment 179 */
 ) /* comment 180 */ .baz /* comment 181 */ {
 }
 
 /* comment 182 */ .foo /* comment 183 */ :local /* comment 184 */ .bar /* comment 185 */ {
 }
-/* comment 186 */ .foo /* comment 187 */ :/* comment 188 */ local(
-  .foo /* comment 189 */
+/* comment 186 */ .foo /* comment 187 */ :local(
+  /* comment 188 */ .foo /* comment 189 */
 ) /* comment 190 */ .bar /* comment 191 */ {
 }
 
@@ -820,6 +820,7 @@ selectors.css:152:75 parse ━━━━━━━━━━━━━━━━━�
   103: a[/* comment 79 */ target /* comment 80 */$=/* comment 81 */ "_blank" /* comment 82 */] {
   105: a[/* comment 83 */ target /* comment 84 */*=/* comment 85 */ "_blank" /* comment 86 */] {
   108: [/* comment 87 */ foo /* comment 88 */| /* comment 89 */att /* comment 90 */=/* comment 91 */ "val" /* comment 92 */] {
+  151:   /* comment 125 */ [/* comment 126 */ disabled /* comment 127 */] /* comment 128 */
   192: /* comment 167 */ article /* comment 168 */ :--heading /* comment 169 */ + /* comment 170 */ p /* comment 171 */ {
   195: /* comment 172 */ .foo /* comment 173 */ :global /* comment 174 */ .bar /* comment 175 */ {
   202: /* comment 182 */ .foo /* comment 183 */ :local /* comment 184 */ .bar /* comment 185 */ {

--- a/crates/biome_css_formatter/tests/specs/scss/selector/interpolation.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/selector/interpolation.scss
@@ -44,3 +44,30 @@ ns|foo-#{$name},
 %placeholder-#{$name}{
 color:red;
 }
+
+:#{$name}/* before opening parenthesis */(bar) {}
+
+:#{$name}(
+	/* inside empty function */
+) {}
+
+:#{$name}(/* inside empty function */) {}
+
+:#{$name}(/* argument */ bar) {}
+
+::#{$name}/* before opening parenthesis */(bar) {}
+
+::#{$name}(
+	/* inside function */
+	bar
+) {}
+
+::#{$name}(
+  /* inside function */
+  bar) {}
+
+::#{$name}(/* inside empty function */) {}
+
+::#{$name}(
+  /* inside empty function */
+) {}

--- a/crates/biome_css_formatter/tests/specs/scss/selector/interpolation.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/selector/interpolation.scss.snap
@@ -53,6 +53,33 @@ ns|foo-#{$name},
 color:red;
 }
 
+:#{$name}/* before opening parenthesis */(bar) {}
+
+:#{$name}(
+	/* inside empty function */
+) {}
+
+:#{$name}(/* inside empty function */) {}
+
+:#{$name}(/* argument */ bar) {}
+
+::#{$name}/* before opening parenthesis */(bar) {}
+
+::#{$name}(
+	/* inside function */
+	bar
+) {}
+
+::#{$name}(
+  /* inside function */
+  bar) {}
+
+::#{$name}(/* inside empty function */) {}
+
+::#{$name}(
+  /* inside empty function */
+) {}
+
 ```
 
 
@@ -104,6 +131,39 @@ ns|foo-#{$name},
 %#{$placeholder},
 %placeholder-#{$name} {
 	color: red;
+}
+
+:/* before opening parenthesis */ #{$name}(bar) {
+}
+
+:#{$name}(/* inside empty function */) {
+}
+
+:#{$name}(/* inside empty function */) {
+}
+
+:#{$name}(/* argument */ bar) {
+}
+
+::/* before opening parenthesis */ #{$name}(bar) {
+}
+
+::#{$name}(
+	/* inside function */
+	bar
+) {
+}
+
+::#{$name}(
+	/* inside function */
+	bar
+) {
+}
+
+::#{$name}(/* inside empty function */) {
+}
+
+::#{$name}(/* inside empty function */) {
 }
 
 ```


### PR DESCRIPTION
> This PR was created with AI assistance (Codex).

## Summary

Fixes #11280

Preserves comments inside functional pseudo-selectors.

```diff
-:/* comment */ where(div) {}
+:where(/* comment */ div) {}
```

Regression introduced by [commit](https://github.com/biomejs/biome/commit/476cd55e4e5b1b03335e14c65ad01b2bbb4b8d42).

Also relocates handwritten SCSS helpers so formatter codegen preserves them.

## Test Plan

- `cargo test -p biome_css_formatter`