### PR TITLE
fix(noLeakedRender): use type inference to reduce false positives

### DIFF
--- a/.changeset/long-sheep-return.md
+++ b/.changeset/long-sheep-return.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10514](https://github.com/biomejs/biome/issues/10514): [`noLeakedRender`](https://biomejs.dev/linter/rules/no-leaked-render/) no longer reports typed values that can never leak a falsy primitive into the rendered output.

--- a/crates/biome_configuration/src/generated/domain_selector.rs
+++ b/crates/biome_configuration/src/generated/domain_selector.rs
@@ -152,6 +152,7 @@ static TYPES_FILTERS: LazyLock<Vec<RuleFilter<'static>>> = LazyLock::new(|| {
         RuleFilter::Rule("nursery", "useRegexpExec"),
         RuleFilter::Rule("nursery", "useStringStartsEndsWith"),
         RuleFilter::Rule("style", "useConsistentEnumValueType"),
+        RuleFilter::Rule("suspicious", "noLeakedRender"),
         RuleFilter::Rule("suspicious", "noUnnecessaryConditions"),
         RuleFilter::Rule("suspicious", "useArraySortCompare"),
     ]

--- a/crates/biome_js_analyze/src/lint/suspicious/no_leaked_render.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_leaked_render.rs
@@ -9,7 +9,6 @@ use biome_js_syntax::{
     JsLogicalOperator, JsReferenceIdentifier, JsSyntaxNode, JsUnaryOperator, JsxExpressionChild,
     JsxTagExpression, binding_ext::AnyJsBindingDeclaration, jsx_ext::AnyJsxElement,
 };
-use biome_js_type_info::InferredType;
 use biome_rowan::{AstNode, declare_node_union};
 use biome_rule_options::no_leaked_render::NoLeakedRenderOptions;
 
@@ -284,9 +283,13 @@ fn is_logical_left_hand_side_safe_by_type(
     ctx: &RuleContext<NoLeakedRender>,
     expr: &AnyJsExpression,
 ) -> bool {
-    ctx.type_of_expression(expr)
-        .and_then(InferredType::is_never_leaked_render_value)
-        .unwrap_or(false)
+    let Some(ty) = ctx.type_of_expression(expr) else {
+        return false;
+    };
+    if ty.is_nullish() {
+        return false;
+    }
+    ty.is_never_leaked_render_value().unwrap_or(false)
 }
 
 /// Whether the ternary alternate is always truthy. `null`/`undefined` still

--- a/crates/biome_js_analyze/src/lint/suspicious/no_leaked_render.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_leaked_render.rs
@@ -9,10 +9,11 @@ use biome_js_syntax::{
     JsLogicalOperator, JsReferenceIdentifier, JsSyntaxNode, JsUnaryOperator, JsxExpressionChild,
     JsxTagExpression, binding_ext::AnyJsBindingDeclaration, jsx_ext::AnyJsxElement,
 };
+use biome_js_type_info::InferredType;
 use biome_rowan::{AstNode, declare_node_union};
 use biome_rule_options::no_leaked_render::NoLeakedRenderOptions;
 
