### PR TITLE
perf(format/html): replace string comparisons with token set checks

### DIFF
--- a/.changeset/fix-html-component-tag-classification.md
+++ b/.changeset/fix-html-component-tag-classification.md
@@ -1,0 +1,12 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed the HTML formatter incorrectly applying native HTML element formatting to PascalCase component names such as `<Ul>` and `<Body>` in Vue, Svelte, and Astro files.
+
+```diff
+-<Body>
+-  <div>content</div>
+-</Body>
++<Body><div>content</div></Body>
+```

--- a/.changeset/fix-html-unknown-svg-display.md
+++ b/.changeset/fix-html-unknown-svg-display.md
@@ -1,0 +1,12 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed the HTML formatter incorrectly applying SVG block formatting to unknown elements whose names matched SVG element names.
+
+```diff
+-<foreignobject>
+-  <div>content</div>
+-</foreignobject>
++<foreignobject><div>content</div></foreignobject>
+```

--- a/.changeset/improve-html-tag-check-performance.md
+++ b/.changeset/improve-html-tag-check-performance.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Improved performance of the HTML formatter for documents that contain many HTML-native or SVG-native tags.

--- a/.changeset/remove-listing-formatter-handling.md
+++ b/.changeset/remove-listing-formatter-handling.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Removed special HTML formatter handling for the obsolete `<listing>` element.

--- a/crates/biome_html_formatter/src/html/auxiliary/element.rs
+++ b/crates/biome_html_formatter/src/html/auxiliary/element.rs
@@ -1,5 +1,5 @@
 use crate::html::lists::element_list::{FormatHtmlElementListOptions, HtmlChildListLayout};
-use crate::utils::css_display::{CssDisplay, get_css_display, get_css_display_from_tag};
+use crate::utils::css_display::{CssDisplay, get_css_display_from_tag};
 use crate::utils::metadata::{get_css_whitespace, get_element_css_display};
 use crate::verbatim::{format_html_leading_comments, format_html_leading_comments_for_block};
 use crate::{html::lists::element_list::FormatHtmlElementList, prelude::*};
