### PR TITLE
fix(lint): mark useSimplifiedLogicExpression fix as unsafe

### DIFF
--- a/.changeset/simplified-logic-unsafe-fix.md
+++ b/.changeset/simplified-logic-unsafe-fix.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Changed the `useSimplifiedLogicExpression` fix to unsafe because removing boolean fallbacks can change TypeScript assignability for values such as `boolean | undefined`.

--- a/crates/biome_js_analyze/src/lint/complexity/use_simplified_logic_expression.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_simplified_logic_expression.rs
@@ -56,7 +56,7 @@ declare_lint_rule! {
         language: "js",
         recommended: false,
         severity: Severity::Information,
-        fix_kind: FixKind::Safe,
+        fix_kind: FixKind::Unsafe,
     }
 }
 

--- a/crates/biome_js_analyze/tests/specs/complexity/useSimplifiedLogicExpression/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useSimplifiedLogicExpression/invalid.js.snap
@@ -26,7 +26,7 @@ invalid.js:1:11 lint/complexity/useSimplifiedLogicExpression  FIXABLE  ━━━
     2 │ const boolExp2 = true;
     3 │ const r2 = boolExp || true;
   
-  i Safe fix: Discard redundant terms from the logical expression.
+  i Unsafe fix: Discard redundant terms from the logical expression.
   
     1 │ const·r·=·true·&&·boolExp;
       │           --------        
@@ -45,7 +45,7 @@ invalid.js:3:12 lint/complexity/useSimplifiedLogicExpression  FIXABLE  ━━━
     4 │ const nonNullExp = 123;
     5 │ const r3 = null ?? nonNullExp;
   
-  i Safe fix: Discard redundant terms from the logical expression.
+  i Unsafe fix: Discard redundant terms from the logical expression.
   
     3 │ const·r2·=·boolExp·||·true;
       │            -----------     
@@ -64,7 +64,7 @@ invalid.js:5:12 lint/complexity/useSimplifiedLogicExpression  FIXABLE  ━━━
     6 │ const boolExpr1 = true;
     7 │ const boolExpr2 = false;
   
-  i Safe fix: Discard redundant terms from the logical expression.
+  i Unsafe fix: Discard redundant terms from the logical expression.
   
     5 │ const·r3·=·null·??·nonNullExp;
       │            --------           
@@ -82,7 +82,7 @@ invalid.js:8:18 lint/complexity/useSimplifiedLogicExpression  FIXABLE  ━━━
       │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     9 │ 
   
-  i Safe fix: Reduce the complexity of the logical expression.
+  i Unsafe fix: Reduce the complexity of the logical expression.
   
     6 6 │   const boolExpr1 = true;
     7 7 │   const boolExpr2 = false;

--- a/crates/biome_js_analyze/tests/specs/complexity/useSimplifiedLogicExpression/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/complexity/useSimplifiedLogicExpression/invalid.ts
@@ -1,0 +1,3 @@
+let x: boolean | undefined;
+let y: boolean;
+y = x || false;

--- a/crates/biome_js_analyze/tests/specs/complexity/useSimplifiedLogicExpression/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useSimplifiedLogicExpression/invalid.ts.snap
@@ -1,0 +1,30 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid.ts
+---
+# Input
+```ts
+let x: boolean | undefined;
+let y: boolean;
+y = x || false;
+
+```
+
+# Diagnostics
+```
+invalid.ts:3:5 lint/complexity/useSimplifiedLogicExpression  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Logical expression contains unnecessary complexity.
+  
+    1 │ let x: boolean | undefined;
+    2 │ let y: boolean;
+  > 3 │ y = x || false;
+      │     ^^^^^^^^^^
+    4 │ 
+  
+  i Unsafe fix: Discard redundant terms from the logical expression.
+  
+    3 │ y·=·x·||·false;
+      │      --------- 
+
+```


### PR DESCRIPTION
## Summary

Fixes #11351.

`useSimplifiedLogicExpression` now reports its simplification as an unsafe fix. Removing boolean fallbacks can change assignability for values such as `boolean | undefined`.

I used codex to help prepare the code/test change; I reviewed the final diff and validation before opening this PR.

## Test Plan

Added an `invalid.ts` fixture for `x || false` where `x` is `boolean | undefined`, and updated snapshots to show the fix as unsafe.

## Docs

No docs change; this changes the fix safety classification for an existing lint rule.
