### PR TITLE
fix(format/html): correct whitespace display classifications

### DIFF
--- a/.changeset/grumpy-shrimps-refuse.md
+++ b/.changeset/grumpy-shrimps-refuse.md
@@ -1,0 +1,10 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed the HTML formatter's whitespace handling for `marquee`, `noscript`, `video`, `audio`, and `object` elements.
+
+```diff
+- <marquee behavior="alternate"> This text will bounce </marquee>
++ <marquee behavior="alternate">This text will bounce</marquee>
+```

--- a/crates/biome_html_formatter/Cargo.toml
+++ b/crates/biome_html_formatter/Cargo.toml
@@ -23,6 +23,7 @@ biome_diagnostics_categories = { workspace = true }
 biome_formatter              = { workspace = true }
 biome_html_syntax            = { workspace = true }
 biome_languages              = { workspace = true, features = ["lang_html"] }
+biome_parser                 = { workspace = true }
 biome_rowan                  = { workspace = true }
 biome_string_case            = { workspace = true }
 biome_suppression            = { workspace = true }
@@ -37,7 +38,6 @@ biome_formatter      = { path = "../biome_formatter", features = ["countme"] }
 biome_formatter_test = { path = "../biome_formatter_test", features = ["lang_html"] }
 biome_fs             = { path = "../biome_fs" }
 biome_html_parser    = { path = "../biome_html_parser" }
-biome_parser         = { path = "../biome_parser" }
 biome_service        = { path = "../biome_service", features = ["html_embeds", "lang_html"] }
 biome_test_utils     = { path = "../biome_test_utils", features = ["lang_html"] }
 camino               = { workspace = true }

--- a/crates/biome_html_formatter/src/html/auxiliary/element.rs
+++ b/crates/biome_html_formatter/src/html/auxiliary/element.rs
@@ -1,14 +1,16 @@
 use crate::html::lists::element_list::{FormatHtmlElementListOptions, HtmlChildListLayout};
 use crate::utils::css_display::{CssDisplay, get_css_display, get_css_display_from_tag};
-use crate::utils::metadata::get_css_whitespace;
+use crate::utils::metadata::{get_css_whitespace, get_element_css_display};
 use crate::verbatim::{format_html_leading_comments, format_html_leading_comments_for_block};
 use crate::{html::lists::element_list::FormatHtmlElementList, prelude::*};
 use biome_formatter::{CstFormatContext, FormatRefWithRule, FormatRuleWithOptions, write};
 use biome_html_syntax::{
     AnyHtmlContent, AnyHtmlElement, AnyHtmlTagName, HtmlElement, HtmlElementFields,
-    HtmlElementList, HtmlRoot, HtmlSelfClosingElement, HtmlSyntaxToken,
+    HtmlElementList, HtmlRoot, HtmlSelfClosingElement,
+    HtmlSyntaxKind::{self, AUDIO_KW, OBJECT_KW, TEMPLATE_KW, VIDEO_KW},
+    HtmlSyntaxToken,
 };
