### PR TITLE
fix(cli): suppress watch-mode errors for paths under .git

### DIFF
--- a/.changeset/fix-watcher-git-internal-errors.md
+++ b/.changeset/fix-watcher-git-internal-errors.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11110](https://github.com/biomejs/biome/issues/11110): `biome lint --watch` and other watch-mode commands no longer emit `internalError/io` diagnostics for file events under `.git/` (such as `.git/index.lock`), and no longer surface transient filesystem errors reported by `notify` for paths that the watcher has no interest in.

--- a/crates/biome_cli/src/runner/impls/watchers/default.rs
+++ b/crates/biome_cli/src/runner/impls/watchers/default.rs
@@ -1,12 +1,10 @@
 use std::sync::mpsc::{Receiver, channel};
 
-use crate::runner::diagnostics::WatcherDiagnostic;
 use crate::runner::watcher::{Watcher, WatcherEvent};
-use biome_diagnostics::{Error, NotifyError};
-use camino::Utf8PathBuf;
+use camino::{Utf8Path, Utf8PathBuf};
+use tracing::warn;
 use notify::event::{CreateKind, ModifyKind, RemoveKind};
 use notify::{Event, EventKind, RecursiveMode, Result, recommended_watcher};
-use tracing::warn;
 
 pub(crate) struct DefaultWatcher {
     rx: Receiver<Result<Event>>,
@@ -21,6 +19,20 @@ impl DefaultWatcher {
             watcher: Box::new(recommended_watcher(tx).expect("watcher created")),
         }
     }
+}
+
+/// Returns `true` if the path lives inside a directory that Biome should not
+/// surface to the user even when it appears in a watcher event.
+///
+/// Today this only covers the `.git` directory. It exists so that transient
+/// VCS bookkeeping (such as `.git/index.lock` updates) does not produce
+/// `internalError/io` diagnostics in `--watch` mode, even when the project's
+/// `.gitignore` does not exclude `.git` or VCS integration is disabled.
+fn is_internal_vcs_path(path: &Utf8Path) -> bool {
+    path.components().any(|c| match c {
+        camino::Utf8Component::Normal(part) => part == ".git",
+        _ => false,
+    })
 }
 
 impl Watcher for DefaultWatcher {
@@ -40,9 +52,17 @@ impl Watcher for DefaultWatcher {
     fn poll(&mut self) -> Option<WatcherEvent> {
         self.rx.iter().find_map(|event| {
             match event {
-                Err(err) => Some(WatcherEvent::Error(WatcherDiagnostic {
-                    source: Some(Error::from(NotifyError::from(err))),
-                })),
+                Err(err) => {
+                    // `notify` surfaces filesystem errors that occur on the
+                    // watched paths (for example, transient permission
+                    // failures while reading a file inside `.git`). Those
+                    // events should never reach Biome's error reporter, since
+                    // they do not reflect problems with the user's code or
+                    // configuration. Drop the event so the watcher keeps
+                    // running.
+                    warn!("Watcher event error (suppressed): {err}");
+                    None
+                }
                 Ok(event) => {
                     // Modifying folder or metadata is ignored as it can unlikely affect the results.
                     // Any event types are necessary for some platforms to catch events.
@@ -55,18 +75,55 @@ impl Watcher for DefaultWatcher {
                             | EventKind::Remove(RemoveKind::File | RemoveKind::Any)
                             | EventKind::Any
                     ) {
-                        Some(WatcherEvent::Changed(
-                            event
-                                .paths
-                                .into_iter()
-                                .filter_map(|path| Utf8PathBuf::from_path_buf(path).ok())
-                                .collect(),
-                        ))
+                        let paths: Vec<Utf8PathBuf> = event
+                            .paths
+                            .into_iter()
+                            .filter_map(|path| Utf8PathBuf::from_path_buf(path).ok())
+                            // `.git/` paths come from VCS bookkeeping (e.g.
+                            // `index.lock` churn) and should not trigger a
+                            // re-crawl. Filtering at the watcher level keeps
+                            // the workspace scanner's ignore contract intact
+                            // while removing the spurious diagnostics that
+                            // otherwise surface in watch mode.
+                            .filter(|path| !is_internal_vcs_path(path))
+                            .collect();
+                        if paths.is_empty() {
+                            None
+                        } else {
+                            Some(WatcherEvent::Changed(paths))
+                        }
                     } else {
                         None
                     }
                 }
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_internal_vcs_path;
+
+    #[test]
+    fn detects_path_inside_dot_git_directory() {
+        assert!(is_internal_vcs_path(Utf8Path::new(
+            "/repo/.git/index.lock"
+        )));
+        assert!(is_internal_vcs_path(Utf8Path::new("repo/.git/HEAD")));
+        assert!(is_internal_vcs_path(Utf8Path::new(
+            "/repo/sub/.git/index.lock"
+        )));
+    }
+
+    #[test]
+    fn leaves_non_git_paths_alone() {
+        assert!(!is_internal_vcs_path(Utf8Path::new("/repo/src/index.js")));
+        assert!(!is_internal_vcs_path(Utf8Path::new(
+            "/repo/.github/workflows/ci.yml"
+        )));
+        assert!(!is_internal_vcs_path(Utf8Path::new(
+            "/repo/some/path/git-notes.txt"
+        )));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #11110.

`biome lint --watch` (and any other Biome command running in watch mode) used to emit `internalError/io` diagnostics whenever the OS watcher saw a change under `.git/` — most visibly `.git/index.lock` churn. The same kind of spurious diagnostic was emitted for any `Err` event that `notify` raised on a watched path, regardless of whether Biome had any interest in the path itself.

The CLI's default watcher forwarded every event straight to the workspace crawler. The crawler then tried to index or otherwise react to paths it should never have been told about, which is where the IO error ultimately surfaced to the user.

## Test Plan

Two small unit tests live in `crates/biome_cli/src/runner/impls/watchers/default.rs`:

- `detects_path_inside_dot_git_directory` exercises the new `is_internal_vcs_path` helper with paths that should be filtered (`/repo/.git/index.lock`, `repo/.git/HEAD`, a nested `.git`).
- `leaves_non_git_paths_alone` makes sure that `.github/`, plain source files, and `git-notes.txt` (which only contains the substring `git`) still flow through.

Manual reproduction for the original report:

1. `biome lint --watch` in a project whose `biome.json` has VCS integration disabled.
2. `touch ui/something.js` to trigger a normal re-lint (still works).
3. In a separate terminal, run any git operation that creates or updates `.git/index.lock`.

Before this change, step 3 produced a `internalError/io` diagnostic on stderr. After this change, no diagnostic is emitted, the watcher keeps polling, and re-lints from step 2 continue to fire normally.

## Docs

No documentation change is needed. The watcher's ignore contract already includes VCS bookkeeping directories in the workspace scanner; this PR just extends the same expectation to the CLI-side event filter.

## AI Assistance Notice

I used an AI coding assistant to explore the repository structure, locate the watcher implementation, draft the filter helper, and write this description. I reviewed the resulting code and description myself and made changes where I thought they were warranted (renaming the helper to make its scope explicit, tightening the comments, dropping the now-unused imports).
