### PR TITLE
fix(lint): recognize expect.element assertions

### DIFF
--- a/.changeset/expect-element-useexpect.md
+++ b/.changeset/expect-element-useexpect.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11328](https://github.com/biomejs/biome/issues/11328): `lint/nursery/useExpect` now recognizes Vitest Browser Mode `expect.element()` calls as assertions.

--- a/crates/biome_js_analyze/src/frameworks/playwright.rs
+++ b/crates/biome_js_analyze/src/frameworks/playwright.rs
@@ -236,7 +236,7 @@ fn is_expect_expression(expr: &AnyJsExpression) -> bool {
                     {
                         return matches!(
                             member_token.text_trimmed(),
-                            "soft" | "poll" | "assertions" | "hasAssertions"
+                            "soft" | "poll" | "element" | "assertions" | "hasAssertions"
                         );
                     }
                     return false;

--- a/crates/biome_js_analyze/tests/specs/nursery/useExpect/valid/vitest-expect-variants.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExpect/valid/vitest-expect-variants.ts
@@ -13,6 +13,10 @@ describe("math", () => {
   });
 });
 
+test("element assertion", async () => {
+  await expect.element(document.body).toBeVisible();
+});
+
 type MyType<T> = (arg: T) => void;
 
 describe("MyType", () => {

--- a/crates/biome_js_analyze/tests/specs/nursery/useExpect/valid/vitest-expect-variants.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExpect/valid/vitest-expect-variants.ts.snap
@@ -19,6 +19,10 @@ describe("math", () => {
   });
 });
 
+test("element assertion", async () => {
+  await expect.element(document.body).toBeVisible();
+});
+
 type MyType<T> = (arg: T) => void;
 
 describe("MyType", () => {


### PR DESCRIPTION
## Summary

Fixes #11328.

`lint/nursery/useExpect` now recognizes Vitest Browser Mode `expect.element()` calls as assertions.

I used codex to help prepare the code/test change; but reviewed the final diff and validation before opening this PR.

## Test Plan

Added a valid `vitest-expect-variants.ts` case for `expect.element(document.body).toBeVisible()`; `cargo test -p biome_js_analyze -- use_expect --show-output` passes.

## Docs

No docs change; this is a bug fix for existing lint.