@@ -7,11 +7,13 @@ use biome_formatter::{CstFormatContext, FormatRefWithRule, FormatRuleWithOptions
 use biome_html_syntax::{
     AnyHtmlContent, AnyHtmlElement, AnyHtmlTagName, HtmlElement, HtmlElementFields,
     HtmlElementList, HtmlRoot, HtmlSelfClosingElement,
-    HtmlSyntaxKind::{self, AUDIO_KW, OBJECT_KW, TEMPLATE_KW, VIDEO_KW},
+    HtmlSyntaxKind::{
+        self, AUDIO_KW, BODY_KW, HEAD_KW, HTML_KW, OBJECT_KW, OL_KW, SCRIPT_KW, SELECT_KW,
+        STYLE_KW, TEMPLATE_KW, UL_KW, VIDEO_KW,
+    },
     HtmlSyntaxToken,
 };
 use biome_parser::{TokenSet, token_set};
-use biome_string_case::StrLikeExtension;
 
 use super::{
     closing_element::{FormatHtmlClosingElement, FormatHtmlClosingElementOptions},
@@ -25,14 +27,16 @@ use super::{
 /// browser user-agent CSS.
 ///
 /// See also: <https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/white-space>
-fn is_verbatim_tag(tag_name: &str) -> bool {
-    tag_name.eq_ignore_ascii_case("script")
-        || tag_name.eq_ignore_ascii_case("style")
+fn is_verbatim_tag(tag_name: &AnyHtmlTagName) -> bool {
+    matches!(tag_name.tag_name_kind(), Some(SCRIPT_KW | STYLE_KW))
         || get_css_whitespace(tag_name).preserves_content()
 }
 
 const STRUCTURAL_FALLBACK_ELEMENTS: TokenSet<HtmlSyntaxKind> =
     token_set!(AUDIO_KW, OBJECT_KW, VIDEO_KW);
+
+const FORCE_BREAK_CHILDREN_ELEMENTS: TokenSet<HtmlSyntaxKind> =
+    token_set!(HTML_KW, HEAD_KW, UL_KW, OL_KW, SELECT_KW);
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatHtmlElement {
@@ -94,8 +98,9 @@ impl FormatNodeRule<HtmlElement> for FormatHtmlElement {
         // Instead of:
         // <!-- comment --> <div>...</div>
         let css_display = node
-            .tag_name()
-            .map_or(CssDisplay::Block, |tag| get_css_display(&tag));
+            .name()
+            .as_ref()
+            .map_or(CssDisplay::Block, get_css_display_from_tag);
 
         if css_display.is_block_like() {
             format_html_leading_comments_for_block(node.syntax()).fmt(f)
@@ -142,12 +147,12 @@ impl FormatHtmlElement {
             closing_element,
         } = node.as_fields();
 
-        let should_force_break_content = should_force_break_content(node);
-
         let closing_element = closing_element?;
         let opening_element = opening_element?;
         let tag_name = opening_element.name()?;
         let css_display = get_css_display_from_tag(&tag_name);
+        let should_force_break_content =
+            should_force_break_content(node, tag_name.tag_name_kind(), css_display);
         let is_element_internally_whitespace_sensitive =
             css_display.is_internally_whitespace_sensitive(f);
         let is_root_element_list = node
@@ -179,14 +184,7 @@ impl FormatHtmlElement {
                 AnyHtmlElement::AnyHtmlContent(AnyHtmlContent::HtmlEmbeddedContent(_))
             )
         });
-        let should_be_verbatim = has_embedded_content
-            || match tag_name {
-                AnyHtmlTagName::HtmlComponentName(_) | AnyHtmlTagName::HtmlMemberName(_) => false,
-                AnyHtmlTagName::HtmlTagName(tag_name) => tag_name
-                    .value_token()
-                    .as_ref()
-                    .is_ok_and(|tag_name_token| is_verbatim_tag(tag_name_token.text_trimmed())),
-            };
+        let should_be_verbatim = has_embedded_content || is_verbatim_tag(&tag_name);
 
         let should_format_embedded_nodes = if f.context().should_delegate_fmt_embedded_nodes() {
             // Only delegate for supported <script> or <style> content
@@ -345,33 +343,33 @@ impl FormatHtmlElement {
 /// This is equivalent to Prettier's `function forceBreakChildren()`.
 ///
 /// Prettier source: src/language-html/utilities/index.js:271-278
-fn should_force_break_children(tag_name: &str) -> bool {
-    let tag_lower = tag_name.to_ascii_lowercase_cow();
-
-    // These elements always break children
-    if matches!(tag_lower.as_ref(), "html" | "head" | "ul" | "ol" | "select") {
+fn should_force_break_children(
+    tag_name_kind: Option<HtmlSyntaxKind>,
+    css_display: CssDisplay,
+) -> bool {
+    if tag_name_kind.is_some_and(|kind| FORCE_BREAK_CHILDREN_ELEMENTS.contains(kind)) {
         return true;
     }
 
     // Table-related elements (except table-cell) break children
-    let display = get_css_display(&tag_lower);
-    display.is_table_like() && !matches!(display, CssDisplay::TableCell)
+    css_display.is_table_like() && !matches!(css_display, CssDisplay::TableCell)
 }
 
 /// Determines if the content of an element should be forcefully broken into multiple lines.
 ///
 /// This is equivalent to Prettier's `function forceBreakContent()`.
-fn should_force_break_content(node: &HtmlElement) -> bool {
-    let Some(tag_name) = node.tag_name() else {
-        return false;
-    };
-    if should_force_break_children(&tag_name) {
+fn should_force_break_content(
+    node: &HtmlElement,
+    tag_name_kind: Option<HtmlSyntaxKind>,
+    css_display: CssDisplay,
+) -> bool {
+    if should_force_break_children(tag_name_kind, css_display) {
         return true;
     }
 
     // prettier also considers `<script>` and `<style>` here, but we handle those elsewhere.
     // if its a `<body>` or if the grandchildren contain non-text nodes
-    if !node.children().is_empty() && tag_name.eq_ignore_ascii_case("body")
+    if !node.children().is_empty() && tag_name_kind == Some(BODY_KW)
         || node.children().iter().any(|child| {
             if let Some(element) = child.as_html_element() {
                 has_non_text_child(&element.children())

--- a/crates/biome_html_formatter/src/utils/css_display.rs
+++ b/crates/biome_html_formatter/src/utils/css_display.rs
@@ -9,9 +9,209 @@
 //! - HTML WHATWG spec: <https://html.spec.whatwg.org/multipage/rendering.html#the-css-user-agent-style-sheet-and-presentational-hints>
 
 use crate::HtmlFormatter;
-use crate::utils::metadata::{MATHML_ALL_TAGS, SVG_ALL_TAGS};
-use biome_html_syntax::AnyHtmlTagName;
+use crate::utils::metadata::MATHML_ALL_TAGS;
+use biome_html_syntax::{
+    AnyHtmlTagName,
+    HtmlSyntaxKind::{self, *},
+};
+use biome_parser::{TokenSet, token_set};
 use biome_string_case::StrLikeExtension;
+
+const BLOCK_ELEMENTS: TokenSet<HtmlSyntaxKind> = token_set!(
+    HTML_KW,
+    BODY_KW,
+    ADDRESS_KW,
+    BLOCKQUOTE_KW,
+    CENTER_KW,
+    DIALOG_KW,
+    DIV_KW,
+    FIGURE_KW,
+    FIGCAPTION_KW,
+    FOOTER_KW,
+    FORM_KW,
+    HEADER_KW,
+    HR_KW,
+    LEGEND_KW,
+    MAIN_KW,
+    P_KW,
+    PLAINTEXT_KW,
+    PRE_KW,
+    SEARCH_KW,
+    XMP_KW,
+    ARTICLE_KW,
+    ASIDE_KW,
+    H1_KW,
+    H2_KW,
+    H3_KW,
+    H4_KW,
+    H5_KW,
+    H6_KW,
+    HGROUP_KW,
+    NAV_KW,
+    SECTION_KW,
+    DIR_KW,
+    DD_KW,
+    DL_KW,
+    DT_KW,
+    MENU_KW,
+    OL_KW,
+    UL_KW,
+    DETAILS_KW,
+    SUMMARY_KW,
+    PARAM_KW,
+    SOURCE_KW,
+    TRACK_KW,
+    FIELDSET_KW,
+    OPTION_KW,
+    OPTGROUP_KW,
+    ANIMATE_KW,
+    ANIMATE_MOTION_KW,
+    ANIMATE_TRANSFORM_KW,
+    CIRCLE_KW,
+    CLIP_PATH_KW,
+    DEFS_KW,
+    DESC_KW,
+    ELLIPSE_KW,
+    FE_BLEND_KW,
+    FE_COLOR_MATRIX_KW,
+    FE_COMPONENT_TRANSFER_KW,
+    FE_COMPOSITE_KW,
+    FE_CONVOLVE_MATRIX_KW,
+    FE_DIFFUSE_LIGHTING_KW,
+    FE_DISPLACEMENT_MAP_KW,
+    FE_DISTANT_LIGHT_KW,
+    FE_DROP_SHADOW_KW,
+    FE_FLOOD_KW,
+    FE_FUNC_A_KW,
+    FE_FUNC_B_KW,
+    FE_FUNC_G_KW,
+    FE_FUNC_R_KW,
+    FE_GAUSSIAN_BLUR_KW,
+    FE_IMAGE_KW,
+    FE_MERGE_KW,
+    FE_MERGE_NODE_KW,
+    FE_MORPHOLOGY_KW,
+    FE_OFFSET_KW,
+    FE_POINT_LIGHT_KW,
+    FE_SPECULAR_LIGHTING_KW,
+    FE_SPOT_LIGHT_KW,
+    FE_TILE_KW,
+    FE_TURBULENCE_KW,
+    FILTER_KW,
+    FOREIGN_OBJECT_KW,
+    G_KW,
+    IMAGE_KW,
+    LINE_KW,
+    LINEAR_GRADIENT_KW,
+    MARKER_KW,
+    MASK_KW,
+    METADATA_KW,
+    MPATH_KW,
+    PATH_KW,
+    PATTERN_KW,
+    POLYGON_KW,
+    POLYLINE_KW,
+    RADIAL_GRADIENT_KW,
+    RECT_KW,
+    SET_KW,
+    STOP_KW,
+    SWITCH_KW,
+    SYMBOL_KW,
+    TEXT_KW,
+    TEXT_PATH_KW,
+    TSPAN_KW,
+    USE_KW,
+    VIEW_KW
+);
+
+const INLINE_ELEMENTS: TokenSet<HtmlSyntaxKind> = token_set!(
+    IMG_KW,
+    EMBED_KW,
+    IFRAME_KW,
+    CANVAS_KW,
+    TEMPLATE_KW,
+    A_KW,
+    ABBR_KW,
+    ACRONYM_KW,
+    B_KW,
+    BDI_KW,
+    BDO_KW,
+    BIG_KW,
+    BR_KW,
+    CITE_KW,
+    CODE_KW,
+    DATA_KW,
+    DEL_KW,
+    DFN_KW,
+    EM_KW,
+    FONT_KW,
+    I_KW,
+    INS_KW,
+    KBD_KW,
+    LABEL_KW,
+    MAP_KW,
+    MARK_KW,
+    NOBR_KW,
+    OUTPUT_KW,
+    PICTURE_KW,
+    Q_KW,
+    S_KW,
+    SAMP_KW,
+    SLOT_KW,
+    SMALL_KW,
+    SPAN_KW,
+    STRIKE_KW,
+    STRONG_KW,
+    SUB_KW,
+    SUP_KW,
+    TIME_KW,
+    TT_KW,
+    U_KW,
+    VAR_KW,
+    WBR_KW,
+    AUDIO_KW,
+    BGSOUND_KW,
+    BLINK_KW,
+    COMPONENT_KW,
+    FRAME_KW,
+    FRAMESET_KW,
+    KEYGEN_KW,
+    MENUITEM_KW,
+    NOSCRIPT_KW,
+    OBJECT_KW,
+    VIDEO_KW
+);
+
+const HIDDEN_ELEMENTS: TokenSet<HtmlSyntaxKind> = token_set!(
+    RP_KW,
+    AREA_KW,
+    BASE_KW,
+    BASEFONT_KW,
+    DATALIST_KW,
+    HEAD_KW,
+    LINK_KW,
+    META_KW,
+    NOEMBED_KW,
+    NOFRAMES_KW,
+    SCRIPT_KW,
+    STYLE_KW,
+    TITLE_KW
+);
+
+const INLINE_BLOCK_ELEMENTS: TokenSet<HtmlSyntaxKind> = token_set!(
+    SVG_KW,
+    BUTTON_KW,
+    TEXTAREA_KW,
+    INPUT_KW,
+    SELECT_KW,
+    METER_KW,
+    PROGRESS_KW,
+    MARQUEE_KW
+);
+
+const TABLE_CELL_ELEMENTS: TokenSet<HtmlSyntaxKind> = token_set!(TD_KW, TH_KW);
+
+const RUBY_TEXT_ELEMENTS: TokenSet<HtmlSyntaxKind> = token_set!(RT_KW, RTC_KW);
 
 /// CSS display values that are relevant for HTML formatting decisions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -149,98 +349,43 @@ impl CssDisplay {
     }
 }
 
-/// Gets the CSS display value for a given HTML tag name.
-///
-/// This returns the default display value from the browser's user-agent stylesheet.
-/// For unknown elements, returns `CssDisplay::Inline` (the CSS default).
-///
-/// Data source: `html-ua-styles` npm package and HTML WHATWG spec.
-/// Includes Prettier-specific adjustments for formatting purposes.
-pub fn get_css_display(tag_name: &str) -> CssDisplay {
-    // Use case-insensitive matching
-    let tag_lower = tag_name.to_ascii_lowercase_cow();
+fn get_unknown_css_display(tag_name: &str) -> CssDisplay {
+    let tag_name = tag_name.to_ascii_lowercase_cow();
+    if MATHML_ALL_TAGS.binary_search(&tag_name.as_ref()).is_ok() {
+        CssDisplay::Block
+    } else {
+        CssDisplay::Inline
+    }
+}
 
-    match tag_lower.as_ref() {
-        // Block elements
-        "html" | "body" | "address" | "blockquote" | "center" | "dialog" | "div" | "figure"
-        | "figcaption" | "footer" | "form" | "header" | "hr" | "legend" | "listing" | "main"
-        | "p" | "plaintext" | "pre" | "search" | "xmp" => CssDisplay::Block,
-
-        // Sections and headings (block)
-        "article" | "aside" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "hgroup" | "nav"
-        | "section" => CssDisplay::Block,
-
-        // Lists (block)
-        "dir" | "dd" | "dl" | "dt" | "menu" | "ol" | "ul" => CssDisplay::Block,
-
-        // List items
-        "li" => CssDisplay::ListItem,
-
-        // Details/summary (block)
-        "details" | "summary" => CssDisplay::Block,
-
-        // Table elements
-        "table" => CssDisplay::Table,
-        "caption" => CssDisplay::TableCaption,
-        "colgroup" => CssDisplay::TableColumnGroup,
-        "col" => CssDisplay::TableColumn,
-        "thead" => CssDisplay::TableHeaderGroup,
-        "tbody" => CssDisplay::TableRowGroup,
-        "tfoot" => CssDisplay::TableFooterGroup,
-        "tr" => CssDisplay::TableRow,
-        "td" | "th" => CssDisplay::TableCell,
-
-        // Ruby elements
-        "ruby" => CssDisplay::Ruby,
-        "rb" => CssDisplay::RubyBase,
-        "rt" | "rtc" => CssDisplay::RubyText,
-        "rp" => CssDisplay::None,
-
-        // Hidden elements
-        "area" | "base" | "basefont" | "datalist" | "head" | "link" | "meta" | "noembed"
-        | "noframes" | "script" | "style" | "title" => CssDisplay::None,
-
-        // Media elements
-        "svg" => CssDisplay::InlineBlock,
-        "param" => CssDisplay::Block,
-
-        // Form elements - inline-block
-        "button" | "textarea" | "input" | "select" | "meter" | "progress" => {
-            CssDisplay::InlineBlock
-        }
-
-        // https://html.spec.whatwg.org/multipage/rendering.html#the-marquee-element-2
-        "marquee" => CssDisplay::InlineBlock,
-
-        // Replaced/embedded content (inline or inline-block depending on context)
-        "img" | "embed" | "iframe" | "canvas" | "template" => CssDisplay::Inline,
-
-        // Other inline elements
-        "a" | "abbr" | "acronym" | "b" | "bdi" | "bdo" | "big" | "br" | "cite" | "code"
-        | "data" | "del" | "dfn" | "em" | "font" | "i" | "ins" | "kbd" | "label" | "map"
-        | "mark" | "nobr" | "output" | "picture" | "q" | "s" | "samp" | "slot" | "small"
-        | "span" | "strike" | "strong" | "sub" | "sup" | "time" | "tt" | "u" | "var" | "wbr" => {
-            CssDisplay::Inline
-        }
-
-        // Source and track are hidden, but prettier treats them as block for formatting purposes
-        "source" | "track" => CssDisplay::Block,
-
-        // Fieldset is block
-        "fieldset" => CssDisplay::Block,
-
-        // Option/optgroup have special handling in selects
-        "option" | "optgroup" => CssDisplay::Block,
-
-        // Unknown elements default to inline (CSS default behavior)
-        other => {
-            if SVG_ALL_TAGS.binary_search(&other).is_ok()
-                || MATHML_ALL_TAGS.binary_search(&other).is_ok()
-            {
-                CssDisplay::Block
-            } else {
-                CssDisplay::Inline
-            }
+fn get_css_display(kind: HtmlSyntaxKind, tag_name: &str) -> CssDisplay {
+    if INLINE_ELEMENTS.contains(kind) {
+        CssDisplay::Inline
+    } else if BLOCK_ELEMENTS.contains(kind) {
+        CssDisplay::Block
+    } else if HIDDEN_ELEMENTS.contains(kind) {
+        CssDisplay::None
+    } else if INLINE_BLOCK_ELEMENTS.contains(kind) {
+        CssDisplay::InlineBlock
+    } else if TABLE_CELL_ELEMENTS.contains(kind) {
+        CssDisplay::TableCell
+    } else if RUBY_TEXT_ELEMENTS.contains(kind) {
+        CssDisplay::RubyText
+    } else {
+        match kind {
+            LI_KW => CssDisplay::ListItem,
+            TABLE_KW => CssDisplay::Table,
+            CAPTION_KW => CssDisplay::TableCaption,
+            COLGROUP_KW => CssDisplay::TableColumnGroup,
+            COL_KW => CssDisplay::TableColumn,
+            THEAD_KW => CssDisplay::TableHeaderGroup,
+            TBODY_KW => CssDisplay::TableRowGroup,
+            TFOOT_KW => CssDisplay::TableFooterGroup,
+            TR_KW => CssDisplay::TableRow,
+            RUBY_KW => CssDisplay::Ruby,
+            RB_KW => CssDisplay::RubyBase,
+            HTML_UNKNOWN_TAG => get_unknown_css_display(tag_name),
+            _ => CssDisplay::Inline,
         }
     }
 }
@@ -254,7 +399,13 @@ pub fn get_css_display_from_tag(tag_name: &AnyHtmlTagName) -> CssDisplay {
             let Ok(token) = tag_name.value_token() else {
                 return CssDisplay::Inline;
             };
-            get_css_display(token.text_trimmed())
+            let kind = token.kind();
+            let tag_name = if kind == HTML_UNKNOWN_TAG {
+                token.text_trimmed()
+            } else {
+                ""
+            };
+            get_css_display(kind, tag_name)
         }
     }
 }
@@ -263,88 +414,114 @@ pub fn get_css_display_from_tag(tag_name: &AnyHtmlTagName) -> CssDisplay {
 mod tests {
     use super::*;
 
+    fn display(kind: HtmlSyntaxKind) -> CssDisplay {
+        get_css_display(kind, "")
+    }
+
     #[test]
     fn test_block_elements() {
         let block_tags = [
-            "div", "p", "h1", "ul", "ol", "section", "article", "header", "footer",
+            DIV_KW, P_KW, H1_KW, UL_KW, OL_KW, SECTION_KW, ARTICLE_KW, HEADER_KW, FOOTER_KW,
         ];
         for tag in block_tags {
             assert!(
-                get_css_display(tag).is_block_like(),
-                "Expected '{tag}' to be block-like"
+                display(tag).is_block_like(),
+                "Expected '{tag:?}' to be block-like"
             );
         }
     }
 
     #[test]
     fn test_inline_elements() {
-        let inline_tags = ["span", "a", "strong", "em", "b", "i", "code", "label"];
+        let inline_tags = [
+            SPAN_KW, A_KW, STRONG_KW, EM_KW, B_KW, I_KW, CODE_KW, LABEL_KW,
+        ];
         for tag in inline_tags {
             assert!(
-                get_css_display(tag).is_inline_like(),
-                "Expected '{tag}' to be inline-like"
+                display(tag).is_inline_like(),
+                "Expected '{tag:?}' to be inline-like"
             );
         }
     }
 
     #[test]
     fn test_tr_is_table_like() {
-        assert!(get_css_display("tr").is_table_like());
-    }
-
-    #[test]
-    fn test_case_insensitive() {
-        assert_eq!(get_css_display("DIV"), CssDisplay::Block);
-        assert_eq!(get_css_display("Span"), CssDisplay::Inline);
-        assert_eq!(get_css_display("TD"), CssDisplay::TableCell);
+        assert!(display(TR_KW).is_table_like());
     }
 
     #[test]
     fn test_hidden_elements() {
-        let hidden_tags = ["head", "script", "style", "meta", "link"];
+        let hidden_tags = [HEAD_KW, SCRIPT_KW, STYLE_KW, META_KW, LINK_KW];
         for tag in hidden_tags {
             assert_eq!(
-                get_css_display(tag),
+                display(tag),
                 CssDisplay::None,
-                "Expected '{tag}' to be display: none"
+                "Expected '{tag:?}' to be display: none"
             );
         }
     }
 
     #[test]
     fn test_form_elements_are_inline_block() {
-        let form_tags = ["button", "input", "select", "textarea"];
+        let form_tags = [BUTTON_KW, INPUT_KW, SELECT_KW, TEXTAREA_KW];
         for tag in form_tags {
             assert_eq!(
-                get_css_display(tag),
+                display(tag),
                 CssDisplay::InlineBlock,
-                "Expected '{tag}' to be inline-block"
+                "Expected '{tag:?}' to be inline-block"
             );
         }
     }
 
     #[test]
     fn test_whitespace_sensitive_display_classifications() {
-        assert_eq!(get_css_display("marquee"), CssDisplay::InlineBlock);
+        assert_eq!(display(MARQUEE_KW), CssDisplay::InlineBlock);
 
-        for tag in ["noscript", "video", "audio", "object"] {
+        for tag in [NOSCRIPT_KW, VIDEO_KW, AUDIO_KW, OBJECT_KW] {
             assert_eq!(
-                get_css_display(tag),
+                display(tag),
                 CssDisplay::Inline,
-                "Expected '{tag}' to be inline"
+                "Expected '{tag:?}' to be inline"
             );
         }
     }
 
     #[test]
     fn test_unknown_elements_default_to_inline() {
-        assert_eq!(get_css_display("custom-element"), CssDisplay::Inline);
-        assert_eq!(get_css_display("my-component"), CssDisplay::Inline);
+        assert_eq!(
+            get_css_display(HTML_UNKNOWN_TAG, "custom-element"),
+            CssDisplay::Inline
+        );
+        assert_eq!(
+            get_css_display(HTML_UNKNOWN_TAG, "my-component"),
+            CssDisplay::Inline
+        );
+        assert_eq!(
+            get_css_display(HTML_UNKNOWN_TAG, "foreignobject"),
+            CssDisplay::Inline
+        );
+    }
+
+    #[test]
+    fn test_svg_element_is_block() {
+        assert_eq!(display(IMAGE_KW), CssDisplay::Block);
+    }
+
+    #[test]
+    fn test_mathml_elements_are_block() {
+        assert_eq!(
+            get_css_display(HTML_UNKNOWN_TAG, "mfrac"),
+            CssDisplay::Block
+        );
+        assert_eq!(
+            get_css_display(HTML_UNKNOWN_TAG, "ANNOTATION-XML"),
+            CssDisplay::Block
+        );
     }
 
     #[test]
     fn test_list_item() {
-        assert_eq!(get_css_display("li"), CssDisplay::ListItem);
+        assert_eq!(display(LI_KW), CssDisplay::ListItem);
         // ListItem is block-like
         assert!(CssDisplay::ListItem.is_block_like());
     }

--- a/crates/biome_html_formatter/src/utils/metadata.rs
+++ b/crates/biome_html_formatter/src/utils/metadata.rs
@@ -1,17 +1,22 @@
 use std::{borrow::Cow, collections::HashMap, sync::LazyLock};
 
-use biome_html_syntax::{AnyHtmlElement, AnyHtmlTagName, HtmlAttributeName, HtmlTagName};
+use biome_html_syntax::{
+    AnyHtmlElement, AnyHtmlTagName, HtmlAttributeName,
+    HtmlSyntaxKind::{self, *},
+    HtmlTagName,
+};
+use biome_parser::{TokenSet, token_set};
 use biome_string_case::{StrLikeExtension, StrOnlyExtension};
 
 use crate::{
     HtmlFormatter,
-    utils::css_display::{CssDisplay, get_css_display},
+    utils::css_display::{CssDisplay, get_css_display_from_tag},
 };
 
 /// HTML tags that have a "block" layout, or anything that is not inline by default.
 ///
 /// **NOTE**: This list is kept for reference but is no longer used directly.
-/// Use [`crate::utils::css_display::get_css_display`] instead for accurate CSS display values.
+/// Use [`crate::utils::css_display::get_css_display_from_tag`] instead for accurate CSS display values.
 ///
 /// ### References
 ///  - <https://html.spec.whatwg.org/#flow-content-3>
@@ -35,7 +40,6 @@ pub const HTML_BLOCK_TAGS: &[&str] = &[
     "header",
     "hr",
     "legend",
-    "listing",
     "main",
     "p",
     "plaintext",
@@ -170,7 +174,6 @@ pub const HTML_ALL_TAGS: &[&str] = &[
     "li",
     "li",
     "link",
-    "listing",
     "main",
     "map",
     "mark",
@@ -794,20 +797,135 @@ pub static MATHML_ALL_TAGS: &[&str] = &[
     "semantics",
 ];
 
-/// Whether the given tag name is a known HTML element. See also: [`HTML_ALL_TAGS`].
-pub(crate) fn is_canonical_html_tag_name(tag_name: &str) -> bool {
-    match tag_name.to_ascii_lowercase_cow() {
-        Cow::Owned(name) => HTML_ALL_TAGS.binary_search(&name.as_str()).is_ok(),
-        Cow::Borrowed(name) => HTML_ALL_TAGS.binary_search(&name).is_ok(),
-    }
-}
+const CANONICAL_HTML_TAGS: TokenSet<HtmlSyntaxKind> = token_set!(
+    A_KW,
+    ABBR_KW,
+    ADDRESS_KW,
+    AREA_KW,
+    ARTICLE_KW,
+    ASIDE_KW,
+    AUDIO_KW,
+    B_KW,
+    BASE_KW,
+    BASEFONT_KW,
+    BDI_KW,
+    BDO_KW,
+    BIG_KW,
+    BLOCKQUOTE_KW,
+    BODY_KW,
+    BR_KW,
+    BUTTON_KW,
+    CANVAS_KW,
+    CAPTION_KW,
+    CENTER_KW,
+    CITE_KW,
+    CODE_KW,
+    COL_KW,
+    COLGROUP_KW,
+    DATA_KW,
+    DATALIST_KW,
+    DD_KW,
+    DETAILS_KW,
+    DFN_KW,
+    DIALOG_KW,
+    DIR_KW,
+    DIV_KW,
+    DL_KW,
+    DT_KW,
+    EM_KW,
+    EMBED_KW,
+    FIELDSET_KW,
+    FIGCAPTION_KW,
+    FIGURE_KW,
+    FOOTER_KW,
+    FORM_KW,
+    H1_KW,
+    H2_KW,
+    H3_KW,
+    H4_KW,
+    H5_KW,
+    H6_KW,
+    HEAD_KW,
+    HEADER_KW,
+    HGROUP_KW,
+    HR_KW,
+    HTML_KW,
+    I_KW,
+    IFRAME_KW,
+    IMG_KW,
+    INPUT_KW,
+    KBD_KW,
+    LABEL_KW,
+    LEGEND_KW,
+    LI_KW,
+    LINK_KW,
+    MAIN_KW,
+    MAP_KW,
+    MARK_KW,
+    MENU_KW,
+    META_KW,
+    METER_KW,
+    NAV_KW,
+    NOEMBED_KW,
+    NOFRAMES_KW,
+    NOSCRIPT_KW,
+    OBJECT_KW,
+    OL_KW,
+    OPTGROUP_KW,
+    OPTION_KW,
+    OUTPUT_KW,
+    P_KW,
+    PARAM_KW,
+    PICTURE_KW,
+    PLAINTEXT_KW,
+    PRE_KW,
+    PROGRESS_KW,
+    Q_KW,
+    RP_KW,
+    RT_KW,
+    RUBY_KW,
+    S_KW,
+    SAMP_KW,
+    SCRIPT_KW,
+    SEARCH_KW,
+    SECTION_KW,
+    SELECT_KW,
+    SLOT_KW,
+    SMALL_KW,
+    SOURCE_KW,
+    SPAN_KW,
+    STRONG_KW,
+    STYLE_KW,
+    SUB_KW,
+    SUMMARY_KW,
+    SUP_KW,
+    TABLE_KW,
+    TBODY_KW,
+    TD_KW,
+    TEMPLATE_KW,
+    TEXTAREA_KW,
+    TFOOT_KW,
+    TH_KW,
+    THEAD_KW,
+    TIME_KW,
+    TITLE_KW,
+    TR_KW,
+    TRACK_KW,
+    U_KW,
+    UL_KW,
+    VAR_KW,
+    VIDEO_KW,
+    WBR_KW,
+    XMP_KW
+);
 
 /// Whether the given tag name is a known HTML element. See also: [`HTML_ALL_TAGS`].
 pub(crate) fn is_canonical_html_tag(tag_name: &HtmlTagName) -> bool {
-    let Ok(tag_name) = tag_name.value_token() else {
+    let Ok(token) = tag_name.value_token() else {
         return false;
     };
-    is_canonical_html_tag_name(tag_name.text_trimmed())
+    let kind = token.kind();
+    CANONICAL_HTML_TAGS.contains(kind)
 }
 
 /// Whether a tag should be lowercased in the current formatting context.
@@ -895,10 +1013,20 @@ pub(crate) fn get_element_css_display(element: &AnyHtmlElement) -> CssDisplay {
         };
     }
 
-    if let Some(tag_name) = element.name() {
-        get_css_display(&tag_name)
-    } else {
-        CssDisplay::Inline
+    match element {
+        AnyHtmlElement::HtmlElement(element) => element
+            .name()
+            .as_ref()
+            .map_or(CssDisplay::Inline, get_css_display_from_tag),
+        AnyHtmlElement::HtmlSelfClosingElement(element) => element
+            .name()
+            .as_ref()
+            .map_or(CssDisplay::Inline, get_css_display_from_tag),
+        AnyHtmlElement::AnyHtmlContent(_)
+        | AnyHtmlElement::AstroFragment(_)
+        | AnyHtmlElement::HtmlBogusElement(_)
+        | AnyHtmlElement::HtmlProcessingInstruction(_)
+        | AnyHtmlElement::HtmlCdataSection(_) => CssDisplay::Inline,
     }
 }
 
@@ -933,29 +1061,40 @@ impl CssWhitespace {
 /// Gets the CSS whitespace handling mode for an HTML element, based on its tag name.
 ///
 /// See: <https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/white-space>
-pub(crate) fn get_css_whitespace(tag_name: &str) -> CssWhitespace {
+const PRE_WHITESPACE_ELEMENTS: TokenSet<HtmlSyntaxKind> = token_set!(PLAINTEXT_KW, PRE_KW, XMP_KW);
+
+fn get_css_whitespace_by_kind(kind: HtmlSyntaxKind) -> CssWhitespace {
     // Mirrors Prettier's CSS white-space lookup:
     // prettier/src/language-html/constants.evaluate.js
     // prettier/src/language-html/utilities/index.js#getNodeCssStyleWhiteSpace
     //
     // Final tag mapping in Prettier:
-    // - listing, plaintext, pre, xmp: "pre"
+    // - plaintext, pre, xmp: "pre"
     // - textarea: "pre-wrap"
     // - nobr: "nowrap"
     // - table: "initial" (effectively treated as default "normal")
 
-    // The cow makes this have a lower allocation chance. Also, this intentionally
-    // avoids using multiple `eq_ignore_ascii_case` checks because this optimizes
-    // into SIMD instructions, and overall less CPU instructions.
-    let tag_name = tag_name.to_ascii_lowercase_cow();
-    let tag_name = tag_name.as_ref();
+    if PRE_WHITESPACE_ELEMENTS.contains(kind) {
+        CssWhitespace::Pre
+    } else {
+        match kind {
+            TEXTAREA_KW => CssWhitespace::PreWrap,
+            NOBR_KW => CssWhitespace::PreserveNoWrap,
+            _ => CssWhitespace::Normal,
+        }
+    }
+}
+
+pub(crate) fn get_css_whitespace(tag_name: &AnyHtmlTagName) -> CssWhitespace {
     match tag_name {
-        "listing" | "plaintext" | "pre" | "xmp" => CssWhitespace::Pre,
-        "textarea" => CssWhitespace::PreWrap,
-        "nobr" => CssWhitespace::PreserveNoWrap,
-        // In Prettier this is "initial", which computes to the initial value (`normal`).
-        "table" => CssWhitespace::Normal,
-        _ => CssWhitespace::Normal,
+        AnyHtmlTagName::HtmlTagName(tag_name) => tag_name
+            .value_token()
+            .map_or(CssWhitespace::Normal, |token| {
+                get_css_whitespace_by_kind(token.kind())
+            }),
+        AnyHtmlTagName::HtmlComponentName(_) | AnyHtmlTagName::HtmlMemberName(_) => {
+            CssWhitespace::Normal
+        }
     }
 }
 
@@ -970,6 +1109,17 @@ mod tests {
             let mut sorted = HTML_ALL_TAGS.to_vec();
             sorted.sort_unstable();
             panic!("All tags array is not sorted. Here it is sorted {sorted:?}");
+        }
+    }
+
+    #[test]
+    fn canonical_html_tag_set_contains_all_classified_tags() {
+        for tag in HTML_ALL_TAGS {
+            assert!(
+                HtmlSyntaxKind::from_keyword(tag)
+                    .is_some_and(|kind| CANONICAL_HTML_TAGS.contains(kind)),
+                "Canonical tag '{tag}' is missing from the token set"
+            );
         }
     }
 
@@ -1018,36 +1168,32 @@ mod tests {
     }
 
     #[test]
-    fn test_is_canonical_html_tag_name_should_match_case_insensitive() {
-        let cases = ["div", "DIV", "Div"];
-        for case in cases {
-            assert!(
-                is_canonical_html_tag_name(case),
-                "Did not recognize '{case}' as a canonical HTML tag name, but it should be."
-            );
-        }
-    }
-
-    #[test]
     fn test_get_css_whitespace_matches_prettier() {
         // From Prettier's computed `CSS_WHITE_SPACE_TAGS` mapping:
         // prettier/src/language-html/constants.evaluate.js
-        assert_eq!(get_css_whitespace("pre"), CssWhitespace::Pre);
-        assert_eq!(get_css_whitespace("listing"), CssWhitespace::Pre);
-        assert_eq!(get_css_whitespace("plaintext"), CssWhitespace::Pre);
-        assert_eq!(get_css_whitespace("xmp"), CssWhitespace::Pre);
+        assert_eq!(get_css_whitespace_by_kind(PRE_KW), CssWhitespace::Pre);
+        assert_eq!(get_css_whitespace_by_kind(PLAINTEXT_KW), CssWhitespace::Pre);
+        assert_eq!(get_css_whitespace_by_kind(XMP_KW), CssWhitespace::Pre);
 
-        assert_eq!(get_css_whitespace("textarea"), CssWhitespace::PreWrap);
-        assert_eq!(get_css_whitespace("nobr"), CssWhitespace::PreserveNoWrap);
+        assert_eq!(
+            get_css_whitespace_by_kind(TEXTAREA_KW),
+            CssWhitespace::PreWrap
+        );
+        assert_eq!(
+            get_css_whitespace_by_kind(NOBR_KW),
+            CssWhitespace::PreserveNoWrap
+        );
 
         // Prettier returns the CSS value "initial" for table, which computes to `normal`.
-        assert_eq!(get_css_whitespace("table"), CssWhitespace::Normal);
+        assert_eq!(
+            get_css_whitespace_by_kind(HtmlSyntaxKind::TABLE_KW),
+            CssWhitespace::Normal
+        );
 
         // Default value
-        assert_eq!(get_css_whitespace("div"), CssWhitespace::Normal);
-
-        // Case-insensitive
-        assert_eq!(get_css_whitespace("PRE"), CssWhitespace::Pre);
-        assert_eq!(get_css_whitespace("NoBr"), CssWhitespace::PreserveNoWrap);
+        assert_eq!(
+            get_css_whitespace_by_kind(HtmlSyntaxKind::DIV_KW),
+            CssWhitespace::Normal
+        );
     }
 }

--- a/crates/biome_html_formatter/tests/specs/html/component-frameworks/astro-component-casing.astro
+++ b/crates/biome_html_formatter/tests/specs/html/component-frameworks/astro-component-casing.astro
@@ -5,5 +5,7 @@ import TextInput from './TextInput.astro';
 
 <Button label="test button" />
 <TextInput placeholder="enter text" />
+<Ul><li>a</li><li>b</li></Ul>
+<Body><div>content</div></Body>
 <button>native button</button>
 <input type="text" />

--- a/crates/biome_html_formatter/tests/specs/html/component-frameworks/astro-component-casing.astro.snap
+++ b/crates/biome_html_formatter/tests/specs/html/component-frameworks/astro-component-casing.astro.snap
@@ -13,6 +13,8 @@ import TextInput from './TextInput.astro';
 
 <Button label="test button" />
 <TextInput placeholder="enter text" />
+<Ul><li>a</li><li>b</li></Ul>
+<Body><div>content</div></Body>
 <button>native button</button>
 <input type="text" />
 
@@ -29,6 +31,11 @@ import TextInput from "./TextInput.astro";
 
 <Button label="test button" />
 <TextInput placeholder="enter text" />
+<Ul
+	><li>a</li>
+	<li>b</li></Ul
+>
+<Body><div>content</div></Body>
 <button>native button</button>
 <input type="text">
 

--- a/crates/biome_html_formatter/tests/specs/html/component-frameworks/svelte-component-casing.svelte
+++ b/crates/biome_html_formatter/tests/specs/html/component-frameworks/svelte-component-casing.svelte
@@ -7,6 +7,8 @@
 <Button label="test button" />
 <TextInput placeholder="enter text" />
 <Select options={['a', 'b']} />
+<Ul><li>a</li><li>b</li></Ul>
+<Body><div>content</div></Body>
 <button>native button</button>
 <input type="text" />
 <select><option>native</option></select>

--- a/crates/biome_html_formatter/tests/specs/html/component-frameworks/svelte-component-casing.svelte.snap
+++ b/crates/biome_html_formatter/tests/specs/html/component-frameworks/svelte-component-casing.svelte.snap
@@ -15,6 +15,8 @@ info: component-frameworks/svelte-component-casing.svelte
 <Button label="test button" />
 <TextInput placeholder="enter text" />
 <Select options={['a', 'b']} />
+<Ul><li>a</li><li>b</li></Ul>
+<Body><div>content</div></Body>
 <button>native button</button>
 <input type="text" />
 <select><option>native</option></select>
@@ -34,6 +36,11 @@ import Select from "./Select.svelte";
 <Button label="test button" />
 <TextInput placeholder="enter text" />
 <Select options={['a', 'b']} />
+<Ul
+	><li>a</li>
+	<li>b</li></Ul
+>
+<Body><div>content</div></Body>
 <button>native button</button>
 <input type="text">
 <select>

--- a/crates/biome_html_formatter/tests/specs/html/component-frameworks/vue-component-casing.vue
+++ b/crates/biome_html_formatter/tests/specs/html/component-frameworks/vue-component-casing.vue
@@ -6,5 +6,7 @@ import TextInput from './TextInput.vue';
 <template>
   <Button label="test button" />
   <TextInput placeholder="enter text" />
+  <Ul><li>a</li><li>b</li></Ul>
+  <Body><div>content</div></Body>
   <button>native button</button>
 </template>

--- a/crates/biome_html_formatter/tests/specs/html/component-frameworks/vue-component-casing.vue.snap
+++ b/crates/biome_html_formatter/tests/specs/html/component-frameworks/vue-component-casing.vue.snap
@@ -14,6 +14,8 @@ import TextInput from './TextInput.vue';
 <template>
   <Button label="test button" />
   <TextInput placeholder="enter text" />
+  <Ul><li>a</li><li>b</li></Ul>
+  <Body><div>content</div></Body>
   <button>native button</button>
 </template>
 
@@ -31,6 +33,11 @@ import TextInput from "./TextInput.vue";
 <template>
 	<Button label="test button" />
 	<TextInput placeholder="enter text" />
+	<Ul
+		><li>a</li>
+		<li>b</li></Ul
+	>
+	<Body><div>content</div></Body>
 	<button>native button</button>
 </template>
 


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
The main purpose of this PR was to refactor the HTML formatter to get rid of most string comparisons and related possible memory allocations. However, it turned out there were some bugs, and I just went ahead and fixed those because it made the code more simple.

On my machine, I got a ~1-3% perf improvement

implemented by gpt 5.6 sol

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
