### PR TITLE
fix(noExtraBooleanCast): preserve conditional parentheses

### DIFF
--- a/.changeset/shaky-bottles-tie.md
+++ b/.changeset/shaky-bottles-tie.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11289](https://github.com/biomejs/biome/issues/11289): the safe fix for [`noExtraBooleanCast`](https://biomejs.dev/linter/rules/no-extra-boolean-cast/) now preserves parentheses around nested conditional expressions.

--- a/crates/biome_js_analyze/src/lint/complexity/no_extra_boolean_cast.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_extra_boolean_cast.rs
@@ -9,7 +9,7 @@ use biome_js_syntax::{
     AnyJsExpression, JsAssignmentExpression, JsBinaryExpression, JsCallArgumentList,
     JsCallArguments, JsCallExpression, JsConditionalExpression, JsLogicalExpression,
     JsNewExpression, JsParenthesizedExpression, JsSequenceExpression, JsSyntaxNode,
-    JsUnaryExpression, JsUnaryOperator, T, is_in_boolean_context, is_negation,
+    JsUnaryExpression, JsUnaryOperator, OperatorPrecedence, T, is_in_boolean_context, is_negation,
 };
 use biome_rowan::{AstNode, AstSeparatedList, BatchMutationExt, declare_node_union};
 use biome_rule_options::no_extra_boolean_cast::NoExtraBooleanCastOptions;
@@ -206,10 +206,9 @@ impl Rule for NoExtraBooleanCast {
             ExtraBooleanCastType::BooleanCall => "Remove redundant `Boolean` call",
         };
 
-        // Check if the Boolean call is inside a unary negation and the argument needs parentheses
+        // Check if removing the Boolean call requires preserving its grouping.
         let mut replacement = node_to_replace.clone();
 
-        // Only wrap in parentheses if this is a Boolean call inside a logical NOT with complex expression
         if matches!(extra_boolean_cast_type, ExtraBooleanCastType::BooleanCall) {
             let is_negated_boolean_call = node
                 .syntax()
@@ -218,7 +217,19 @@ impl Rule for NoExtraBooleanCast {
                 .and_then(|expr| expr.operator().ok())
                 .is_some_and(|op| op == JsUnaryOperator::LogicalNot);
 
-            if is_negated_boolean_call && needs_parentheses_when_negated(node_to_replace) {
+            let is_conditional_test = node
+                .syntax()
+                .parent()
+                .and_then(JsConditionalExpression::cast)
+                .and_then(|expression| expression.test().ok())
+                .is_some_and(|test| test.syntax() == node.syntax());
+
+            if (is_negated_boolean_call && needs_parentheses_when_negated(node_to_replace))
+                || (is_conditional_test
+                    && node_to_replace
+                        .precedence()
+                        .is_ok_and(|precedence| precedence <= OperatorPrecedence::Conditional))
+            {
                 replacement =
                     AnyJsExpression::JsParenthesizedExpression(make::js_parenthesized_expression(
                         make::token(T!['(']),

--- a/crates/biome_js_analyze/tests/specs/complexity/noExtraBooleanCast/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/complexity/noExtraBooleanCast/invalid.js
@@ -26,3 +26,6 @@ new Boolean(!!x);
 const b0 = false;
 const b1 = false;
 const boolean = !Boolean(b0 && b1);
+
+// Test case for issue #11289 - should preserve parentheses
+const result = Boolean(foo ? bar : baz) ? "X" : "Y";

--- a/crates/biome_js_analyze/tests/specs/complexity/noExtraBooleanCast/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noExtraBooleanCast/invalid.js.snap
@@ -32,6 +32,10 @@ new Boolean(!!x);
 const b0 = false;
 const b1 = false;
 const boolean = !Boolean(b0 && b1);
+
+// Test case for issue #11289 - should preserve parentheses
+const result = Boolean(foo ? bar : baz) ? "X" : "Y";
+
 ```
 
 # Diagnostics
@@ -252,6 +256,8 @@ invalid.js:28:18 lint/complexity/noExtraBooleanCast  FIXABLE  ━━━━━━
     27 │ const b1 = false;
   > 28 │ const boolean = !Boolean(b0 && b1);
        │                  ^^^^^^^^^^^^^^^^^
+    29 │ 
+    30 │ // Test case for issue #11289 - should preserve parentheses
   
   i It is not necessary to use `Boolean` call when a value will already be coerced to a boolean.
   
@@ -259,5 +265,24 @@ invalid.js:28:18 lint/complexity/noExtraBooleanCast  FIXABLE  ━━━━━━
   
     28 │ const·boolean·=·!Boolean(b0·&&·b1);
        │                  -------           
+
+```
+
+```
+invalid.js:31:16 lint/complexity/noExtraBooleanCast  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Avoid redundant `Boolean` call
+  
+    30 │ // Test case for issue #11289 - should preserve parentheses
+  > 31 │ const result = Boolean(foo ? bar : baz) ? "X" : "Y";
+       │                ^^^^^^^^^^^^^^^^^^^^^^^^
+    32 │ 
+  
+  i It is not necessary to use `Boolean` call when a value will already be coerced to a boolean.
+  
+  i Safe fix: Remove redundant `Boolean` call
+  
+    31 │ const·result·=·Boolean(foo·?·bar·:·baz)·?·"X"·:·"Y";
+       │                -------                              
 
 ```


### PR DESCRIPTION
## Summary

Fixes #11289.

Preserve parentheses when the safe fix removes `Boolean(...)` from a conditional test.

AI disclosure: OpenAI Codex implemented the fix, added the regression test and changeset, ran the validation commands, and submitted this PR.

## Test Plan

- `cargo test -p biome_js_analyze`
- `just gen-analyzer`
- `just lint`

## Docs

Not applicable; this does not add or change a rule or option.