### PR TITLE
fix: widen mutable property literal types

### DIFF
--- a/.changeset/witty-badgers-widen.md
+++ b/.changeset/witty-badgers-widen.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11174](https://github.com/biomejs/biome/issues/11174): [`noUnnecessaryConditions`](https://biomejs.dev/linter/rules/no-unnecessary-conditions/) no longer reports mutable object properties initialized with literal values as always truthy or falsy.

--- a/crates/biome_js_analyze/tests/specs/suspicious/noUnnecessaryConditions/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noUnnecessaryConditions/valid.ts
@@ -202,6 +202,26 @@ function fn(f: (() => string) | undefined) {
   return f?.();
 }
 
+// Mutable property literal initializers can change after initialization.
+const guard = { current: false };
+function runOnce() {
+  if (guard.current) {
+    return;
+  }
+  guard.current = true;
+}
+
+class Once {
+  #done = false;
+
+  run() {
+    if (this.#done) {
+      return;
+    }
+    this.#done = true;
+  }
+}
+
 // Nullable member access - must NOT be flagged
 interface MaybeConfig {
   items?: string[];

--- a/crates/biome_js_analyze/tests/specs/suspicious/noUnnecessaryConditions/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noUnnecessaryConditions/valid.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 196
 expression: valid.ts
 ---
 # Input
@@ -206,6 +207,26 @@ function arr(xs: string[] | undefined) {
 
 function fn(f: (() => string) | undefined) {
   return f?.();
+}
+
+// Mutable property literal initializers can change after initialization.
+const guard = { current: false };
+function runOnce() {
+  if (guard.current) {
+    return;
+  }
+  guard.current = true;
+}
+
+class Once {
+  #done = false;
+
+  run() {
+    if (this.#done) {
+      return;
+    }
+    this.#done = true;
+  }
 }
 
 // Nullable member access - must NOT be flagged

--- a/crates/biome_js_type_info/src/local_inference.rs
+++ b/crates/biome_js_type_info/src/local_inference.rs
@@ -1901,6 +1901,34 @@ impl TupleElementType {
     }
 }
 
+fn reference_to_widened_property_value(
+    collector: &mut dyn RawTypeCollector,
+    scope_id: ScopeId,
+    expression: &AnyJsExpression,
+) -> TypeReference {
+    match widen_property_value_type_data(
+        collector
+            .resolve_expression(scope_id, expression)
+            .into_owned(),
+    ) {
+        TypeData::Reference(reference) => reference,
+        ty => collector.reference_to_owned_data(ty),
+    }
+}
+
+fn widen_property_value_type_data(ty: TypeData) -> TypeData {
+    match ty {
+        TypeData::Literal(literal) => match literal.as_ref() {
+            Literal::BigInt(_) => TypeData::BigInt,
+            Literal::Boolean(_) => TypeData::Boolean,
+            Literal::Number(_) => TypeData::Number,
+            Literal::String(_) | Literal::Template(_) => TypeData::String,
+            Literal::Object(_) | Literal::RegExp(_) => TypeData::Literal(literal),
+        },
+        ty => ty,
+    }
+}
+
 impl TypeMember {
     pub fn from_any_js_class_member(
         collector: &mut dyn RawTypeCollector,
@@ -1982,7 +2010,9 @@ impl TypeMember {
                         None => member
                             .value()
                             .and_then(|initializer| initializer.expression().ok())
-                            .map(|expr| collector.reference_to_resolved_expression(scope_id, &expr))
+                            .map(|expr| {
+                                reference_to_widened_property_value(collector, scope_id, &expr)
+                            })
                             .unwrap_or_default(),
                     };
                     let is_static = member
@@ -2184,7 +2214,7 @@ impl TypeMember {
                         kind,
                         ty: value
                             .map(|value| {
-                                collector.reference_to_resolved_expression(scope_id, &value)
+                                reference_to_widened_property_value(collector, scope_id, &value)
                             })
                             .unwrap_or_default(),
                     }


### PR DESCRIPTION
Fixes #11174.

This widens primitive literal initializers for mutable object/class properties, so `noUnnecessaryConditions` does not treat checks like `guard.current` after `{ current: false }` as permanently falsy.

Added regression coverage for object and class properties.

@ematipico this follows up on the confirmed issue.

AI assistance disclosure: I used AI assistance to inspect the relevant inference path and draft the patch; I reviewed the changes and ran the focused checks locally.
