### PR TITLE
fix(inference): skip return arguments lookup

### DIFF
--- a/crates/biome_module_graph/src/db/type_inference/promise_classification.rs
+++ b/crates/biome_module_graph/src/db/type_inference/promise_classification.rs
@@ -26,7 +26,9 @@ use crate::{JsExport, JsModuleInfo, JsOwnExport, ModuleDb, ResolvedPath, SymbolF
 use biome_js_type_info::{
     GlobalTypeId, ImportSymbol, Literal, RawTypeData, RawTypeId, ScopeId, TypeId, TypeMember,
     TypeReference, TypeReferenceQualifier, TypeResolverLevel, TypeofExpression, global_types,
-    interned_types::{ReturnType, TypeData as InferredTypeData},
+    interned_types::{
+        ReturnType, TypeData as InferredTypeData, TypeSubstitution, TypeTransformResult,
+    },
 };
 use biome_rowan::Text;
 use rustc_hash::FxHashSet;
@@ -278,6 +280,16 @@ fn classify_expression(
                                     .map(|binding| (id, binding))
                             });
                         if let Some((binding_id, binding)) = binding {
+                            if !qualifier.type_parameters.is_empty()
+                                && matches!(
+                                    state.projection,
+                                    Projection::FunctionReturn
+                                        | Projection::ArrayFunctionReturn
+                                        | Projection::AwaitedArrayFunctionReturn
+                                )
+                            {
+                                return Indeterminate;
+                            }
                             if matches!(
                                 state.projection,
                                 Projection::FunctionReturn
@@ -444,17 +456,6 @@ fn classify_expression(
                         ) {
                             return DoesNotReturnPromise;
                         }
-                        if !function.type_parameters.is_empty()
-                            && matches!(
-                                state.projection,
-                                Projection::ArrayFunctionReturn
-                                    | Projection::AwaitedArrayFunctionReturn
-                            )
-                        {
-                            // Call arguments are required to substitute a generic return before
-                            // its array shape is known.
-                            return Indeterminate;
-                        }
                         if function.is_async {
                             match state.projection {
                                 Projection::FunctionReturn => return ReturnsPromise,
@@ -518,6 +519,25 @@ fn classify_expression(
                                 | Projection::ArrayPromise
                                 | Projection::AwaitedArrayPromise => unreachable!(),
                             };
+                            if matches!(result, Some(false)) {
+                                for parameter in &function.type_parameters {
+                                    let parameter = ctx.resolve(parameter);
+                                    let TypeTransformResult::Transformed(substituted) = ty
+                                        .substitute_type(
+                                            db,
+                                            TypeSubstitution {
+                                                generic: parameter,
+                                                replacement: InferredTypeData::Unknown,
+                                            },
+                                        )
+                                    else {
+                                        return Indeterminate;
+                                    };
+                                    if substituted != ty {
+                                        return Indeterminate;
+                                    }
+                                }
+                            }
                             return match result {
                                 Some(true) => ReturnsPromise,
                                 Some(false) => DoesNotReturnPromise,
@@ -633,6 +653,17 @@ fn classify_expression(
                         | TypeofExpression::Typeof(_)
                         | TypeofExpression::UnaryMinus(_) => return Indeterminate,
                     },
+                    RawTypeData::InstanceOf(instance)
+                        if !instance.type_parameters.is_empty()
+                            && matches!(
+                                state.projection,
+                                Projection::FunctionReturn
+                                    | Projection::ArrayFunctionReturn
+                                    | Projection::AwaitedArrayFunctionReturn
+                            ) =>
+                    {
+                        return Indeterminate;
+                    }
                     RawTypeData::InstanceOf(instance) => match state.projection {
                         Projection::FunctionReturn
                         | Projection::ArrayFunctionReturn

--- a/crates/biome_module_graph/src/db/type_inference/promise_classification.rs
+++ b/crates/biome_module_graph/src/db/type_inference/promise_classification.rs
@@ -486,11 +486,8 @@ fn classify_expression(
                             | Projection::AwaitedArrayPromise => None,
                         };
                         if let Some(projection) = returned_call_projection
-                            && let Some(returned_call) = returned_call_reference(
-                                &js_info,
-                                return_ty,
-                                function.is_async,
-                            )
+                            && let Some(returned_call) =
+                                returned_call_reference(&js_info, return_ty, function.is_async)
                         {
                             ClassificationState {
                                 module: state.module,

--- a/crates/biome_module_graph/src/db/type_inference/promise_classification.rs
+++ b/crates/biome_module_graph/src/db/type_inference/promise_classification.rs
@@ -22,7 +22,7 @@ use crate::db::queries::{
 };
 use crate::js_module_info::TsBindingReferenceExt;
 use crate::module_graph::{ModuleInfo, ModuleInfoKind};
-use crate::{JsExport, JsOwnExport, ModuleDb, ResolvedPath, SymbolFromModuleInfo};
+use crate::{JsExport, JsModuleInfo, JsOwnExport, ModuleDb, ResolvedPath, SymbolFromModuleInfo};
 use biome_js_type_info::{
     GlobalTypeId, ImportSymbol, Literal, RawTypeData, RawTypeId, ScopeId, TypeId, TypeMember,
     TypeReference, TypeReferenceQualifier, TypeResolverLevel, TypeofExpression, global_types,
@@ -444,6 +444,17 @@ fn classify_expression(
                         ) {
                             return DoesNotReturnPromise;
                         }
+                        if !function.type_parameters.is_empty()
+                            && matches!(
+                                state.projection,
+                                Projection::ArrayFunctionReturn
+                                    | Projection::AwaitedArrayFunctionReturn
+                            )
+                        {
+                            // Call arguments are required to substitute a generic return before
+                            // its array shape is known.
+                            return Indeterminate;
+                        }
                         if function.is_async {
                             match state.projection {
                                 Projection::FunctionReturn => return ReturnsPromise,
@@ -458,21 +469,35 @@ fn classify_expression(
                         let Some(return_ty) = function.return_type.as_type() else {
                             return DoesNotReturnPromise;
                         };
-                        if matches!(state.projection, Projection::FunctionReturn)
-                            && let TypeReference::Resolved(resolved) = return_ty
-                            && resolved.level() == TypeResolverLevel::Thin
-                            && matches!(
-                                js_info.raw_types.get(resolved.id().index()),
-                                Some(RawTypeData::TypeofExpression(expression))
-                                    if matches!(expression.as_ref(), TypeofExpression::Call(_))
+                        // Only function-return projections can follow a returned call. The next
+                        // target is the call expression itself, so map them to their equivalent
+                        // expression projections while retaining whether the result is awaited.
+                        // Other projections classify values rather than function returns; `None`
+                        // leaves them on the regular resolution path.
+                        let returned_call_projection = match state.projection {
+                            Projection::FunctionReturn => Some(Projection::Promise),
+                            Projection::ArrayFunctionReturn => Some(Projection::ArrayPromise),
+                            Projection::AwaitedArrayFunctionReturn => {
+                                Some(Projection::AwaitedArrayPromise)
+                            }
+                            Projection::Promise
+                            | Projection::PromiseTarget
+                            | Projection::ArrayPromise
+                            | Projection::AwaitedArrayPromise => None,
+                        };
+                        if let Some(projection) = returned_call_projection
+                            && let Some(returned_call) = returned_call_reference(
+                                &js_info,
+                                return_ty,
+                                function.is_async,
                             )
                         {
                             ClassificationState {
                                 module: state.module,
-                                target: ClassificationTarget::Reference(return_ty.clone()),
+                                target: ClassificationTarget::Reference(returned_call),
                                 mode: MemberLookupMode::Value,
                                 members: Box::default(),
-                                projection: Projection::Promise,
+                                projection,
                             }
                         } else {
                             let mut ctx = ResolutionCtx::new(
@@ -1001,4 +1026,47 @@ fn sole_call_signature(members: &[TypeMember]) -> Result<Option<&TypeMember>, ()
     } else {
         Ok(call_signature)
     }
+}
+
+fn returned_call_reference(
+    js_info: &JsModuleInfo,
+    return_ty: &TypeReference,
+    is_async: bool,
+) -> Option<TypeReference> {
+    let TypeReference::Resolved(resolved) = return_ty else {
+        return None;
+    };
+    if resolved.level() != TypeResolverLevel::Thin {
+        return None;
+    }
+    let raw = js_info.raw_types.get(resolved.id().index())?;
+
+    let (return_ty, raw) = if is_async {
+        let RawTypeData::InstanceOf(instance) = raw else {
+            return None;
+        };
+        let TypeReference::Qualifier(qualifier) = &instance.ty else {
+            return None;
+        };
+        if !qualifier.is_promise() {
+            return None;
+        }
+        let return_ty = qualifier.type_parameters.first()?;
+        let TypeReference::Resolved(resolved) = return_ty else {
+            return None;
+        };
+        if resolved.level() != TypeResolverLevel::Thin {
+            return None;
+        }
+        let raw = js_info.raw_types.get(resolved.id().index())?;
+        (return_ty, raw)
+    } else {
+        (return_ty, raw)
+    };
+    matches!(
+        raw,
+        RawTypeData::TypeofExpression(expression)
+            if matches!(expression.as_ref(), TypeofExpression::Call(_))
+    )
+    .then(|| return_ty.clone())
 }

--- a/crates/biome_module_graph/tests/spec_tests/queries.test.rs
+++ b/crates/biome_module_graph/tests/spec_tests/queries.test.rs
@@ -712,15 +712,27 @@ fn test_expression_array_promise_query_skips_returned_call_arguments() {
         import { argument } from "./argument.ts";
         declare function invoke(value: number): Array<Promise<void>>;
         declare function invokeAwaited(value: number): Promise<Array<Promise<void>>>;
+        declare function invokeGeneric<T>(value: T): Array<Promise<void>>;
+        declare function invokeArray<T>(value: T): Array<T>;
         declare function identity<T>(value: T): T;
+        interface Holder<T> {
+            get(): T;
+        }
+        declare const holder: Holder<Array<Promise<void>>>;
         const callback = () => invoke(argument);
         const awaitedCallback = () => invokeAwaited(argument);
         const asyncCallback = async () => invoke(argument);
+        const genericIndependentCallback = () => invokeGeneric(argument);
+        const genericArrayCallback = () => invokeArray(Promise.resolve());
         const genericCallback = () => identity(Promise.resolve([Promise.resolve()]));
+        const holderCallback = () => holder.get();
         callback();
         await awaitedCallback();
         await asyncCallback();
+        genericIndependentCallback();
+        genericArrayCallback();
         await genericCallback();
+        holderCallback();
     "#;
     let fs = MemoryFileSystem::default();
     fs.insert("/src/argument.ts".into(), "export const argument = 1;");
@@ -734,6 +746,7 @@ fn test_expression_array_promise_query_skips_returned_call_arguments() {
         "callback()",
         "await awaitedCallback()",
         "await asyncCallback()",
+        "genericIndependentCallback()",
     ]
     .map(|source| {
         ExpressionTypeInput::new(
@@ -757,6 +770,24 @@ fn test_expression_array_promise_query_skips_returned_call_arguments() {
     );
     assert_eq!(
         infer_expression_is_array_of_promises(&db, generic_expression),
+        TypeInferenceClassification::Indeterminate
+    );
+    let generic_array_expression = ExpressionTypeInput::new(
+        &db,
+        module,
+        expression_range_by_source(&db, module, SOURCE, "genericArrayCallback()"),
+    );
+    assert_eq!(
+        infer_expression_is_array_of_promises(&db, generic_array_expression),
+        TypeInferenceClassification::Indeterminate
+    );
+    let holder_expression = ExpressionTypeInput::new(
+        &db,
+        module,
+        expression_range_by_source(&db, module, SOURCE, "holderCallback()"),
+    );
+    assert_eq!(
+        infer_expression_is_array_of_promises(&db, holder_expression),
         TypeInferenceClassification::Indeterminate
     );
     let events = db.take_salsa_events();

--- a/crates/biome_module_graph/tests/spec_tests/queries.test.rs
+++ b/crates/biome_module_graph/tests/spec_tests/queries.test.rs
@@ -707,6 +707,67 @@ fn test_expression_array_promise_query_skips_sibling_type_queries() {
 }
 
 #[test]
+fn test_expression_array_promise_query_skips_returned_call_arguments() {
+    const SOURCE: &str = r#"
+        import { argument } from "./argument.ts";
+        declare function invoke(value: number): Array<Promise<void>>;
+        declare function invokeAwaited(value: number): Promise<Array<Promise<void>>>;
+        declare function identity<T>(value: T): T;
+        const callback = () => invoke(argument);
+        const awaitedCallback = () => invokeAwaited(argument);
+        const asyncCallback = async () => invoke(argument);
+        const genericCallback = () => identity(Promise.resolve([Promise.resolve()]));
+        callback();
+        await awaitedCallback();
+        await asyncCallback();
+        await genericCallback();
+    "#;
+    let fs = MemoryFileSystem::default();
+    fs.insert("/src/argument.ts".into(), "export const argument = 1;");
+    fs.insert("/src/index.ts".into(), SOURCE);
+
+    let db = build_js_test_module_db(&fs, &["/src/argument.ts", "/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let expressions = [
+        "callback()",
+        "await awaitedCallback()",
+        "await asyncCallback()",
+    ]
+    .map(|source| {
+        ExpressionTypeInput::new(
+            &db,
+            module,
+            expression_range_by_source(&db, module, SOURCE, source),
+        )
+    });
+
+    db.clear_salsa_events();
+    for expression in expressions {
+        assert_eq!(
+            infer_expression_is_array_of_promises(&db, expression),
+            TypeInferenceClassification::Match
+        );
+    }
+    let generic_expression = ExpressionTypeInput::new(
+        &db,
+        module,
+        expression_range_by_source(&db, module, SOURCE, "await genericCallback()"),
+    );
+    assert_eq!(
+        infer_expression_is_array_of_promises(&db, generic_expression),
+        TypeInferenceClassification::Indeterminate
+    );
+    let events = db.take_salsa_events();
+
+    assert_eq!(
+        function_query_will_execute_count_by_name(&db, BUDGETED_BINDING_QUERY, &events),
+        0
+    );
+}
+
+#[test]
 fn test_expression_array_promise_query_unwraps_awaited_function_returns_selectively() {
     const SOURCE: &str = r#"
         interface Noise {


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR further improves promise projection performance. 

Bug found and fixed with AI agent.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added a new test to assert a case where a binding shouldn't be resolved.
Locally ran benchmarks to prove the improvement. 

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