-use biome_rowan::TokenText;
+use biome_parser::{TokenSet, token_set};
 use biome_string_case::StrLikeExtension;
 
 use super::{
@@ -29,14 +31,8 @@ fn is_verbatim_tag(tag_name: &str) -> bool {
         || get_css_whitespace(tag_name).preserves_content()
 }
 
-/// Helper to get token text from any tag name variant
-fn get_tag_name_text(name: &AnyHtmlTagName) -> Option<TokenText> {
-    match name {
-        AnyHtmlTagName::HtmlTagName(tag) => tag.value_token().ok().map(|t| t.token_text_trimmed()),
-        AnyHtmlTagName::HtmlComponentName(_) => None,
-        AnyHtmlTagName::HtmlMemberName(_) => None,
-    }
-}
+const STRUCTURAL_FALLBACK_ELEMENTS: TokenSet<HtmlSyntaxKind> =
+    token_set!(AUDIO_KW, OBJECT_KW, VIDEO_KW);
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatHtmlElement {
@@ -162,8 +158,13 @@ impl FormatHtmlElement {
             // third one is either `HtmlRoot` or another `HtmlElement`
             .nth(2)
             .is_some_and(|ancestor| HtmlRoot::can_cast(ancestor.kind()));
-        let is_template_element = get_tag_name_text(&tag_name)
-            .is_some_and(|tt| tt.to_ascii_lowercase_cow() == "template");
+        let tag_name_kind = tag_name.tag_name_kind();
+        let is_template_element = tag_name_kind == Some(TEMPLATE_KW);
+        // Although audio, video, and object are inline elements, their children describe
+        // resources or fallback content and retain their own display layout. Borrowing a tag
+        // boundary across a block-like edge child would incorrectly make it hug the parent tag.
+        let has_structural_fallback_children =
+            tag_name_kind.is_some_and(|kind| STRUCTURAL_FALLBACK_ELEMENTS.contains(kind));
         // The parser hands us a single `HtmlEmbeddedContent` child whenever it
         // read the content as raw text, which covers the tags below as well as
         // the blocks of a Vue single-file component, whose names are arbitrary.
@@ -253,11 +254,19 @@ impl FormatHtmlElement {
         // should NOT borrow tokens because their children are always multiline.
         let should_borrow_opening_r_angle = is_element_internally_whitespace_sensitive
             && !children.is_empty()
+            && (!has_structural_fallback_children
+                || children.iter().next().is_none_or(|child| {
+                    get_element_css_display(&child).is_externally_whitespace_sensitive(f)
+                }))
             && !content_has_leading_whitespace
             && !should_be_verbatim
             && !should_format_embedded_nodes;
         let should_borrow_closing_tag = is_element_internally_whitespace_sensitive
             && !children.is_empty()
+            && (!has_structural_fallback_children
+                || children.iter().next_back().is_none_or(|child| {
+                    get_element_css_display(&child).is_externally_whitespace_sensitive(f)
+                }))
             && !content_has_trailing_whitespace
             && !should_be_verbatim
             && !should_format_embedded_nodes;

--- a/crates/biome_html_formatter/src/html/lists/element_list.rs
+++ b/crates/biome_html_formatter/src/html/lists/element_list.rs
@@ -524,6 +524,10 @@ impl FormatHtmlElementList {
                 match child {
                     // A single word in text content
                     HtmlChild::Word(word) => {
+                        if let Some(r_angle_token) = borrowed_sibling_r_angle.take() {
+                            write!(f, [r_angle_token.format()])?;
+                        }
+
                         // when we encounter a word, we need to collect all subsequent words
                         // so we can use fill to format them together.
                         let mut fill = f.fill();
@@ -841,11 +845,15 @@ impl FormatHtmlElementList {
                         // Take any borrowed `>` from the previous sibling element
                         let current_borrowed_r_angle = borrowed_sibling_r_angle.take();
 
-                        let next_can_borrow = next_is_adjacent_inline
-                            && matches!(
-                                children_iter.peek(),
-                                Some(HtmlChild::NonText(AnyHtmlElement::HtmlElement(_)))
-                            );
+                        let next_word_borrows_r_angle = is_noscript_element(non_text)
+                            && matches!(children_iter.peek(), Some(HtmlChild::Word(_)));
+
+                        let next_can_borrow = next_word_borrows_r_angle
+                            || (next_is_adjacent_inline
+                                && matches!(
+                                    children_iter.peek(),
+                                    Some(HtmlChild::NonText(AnyHtmlElement::HtmlElement(_)))
+                                ));
 
                         // Create the element formatter with borrowing options
                         let element_format = format_element_with_borrowing(
@@ -854,7 +862,14 @@ impl FormatHtmlElementList {
                             next_can_borrow,
                         );
 
-                        if needs_outer_group {
+                        if next_word_borrows_r_angle {
+                            write!(
+                                f,
+                                [group(&format_args![&element_format, soft_line_break()])
+                                    .with_group_id(Some(non_text_group_id))]
+                            )?;
+                            last_nontext_had_trailing_line = false;
+                        } else if needs_outer_group {
                             // Wrap inline element in outer group with `line` before it.
                             // This makes the line break happen BEFORE the element when it doesn't fit.
                             // Pattern: group([line, group([element, line?])])
@@ -953,6 +968,9 @@ impl FormatHtmlElementList {
                             }
                         } else {
                             prev_inline_group_id = None;
+                            if next_word_borrows_r_angle {
+                                borrowed_sibling_r_angle = non_text.closing_r_angle_token();
+                            }
                         }
                     }
 
@@ -998,6 +1016,12 @@ fn is_br_element(element: &AnyHtmlElement) -> bool {
     element
         .name()
         .is_some_and(|name| name.text().eq_ignore_ascii_case("br"))
+}
+
+fn is_noscript_element(element: &AnyHtmlElement) -> bool {
+    element
+        .name()
+        .is_some_and(|name| name.text().eq_ignore_ascii_case("noscript"))
 }
 
 fn has_single_interpolation_child(children: &[HtmlChild]) -> bool {

--- a/crates/biome_html_formatter/src/utils/css_display.rs
+++ b/crates/biome_html_formatter/src/utils/css_display.rs
@@ -196,19 +196,21 @@ pub fn get_css_display(tag_name: &str) -> CssDisplay {
         "rt" | "rtc" => CssDisplay::RubyText,
         "rp" => CssDisplay::None,
 
-        // Hidden elements (display: none)
+        // Hidden elements
         "area" | "base" | "basefont" | "datalist" | "head" | "link" | "meta" | "noembed"
-        | "noframes" | "script" | "style" | "title" | "noscript" => CssDisplay::None,
+        | "noframes" | "script" | "style" | "title" => CssDisplay::None,
 
-        // Media elements - these have special handling but are essentially block-like
-        // for formatting purposes when considering children
-        "audio" | "video" | "object" | "svg" => CssDisplay::InlineBlock,
+        // Media elements
+        "svg" => CssDisplay::InlineBlock,
         "param" => CssDisplay::Block,
 
         // Form elements - inline-block
         "button" | "textarea" | "input" | "select" | "meter" | "progress" => {
             CssDisplay::InlineBlock
         }
+
+        // https://html.spec.whatwg.org/multipage/rendering.html#the-marquee-element-2
+        "marquee" => CssDisplay::InlineBlock,
 
         // Replaced/embedded content (inline or inline-block depending on context)
         "img" | "embed" | "iframe" | "canvas" | "template" => CssDisplay::Inline,
@@ -317,6 +319,19 @@ mod tests {
                 get_css_display(tag),
                 CssDisplay::InlineBlock,
                 "Expected '{tag}' to be inline-block"
+            );
+        }
+    }
+
+    #[test]
+    fn test_whitespace_sensitive_display_classifications() {
+        assert_eq!(get_css_display("marquee"), CssDisplay::InlineBlock);
+
+        for tag in ["noscript", "video", "audio", "object"] {
+            assert_eq!(
+                get_css_display(tag),
+                CssDisplay::Inline,
+                "Expected '{tag}' to be inline"
             );
         }
     }

--- a/crates/biome_html_formatter/tests/specs/html/whitespace/css-display-classifications/classifications.html
+++ b/crates/biome_html_formatter/tests/specs/html/whitespace/css-display-classifications/classifications.html
@@ -1,0 +1,11 @@
+<marquee behavior="alternate">This text will bounce</marquee>
+before<noscript>fallback text</noscript>after
+before<video>fallback video text</video>after
+before<audio>fallback audio text</audio>after
+before<object>fallback object text</object>after
+
+<marquee behavior="alternate"> This text will bounce </marquee>
+before<noscript>fallback text</noscript>after
+before<video>fallback video text</video>after
+before<audio>fallback audio text</audio>after
+before<object>fallback object text</object>after

--- a/crates/biome_html_formatter/tests/specs/html/whitespace/css-display-classifications/classifications.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/whitespace/css-display-classifications/classifications.html.snap
@@ -1,0 +1,53 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: whitespace/css-display-classifications/classifications.html
+---
+
+# Input
+
+```html
+<marquee behavior="alternate">This text will bounce</marquee>
+before<noscript>fallback text</noscript>after
+before<video>fallback video text</video>after
+before<audio>fallback audio text</audio>after
+before<object>fallback object text</object>after
+
+<marquee behavior="alternate"> This text will bounce </marquee>
+before<noscript>fallback text</noscript>after
+before<video>fallback video text</video>after
+before<audio>fallback audio text</audio>after
+before<object>fallback object text</object>after
+
+```
+
+
+# Options
+
+```json
+{
+	"formatter": {
+		"lineWidth": 50
+	}
+}
+```
+
+# Formatted
+
+```html
+<marquee behavior="alternate">
+	This text will bounce
+</marquee>
+before<noscript>fallback text</noscript>after
+before<video>fallback video text</video>after
+before<audio>fallback audio text</audio>after
+before<object>fallback object text</object>after
+
+<marquee behavior="alternate">
+	This text will bounce
+</marquee>
+before<noscript>fallback text</noscript>after
+before<video>fallback video text</video>after
+before<audio>fallback audio text</audio>after
+before<object>fallback object text</object>after
+
+```

--- a/crates/biome_html_formatter/tests/specs/html/whitespace/css-display-classifications/classifications.svelte
+++ b/crates/biome_html_formatter/tests/specs/html/whitespace/css-display-classifications/classifications.svelte
@@ -1,0 +1,11 @@
+<marquee behavior="alternate">This text will bounce</marquee>
+before<noscript>fallback text</noscript>after
+before<video>fallback video text</video>after
+before<audio>fallback audio text</audio>after
+before<object>fallback object text</object>after
+
+<marquee behavior="alternate"> This text will bounce </marquee>
+before<noscript>fallback text</noscript>after
+before<video>fallback video text</video>after
+before<audio>fallback audio text</audio>after
+before<object>fallback object text</object>after

--- a/crates/biome_html_formatter/tests/specs/html/whitespace/css-display-classifications/classifications.svelte.snap
+++ b/crates/biome_html_formatter/tests/specs/html/whitespace/css-display-classifications/classifications.svelte.snap
@@ -1,0 +1,53 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: whitespace/css-display-classifications/classifications.svelte
+---
+
+# Input
+
+```svelte
+<marquee behavior="alternate">This text will bounce</marquee>
+before<noscript>fallback text</noscript>after
+before<video>fallback video text</video>after
+before<audio>fallback audio text</audio>after
+before<object>fallback object text</object>after
+
+<marquee behavior="alternate"> This text will bounce </marquee>
+before<noscript>fallback text</noscript>after
+before<video>fallback video text</video>after
+before<audio>fallback audio text</audio>after
+before<object>fallback object text</object>after
+
+```
+
+
+# Options
+
+```json
+{
+	"formatter": {
+		"lineWidth": 50
+	}
+}
+```
+
+# Formatted
+
+```svelte
+<marquee behavior="alternate">
+	This text will bounce
+</marquee>
+before<noscript>fallback text</noscript>after
+before<video>fallback video text</video>after
+before<audio>fallback audio text</audio>after
+before<object>fallback object text</object>after
+
+<marquee behavior="alternate">
+	This text will bounce
+</marquee>
+before<noscript>fallback text</noscript>after
+before<video>fallback video text</video>after
+before<audio>fallback audio text</audio>after
+before<object>fallback object text</object>after
+
+```

--- a/crates/biome_html_formatter/tests/specs/html/whitespace/css-display-classifications/classifications.vue
+++ b/crates/biome_html_formatter/tests/specs/html/whitespace/css-display-classifications/classifications.vue
@@ -1,0 +1,9 @@
+<template>
+  <marquee behavior="alternate">This text will bounce</marquee>
+  before<noscript>fallback text</noscript>after
+  before<video>fallback video text</video>after
+  before<audio>fallback audio text</audio>after
+  before<object>fallback object text</object>after
+</template>
+
+<template><marquee behavior="alternate"> This text will bounce </marquee>before<noscript>fallback text</noscript>after before<video>fallback video text</video>after before<audio>fallback audio text</audio>after before<object>fallback object text</object>after</template>

--- a/crates/biome_html_formatter/tests/specs/html/whitespace/css-display-classifications/classifications.vue.snap
+++ b/crates/biome_html_formatter/tests/specs/html/whitespace/css-display-classifications/classifications.vue.snap
@@ -1,0 +1,59 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: whitespace/css-display-classifications/classifications.vue
+---
+
+# Input
+
+```vue
+<template>
+  <marquee behavior="alternate">This text will bounce</marquee>
+  before<noscript>fallback text</noscript>after
+  before<video>fallback video text</video>after
+  before<audio>fallback audio text</audio>after
+  before<object>fallback object text</object>after
+</template>
+
+<template><marquee behavior="alternate"> This text will bounce </marquee>before<noscript>fallback text</noscript>after before<video>fallback video text</video>after before<audio>fallback audio text</audio>after before<object>fallback object text</object>after</template>
+
+```
+
+
+# Options
+
+```json
+{
+	"formatter": {
+		"lineWidth": 50
+	}
+}
+```
+
+# Formatted
+
+```vue
+<template>
+	<marquee behavior="alternate">
+		This text will bounce
+	</marquee>
+	before<noscript>fallback text</noscript>after
+	before<video>fallback video text</video>after
+	before<audio>fallback audio text</audio>after
+	before<object>fallback object text</object>after
+</template>
+
+<template
+	><marquee behavior="alternate">
+		This text will bounce
+	</marquee>before<noscript
+		>fallback text</noscript
+	>after before<video
+		>fallback video text</video
+	>after before<audio
+		>fallback audio text</audio
+	>after before<object
+		>fallback object text</object
+	>after</template
+>
+
+```

--- a/crates/biome_html_formatter/tests/specs/html/whitespace/css-display-classifications/options.json
+++ b/crates/biome_html_formatter/tests/specs/html/whitespace/css-display-classifications/options.json
@@ -1,0 +1,5 @@
+{
+	"formatter": {
+		"lineWidth": 50
+	}
+}

--- a/crates/biome_html_formatter/tests/specs/html/whitespace/noscript-adjacency/noscript.html
+++ b/crates/biome_html_formatter/tests/specs/html/whitespace/noscript-adjacency/noscript.html
@@ -1,0 +1,6 @@
+<div>
+	before<noscript>noscript long long long long long long long long</noscript
+	>after
+</div>
+
+<div>before<noscript>noscript long long long long long long long long</noscript>after</div>

--- a/crates/biome_html_formatter/tests/specs/html/whitespace/noscript-adjacency/noscript.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/whitespace/noscript-adjacency/noscript.html.snap
@@ -1,0 +1,32 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: whitespace/noscript-adjacency/noscript.html
+---
+
+# Input
+
+```html
+<div>
+	before<noscript>noscript long long long long long long long long</noscript
+	>after
+</div>
+
+<div>before<noscript>noscript long long long long long long long long</noscript>after</div>
+
+```
+
+
+# Formatted
+
+```html
+<div>
+	before<noscript>noscript long long long long long long long long</noscript
+	>after
+</div>
+
+<div>
+	before<noscript>noscript long long long long long long long long</noscript
+	>after
+</div>
+
+```

--- a/crates/biome_html_formatter/tests/specs/prettier/html/tags/marquee.html.snap
+++ b/crates/biome_html_formatter/tests/specs/prettier/html/tags/marquee.html.snap
@@ -34,8 +34,7 @@ info: html/tags/marquee.html
 -  style="border: solid"
 +  style="border:solid"
  >
--  <marquee behavior="alternate">This text will bounce</marquee>
-+  <marquee behavior="alternate"> This text will bounce </marquee>
+   <marquee behavior="alternate">This text will bounce</marquee>
  </marquee>
 ```
 
@@ -53,6 +52,6 @@ info: html/tags/marquee.html
   behavior="alternate"
   style="border:solid"
 >
-  <marquee behavior="alternate"> This text will bounce </marquee>
+  <marquee behavior="alternate">This text will bounce</marquee>
 </marquee>
 ```

--- a/crates/biome_html_formatter/tests/specs/prettier/html/tags/tags2.html.snap
+++ b/crates/biome_html_formatter/tests/specs/prettier/html/tags/tags2.html.snap
@@ -26,15 +26,6 @@ info: html/tags/tags2.html
 ```diff
 --- Prettier
 +++ Biome
-@@ -1,6 +1,6 @@
- <div>
--  before<noscript>noscript long long long long long long long long</noscript
--  >after
-+  before<noscript>noscript long long long long long long long long</noscript>
-+  after
- </div>
- 
- <div>
 @@ -21,8 +21,8 @@
  <div>
    before<object data="horse.wav">
@@ -62,8 +53,8 @@ info: html/tags/tags2.html
 
 ```html
 <div>
-  before<noscript>noscript long long long long long long long long</noscript>
-  after
+  before<noscript>noscript long long long long long long long long</noscript
+  >after
 </div>
 
 <div>


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
    Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
    Please provide enough information so that others can review your PR.
    Once created, your PR will be automatically labeled according to changed files.
    Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This simply changes the whitespace sentitivity classifications for some elements.

implemented by gpt sol 5.6
<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>