-use crate::services::semantic::Semantic;
+use crate::services::typed::Typed;
 
 declare_lint_rule! {
     /// Prevent problematic leaked values from being rendered.
@@ -90,7 +91,7 @@ declare_lint_rule! {
         version: "2.3.8",
         name: "noLeakedRender",
         language: "jsx",
-        domains: &[RuleDomain::React],
+        domains: &[RuleDomain::React, RuleDomain::Types],
         sources: &[
             RuleSource::EslintReact("jsx-no-leaked-render").inspired(),
         ],
@@ -99,15 +100,21 @@ declare_lint_rule! {
     }
 }
 
+/// The specific falsy value that would leak into the rendered output, when known.
+pub enum LeakedValueKind {
+    Zero,
+    EmptyString,
+    Generic,
+}
+
 impl Rule for NoLeakedRender {
-    type Query = Semantic<NoLeakedRenderQuery>;
-    type State = ();
+    type Query = Typed<NoLeakedRenderQuery>;
+    type State = LeakedValueKind;
     type Signals = Option<Self::State>;
     type Options = NoLeakedRenderOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let query = ctx.query();
-        let model = ctx.model();
 
         if !is_inside_jsx_expression(query.syntax()).unwrap_or_default() {
             return None;
@@ -158,6 +165,10 @@ impl Rule for NoLeakedRender {
                     return None;
                 }
 
+                if is_logical_left_hand_side_safe_by_type(ctx, &left) {
+                    return None;
+                }
+
                 if let AnyJsExpression::JsIdentifierExpression(ident) = &left {
                     let name = ident.name().ok()?;
                     // Use the semantic model to resolve the variable binding and check
@@ -165,12 +176,15 @@ impl Rule for NoLeakedRender {
                     // Safe: let isOpen = false; let isError = errorCount > 0; let isEqual = a === b;
                     // Unsafe: let emptyStr = '';
 
-                    if let Some(variable) = find_variable(model, &name) {
+                    if let Some(variable) =
+                        ctx.model().and_then(|model| find_variable(model, &name))
+                    {
                         match variable {
                             AnyJsExpression::AnyJsLiteralExpression(expr)
-                                if is_unsafe_literal(&expr)? => {
-                                    return Some(());
-                                }
+                                if is_unsafe_literal(&expr)? =>
+                            {
+                                return Some(leaked_value_kind(&expr));
+                            }
                             AnyJsExpression::JsUnaryExpression(_)
                             | AnyJsExpression::JsBinaryExpression(_)
                             | AnyJsExpression::JsCallExpression(_) => return None,
@@ -181,10 +195,10 @@ impl Rule for NoLeakedRender {
                 if let AnyJsExpression::AnyJsLiteralExpression(literal) = left
                     && is_unsafe_literal(&literal)?
                 {
-                    return Some(());
+                    return Some(leaked_value_kind(&literal));
                 }
 
-                Some(())
+                Some(LeakedValueKind::Generic)
             }
             NoLeakedRenderQuery::JsConditionalExpression(expr) => {
                 let alternate = expr.alternate().ok()?;
@@ -195,29 +209,38 @@ impl Rule for NoLeakedRender {
                     return None;
                 }
 
-                Some(())
+                if is_conditional_alternate_safe_by_type(ctx, &alternate) {
+                    return None;
+                }
+
+                Some(LeakedValueKind::Generic)
             }
         }
     }
 
-    fn diagnostic(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<RuleDiagnostic> {
+    fn diagnostic(ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
         let node = ctx.query();
 
         match node {
             NoLeakedRenderQuery::JsLogicalExpression(_) => {
+                let message = match state {
+                    LeakedValueKind::Zero => markup! {
+                        "Potential leaked value: "<Emphasis>"0"</Emphasis>" will be rendered as visible text instead of nothing."
+                    }.to_owned(),
+                    LeakedValueKind::EmptyString => markup! {
+                        "Potential leaked value: an empty string will be rendered as visible text instead of nothing."
+                    }.to_owned(),
+                    LeakedValueKind::Generic => markup! {
+                        "Potential leaked value that might cause unintended rendering."
+                    }.to_owned(),
+                };
                 Some(
-                    RuleDiagnostic::new(
-                        rule_category!(),
-                        node.range(),
-                        markup! {
-                            "Potential leaked value that might cause unintended rendering."
-                        },
-                    )
+                    RuleDiagnostic::new(rule_category!(), node.range(), message)
                     .note(markup! {
                         "JavaScript's && operator returns the left value when it's falsy (e.g., 0, NaN, ''). React will render that value, causing unexpected UI output."
                     })
                     .note(markup! {
-                        "Make sure the condition is explicitly boolean.Use !!value, value > 0, or a ternary expression."
+                        "Make sure the condition is explicitly boolean. Use !!value, value > 0, or a ternary expression."
                     })
                 )
             }
@@ -234,7 +257,7 @@ impl Rule for NoLeakedRender {
                         "This happens when you use ternary operators in JSX with alternate values that could be variables."
                     })
                     .note(markup! {
-                        "Replace with a safe alternate value like an empty string , null or another JSX element."
+                        "Replace with a safe alternate value like an empty string, null or another JSX element."
                     })
                 )
             }
@@ -256,6 +279,26 @@ fn is_inside_jsx_expression(node: &JsSyntaxNode) -> Option<bool> {
     )
 }
 
+/// Whether the left-hand side can never be `0`, `NaN`, or `""` by type.
+fn is_logical_left_hand_side_safe_by_type(
+    ctx: &RuleContext<NoLeakedRender>,
+    expr: &AnyJsExpression,
+) -> bool {
+    ctx.type_of_expression(expr)
+        .and_then(InferredType::is_never_leaked_render_value)
+        .unwrap_or(false)
+}
+
+/// Whether the ternary alternate is always truthy. `null`/`undefined` still
+/// flagged, to nudge an explicit `null` or JSX element instead.
+fn is_conditional_alternate_safe_by_type(
+    ctx: &RuleContext<NoLeakedRender>,
+    expr: &AnyJsExpression,
+) -> bool {
+    ctx.type_of_expression(expr)
+        .is_some_and(|ty| ty.is_always_truthy())
+}
+
 fn find_variable(model: &SemanticModel, name: &JsReferenceIdentifier) -> Option<AnyJsExpression> {
     let binding = model.binding(name)?;
     let declaration = binding.tree().declaration()?;
@@ -265,6 +308,17 @@ fn find_variable(model: &SemanticModel, name: &JsReferenceIdentifier) -> Option<
 
     let expr = declarator.initializer()?.expression().ok()?;
     Some(expr)
+}
+
+/// Classifies an already-confirmed-unsafe literal for the diagnostic message.
+/// Only called after `is_unsafe_literal` returns `Some(true)`.
+fn leaked_value_kind(literal: &AnyJsLiteralExpression) -> LeakedValueKind {
+    match literal {
+        AnyJsLiteralExpression::JsStringLiteralExpression(_) => LeakedValueKind::EmptyString,
+        AnyJsLiteralExpression::JsNumberLiteralExpression(_)
+        | AnyJsLiteralExpression::JsBigintLiteralExpression(_) => LeakedValueKind::Zero,
+        _ => LeakedValueKind::Generic,
+    }
 }
 
 fn is_unsafe_literal(literal: &AnyJsLiteralExpression) -> Option<bool> {

--- a/crates/biome_js_analyze/src/services/typed.rs
+++ b/crates/biome_js_analyze/src/services/typed.rs
@@ -305,6 +305,10 @@ impl TypedService {
             .as_ref()
             .is_some_and(|model| model.binding(reference).is_some())
     }
+
+    pub fn model(&self) -> Option<&SemanticModel> {
+        self.model.as_ref()
+    }
 }
 
 impl FromServices for TypedService {

--- a/crates/biome_js_analyze/tests/specs/suspicious/noLeakedRender/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noLeakedRender/invalid.jsx.snap
@@ -97,7 +97,7 @@ const MyComponent7 = () => {
 ```
 invalid.jsx:6:5 lint/suspicious/noLeakedRender ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Potential leaked value that might cause unintended rendering.
+  ! Potential leaked value: 0 will be rendered as visible text instead of nothing.
   
     4 │ 	return (
     5 │ 		<>
@@ -108,7 +108,7 @@ invalid.jsx:6:5 lint/suspicious/noLeakedRender ━━━━━━━━━━━
   
   i JavaScript's && operator returns the left value when it's falsy (e.g., 0, NaN, ''). React will render that value, causing unexpected UI output.
   
-  i Make sure the condition is explicitly boolean.Use !!value, value > 0, or a ternary expression.
+  i Make sure the condition is explicitly boolean. Use !!value, value > 0, or a ternary expression.
   
 
 ```
@@ -116,7 +116,7 @@ invalid.jsx:6:5 lint/suspicious/noLeakedRender ━━━━━━━━━━━
 ```
 invalid.jsx:7:5 lint/suspicious/noLeakedRender ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Potential leaked value that might cause unintended rendering.
+  ! Potential leaked value: 0 will be rendered as visible text instead of nothing.
   
     5 │ 		<>
     6 │ 			{0 && <Something />}
@@ -127,7 +127,7 @@ invalid.jsx:7:5 lint/suspicious/noLeakedRender ━━━━━━━━━━━
   
   i JavaScript's && operator returns the left value when it's falsy (e.g., 0, NaN, ''). React will render that value, causing unexpected UI output.
   
-  i Make sure the condition is explicitly boolean.Use !!value, value > 0, or a ternary expression.
+  i Make sure the condition is explicitly boolean. Use !!value, value > 0, or a ternary expression.
   
 
 ```
@@ -146,7 +146,7 @@ invalid.jsx:8:5 lint/suspicious/noLeakedRender ━━━━━━━━━━━
   
   i JavaScript's && operator returns the left value when it's falsy (e.g., 0, NaN, ''). React will render that value, causing unexpected UI output.
   
-  i Make sure the condition is explicitly boolean.Use !!value, value > 0, or a ternary expression.
+  i Make sure the condition is explicitly boolean. Use !!value, value > 0, or a ternary expression.
   
 
 ```
@@ -165,7 +165,7 @@ invalid.jsx:9:5 lint/suspicious/noLeakedRender ━━━━━━━━━━━
   
   i JavaScript's && operator returns the left value when it's falsy (e.g., 0, NaN, ''). React will render that value, causing unexpected UI output.
   
-  i Make sure the condition is explicitly boolean.Use !!value, value > 0, or a ternary expression.
+  i Make sure the condition is explicitly boolean. Use !!value, value > 0, or a ternary expression.
   
 
 ```
@@ -173,7 +173,7 @@ invalid.jsx:9:5 lint/suspicious/noLeakedRender ━━━━━━━━━━━
 ```
 invalid.jsx:10:5 lint/suspicious/noLeakedRender ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Potential leaked value that might cause unintended rendering.
+  ! Potential leaked value: 0 will be rendered as visible text instead of nothing.
   
      8 │ 			{-0 && <Something />}
      9 │ 			{-0.0 && <Something />}
@@ -184,7 +184,7 @@ invalid.jsx:10:5 lint/suspicious/noLeakedRender ━━━━━━━━━━�
   
   i JavaScript's && operator returns the left value when it's falsy (e.g., 0, NaN, ''). React will render that value, causing unexpected UI output.
   
-  i Make sure the condition is explicitly boolean.Use !!value, value > 0, or a ternary expression.
+  i Make sure the condition is explicitly boolean. Use !!value, value > 0, or a ternary expression.
   
 
 ```
@@ -203,7 +203,7 @@ invalid.jsx:11:5 lint/suspicious/noLeakedRender ━━━━━━━━━━�
   
   i JavaScript's && operator returns the left value when it's falsy (e.g., 0, NaN, ''). React will render that value, causing unexpected UI output.
   
-  i Make sure the condition is explicitly boolean.Use !!value, value > 0, or a ternary expression.
+  i Make sure the condition is explicitly boolean. Use !!value, value > 0, or a ternary expression.
   
 
 ```
@@ -211,7 +211,7 @@ invalid.jsx:11:5 lint/suspicious/noLeakedRender ━━━━━━━━━━�
 ```
 invalid.jsx:12:5 lint/suspicious/noLeakedRender ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Potential leaked value that might cause unintended rendering.
+  ! Potential leaked value: an empty string will be rendered as visible text instead of nothing.
   
     10 │ 			{0n && <Something />}
     11 │ 			{-0n && <Something />}
@@ -222,7 +222,7 @@ invalid.jsx:12:5 lint/suspicious/noLeakedRender ━━━━━━━━━━�
   
   i JavaScript's && operator returns the left value when it's falsy (e.g., 0, NaN, ''). React will render that value, causing unexpected UI output.
   
-  i Make sure the condition is explicitly boolean.Use !!value, value > 0, or a ternary expression.
+  i Make sure the condition is explicitly boolean. Use !!value, value > 0, or a ternary expression.
   
 
 ```
@@ -241,7 +241,7 @@ invalid.jsx:13:5 lint/suspicious/noLeakedRender ━━━━━━━━━━�
   
   i JavaScript's && operator returns the left value when it's falsy (e.g., 0, NaN, ''). React will render that value, causing unexpected UI output.
   
-  i Make sure the condition is explicitly boolean.Use !!value, value > 0, or a ternary expression.
+  i Make sure the condition is explicitly boolean. Use !!value, value > 0, or a ternary expression.
   
 
 ```
@@ -259,7 +259,7 @@ invalid.jsx:19:15 lint/suspicious/noLeakedRender ━━━━━━━━━━�
   
   i JavaScript's && operator returns the left value when it's falsy (e.g., 0, NaN, ''). React will render that value, causing unexpected UI output.
   
-  i Make sure the condition is explicitly boolean.Use !!value, value > 0, or a ternary expression.
+  i Make sure the condition is explicitly boolean. Use !!value, value > 0, or a ternary expression.
   
 
 ```
@@ -277,7 +277,7 @@ invalid.jsx:23:15 lint/suspicious/noLeakedRender ━━━━━━━━━━�
   
   i JavaScript's && operator returns the left value when it's falsy (e.g., 0, NaN, ''). React will render that value, causing unexpected UI output.
   
-  i Make sure the condition is explicitly boolean.Use !!value, value > 0, or a ternary expression.
+  i Make sure the condition is explicitly boolean. Use !!value, value > 0, or a ternary expression.
   
 
 ```
@@ -295,7 +295,7 @@ invalid.jsx:27:15 lint/suspicious/noLeakedRender ━━━━━━━━━━�
   
   i JavaScript's && operator returns the left value when it's falsy (e.g., 0, NaN, ''). React will render that value, causing unexpected UI output.
   
-  i Make sure the condition is explicitly boolean.Use !!value, value > 0, or a ternary expression.
+  i Make sure the condition is explicitly boolean. Use !!value, value > 0, or a ternary expression.
   
 
 ```
@@ -314,7 +314,7 @@ invalid.jsx:32:9 lint/suspicious/noLeakedRender ━━━━━━━━━━�
   
   i JavaScript's && operator returns the left value when it's falsy (e.g., 0, NaN, ''). React will render that value, causing unexpected UI output.
   
-  i Make sure the condition is explicitly boolean.Use !!value, value > 0, or a ternary expression.
+  i Make sure the condition is explicitly boolean. Use !!value, value > 0, or a ternary expression.
   
 
 ```
@@ -332,7 +332,7 @@ invalid.jsx:37:15 lint/suspicious/noLeakedRender ━━━━━━━━━━�
   
   i JavaScript's && operator returns the left value when it's falsy (e.g., 0, NaN, ''). React will render that value, causing unexpected UI output.
   
-  i Make sure the condition is explicitly boolean.Use !!value, value > 0, or a ternary expression.
+  i Make sure the condition is explicitly boolean. Use !!value, value > 0, or a ternary expression.
   
 
 ```
@@ -350,7 +350,7 @@ invalid.jsx:41:15 lint/suspicious/noLeakedRender ━━━━━━━━━━�
   
   i JavaScript's && operator returns the left value when it's falsy (e.g., 0, NaN, ''). React will render that value, causing unexpected UI output.
   
-  i Make sure the condition is explicitly boolean.Use !!value, value > 0, or a ternary expression.
+  i Make sure the condition is explicitly boolean. Use !!value, value > 0, or a ternary expression.
   
 
 ```
@@ -374,7 +374,7 @@ invalid.jsx:47:5 lint/suspicious/noLeakedRender ━━━━━━━━━━�
   
   i JavaScript's && operator returns the left value when it's falsy (e.g., 0, NaN, ''). React will render that value, causing unexpected UI output.
   
-  i Make sure the condition is explicitly boolean.Use !!value, value > 0, or a ternary expression.
+  i Make sure the condition is explicitly boolean. Use !!value, value > 0, or a ternary expression.
   
 
 ```
@@ -392,7 +392,7 @@ invalid.jsx:57:12 lint/suspicious/noLeakedRender ━━━━━━━━━━�
   
   i JavaScript's && operator returns the left value when it's falsy (e.g., 0, NaN, ''). React will render that value, causing unexpected UI output.
   
-  i Make sure the condition is explicitly boolean.Use !!value, value > 0, or a ternary expression.
+  i Make sure the condition is explicitly boolean. Use !!value, value > 0, or a ternary expression.
   
 
 ```
@@ -410,7 +410,7 @@ invalid.jsx:61:15 lint/suspicious/noLeakedRender ━━━━━━━━━━�
   
   i JavaScript's && operator returns the left value when it's falsy (e.g., 0, NaN, ''). React will render that value, causing unexpected UI output.
   
-  i Make sure the condition is explicitly boolean.Use !!value, value > 0, or a ternary expression.
+  i Make sure the condition is explicitly boolean. Use !!value, value > 0, or a ternary expression.
   
 
 ```
@@ -428,7 +428,7 @@ invalid.jsx:65:15 lint/suspicious/noLeakedRender ━━━━━━━━━━�
   
   i JavaScript's && operator returns the left value when it's falsy (e.g., 0, NaN, ''). React will render that value, causing unexpected UI output.
   
-  i Make sure the condition is explicitly boolean.Use !!value, value > 0, or a ternary expression.
+  i Make sure the condition is explicitly boolean. Use !!value, value > 0, or a ternary expression.
   
 
 ```
@@ -446,7 +446,7 @@ invalid.jsx:73:15 lint/suspicious/noLeakedRender ━━━━━━━━━━�
   
   i JavaScript's && operator returns the left value when it's falsy (e.g., 0, NaN, ''). React will render that value, causing unexpected UI output.
   
-  i Make sure the condition is explicitly boolean.Use !!value, value > 0, or a ternary expression.
+  i Make sure the condition is explicitly boolean. Use !!value, value > 0, or a ternary expression.
   
 
 ```
@@ -465,7 +465,7 @@ invalid.jsx:81:10 lint/suspicious/noLeakedRender ━━━━━━━━━━�
   
   i JavaScript's && operator returns the left value when it's falsy (e.g., 0, NaN, ''). React will render that value, causing unexpected UI output.
   
-  i Make sure the condition is explicitly boolean.Use !!value, value > 0, or a ternary expression.
+  i Make sure the condition is explicitly boolean. Use !!value, value > 0, or a ternary expression.
   
 
 ```
@@ -473,7 +473,7 @@ invalid.jsx:81:10 lint/suspicious/noLeakedRender ━━━━━━━━━━�
 ```
 invalid.jsx:82:10 lint/suspicious/noLeakedRender ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Potential leaked value that might cause unintended rendering.
+  ! Potential leaked value: 0 will be rendered as visible text instead of nothing.
   
     80 │ 	return <>
     81 │ 		<div> {isNan && 'NaN'} </div>
@@ -484,7 +484,7 @@ invalid.jsx:82:10 lint/suspicious/noLeakedRender ━━━━━━━━━━�
   
   i JavaScript's && operator returns the left value when it's falsy (e.g., 0, NaN, ''). React will render that value, causing unexpected UI output.
   
-  i Make sure the condition is explicitly boolean.Use !!value, value > 0, or a ternary expression.
+  i Make sure the condition is explicitly boolean. Use !!value, value > 0, or a ternary expression.
   
 
 ```
@@ -492,7 +492,7 @@ invalid.jsx:82:10 lint/suspicious/noLeakedRender ━━━━━━━━━━�
 ```
 invalid.jsx:83:9 lint/suspicious/noLeakedRender ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Potential leaked value that might cause unintended rendering.
+  ! Potential leaked value: an empty string will be rendered as visible text instead of nothing.
   
     81 │ 		<div> {isNan && 'NaN'} </div>
     82 │ 		<div> {isZero && 'Zero'} </div>
@@ -503,7 +503,7 @@ invalid.jsx:83:9 lint/suspicious/noLeakedRender ━━━━━━━━━━�
   
   i JavaScript's && operator returns the left value when it's falsy (e.g., 0, NaN, ''). React will render that value, causing unexpected UI output.
   
-  i Make sure the condition is explicitly boolean.Use !!value, value > 0, or a ternary expression.
+  i Make sure the condition is explicitly boolean. Use !!value, value > 0, or a ternary expression.
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noLeakedRender/issue10514.valid.tsx
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noLeakedRender/issue10514.valid.tsx
@@ -1,0 +1,44 @@
+/* should not generate diagnostics */
+type User = { readonly name: string };
+type State = "WAIT" | "PICK" | "PACK";
+
+type Props = {
+	readonly showTrigger?: boolean;
+	readonly isAdmin: boolean;
+	readonly error: Error | null;
+	readonly selectedUser: User | null;
+	readonly title: "Home" | "Settings" | undefined;
+	readonly onExportData: (() => void) | undefined;
+	readonly state: State;
+	readonly isMobile: boolean;
+	readonly decorations: { readonly kind: string };
+};
+
+function FalsePositiveCases({
+	showTrigger = true,
+	isAdmin,
+	error,
+	selectedUser,
+	title,
+	onExportData,
+	state,
+	isMobile,
+	decorations,
+}: Props) {
+	return (
+		<>
+			{showTrigger && <button type="button">Open</button>}
+			{isAdmin && <section>Admin tools</section>}
+			{error && <p>{error.message}</p>}
+			{selectedUser && <span>{selectedUser.name}</span>}
+			{title && <h1>{title}</h1>}
+			{onExportData && (
+				<button onClick={onExportData} type="button">
+					Export
+				</button>
+			)}
+			<p>{state === "WAIT" ? "Move to WAIT" : state}</p>
+			{isMobile ? null : decorations}
+		</>
+	);
+}

--- a/crates/biome_js_analyze/tests/specs/suspicious/noLeakedRender/issue10514.valid.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noLeakedRender/issue10514.valid.tsx.snap
@@ -1,0 +1,52 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue10514.valid.tsx
+---
+# Input
+```tsx
+/* should not generate diagnostics */
+type User = { readonly name: string };
+type State = "WAIT" | "PICK" | "PACK";
+
+type Props = {
+	readonly showTrigger?: boolean;
+	readonly isAdmin: boolean;
+	readonly error: Error | null;
+	readonly selectedUser: User | null;
+	readonly title: "Home" | "Settings" | undefined;
+	readonly onExportData: (() => void) | undefined;
+	readonly state: State;
+	readonly isMobile: boolean;
+	readonly decorations: { readonly kind: string };
+};
+
+function FalsePositiveCases({
+	showTrigger = true,
+	isAdmin,
+	error,
+	selectedUser,
+	title,
+	onExportData,
+	state,
+	isMobile,
+	decorations,
+}: Props) {
+	return (
+		<>
+			{showTrigger && <button type="button">Open</button>}
+			{isAdmin && <section>Admin tools</section>}
+			{error && <p>{error.message}</p>}
+			{selectedUser && <span>{selectedUser.name}</span>}
+			{title && <h1>{title}</h1>}
+			{onExportData && (
+				<button onClick={onExportData} type="button">
+					Export
+				</button>
+			)}
+			<p>{state === "WAIT" ? "Move to WAIT" : state}</p>
+			{isMobile ? null : decorations}
+		</>
+	);
+}
+
+```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noLeakedRender/issue8288.invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noLeakedRender/issue8288.invalid.jsx.snap
@@ -30,7 +30,7 @@ issue8288.invalid.jsx:5:19 lint/suspicious/noLeakedRender ━━━━━━━�
   
   i This happens when you use ternary operators in JSX with alternate values that could be variables.
   
-  i Replace with a safe alternate value like an empty string , null or another JSX element.
+  i Replace with a safe alternate value like an empty string, null or another JSX element.
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noLeakedRender/typed.invalid.tsx
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noLeakedRender/typed.invalid.tsx
@@ -1,0 +1,26 @@
+/* should generate diagnostics */
+type Props = {
+	readonly count: number;
+	readonly label: string;
+	readonly optionalCount: number | undefined;
+	readonly nullableLabel: string | null;
+	readonly selectedUser: { readonly name: string } | null;
+};
+
+function Component({
+	count,
+	label,
+	optionalCount,
+	nullableLabel,
+	selectedUser,
+}: Props) {
+	return (
+		<div>
+			{count && <span>Count: {count}</span>}
+			{label && <span>{label}</span>}
+			{optionalCount && <span>Count: {optionalCount}</span>}
+			{nullableLabel && <span>{nullableLabel}</span>}
+			<p>{count ? "has count" : selectedUser}</p>
+		</div>
+	);
+}

--- a/crates/biome_js_analyze/tests/specs/suspicious/noLeakedRender/typed.invalid.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noLeakedRender/typed.invalid.tsx.snap
@@ -1,0 +1,130 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: typed.invalid.tsx
+---
+# Input
+```tsx
+/* should generate diagnostics */
+type Props = {
+	readonly count: number;
+	readonly label: string;
+	readonly optionalCount: number | undefined;
+	readonly nullableLabel: string | null;
+	readonly selectedUser: { readonly name: string } | null;
+};
+
+function Component({
+	count,
+	label,
+	optionalCount,
+	nullableLabel,
+	selectedUser,
+}: Props) {
+	return (
+		<div>
+			{count && <span>Count: {count}</span>}
+			{label && <span>{label}</span>}
+			{optionalCount && <span>Count: {optionalCount}</span>}
+			{nullableLabel && <span>{nullableLabel}</span>}
+			<p>{count ? "has count" : selectedUser}</p>
+		</div>
+	);
+}
+
+```
+
+# Diagnostics
+```
+typed.invalid.tsx:19:5 lint/suspicious/noLeakedRender ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Potential leaked value that might cause unintended rendering.
+  
+    17 │ 	return (
+    18 │ 		<div>
+  > 19 │ 			{count && <span>Count: {count}</span>}
+       │ 			 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    20 │ 			{label && <span>{label}</span>}
+    21 │ 			{optionalCount && <span>Count: {optionalCount}</span>}
+  
+  i JavaScript's && operator returns the left value when it's falsy (e.g., 0, NaN, ''). React will render that value, causing unexpected UI output.
+  
+  i Make sure the condition is explicitly boolean. Use !!value, value > 0, or a ternary expression.
+  
+
+```
+
+```
+typed.invalid.tsx:20:5 lint/suspicious/noLeakedRender ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Potential leaked value that might cause unintended rendering.
+  
+    18 │ 		<div>
+    19 │ 			{count && <span>Count: {count}</span>}
+  > 20 │ 			{label && <span>{label}</span>}
+       │ 			 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    21 │ 			{optionalCount && <span>Count: {optionalCount}</span>}
+    22 │ 			{nullableLabel && <span>{nullableLabel}</span>}
+  
+  i JavaScript's && operator returns the left value when it's falsy (e.g., 0, NaN, ''). React will render that value, causing unexpected UI output.
+  
+  i Make sure the condition is explicitly boolean. Use !!value, value > 0, or a ternary expression.
+  
+
+```
+
+```
+typed.invalid.tsx:21:5 lint/suspicious/noLeakedRender ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Potential leaked value that might cause unintended rendering.
+  
+    19 │ 			{count && <span>Count: {count}</span>}
+    20 │ 			{label && <span>{label}</span>}
+  > 21 │ 			{optionalCount && <span>Count: {optionalCount}</span>}
+       │ 			 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    22 │ 			{nullableLabel && <span>{nullableLabel}</span>}
+    23 │ 			<p>{count ? "has count" : selectedUser}</p>
+  
+  i JavaScript's && operator returns the left value when it's falsy (e.g., 0, NaN, ''). React will render that value, causing unexpected UI output.
+  
+  i Make sure the condition is explicitly boolean. Use !!value, value > 0, or a ternary expression.
+  
+
+```
+
+```
+typed.invalid.tsx:22:5 lint/suspicious/noLeakedRender ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Potential leaked value that might cause unintended rendering.
+  
+    20 │ 			{label && <span>{label}</span>}
+    21 │ 			{optionalCount && <span>Count: {optionalCount}</span>}
+  > 22 │ 			{nullableLabel && <span>{nullableLabel}</span>}
+       │ 			 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    23 │ 			<p>{count ? "has count" : selectedUser}</p>
+    24 │ 		</div>
+  
+  i JavaScript's && operator returns the left value when it's falsy (e.g., 0, NaN, ''). React will render that value, causing unexpected UI output.
+  
+  i Make sure the condition is explicitly boolean. Use !!value, value > 0, or a ternary expression.
+  
+
+```
+
+```
+typed.invalid.tsx:23:8 lint/suspicious/noLeakedRender ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Potential leaked value that might cause unintended rendering.
+  
+    21 │ 			{optionalCount && <span>Count: {optionalCount}</span>}
+    22 │ 			{nullableLabel && <span>{nullableLabel}</span>}
+  > 23 │ 			<p>{count ? "has count" : selectedUser}</p>
+       │ 			    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    24 │ 		</div>
+    25 │ 	);
+  
+  i This happens when you use ternary operators in JSX with alternate values that could be variables.
+  
+  i Replace with a safe alternate value like an empty string, null or another JSX element.
+  
+
+```

--- a/crates/biome_js_type_info/src/inferred_type.rs
+++ b/crates/biome_js_type_info/src/inferred_type.rs
@@ -962,6 +962,44 @@ impl<'db> InferredType<'db> {
         .ok()
     }
 
+    /// Returns whether this type can never produce a leaked render value:
+    /// a falsy primitive (`0`, `NaN`, or `""`) that React renders as visible
+    /// text instead of nothing. `false`, `null`, and `undefined` are safe.
+    ///
+    /// Returns `None` when variant traversal cannot establish a result because
+    /// it encounters an unresolved or recursive type, or exceeds its limit.
+    pub fn is_never_leaked_render_value(self) -> Option<bool> {
+        self.try_all_variants_match(|data| match data {
+            TypeData::Boolean
+            | TypeData::Null
+            | TypeData::Undefined
+            | TypeData::VoidKeyword
+            | TypeData::Function(_)
+            | TypeData::Class(_)
+            | TypeData::Constructor(_)
+            | TypeData::Object(_)
+            | TypeData::ObjectKeyword
+            | TypeData::Interface(_)
+            | TypeData::Tuple(_)
+            | TypeData::Symbol
+            | TypeData::Global
+            | TypeData::Module(_)
+            | TypeData::Namespace(_)
+            | TypeData::InstanceOf(_) => true,
+            TypeData::Literal(literal) => match literal.literal(self.db) {
+                Literal::Boolean(_) | Literal::Object(_) | Literal::RegExp(_) => true,
+                Literal::String(string) => !string.as_str().is_empty(),
+                Literal::Number(number) => number.to_f64().is_some_and(|n| n != 0. && !n.is_nan()),
+                Literal::BigInt(text) => {
+                    canonicalize_js_bigint_literal(text.text()).as_deref() != Some("0n")
+                }
+                Literal::Template(_) => false,
+            },
+            _ => false,
+        })
+        .ok()
+    }
+
     /// Returns whether every variant of a nullish union is nullish or an ignored
     /// primitive. Non-union types return `Some(false)`.
     ///

--- a/crates/biome_service/src/configuration.rs
+++ b/crates/biome_service/src/configuration.rs
@@ -1187,7 +1187,7 @@ mod tests {
 
         assert_eq!(
             ProjectScanComputer::new(&configuration)
-                .with_rule_selectors(&[], &[DomainSelector("react").into()])
+                .with_rule_selectors(&[], &[DomainSelector("test").into()])
                 .compute(),
             ScanKind::NoScanner
         );


### PR DESCRIPTION
## Summary

Fixes #10514: `noLeakedRender` false-positived on destructured typed React props.

The rule now uses type inference to check `&&` conditions: it suppresses the diagnostic when the left-hand side's type can never be `0`, `NaN`, or `""`.

The diagnostic has been improved to provide more precise information to the user. (+ typo fixed)

## Test Plan

- `issue10514.valid.tsx`: original repro from the issue.
- `typed.invalid.tsx`: `number`/`string`/nullable-`number`/nullable-`string` props still flagged on `&&`, typed nullable identifier still flagged as ternary alternate.

## Docs

N/A

> Claude Code with Opus 5 was used with Biome skills, but reviewed and PR written by me.