### PR TITLE
fix(linter): noSvgWithoutTitle allows svg with shorthand aria-hidden

### DIFF
--- a/.changeset/olive-bees-enter.md
+++ b/.changeset/olive-bees-enter.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11317](https://github.com/biomejs/biome/issues/11317): [`noSvgWithoutTitle`](https://biomejs.dev/linter/rules/no-svg-without-title/) no longer reports an `svg` that uses the boolean shorthand `aria-hidden` (equivalent to `aria-hidden={true}` in React).

--- a/crates/biome_js_analyze/src/lint/a11y/no_svg_without_title.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_svg_without_title.rs
@@ -83,6 +83,10 @@ declare_lint_rule! {
     /// ```
     ///
     /// ```jsx
+    /// <svg aria-hidden><rect /></svg>
+    /// ```
+    ///
+    /// ```jsx
     /// <svg role="img" aria-label="">
     ///     <span id="">Pass</span>
     /// </svg>
@@ -123,11 +127,14 @@ impl Rule for NoSvgWithoutTitle {
             return None;
         }
 
-        if let Some(aria_hidden_attr) = node.find_attribute_by_name("aria-hidden")
-            && let Some(attr_static_val) = aria_hidden_attr.as_static_value()
-        {
-            let attr_text = attr_static_val.text();
-            if attr_text == "true" {
+        if let Some(aria_hidden_attr) = node.find_attribute_by_name("aria-hidden") {
+            // In JSX the boolean shorthand `aria-hidden` (an attribute with no
+            // initializer) is equivalent to `aria-hidden={true}`, so it hides
+            // the svg from the accessibility tree and no title is required.
+            aria_hidden_attr.initializer()?;
+            if let Some(attr_static_val) = aria_hidden_attr.as_static_value()
+                && attr_static_val.text() == "true"
+            {
                 return None;
             }
         }

--- a/crates/biome_js_analyze/tests/specs/a11y/noSvgWithoutTitle/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/a11y/noSvgWithoutTitle/valid.jsx
@@ -39,4 +39,7 @@
 			</pattern>
 		</defs>
 	</svg>
+
+	<svg aria-hidden><rect /></svg>
+	<svg aria-hidden={true}><rect /></svg>
 </>;

--- a/crates/biome_js_analyze/tests/specs/a11y/noSvgWithoutTitle/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/noSvgWithoutTitle/valid.jsx.snap
@@ -45,6 +45,9 @@ expression: valid.jsx
 			</pattern>
 		</defs>
 	</svg>
+
+	<svg aria-hidden><rect /></svg>
+	<svg aria-hidden={true}><rect /></svg>
 </>;
 
 ```


### PR DESCRIPTION
## Summary

`noSvgWithoutTitle` reported `<svg aria-hidden>` as missing a title, even though that svg is hidden from the accessibility tree and does not need one. In JSX the boolean shorthand `aria-hidden` means the same thing as `aria-hidden={true}`.

The old guard only bailed out when the attribute had a static value of `"true"`. A shorthand attribute has no initializer, so `JsxAttribute::as_static_value()` returned `None`, the guard was skipped and the svg was flagged. The forms `aria-hidden="true"` and `aria-hidden={true}` both have an initializer, so they already worked.

The fix treats a present `aria-hidden` attribute with no initializer as `true` and returns early with no diagnostic. The existing `"true"` check stays for the forms that carry a value.

Closes #11317.

## Test Plan

Added two valid cases to the rule spec at `crates/biome_js_analyze/tests/specs/a11y/noSvgWithoutTitle/valid.jsx`:

```jsx
<svg aria-hidden><rect /></svg>
<svg aria-hidden={true}><rect /></svg>
```

- With the fix, `cargo test -p biome_js_analyze -- no_svg_without_title` passes (both `valid_jsx` and `invalid_jsx`).
- Without the fix, `valid_jsx` fails: `<svg aria-hidden>` produces the "title element cannot be empty" diagnostic, which is the false positive from the issue. The `<svg aria-hidden={true}>` case passes either way, which matches the report.
- `cargo run -p rules_check` passes, so the new valid rustdoc example is checked as well.
- `cargo fmt --all --check` is clean. `cargo clippy -p biome_js_analyze --all-features --all-targets -- --deny warnings` is clean.
- The snapshot was regenerated with `INSTA_UPDATE=always` and produced no changes beyond the new input lines.

## Docs

Added `<svg aria-hidden><rect /></svg>` to the rule's `### Valid` rustdoc examples. No website PR is needed for a bugfix.

---

Disclosure: AI assistance (Claude, Anthropic) was used to help write this change and its tests. It was verified locally before submitting with the commands listed in the Test Plan above.
