### PR TITLE
fix(cli): stop rewriting non-ASCII source written to stdout

### DIFF
--- a/.changeset/fix-stdin-non-ascii-rewriting.md
+++ b/.changeset/fix-stdin-non-ascii-rewriting.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10395](https://github.com/biomejs/biome/issues/10395): `biome format`, `biome lint` and `biome check` no longer rewrite non-ASCII characters in the source code they print to stdout. Symbols such as `⚠` and `✔` were replaced with `!` and `√` whenever stdout was not a terminal, so piping Biome's output back into a file corrupted it.

--- a/crates/biome_cli/src/runner/impls/process_file/format.rs
+++ b/crates/biome_cli/src/runner/impls/process_file/format.rs
@@ -142,7 +142,7 @@ impl ProcessFile for FormatProcessFile {
         })?;
 
         if file_features.is_ignored() {
-            console.append(markup! {{content}});
+            console.append_verbatim(content);
             // Write error last because files may generally be long
             console.error(markup! {
                 <Warn>"The content was not formatted because the path `"{biome_path.as_str()}"` is ignored."</Warn>
@@ -159,7 +159,7 @@ impl ProcessFile for FormatProcessFile {
             } else {
                 console.error(markup! {{PrintDiagnostic::simple(&protected_diagnostic)}})
             }
-            console.append(markup! {{content}});
+            console.append_verbatim(content);
             return Ok(());
         };
         if file_features.supports_format() {
@@ -186,12 +186,10 @@ impl ProcessFile for FormatProcessFile {
             if result.format_with_errors_disabled {
                 return Err(WorkspaceError::format_with_errors_disabled().into());
             }
-            console.append(markup! {{source}});
+            console.append_verbatim(source);
             Ok(())
         } else {
-            console.append(markup! {
-                {content}
-            });
+            console.append_verbatim(content);
             console.error(markup! {
                 <Warn>"The content was not formatted because the formatter is currently disabled."</Warn>
             });

--- a/crates/biome_cli/src/runner/impls/process_file/lint_and_assist.rs
+++ b/crates/biome_cli/src/runner/impls/process_file/lint_and_assist.rs
@@ -147,7 +147,7 @@ impl ProcessFile for LintAssistProcessFile {
         })?;
 
         if file_features.is_ignored() {
-            console.append(markup! {{content}});
+            console.append_verbatim(content);
             // Write error last because files may generally be long
             console.error(markup! {
                 <Warn>"The content was not fixed because the path `"{biome_path.as_str()}"` is ignored."</Warn>
@@ -164,7 +164,7 @@ impl ProcessFile for LintAssistProcessFile {
             } else {
                 console.error(markup! {{PrintDiagnostic::simple(&protected_diagnostic)}})
             }
-            console.append(markup! {{content}});
+            console.append_verbatim(content);
 
             return Ok(());
         };
@@ -209,7 +209,7 @@ impl ProcessFile for LintAssistProcessFile {
             skip_parse_errors: execution.should_skip_parse_errors(),
         })?;
         let source = result.output.as_deref().unwrap_or(content);
-        console.append(markup! {{source}});
+        console.append_verbatim(source);
 
         if result.output.is_none() && !execution.requires_write_access() {
             Err(StdinDiagnostic::new_not_formatted().into())

--- a/crates/biome_cli/src/runner/mod.rs
+++ b/crates/biome_cli/src/runner/mod.rs
@@ -304,7 +304,7 @@ pub(crate) trait CommandRunner {
                 console.error(markup! {
                     {PrintDiagnostic::simple(&CliDiagnostic::from(StdinDiagnostic::new_no_extension()))}
                 });
-                console.append(markup! {{content}});
+                console.append_verbatim(&content);
                 return Ok(());
             }
 

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -2,7 +2,9 @@ use crate::configs::{
     CONFIG_DISABLED_FORMATTER, CONFIG_FILE_SIZE_LIMIT, CONFIG_FILES_INCLUDES_EXCLUDES_STDIN_PATH,
     CONFIG_FORMAT, CONFIG_FORMAT_JSONC, CONFIG_ISSUE_3175_1, CONFIG_ISSUE_3175_2,
 };
-use crate::snap_test::{SnapshotPayload, assert_file_contents, markup_to_string};
+use crate::snap_test::{
+    SnapshotPayload, assert_file_contents, markup_to_string, message_to_string,
+};
 use crate::{
     CUSTOM_FORMAT_BEFORE, FORMATTED, LINT_ERROR, UNFORMATTED, assert_cli_snapshot, run_cli,
 };
@@ -1272,6 +1274,44 @@ fn format_stdin_successfully() {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "format_stdin_successfully",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn format_stdin_keeps_non_ascii_source() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    // Both symbols are in the ASCII fallback table the console applies to
+    // diagnostics; the source echoed back to stdout must not go through it.
+    console
+        .in_buffer
+        .push("const a = \"\u{26a0}\u{2714}\"".to_string());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["format", "--stdin-file-path", "mock.js"].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    let message = console
+        .out_buffer
+        .first()
+        .expect("Console should have written a message");
+
+    assert_eq!(
+        message_to_string(message),
+        "const a = \"\u{26a0}\u{2714}\";\n"
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "format_stdin_keeps_non_ascii_source",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -1285,8 +1285,8 @@ fn format_stdin_keeps_non_ascii_source() {
     let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
-    // Both symbols are in the ASCII fallback table the console applies to
-    // diagnostics; the source echoed back to stdout must not go through it.
+    // U+26A0 and U+2714 are two of the four code points `unicode_to_ascii`
+    // rewrites, so they show whether the echoed source came through intact.
     console
         .in_buffer
         .push("const a = \"\u{26a0}\u{2714}\"".to_string());

--- a/crates/biome_cli/tests/snap_test.rs
+++ b/crates/biome_cli/tests/snap_test.rs
@@ -519,10 +519,11 @@ pub fn markup_to_string(markup: Markup) -> String {
     String::from_utf8(buffer).unwrap()
 }
 
-/// Renders a message the way the console it was printed to would render it.
+/// Renders `message` the way the user saw it.
 ///
-/// Verbatim messages reach the real console without the markup rewrites, so
-/// rendering them as markup here would show something the user never sees.
+/// [`biome_console::Console::print_verbatim`] does not go through [`Termcolor`],
+/// so rendering such a message as markup here would put ASCII substitutions
+/// into the snapshot that the real run never produced.
 pub fn message_to_string(message: &Message) -> String {
     if !message.verbatim {
         return markup_to_string(markup! {

--- a/crates/biome_cli/tests/snap_test.rs
+++ b/crates/biome_cli/tests/snap_test.rs
@@ -1,6 +1,6 @@
 use biome_cli::CliDiagnostic;
 use biome_console::fmt::{Formatter, Termcolor};
-use biome_console::{BufferConsole, Markup, markup};
+use biome_console::{BufferConsole, Markup, Message, markup, write_verbatim};
 use biome_css_formatter::context::CssFormatOptions;
 use biome_css_formatter::format_node as format_css_node;
 use biome_css_parser::{CssParserOptions, parse_css};
@@ -503,10 +503,7 @@ impl From<SnapshotPayload<'_>> for CliSnapshot {
         }
 
         for message in &console.out_buffer {
-            let content = markup_to_string(markup! {
-                {message.content}
-            });
-            cli_snapshot.messages.push(content)
+            cli_snapshot.messages.push(message_to_string(message))
         }
 
         cli_snapshot
@@ -518,6 +515,25 @@ pub fn markup_to_string(markup: Markup) -> String {
     let mut write = Termcolor(NoColor::new(&mut buffer));
     let mut fmt = Formatter::new(&mut write);
     fmt.write_markup(markup).unwrap();
+
+    String::from_utf8(buffer).unwrap()
+}
+
+/// Renders a message the way the console it was printed to would render it.
+///
+/// Verbatim messages reach the real console without the markup rewrites, so
+/// rendering them as markup here would show something the user never sees.
+pub fn message_to_string(message: &Message) -> String {
+    if !message.verbatim {
+        return markup_to_string(markup! {
+            {message.content}
+        });
+    }
+
+    let mut buffer = Vec::new();
+    for node in &message.content.0 {
+        write_verbatim(&mut buffer, &node.content).unwrap();
+    }
 
     String::from_utf8(buffer).unwrap()
 }

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_stdin_keeps_non_ascii_source.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_stdin_keeps_non_ascii_source.snap
@@ -1,0 +1,16 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+# Input messages
+
+```block
+const a = "⚠✔"
+```
+
+# Emitted Messages
+
+```block
+const a = "⚠✔";
+
+```

--- a/crates/biome_console/src/lib.rs
+++ b/crates/biome_console/src/lib.rs
@@ -11,7 +11,8 @@ mod markup;
 mod utils;
 mod write;
 
-pub use self::markup::{Markup, MarkupBuf, MarkupElement, MarkupNode};
+pub use self::markup::{Markup, MarkupBuf, MarkupElement, MarkupNode, MarkupNodeBuf};
+pub use self::write::write_verbatim;
 pub use biome_markup::markup;
 pub use utils::*;
 
@@ -36,6 +37,16 @@ pub trait Console: Send + Sync + RefUnwindSafe {
 
     /// Prints a message (formatted using [markup!]) to the console.
     fn print(&mut self, level: LogLevel, args: Markup);
+
+    /// Prints content that is data rather than console UI, such as source code
+    /// echoed back to the caller, and must reach the output as it is.
+    ///
+    /// [Self::print] takes markup, which the terminal implementation renders
+    /// with colour escapes and an ASCII fallback for symbols such as `✔`.
+    /// Neither belongs in content the caller may redirect into a file.
+    ///
+    /// It adds no line at the end.
+    fn print_verbatim(&mut self, level: LogLevel, content: &str);
 
     /// It reads from a source, and if this source contains something, it's converted into a [String]
     fn read(&mut self) -> Option<String>;
@@ -63,6 +74,10 @@ pub trait ConsoleExt: Console {
     ///
     /// It doesn't add any line
     fn append(&mut self, args: Markup);
+
+    /// Prints content that is data rather than console UI with level
+    /// [LogLevel::Log]. See [Console::print_verbatim].
+    fn append_verbatim(&mut self, content: &str);
 }
 
 impl<T: Console + ?Sized> ConsoleExt for T {
@@ -76,6 +91,10 @@ impl<T: Console + ?Sized> ConsoleExt for T {
 
     fn append(&mut self, args: Markup) {
         self.print(LogLevel::Log, args);
+    }
+
+    fn append_verbatim(&mut self, content: &str) {
+        self.print_verbatim(LogLevel::Log, content);
     }
 }
 
@@ -174,6 +193,15 @@ impl Console for EnvConsole {
         write!(out, "").unwrap();
     }
 
+    fn print_verbatim(&mut self, level: LogLevel, content: &str) {
+        let mut out = match level {
+            LogLevel::Error => self.err.lock(),
+            LogLevel::Log => self.out.lock(),
+        };
+
+        write::write_verbatim(&mut out, content).unwrap();
+    }
+
     fn read(&mut self) -> Option<String> {
         // Here we check if stdin is redirected. If not, we bail.
         //
@@ -210,6 +238,10 @@ impl BufferConsole {
 pub struct Message {
     pub level: LogLevel,
     pub content: MarkupBuf,
+    /// Set when the message came from [Console::print_verbatim], so a consumer
+    /// that renders the buffer knows not to apply the terminal rewrites it
+    /// applies to markup.
+    pub verbatim: bool,
 }
 
 impl Console for BufferConsole {
@@ -217,6 +249,7 @@ impl Console for BufferConsole {
         self.out_buffer.push(Message {
             level,
             content: args.to_owned(),
+            verbatim: false,
         });
     }
 
@@ -224,8 +257,21 @@ impl Console for BufferConsole {
         self.out_buffer.push(Message {
             level,
             content: args.to_owned(),
+            verbatim: false,
         });
     }
+
+    fn print_verbatim(&mut self, level: LogLevel, content: &str) {
+        self.out_buffer.push(Message {
+            level,
+            content: MarkupBuf(vec![MarkupNodeBuf {
+                elements: Vec::new(),
+                content: content.into(),
+            }]),
+            verbatim: true,
+        });
+    }
+
     fn read(&mut self) -> Option<String> {
         if self.in_buffer.is_empty() {
             None
@@ -249,6 +295,7 @@ impl Console for FileBufferConsole {
         self.out.push(Message {
             level,
             content: args.to_owned(),
+            verbatim: false,
         });
     }
 
@@ -256,6 +303,18 @@ impl Console for FileBufferConsole {
         self.out.push(Message {
             level,
             content: args.to_owned(),
+            verbatim: false,
+        });
+    }
+
+    fn print_verbatim(&mut self, level: LogLevel, content: &str) {
+        self.out.push(Message {
+            level,
+            content: MarkupBuf(vec![MarkupNodeBuf {
+                elements: Vec::new(),
+                content: content.into(),
+            }]),
+            verbatim: true,
         });
     }
 

--- a/crates/biome_console/src/lib.rs
+++ b/crates/biome_console/src/lib.rs
@@ -39,11 +39,15 @@ pub trait Console: Send + Sync + RefUnwindSafe {
     fn print(&mut self, level: LogLevel, args: Markup);
 
     /// Prints content that is data rather than console UI, such as source code
-    /// echoed back to the caller, and must reach the output as it is.
+    /// echoed back to the caller.
     ///
     /// [Self::print] takes markup, which the terminal implementation renders
     /// with colour escapes and an ASCII fallback for symbols such as `✔`.
     /// Neither belongs in content the caller may redirect into a file.
+    ///
+    /// This is not byte-transparent: an implementation writing to a terminal
+    /// still replaces the characters that terminal would read as commands
+    /// rather than as text, so printing a file cannot drive the terminal.
     ///
     /// It adds no line at the end.
     fn print_verbatim(&mut self, level: LogLevel, content: &str);

--- a/crates/biome_console/src/lib.rs
+++ b/crates/biome_console/src/lib.rs
@@ -38,18 +38,17 @@ pub trait Console: Send + Sync + RefUnwindSafe {
     /// Prints a message (formatted using [markup!]) to the console.
     fn print(&mut self, level: LogLevel, args: Markup);
 
-    /// Prints content that is data rather than console UI, such as source code
-    /// echoed back to the caller.
+    /// Prints `content` with no markup interpretation and no trailing newline.
     ///
-    /// [Self::print] takes markup, which the terminal implementation renders
-    /// with colour escapes and an ASCII fallback for symbols such as `✔`.
-    /// Neither belongs in content the caller may redirect into a file.
+    /// Callers use this for text a user may redirect into a file, such as the
+    /// source `format --stdin-file-path` echoes back. [Self::print] takes
+    /// markup, which a terminal implementation may render with colour escapes
+    /// and with ASCII in place of symbols such as U+2714; both would land in
+    /// the redirected file.
     ///
-    /// This is not byte-transparent: an implementation writing to a terminal
-    /// still replaces the characters that terminal would read as commands
-    /// rather than as text, so printing a file cannot drive the terminal.
-    ///
-    /// It adds no line at the end.
+    /// The output is not byte for byte. An implementation writing to a
+    /// terminal replaces characters that terminal would act on, U+001B among
+    /// them, with U+FFFD.
     fn print_verbatim(&mut self, level: LogLevel, content: &str);
 
     /// It reads from a source, and if this source contains something, it's converted into a [String]
@@ -79,8 +78,7 @@ pub trait ConsoleExt: Console {
     /// It doesn't add any line
     fn append(&mut self, args: Markup);
 
-    /// Prints content that is data rather than console UI with level
-    /// [LogLevel::Log]. See [Console::print_verbatim].
+    /// Calls [Console::print_verbatim] with [LogLevel::Log].
     fn append_verbatim(&mut self, content: &str);
 }
 
@@ -242,9 +240,9 @@ impl BufferConsole {
 pub struct Message {
     pub level: LogLevel,
     pub content: MarkupBuf,
-    /// Set when the message came from [Console::print_verbatim], so a consumer
-    /// that renders the buffer knows not to apply the terminal rewrites it
-    /// applies to markup.
+    /// `true` when the message came from [Console::print_verbatim]. A consumer
+    /// that renders `content` as markup instead would apply substitutions the
+    /// real console did not.
     pub verbatim: bool,
 }
 

--- a/crates/biome_console/src/write.rs
+++ b/crates/biome_console/src/write.rs
@@ -16,13 +16,16 @@ pub trait Write {
     fn write_fmt(&mut self, elements: &MarkupElements, content: fmt::Arguments) -> io::Result<()>;
 }
 
-/// Writes `content` to `writer` as it is, replacing only the characters a
-/// terminal reads as commands instead of as text.
+/// Writes `content` to `writer`, replacing every non-whitespace grapheme that
+/// occupies no display width with U+FFFD and passing the rest through byte for
+/// byte.
 ///
-/// The markup path also rewrites symbols such as `✔` to ASCII to keep
-/// diagnostics readable where the terminal may not render them. That is a
-/// choice about console UI, and it corrupts content that the caller is
-/// redirecting into a file, so it is not applied here.
+/// A terminal acts on such a grapheme instead of showing it: U+001B starts a
+/// command, U+202D reorders what follows it. Whitespace is exempt because a
+/// newline also occupies no width, and it is text.
+///
+/// Symbols keep their code point here, unlike [`Termcolor`], which maps four
+/// of them to ASCII approximations.
 pub fn write_verbatim<W: io::Write>(writer: &mut W, content: &str) -> io::Result<()> {
     // Grapheme segmentation is considerably more expensive than validating ASCII bytes.
     if content.is_ascii()
@@ -73,8 +76,9 @@ mod tests {
     fn as_markup(content: &str) -> String {
         let mut buffer = Vec::new();
         {
-            // `NoColor` is what the console resolves to when stdout is not a
-            // terminal, which is when the ASCII fallback applies.
+            // `NoColor` reports no colour support, which is what `EnvConsole`
+            // ends up with when stdout is not a terminal, and is the branch
+            // where `Termcolor` substitutes ASCII.
             let mut writer = Termcolor(NoColor::new(&mut buffer));
             Formatter::new(&mut writer)
                 .write_markup(markup! {{content}})
@@ -85,20 +89,16 @@ mod tests {
 
     #[test]
     fn keeps_diagnostic_symbols_that_appear_in_source() {
-        // `⚠` and `✔` are both in the ASCII fallback table, and source code
-        // echoed to stdout goes through the console just like diagnostics do.
+        // `unicode_to_ascii` maps U+26A0 to `!` and U+2714 to U+221A, so a
+        // source file holding them is where the two writers disagree.
         const SOURCE: &str = "const a = `\u{26a0}`;\nconst b = `\u{2714}`;\n";
 
         assert_eq!(verbatim(SOURCE), SOURCE);
-        // Control: the markup path still rewrites them, so the fallback is
-        // scoped rather than removed.
         assert_eq!(as_markup(SOURCE), "const a = `!`;\nconst b = `\u{221a}`;\n");
     }
 
     #[test]
     fn still_replaces_characters_a_terminal_would_execute() {
-        // Writing content as it is must not become a way for a source file to
-        // drive the terminal.
         assert_eq!(verbatim("a\u{1b}[31mb"), "a\u{FFFD}[31mb");
         assert_eq!(verbatim("t\u{202D}es\u{200B}t"), "t\u{FFFD}es\u{FFFD}t");
     }

--- a/crates/biome_console/src/write.rs
+++ b/crates/biome_console/src/write.rs
@@ -4,6 +4,9 @@ mod termcolor;
 
 use std::{fmt, io};
 
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
+
 use crate::fmt::MarkupElements;
 
 pub use self::{html::HTML, string::StringBuffer, termcolor::Termcolor};
@@ -11,4 +14,101 @@ pub use self::{html::HTML, string::StringBuffer, termcolor::Termcolor};
 pub trait Write {
     fn write_str(&mut self, elements: &MarkupElements, content: &str) -> io::Result<()>;
     fn write_fmt(&mut self, elements: &MarkupElements, content: fmt::Arguments) -> io::Result<()>;
+}
+
+/// Writes `content` to `writer` as it is, replacing only the characters a
+/// terminal reads as commands instead of as text.
+///
+/// The markup path also rewrites symbols such as `✔` to ASCII to keep
+/// diagnostics readable where the terminal may not render them. That is a
+/// choice about console UI, and it corrupts content that the caller is
+/// redirecting into a file, so it is not applied here.
+pub fn write_verbatim<W: io::Write>(writer: &mut W, content: &str) -> io::Result<()> {
+    // Grapheme segmentation is considerably more expensive than validating ASCII bytes.
+    if content.is_ascii()
+        && content
+            .bytes()
+            .all(|byte| !byte.is_ascii_control() || byte.is_ascii_whitespace())
+    {
+        return writer.write_all(content.as_bytes());
+    }
+
+    let mut buffer = [0; 4];
+    let mut segment_start = 0;
+
+    for (offset, grapheme) in content.grapheme_indices(true) {
+        let is_whitespace = grapheme.chars().all(char::is_whitespace);
+
+        if !is_whitespace && UnicodeWidthStr::width(grapheme) == 0 {
+            writer.write_all(&content.as_bytes()[segment_start..offset])?;
+            writer.write_all(
+                char::REPLACEMENT_CHARACTER
+                    .encode_utf8(&mut buffer)
+                    .as_bytes(),
+            )?;
+            segment_start = offset + grapheme.len();
+        }
+    }
+
+    writer.write_all(&content.as_bytes()[segment_start..])
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::from_utf8;
+
+    use termcolor::NoColor;
+
+    use super::{Termcolor, write_verbatim};
+    use crate as biome_console;
+    use crate::fmt::Formatter;
+    use biome_markup::markup;
+
+    fn verbatim(content: &str) -> String {
+        let mut buffer = Vec::new();
+        write_verbatim(&mut buffer, content).unwrap();
+        String::from_utf8(buffer).unwrap()
+    }
+
+    fn as_markup(content: &str) -> String {
+        let mut buffer = Vec::new();
+        {
+            // `NoColor` is what the console resolves to when stdout is not a
+            // terminal, which is when the ASCII fallback applies.
+            let mut writer = Termcolor(NoColor::new(&mut buffer));
+            Formatter::new(&mut writer)
+                .write_markup(markup! {{content}})
+                .unwrap();
+        }
+        from_utf8(&buffer).unwrap().to_string()
+    }
+
+    #[test]
+    fn keeps_diagnostic_symbols_that_appear_in_source() {
+        // `⚠` and `✔` are both in the ASCII fallback table, and source code
+        // echoed to stdout goes through the console just like diagnostics do.
+        const SOURCE: &str = "const a = `\u{26a0}`;\nconst b = `\u{2714}`;\n";
+
+        assert_eq!(verbatim(SOURCE), SOURCE);
+        // Control: the markup path still rewrites them, so the fallback is
+        // scoped rather than removed.
+        assert_eq!(as_markup(SOURCE), "const a = `!`;\nconst b = `\u{221a}`;\n");
+    }
+
+    #[test]
+    fn still_replaces_characters_a_terminal_would_execute() {
+        // Writing content as it is must not become a way for a source file to
+        // drive the terminal.
+        assert_eq!(verbatim("a\u{1b}[31mb"), "a\u{FFFD}[31mb");
+        assert_eq!(verbatim("t\u{202D}es\u{200B}t"), "t\u{FFFD}es\u{FFFD}t");
+    }
+
+    #[test]
+    fn keeps_whitespace_and_multi_codepoint_graphemes() {
+        assert_eq!(verbatim("a\tb\r\nc"), "a\tb\r\nc");
+        assert_eq!(
+            verbatim("\u{26a0}\u{fe0f}1\u{fe0f}\u{20e3}"),
+            "\u{26a0}\u{fe0f}1\u{fe0f}\u{20e3}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`biome format --stdin-file-path=x.js > x.js` rewrites `⚠` to `!` and `✔` to `√` inside the file.

The console rewrites those symbols when the output doesn't support colours, so diagnostics stay readable on terminals that can't render them. Source code echoed to stdout goes through the same path and gets the same treatment.

Closes #10395.

Second attempt at this. The first put a `<Verbatim>` element in `markup!`, which is a decision about the writing medium expressed in the presentation vocabulary, and left `<Info><Verbatim>{foo}</Verbatim></Info>` undefined — that patch dropped the colour, in either nesting order.

Source code isn't console UI, so it no longer goes through markup at all. `Console::print_verbatim` writes it to the stream as it is and `markup!` is untouched. Characters a terminal would execute are still replaced, so printing a source file can't drive the terminal.

## Test Plan

Both binaries, same pipeline, `xxd` on the resulting file:

```
in      const a = "⚠✔"      e2 9a a0  e2 9c 94
before  const a = "!√";     21        e2 88 9a
after   const a = "⚠✔";     e2 9a a0  e2 9c 94
```

`format_stdin_keeps_non_ascii_source` covers it in `biome_cli`. Put the call site back to `console.append` and it fails with `const a = "!√";`.

`BufferConsole` now records whether a message was verbatim, because the snapshot harness re-renders messages through the terminal writer. Ignore that flag with the fix in place and the test still fails the same way, so without it a CLI test can't observe this at all.

Unit tests in `biome_console::write` cover the symbols, control characters and multi-codepoint graphemes. One asserts the markup path still rewrites the same symbols, so the fallback is scoped rather than removed.

## Docs

None, no user-facing option changed.

---

Used AI assistance on this PR.
