### PR TITLE
fix(cli): stop the daemon reporting a log directory error on first run

### DIFF
--- a/.changeset/fix-daemon-log-dir-stderr.md
+++ b/.changeset/fix-daemon-log-dir-stderr.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11025](https://github.com/biomejs/biome/issues/11025): the Biome daemon no longer prints `Error reading the log directory/files: No such file or directory` to stderr on its first run. The log directory is now created before the log file appender starts, so an editor connecting to a freshly installed Biome no longer reports an error from the language server.

--- a/crates/biome_cli/src/commands/daemon.rs
+++ b/crates/biome_cli/src/commands/daemon.rs
@@ -212,6 +212,16 @@ pub(crate) fn read_most_recent_log_file(
 /// `biome-logs/server.log.yyyy-MM-dd-HH` files inside the system temporary
 /// directory)
 fn setup_tracing_subscriber(log_path: Utf8PathBuf, log_file_name_prefix: String) {
+    // `max_log_files` makes the appender list the log directory before it opens
+    // the first log file, and `tracing-appender` writes a failed listing straight
+    // to stderr. The directory doesn't exist on a first run, so editors report
+    // that as a language server error even though logging then works fine.
+    //
+    // The error is ignored on purpose: `build` below creates the directory too,
+    // so a real failure still reaches its `expect`, and no subscriber exists yet
+    // for a warning to reach.
+    let _ = fs::create_dir_all(&log_path);
+
     let appender_builder = tracing_appender::rolling::RollingFileAppender::builder();
     let file_appender = appender_builder
         .filename_prefix(log_file_name_prefix)


### PR DESCRIPTION
## Summary

Closes #11025.

`biome lsp-proxy` writes this to stderr on a first run, then the server comes up normally:

```
Error reading the log directory/files: No such file or directory (os error 2)
```

`max_log_files` makes `tracing-appender` list the log directory before anything has created it, and the crate reports the failed listing on stderr itself. The daemon inherits the proxy's stderr, so the line reaches whatever launched the proxy. Nothing fails and the exit code is 0 — Helix, where this was reported, logs each stderr line at ERROR level (`recv_server_error` in `helix-lsp/src/transport.rs`) and does nothing else with it. So the effect is a line that reads `Error ...` in the editor's log on a first run, from a startup that worked.

Creating the directory before building the appender is enough. The error is ignored because `build` creates it too, so a real failure still reaches the `expect` below.

## Test Plan

`biome __run_server` with and without the change, capturing stderr, and the same through `biome lsp-proxy`:

| log directory | before | after |
| --- | --- | --- |
| missing | the error above | empty |
| missing, nested | same | empty |
| default path, cache dir removed | same | empty |
| already exists | empty | empty |
| a regular file | panic | same panic |

No automated test: `eprintln!` inside the dependency goes to the process's real fd 2, and the CLI tests all run in process against a mock console. An in-process test would pass without the fix anyway, since the appender creates the directory lazily either way.

`cargo test -p biome_cli` green, fmt and clippy clean.

## Docs

None.

---

Used AI assistance to navigate the codebase. The change and the checks were done by hand.
