### PR TITLE
fix: html and svg bugs, plus false positive on lint rule

### DIFF
--- a/.changeset/orange-glasses-fall.md
+++ b/.changeset/orange-glasses-fall.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed a bug where [`useJsxKeyInIterable`](https://biomejs.dev/linter/rules/use-jsx-key-in-iterable/) incorrectly flagged Astro files.

--- a/.changeset/wise-oranges-jam.md
+++ b/.changeset/wise-oranges-jam.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed SVG parsing for files with an XML declaration followed by a `PUBLIC` doctype, such as `<?xml version="1.0"?><!DOCTYPE svg PUBLIC "a" "b">`.

--- a/crates/biome_html_analyze/src/lint/a11y/use_anchor_content.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_anchor_content.rs
@@ -236,7 +236,6 @@ fn has_accessible_content(html_child_list: &HtmlElementList, is_astro: bool) -> 
         }
         AnyHtmlElement::HtmlBogusElement(_)
         | AnyHtmlElement::HtmlCdataSection(_)
-        | AnyHtmlElement::HtmlDirective(_)
         | AnyHtmlElement::HtmlProcessingInstruction(_) => true,
     })
 }

--- a/crates/biome_html_analyze/src/lint/a11y/use_anchor_content.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_anchor_content.rs
@@ -236,6 +236,7 @@ fn has_accessible_content(html_child_list: &HtmlElementList, is_astro: bool) -> 
         }
         AnyHtmlElement::HtmlBogusElement(_)
         | AnyHtmlElement::HtmlCdataSection(_)
+        | AnyHtmlElement::HtmlDirective(_)
         | AnyHtmlElement::HtmlProcessingInstruction(_) => true,
     })
 }

--- a/crates/biome_html_analyze/src/lint/a11y/use_heading_content.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_heading_content.rs
@@ -203,7 +203,6 @@ fn has_accessible_content(children: &HtmlElementList, is_html: bool, is_astro: b
         }
         AnyHtmlElement::HtmlBogusElement(_)
         | AnyHtmlElement::HtmlCdataSection(_)
-        | AnyHtmlElement::HtmlDirective(_)
         | AnyHtmlElement::HtmlProcessingInstruction(_) => true,
     })
 }

--- a/crates/biome_html_analyze/src/lint/a11y/use_heading_content.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_heading_content.rs
@@ -203,6 +203,7 @@ fn has_accessible_content(children: &HtmlElementList, is_html: bool, is_astro: b
         }
         AnyHtmlElement::HtmlBogusElement(_)
         | AnyHtmlElement::HtmlCdataSection(_)
+        | AnyHtmlElement::HtmlDirective(_)
         | AnyHtmlElement::HtmlProcessingInstruction(_) => true,
     })
 }

--- a/crates/biome_html_factory/src/generated/node_factory.rs
+++ b/crates/biome_html_factory/src/generated/node_factory.rs
@@ -444,6 +444,7 @@ pub fn html_directive(
         excl_token,
         doctype_token,
         r_angle_token,
+        name_token: None,
         html_token: None,
         quirk_token: None,
         public_id_token: None,
@@ -455,12 +456,17 @@ pub struct HtmlDirectiveBuilder {
     excl_token: SyntaxToken,
     doctype_token: SyntaxToken,
     r_angle_token: SyntaxToken,
+    name_token: Option<SyntaxToken>,
     html_token: Option<SyntaxToken>,
     quirk_token: Option<SyntaxToken>,
     public_id_token: Option<SyntaxToken>,
     system_id_token: Option<SyntaxToken>,
 }
 impl HtmlDirectiveBuilder {
+    pub fn with_name_token(mut self, name_token: SyntaxToken) -> Self {
+        self.name_token = Some(name_token);
+        self
+    }
     pub fn with_html_token(mut self, html_token: SyntaxToken) -> Self {
         self.html_token = Some(html_token);
         self
@@ -484,6 +490,7 @@ impl HtmlDirectiveBuilder {
                 Some(SyntaxElement::Token(self.l_angle_token)),
                 Some(SyntaxElement::Token(self.excl_token)),
                 Some(SyntaxElement::Token(self.doctype_token)),
+                self.name_token.map(|token| SyntaxElement::Token(token)),
                 self.html_token.map(|token| SyntaxElement::Token(token)),
                 self.quirk_token.map(|token| SyntaxElement::Token(token)),
                 self.public_id_token

--- a/crates/biome_html_factory/src/generated/node_factory.rs
+++ b/crates/biome_html_factory/src/generated/node_factory.rs
@@ -588,6 +588,7 @@ pub fn html_root(html: HtmlElementList, eof_token: SyntaxToken) -> HtmlRootBuild
         eof_token,
         bom_token: None,
         frontmatter: None,
+        processing_instruction: None,
         directive: None,
     }
 }
@@ -596,6 +597,7 @@ pub struct HtmlRootBuilder {
     eof_token: SyntaxToken,
     bom_token: Option<SyntaxToken>,
     frontmatter: Option<AnyAstroFrontmatterElement>,
+    processing_instruction: Option<HtmlProcessingInstruction>,
     directive: Option<HtmlDirective>,
 }
 impl HtmlRootBuilder {
@@ -605,6 +607,13 @@ impl HtmlRootBuilder {
     }
     pub fn with_frontmatter(mut self, frontmatter: AnyAstroFrontmatterElement) -> Self {
         self.frontmatter = Some(frontmatter);
+        self
+    }
+    pub fn with_processing_instruction(
+        mut self,
+        processing_instruction: HtmlProcessingInstruction,
+    ) -> Self {
+        self.processing_instruction = Some(processing_instruction);
         self
     }
     pub fn with_directive(mut self, directive: HtmlDirective) -> Self {
@@ -617,6 +626,8 @@ impl HtmlRootBuilder {
             [
                 self.bom_token.map(|token| SyntaxElement::Token(token)),
                 self.frontmatter
+                    .map(|token| SyntaxElement::Node(token.into_syntax())),
+                self.processing_instruction
                     .map(|token| SyntaxElement::Node(token.into_syntax())),
                 self.directive
                     .map(|token| SyntaxElement::Node(token.into_syntax())),

--- a/crates/biome_html_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_html_factory/src/generated/syntax_factory.rs
@@ -720,7 +720,7 @@ impl SyntaxFactory for HtmlSyntaxFactory {
             }
             HTML_DIRECTIVE => {
                 let mut elements = (&children).into_iter();
-                let mut slots: RawNodeSlots<8usize> = RawNodeSlots::default();
+                let mut slots: RawNodeSlots<9usize> = RawNodeSlots::default();
                 let mut current_element = elements.next();
                 if let Some(element) = &current_element
                     && element.kind() == T ! [<]
@@ -738,6 +738,13 @@ impl SyntaxFactory for HtmlSyntaxFactory {
                 slots.next_slot();
                 if let Some(element) = &current_element
                     && element.kind() == T![doctype]
+                {
+                    slots.mark_present();
+                    current_element = elements.next();
+                }
+                slots.next_slot();
+                if let Some(element) = &current_element
+                    && element.kind() == HTML_LITERAL
                 {
                     slots.mark_present();
                     current_element = elements.next();

--- a/crates/biome_html_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_html_factory/src/generated/syntax_factory.rs
@@ -993,7 +993,7 @@ impl SyntaxFactory for HtmlSyntaxFactory {
             }
             HTML_ROOT => {
                 let mut elements = (&children).into_iter();
-                let mut slots: RawNodeSlots<5usize> = RawNodeSlots::default();
+                let mut slots: RawNodeSlots<6usize> = RawNodeSlots::default();
                 let mut current_element = elements.next();
                 if let Some(element) = &current_element
                     && element.kind() == T![UNICODE_BOM]
@@ -1004,6 +1004,13 @@ impl SyntaxFactory for HtmlSyntaxFactory {
                 slots.next_slot();
                 if let Some(element) = &current_element
                     && AnyAstroFrontmatterElement::can_cast(element.kind())
+                {
+                    slots.mark_present();
+                    current_element = elements.next();
+                }
+                slots.next_slot();
+                if let Some(element) = &current_element
+                    && HtmlProcessingInstruction::can_cast(element.kind())
                 {
                     slots.mark_present();
                     current_element = elements.next();

--- a/crates/biome_html_formatter/src/html/any/element.rs
+++ b/crates/biome_html_formatter/src/html/any/element.rs
@@ -11,6 +11,7 @@ impl FormatRule<AnyHtmlElement> for FormatAnyHtmlElement {
             AnyHtmlElement::AnyHtmlContent(node) => node.format().fmt(f),
             AnyHtmlElement::HtmlBogusElement(node) => node.format().fmt(f),
             AnyHtmlElement::HtmlCdataSection(node) => node.format().fmt(f),
+            AnyHtmlElement::HtmlDirective(node) => node.format().fmt(f),
             AnyHtmlElement::HtmlElement(node) => node.format().fmt(f),
             AnyHtmlElement::HtmlProcessingInstruction(node) => node.format().fmt(f),
             AnyHtmlElement::HtmlSelfClosingElement(node) => node.format().fmt(f),

--- a/crates/biome_html_formatter/src/html/any/element.rs
+++ b/crates/biome_html_formatter/src/html/any/element.rs
@@ -11,7 +11,6 @@ impl FormatRule<AnyHtmlElement> for FormatAnyHtmlElement {
             AnyHtmlElement::AnyHtmlContent(node) => node.format().fmt(f),
             AnyHtmlElement::HtmlBogusElement(node) => node.format().fmt(f),
             AnyHtmlElement::HtmlCdataSection(node) => node.format().fmt(f),
-            AnyHtmlElement::HtmlDirective(node) => node.format().fmt(f),
             AnyHtmlElement::HtmlElement(node) => node.format().fmt(f),
             AnyHtmlElement::HtmlProcessingInstruction(node) => node.format().fmt(f),
             AnyHtmlElement::HtmlSelfClosingElement(node) => node.format().fmt(f),

--- a/crates/biome_html_formatter/src/html/auxiliary/directive.rs
+++ b/crates/biome_html_formatter/src/html/auxiliary/directive.rs
@@ -9,6 +9,7 @@ impl FormatNodeRule<HtmlDirective> for FormatHtmlDirective {
             l_angle_token,
             excl_token,
             doctype_token,
+            name_token,
             html_token,
             quirk_token,
             public_id_token,
@@ -30,6 +31,9 @@ impl FormatNodeRule<HtmlDirective> for FormatHtmlDirective {
             write!(f, [FormatTokenAsLowercase::from(doctype_token?)])?;
         } else {
             write!(f, [doctype_token.format()])?;
+        }
+        if let Some(name) = name_token {
+            write!(f, [space(), name.format()])?;
         }
         if let Some(html) = html_token {
             write!(f, [space(), FormatTokenAsLowercase::from(html)])?;

--- a/crates/biome_html_formatter/src/html/auxiliary/root.rs
+++ b/crates/biome_html_formatter/src/html/auxiliary/root.rs
@@ -10,6 +10,7 @@ impl FormatNodeRule<HtmlRoot> for FormatHtmlRoot {
             bom_token,
             directive,
             frontmatter,
+            processing_instruction,
             eof_token,
         } = node.as_fields();
 
@@ -19,6 +20,13 @@ impl FormatNodeRule<HtmlRoot> for FormatHtmlRoot {
 
         if let Some(frontmatter) = frontmatter {
             write!(f, [frontmatter.format(), empty_line()])?;
+        }
+
+        if let Some(processing_instruction) = processing_instruction {
+            write!(
+                f,
+                [group(&processing_instruction.format()), hard_line_break()]
+            )?;
         }
 
         if let Some(directive) = directive {

--- a/crates/biome_html_formatter/tests/specs/html/directive/after-processing-instruction.svg
+++ b/crates/biome_html_formatter/tests/specs/html/directive/after-processing-instruction.svg
@@ -1,0 +1,1 @@
+<?xml version="1.0"?><!DOCTYPE    svg   PUBLIC   "a"   "b"><svg></svg>

--- a/crates/biome_html_formatter/tests/specs/html/directive/after-processing-instruction.svg.snap
+++ b/crates/biome_html_formatter/tests/specs/html/directive/after-processing-instruction.svg.snap
@@ -1,0 +1,21 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: directive/after-processing-instruction.svg
+---
+
+# Input
+
+```svg
+<?xml version="1.0"?><!DOCTYPE    svg   PUBLIC   "a"   "b"><svg></svg>
+
+```
+
+
+# Formatted
+
+```svg
+<?xml version="1.0" ?>
+<!DOCTYPE svg PUBLIC "a" "b">
+<svg></svg>
+
+```

--- a/crates/biome_html_formatter/tests/specs/html/directive/svg.svg
+++ b/crates/biome_html_formatter/tests/specs/html/directive/svg.svg
@@ -1,0 +1,1 @@
+<!DOCTYPE    svg   PUBLIC   "a"   "b"><svg></svg>

--- a/crates/biome_html_formatter/tests/specs/html/directive/svg.svg.snap
+++ b/crates/biome_html_formatter/tests/specs/html/directive/svg.svg.snap
@@ -1,0 +1,20 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: directive/svg.svg
+---
+
+# Input
+
+```svg
+<!DOCTYPE    svg   PUBLIC   "a"   "b"><svg></svg>
+
+```
+
+
+# Formatted
+
+```svg
+<!DOCTYPE svg PUBLIC "a" "b">
+<svg></svg>
+
+```

--- a/crates/biome_html_formatter/tests/specs/prettier/html/comments/bogus.html.snap
+++ b/crates/biome_html_formatter/tests/specs/prettier/html/comments/bogus.html.snap
@@ -12,24 +12,6 @@ info: html/comments/bogus.html
 ```
 
 
-# Prettier differences
-
-```diff
---- Prettier
-+++ Biome
-@@ -1,2 +1,2 @@
--<? hello ?>
-+<?hello ?>
- <!- world ->
-```
-
-# Output
-
-```html
-<?hello ?>
-<!- world ->
-```
-
 # Errors
 ```
 bogus.html:1:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -43,37 +25,10 @@ bogus.html:1:3 parse ━━━━━━━━━━━━━━━━━━━�
   
   i Remove the leading space.
   
-bogus.html:2:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Expected an element name but instead found '!'.
-  
-    1 │ <? hello ?>
-  > 2 │ <!- world ->
-      │  ^
-    3 │ 
-  
-  i Expected an element name here.
-  
-    1 │ <? hello ?>
-  > 2 │ <!- world ->
-      │  ^
-    3 │ 
-  
-bogus.html:3:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
 
-  × expected `>` but instead the file ends
-  
-    1 │ <? hello ?>
-    2 │ <!- world ->
-  > 3 │ 
-      │ 
-  
-  i the file ends here
-  
-    1 │ <? hello ?>
-    2 │ <!- world ->
-  > 3 │ 
-      │ 
-  
-
+# Error
+```text
+format: Can't format code because it contains syntax errors
 ```

--- a/crates/biome_html_parser/src/syntax/mod.rs
+++ b/crates/biome_html_parser/src/syntax/mod.rs
@@ -140,12 +140,13 @@ pub(crate) fn parse_root(p: &mut HtmlParser) {
     // content from being incorrectly lexed as a FENCE token.
     p.set_after_frontmatter(true);
 
-    parse_doc_type(p).ok();
+    let allow_directive = parse_doc_type(p).is_absent();
     // Only a real `.vue` document has single-file-component blocks. Plain HTML
     // parsed with the Vue extensions turned on keeps ordinary element nesting,
     // where an unknown top-level tag is a custom element rather than a block.
     ElementList {
         vue_sfc_top_level: Vue.is_supported(p) && !p.options().is_html(),
+        allow_directive,
     }
     .parse_list(p);
 
@@ -167,6 +168,8 @@ fn parse_doc_type(p: &mut HtmlParser) -> ParsedSyntax {
 
     if p.at(T![html]) {
         p.eat_with_context(T![html], HtmlLexContext::Doctype);
+    } else if p.at(HTML_LITERAL) {
+        p.eat_with_context(HTML_LITERAL, HtmlLexContext::Doctype);
     }
 
     if p.at(HTML_LITERAL) {
@@ -579,6 +582,7 @@ struct ElementList {
     /// component. Only the outermost list, so that a `<docs>` nested inside a
     /// `<template>` stays ordinary markup.
     vue_sfc_top_level: bool,
+    allow_directive: bool,
 }
 
 impl ParseNodeList for ElementList {
@@ -587,6 +591,17 @@ impl ParseNodeList for ElementList {
     const LIST_KIND: Self::Kind = HTML_ELEMENT_LIST;
 
     fn parse_element(&mut self, p: &mut Self::Parser<'_>) -> ParsedSyntax {
+        if self.allow_directive {
+            if p.at(T![<?]) {
+                return parse_processing_instruction(p);
+            }
+
+            self.allow_directive = false;
+            if p.at(T![<]) && p.nth_at(1, T![!]) {
+                return parse_doc_type(p);
+            }
+        }
+
         parse_html_element(p, self.vue_sfc_top_level)
     }
 

--- a/crates/biome_html_parser/src/syntax/mod.rs
+++ b/crates/biome_html_parser/src/syntax/mod.rs
@@ -140,13 +140,13 @@ pub(crate) fn parse_root(p: &mut HtmlParser) {
     // content from being incorrectly lexed as a FENCE token.
     p.set_after_frontmatter(true);
 
-    let allow_directive = parse_doc_type(p).is_absent();
+    parse_processing_instruction(p).ok();
+    parse_doc_type(p).ok();
     // Only a real `.vue` document has single-file-component blocks. Plain HTML
     // parsed with the Vue extensions turned on keeps ordinary element nesting,
     // where an unknown top-level tag is a custom element rather than a block.
     ElementList {
         vue_sfc_top_level: Vue.is_supported(p) && !p.options().is_html(),
-        allow_directive,
     }
     .parse_list(p);
 
@@ -582,7 +582,6 @@ struct ElementList {
     /// component. Only the outermost list, so that a `<docs>` nested inside a
     /// `<template>` stays ordinary markup.
     vue_sfc_top_level: bool,
-    allow_directive: bool,
 }
 
 impl ParseNodeList for ElementList {
@@ -591,17 +590,6 @@ impl ParseNodeList for ElementList {
     const LIST_KIND: Self::Kind = HTML_ELEMENT_LIST;
 
     fn parse_element(&mut self, p: &mut Self::Parser<'_>) -> ParsedSyntax {
-        if self.allow_directive {
-            if p.at(T![<?]) {
-                return parse_processing_instruction(p);
-            }
-
-            self.allow_directive = false;
-            if p.at(T![<]) && p.nth_at(1, T![!]) {
-                return parse_doc_type(p);
-            }
-        }
-
         parse_html_element(p, self.vue_sfc_top_level)
     }
 

--- a/crates/biome_html_parser/tests/html_specs/error/angular/event-binding.component.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/angular/event-binding.component.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -65,7 +66,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..44
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..44
     0: HTML_SELF_CLOSING_ELEMENT@0..44
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_TAG_NAME@1..7
@@ -89,7 +91,7 @@ HtmlRoot {
               0: HTML_STRING_LITERAL@26..42 "\"updateField()\"" [] [Whitespace(" ")]
       3: SLASH@42..43 "/" [] []
       4: R_ANGLE@43..44 ">" [] []
-  4: EOF@44..45 "" [Newline("\n")] []
+  5: EOF@44..45 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/angular/property-binding.component.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/angular/property-binding.component.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -68,7 +69,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..47
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..47
     0: HTML_ELEMENT@0..47
       0: HTML_OPENING_ELEMENT@0..34
         0: L_ANGLE@0..1 "<" [] []
@@ -94,7 +96,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@40..46
           0: HTML_LITERAL@40..46 "button" [] []
         3: R_ANGLE@46..47 ">" [] []
-  4: EOF@47..48 "" [Newline("\n")] []
+  5: EOF@47..48 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/angular/structural-directive.component.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/angular/structural-directive.component.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlBogusElement {
@@ -63,7 +64,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..63
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..63
     0: HTML_BOGUS_ELEMENT@0..63
       0: HTML_BOGUS@0..63
         0: L_ANGLE@0..1 "<" [] []
@@ -80,7 +82,7 @@ HtmlRoot {
           1: HTML_BOGUS_ELEMENT@11..63
             0: ERROR_TOKEN@11..63 "\"let data; from: source>The data is: {{ data }}</p>\n" [] []
       1: HTML_ELEMENT_LIST@63..63
-  4: EOF@63..63 "" [] []
+  5: EOF@63..63 "" [] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/angular/template-ref.component.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/angular/template-ref.component.html.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlBogusElement {
@@ -65,7 +66,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..91
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..91
     0: HTML_BOGUS_ELEMENT@0..91
       0: HTML_BOGUS@0..91
         0: L_ANGLE@0..1 "<" [] []
@@ -82,7 +84,7 @@ HtmlRoot {
           1: HTML_BOGUS_ELEMENT@25..91
             0: ERROR_TOKEN@25..91 "\"exportAsName>\n\t<p>This is a template fragment</p>\n</ng-template>\n" [] []
       1: HTML_ELEMENT_LIST@91..91
-  4: EOF@91..91 "" [] []
+  5: EOF@91..91 "" [] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/angular/two-way-binding.component.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/angular/two-way-binding.component.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -64,7 +65,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..50
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..50
     0: HTML_ELEMENT@0..50
       0: HTML_OPENING_ELEMENT@0..36
         0: L_ANGLE@0..1 "<" [] []
@@ -88,7 +90,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@38..49
           0: HTML_LITERAL@38..49 "app-counter" [] []
         3: R_ANGLE@49..50 ">" [] []
-  4: EOF@50..51 "" [Newline("\n")] []
+  5: EOF@50..51 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/astro/attribute_expression.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/astro/attribute_expression.astro.snap
@@ -28,6 +28,7 @@ HtmlRoot {
         },
         r_fence_token: FENCE@31..34 "---" [] [],
     },
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -104,7 +105,8 @@ HtmlRoot {
       0: HTML_LITERAL@3..31 "const foo = \"lorem ipsum\";\n" [Newline("\n")] []
     2: FENCE@31..34 "---" [] []
   2: (empty)
-  3: HTML_ELEMENT_LIST@34..71
+  3: (empty)
+  4: HTML_ELEMENT_LIST@34..71
     0: HTML_ELEMENT@34..71
       0: HTML_OPENING_ELEMENT@34..41
         0: L_ANGLE@34..36 "<" [Newline("\n")] []
@@ -141,7 +143,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@66..70
           0: HTML_KW@66..70 "html" [] []
         3: R_ANGLE@70..71 ">" [] []
-  4: EOF@71..72 "" [Newline("\n")] []
+  5: EOF@71..72 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/astro/missing_fence.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/astro/missing_fence.astro.snap
@@ -23,6 +23,7 @@ HtmlRoot {
         content: missing (required),
         r_fence_token: missing (required),
     },
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -59,7 +60,8 @@ HtmlRoot {
     1: (empty)
     2: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@3..16
+  3: (empty)
+  4: HTML_ELEMENT_LIST@3..16
     0: HTML_ELEMENT@3..16
       0: HTML_OPENING_ELEMENT@3..10
         0: L_ANGLE@3..6 "<" [Newline("\n"), Newline("\n")] []
@@ -74,7 +76,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@12..15
           0: DIV_KW@12..15 "div" [] []
         3: R_ANGLE@15..16 ">" [] []
-  4: EOF@16..17 "" [Newline("\n")] []
+  5: EOF@16..17 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/astro/nested_expression.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/astro/nested_expression.astro.snap
@@ -27,6 +27,7 @@ HtmlRoot {
         },
         r_fence_token: FENCE@29..32 "---" [] [],
     },
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlBogusTextExpression {
@@ -81,7 +82,8 @@ HtmlRoot {
       0: HTML_LITERAL@3..29 "const items = [1, 2, 3];\n" [Newline("\n")] []
     2: FENCE@29..32 "---" [] []
   2: (empty)
-  3: HTML_ELEMENT_LIST@32..71
+  3: (empty)
+  4: HTML_ELEMENT_LIST@32..71
     0: HTML_BOGUS_TEXT_EXPRESSION@32..53
       0: L_CURLY@32..35 "{" [Newline("\n"), Newline("\n")] []
       1: HTML_LITERAL@35..53 "items.map(item =>" [] [Whitespace(" ")]
@@ -106,7 +108,7 @@ HtmlRoot {
         3: R_ANGLE@69..70 ">" [] []
     2: HTML_CONTENT@70..71
       0: HTML_LITERAL@70..71 ")" [] []
-  4: EOF@71..72 "" [Newline("\n")] []
+  5: EOF@71..72 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/astro/spread.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/astro/spread.astro.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -50,7 +51,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..43
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..43
     0: HTML_SELF_CLOSING_ELEMENT@0..43
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_TAG_NAME@1..7
@@ -64,7 +66,7 @@ HtmlRoot {
           3: (empty)
       3: (empty)
       4: (empty)
-  4: EOF@43..43 "" [] []
+  5: EOF@43..43 "" [] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/attributes/invalid-unquoted-value1.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/attributes/invalid-unquoted-value1.html.snap
@@ -20,6 +20,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -134,7 +135,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..62
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..62
     0: HTML_ELEMENT@0..62
       0: HTML_OPENING_ELEMENT@0..5
         0: L_ANGLE@0..1 "<" [] []
@@ -193,7 +195,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@58..61
           0: DIV_KW@58..61 "div" [] []
         3: R_ANGLE@61..62 ">" [] []
-  4: EOF@62..63 "" [Newline("\n")] []
+  5: EOF@62..63 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/attributes/invalid-unquoted-value2.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/attributes/invalid-unquoted-value2.html.snap
@@ -20,6 +20,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -134,7 +135,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..74
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..74
     0: HTML_ELEMENT@0..74
       0: HTML_OPENING_ELEMENT@0..5
         0: L_ANGLE@0..1 "<" [] []
@@ -193,7 +195,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@70..73
           0: DIV_KW@70..73 "div" [] []
         3: R_ANGLE@73..74 ">" [] []
-  4: EOF@74..75 "" [Newline("\n")] []
+  5: EOF@74..75 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/attributes/missing-initializer.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/attributes/missing-initializer.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -60,7 +61,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..18
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..18
     0: HTML_ELEMENT@0..18
       0: HTML_OPENING_ELEMENT@0..12
         0: L_ANGLE@0..1 "<" [] []
@@ -81,7 +83,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@14..17
           0: DIV_KW@14..17 "div" [] []
         3: R_ANGLE@17..18 ">" [] []
-  4: EOF@18..19 "" [Newline("\n")] []
+  5: EOF@18..19 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/element/br-with-end.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/element/br-with-end.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlBogusElement {
@@ -83,7 +84,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..51
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..51
     0: HTML_BOGUS_ELEMENT@0..51
       0: HTML_OPENING_ELEMENT@0..6
         0: L_ANGLE@0..1 "<" [] []
@@ -118,7 +120,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@46..50
           0: SPAN_KW@46..50 "span" [] []
         3: R_ANGLE@50..51 ">" [] []
-  4: EOF@51..52 "" [Newline("\n")] []
+  5: EOF@51..52 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/element/child-no-tag-name.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/element/child-no-tag-name.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -54,7 +55,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..12
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..12
     0: HTML_ELEMENT@0..12
       0: HTML_OPENING_ELEMENT@0..5
         0: L_ANGLE@0..1 "<" [] []
@@ -71,7 +73,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@8..11
           0: DIV_KW@8..11 "div" [] []
         3: R_ANGLE@11..12 ">" [] []
-  4: EOF@12..13 "" [Newline("\n")] []
+  5: EOF@12..13 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/element/missing-close-tag-2.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/element/missing-close-tag-2.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -43,7 +44,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..5
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..5
     0: HTML_ELEMENT@0..5
       0: HTML_OPENING_ELEMENT@0..5
         0: L_ANGLE@0..1 "<" [] []
@@ -53,7 +55,7 @@ HtmlRoot {
         3: R_ANGLE@4..5 ">" [] []
       1: HTML_ELEMENT_LIST@5..5
       2: (empty)
-  4: EOF@5..6 "" [Newline("\n")] []
+  5: EOF@5..6 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/element/missing-close-tag.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/element/missing-close-tag.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -47,7 +48,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..8
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..8
     0: HTML_ELEMENT@0..8
       0: HTML_OPENING_ELEMENT@0..5
         0: L_ANGLE@0..1 "<" [] []
@@ -59,7 +61,7 @@ HtmlRoot {
         0: HTML_CONTENT@5..8
           0: HTML_LITERAL@5..8 "foo" [] []
       2: (empty)
-  4: EOF@8..9 "" [Newline("\n")] []
+  5: EOF@8..9 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/element/missing-element-name.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/element/missing-element-name.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -46,7 +47,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..5
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..5
     0: HTML_ELEMENT@0..5
       0: HTML_OPENING_ELEMENT@0..2
         0: L_ANGLE@0..1 "<" [] []
@@ -59,7 +61,7 @@ HtmlRoot {
         1: SLASH@3..4 "/" [] []
         2: (empty)
         3: R_ANGLE@4..5 ">" [] []
-  4: EOF@5..6 "" [Newline("\n")] []
+  5: EOF@5..6 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/element/solo-no-tag-name.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/element/solo-no-tag-name.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -34,10 +35,11 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..1
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..1
     0: HTML_CONTENT@0..1
       0: HTML_LITERAL@0..1 "<" [] []
-  4: EOF@1..2 "" [Newline("\n")] []
+  5: EOF@1..2 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/element/tag-name-starts-with-digit.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/element/tag-name-starts-with-digit.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -60,7 +61,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..28
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..28
     0: HTML_ELEMENT@0..28
       0: HTML_OPENING_ELEMENT@0..5
         0: L_ANGLE@0..1 "<" [] []
@@ -81,7 +83,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@24..27
           0: DIV_KW@24..27 "div" [] []
         3: R_ANGLE@27..28 ">" [] []
-  4: EOF@28..29 "" [Newline("\n")] []
+  5: EOF@28..29 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/element/void-closing-tag-does-not-close-parent.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/element/void-closing-tag-does-not-close-parent.html.snap
@@ -22,6 +22,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlBogusElement {
@@ -189,7 +190,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..212
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..212
     0: HTML_BOGUS_ELEMENT@0..212
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -292,7 +294,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@203..211
           0: FIELDSET_KW@203..211 "fieldset" [] []
         3: R_ANGLE@211..212 ">" [] []
-  4: EOF@212..213 "" [Newline("\n")] []
+  5: EOF@212..213 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/frontmatter.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/frontmatter.html.snap
@@ -29,6 +29,7 @@ HtmlRoot {
             FENCE@16..19 "---" [] [],
         ],
     },
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -88,7 +89,8 @@ HtmlRoot {
       0: HTML_LITERAL@3..16 "layout: foo\n" [Newline("\n")] []
     2: FENCE@16..19 "---" [] []
   2: (empty)
-  3: HTML_ELEMENT_LIST@19..64
+  3: (empty)
+  4: HTML_ELEMENT_LIST@19..64
     0: HTML_CONTENT@19..25
       0: HTML_LITERAL@19..25 "Test" [Newline("\n")] [Whitespace(" ")]
     1: HTML_ELEMENT@25..63
@@ -116,7 +118,7 @@ HtmlRoot {
         3: R_ANGLE@62..63 ">" [] []
     2: HTML_CONTENT@63..64
       0: HTML_LITERAL@63..64 "." [] []
-  4: EOF@64..65 "" [Newline("\n")] []
+  5: EOF@64..65 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/frontmatter_bogus.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/frontmatter_bogus.html.snap
@@ -31,6 +31,7 @@ HtmlRoot {
             FENCE@20..23 "---" [] [],
         ],
     },
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -107,7 +108,8 @@ HtmlRoot {
       0: HTML_LITERAL@3..20 "const b = \"bar\"\n" [Newline("\n")] []
     2: FENCE@20..23 "---" [] []
   2: (empty)
-  3: HTML_ELEMENT_LIST@23..68
+  3: (empty)
+  4: HTML_ELEMENT_LIST@23..68
     0: HTML_ELEMENT@23..68
       0: HTML_OPENING_ELEMENT@23..30
         0: L_ANGLE@23..25 "<" [Newline("\n")] []
@@ -150,7 +152,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@63..67
           0: HTML_KW@63..67 "html" [] []
         3: R_ANGLE@67..68 ">" [] []
-  4: EOF@68..69 "" [Newline("\n")] []
+  5: EOF@68..69 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/interpolation-attributes.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/interpolation-attributes.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlBogusElement {
@@ -62,7 +63,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..28
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..28
     0: HTML_BOGUS_ELEMENT@0..28
       0: HTML_BOGUS@0..19
         0: L_ANGLE@0..1 "<" [] []
@@ -79,7 +81,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@21..27
           0: BUTTON_KW@21..27 "button" [] []
         3: R_ANGLE@27..28 ">" [] []
-  4: EOF@28..29 "" [Newline("\n")] []
+  5: EOF@28..29 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/interpolation.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/interpolation.html.snap
@@ -26,6 +26,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -87,7 +88,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..193
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..193
     0: HTML_ELEMENT@0..193
       0: HTML_OPENING_ELEMENT@0..5
         0: L_ANGLE@0..1 "<" [] []
@@ -118,7 +120,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@189..192
           0: DIV_KW@189..192 "div" [] []
         3: R_ANGLE@192..193 ">" [] []
-  4: EOF@193..194 "" [Newline("\n")] []
+  5: EOF@193..194 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/processing_instruction.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/processing_instruction.html.snap
@@ -17,29 +17,28 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
-    directive: missing (optional),
-    html: HtmlElementList [
-        HtmlProcessingInstruction {
-            start_token: PI_START@0..3 "<?" [] [Whitespace(" ")],
-            target: HtmlTagName {
-                value_token: HTML_LITERAL@3..7 "xml" [] [Whitespace(" ")],
-            },
-            attributes: HtmlAttributeList [
-                HtmlAttribute {
-                    name: HtmlAttributeName {
-                        value_token: HTML_LITERAL@7..14 "version" [] [],
-                    },
-                    initializer: HtmlAttributeInitializerClause {
-                        eq_token: EQ@14..15 "=" [] [],
-                        value: HtmlString {
-                            value_token: HTML_STRING_LITERAL@15..21 "\"1.0\"" [] [Whitespace(" ")],
-                        },
+    processing_instruction: HtmlProcessingInstruction {
+        start_token: PI_START@0..3 "<?" [] [Whitespace(" ")],
+        target: HtmlTagName {
+            value_token: HTML_LITERAL@3..7 "xml" [] [Whitespace(" ")],
+        },
+        attributes: HtmlAttributeList [
+            HtmlAttribute {
+                name: HtmlAttributeName {
+                    value_token: HTML_LITERAL@7..14 "version" [] [],
+                },
+                initializer: HtmlAttributeInitializerClause {
+                    eq_token: EQ@14..15 "=" [] [],
+                    value: HtmlString {
+                        value_token: HTML_STRING_LITERAL@15..21 "\"1.0\"" [] [Whitespace(" ")],
                     },
                 },
-            ],
-            end_token: PI_END@21..23 "?>" [] [],
-        },
-    ],
+            },
+        ],
+        end_token: PI_END@21..23 "?>" [] [],
+    },
+    directive: missing (optional),
+    html: HtmlElementList [],
     eof_token: EOF@23..24 "" [Newline("\n")] [],
 }
 ```
@@ -50,22 +49,22 @@ HtmlRoot {
 0: HTML_ROOT@0..24
   0: (empty)
   1: (empty)
-  2: (empty)
-  3: HTML_ELEMENT_LIST@0..23
-    0: HTML_PROCESSING_INSTRUCTION@0..23
-      0: PI_START@0..3 "<?" [] [Whitespace(" ")]
-      1: HTML_TAG_NAME@3..7
-        0: HTML_LITERAL@3..7 "xml" [] [Whitespace(" ")]
-      2: HTML_ATTRIBUTE_LIST@7..21
-        0: HTML_ATTRIBUTE@7..21
-          0: HTML_ATTRIBUTE_NAME@7..14
-            0: HTML_LITERAL@7..14 "version" [] []
-          1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@14..21
-            0: EQ@14..15 "=" [] []
-            1: HTML_STRING@15..21
-              0: HTML_STRING_LITERAL@15..21 "\"1.0\"" [] [Whitespace(" ")]
-      3: PI_END@21..23 "?>" [] []
-  4: EOF@23..24 "" [Newline("\n")] []
+  2: HTML_PROCESSING_INSTRUCTION@0..23
+    0: PI_START@0..3 "<?" [] [Whitespace(" ")]
+    1: HTML_TAG_NAME@3..7
+      0: HTML_LITERAL@3..7 "xml" [] [Whitespace(" ")]
+    2: HTML_ATTRIBUTE_LIST@7..21
+      0: HTML_ATTRIBUTE@7..21
+        0: HTML_ATTRIBUTE_NAME@7..14
+          0: HTML_LITERAL@7..14 "version" [] []
+        1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@14..21
+          0: EQ@14..15 "=" [] []
+          1: HTML_STRING@15..21
+            0: HTML_STRING_LITERAL@15..21 "\"1.0\"" [] [Whitespace(" ")]
+    3: PI_END@21..23 "?>" [] []
+  3: (empty)
+  4: HTML_ELEMENT_LIST@23..23
+  5: EOF@23..24 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/at_block_invalid_block_type.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/at_block_invalid_block_type.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteBogusBlock {
@@ -42,13 +43,14 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..20
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..20
     0: SVELTE_BOGUS_BLOCK@0..20
       0: SV_CURLY_AT@0..2 "{@" [] []
       1: HTML_BOGUS@2..19
         0: IDENT@2..19 "notarealblocktype" [] []
       2: R_CURLY@19..20 "}" [] []
-  4: EOF@20..21 "" [Newline("\n")] []
+  5: EOF@20..21 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/at_block_missing_block_type.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/at_block_missing_block_type.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteBogusBlock {
@@ -37,11 +38,12 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..3
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..3
     0: SVELTE_BOGUS_BLOCK@0..3
       0: SV_CURLY_AT@0..2 "{@" [] []
       1: R_CURLY@2..3 "}" [] []
-  4: EOF@3..4 "" [Newline("\n")] []
+  5: EOF@3..4 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/at_block_missing_block_type_and_closing_brace.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/at_block_missing_block_type_and_closing_brace.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteBogusBlock {
@@ -36,10 +37,11 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..2
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..2
     0: SVELTE_BOGUS_BLOCK@0..2
       0: SV_CURLY_AT@0..2 "{@" [] []
-  4: EOF@2..3 "" [Newline("\n")] []
+  5: EOF@2..3 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/attach.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/attach.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -52,7 +53,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..25
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..25
     0: HTML_ELEMENT@0..25
       0: HTML_OPENING_ELEMENT@0..25
         0: L_ANGLE@0..1 "<" [] []
@@ -68,7 +70,7 @@ HtmlRoot {
         3: (empty)
       1: HTML_ELEMENT_LIST@25..25
       2: (empty)
-  4: EOF@25..25 "" [] []
+  5: EOF@25..25 "" [] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/attribute_interpolation_unterminated.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/attribute_interpolation_unterminated.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -169,7 +170,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..74
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..74
     0: HTML_ELEMENT@0..21
       0: HTML_OPENING_ELEMENT@0..15
         0: L_ANGLE@0..1 "<" [] []
@@ -249,7 +251,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@70..73
           0: DIV_KW@70..73 "div" [] []
         3: R_ANGLE@73..74 ">" [] []
-  4: EOF@74..75 "" [Newline("\n")] []
+  5: EOF@74..75 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/await_catch_before_then.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/await_catch_before_then.svelte.snap
@@ -23,6 +23,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteAwaitBlock {
@@ -155,7 +156,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..116
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..116
     0: SVELTE_AWAIT_BLOCK@0..116
       0: SVELTE_AWAIT_OPENING_BLOCK@0..36
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -239,7 +241,7 @@ HtmlRoot {
         0: SV_CURLY_SLASH@107..110 "{/" [Newline("\n")] []
         1: AWAIT_KW@110..115 "await" [] []
         2: R_CURLY@115..116 "}" [] []
-  4: EOF@116..117 "" [Newline("\n")] []
+  5: EOF@116..117 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/await_duplicate_catch.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/await_duplicate_catch.svelte.snap
@@ -25,6 +25,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteAwaitBlock {
@@ -194,7 +195,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..170
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..170
     0: SVELTE_AWAIT_BLOCK@0..170
       0: SVELTE_AWAIT_OPENING_BLOCK@0..36
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -304,7 +306,7 @@ HtmlRoot {
         0: SV_CURLY_SLASH@161..164 "{/" [Newline("\n")] []
         1: AWAIT_KW@164..169 "await" [] []
         2: R_CURLY@169..170 "}" [] []
-  4: EOF@170..171 "" [Newline("\n")] []
+  5: EOF@170..171 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/await_duplicate_then.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/await_duplicate_then.svelte.snap
@@ -23,6 +23,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteAwaitBlock {
@@ -155,7 +156,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..121
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..121
     0: SVELTE_AWAIT_BLOCK@0..121
       0: SVELTE_AWAIT_OPENING_BLOCK@0..36
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -239,7 +241,7 @@ HtmlRoot {
         0: SV_CURLY_SLASH@112..115 "{/" [Newline("\n")] []
         1: AWAIT_KW@115..120 "await" [] []
         2: R_CURLY@120..121 "}" [] []
-  4: EOF@121..122 "" [Newline("\n")] []
+  5: EOF@121..122 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/await_invalid_catch_only_with_clause.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/await_invalid_catch_only_with_clause.svelte.snap
@@ -21,6 +21,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteAwaitBlock {
@@ -125,7 +126,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..116
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..116
     0: SVELTE_AWAIT_BLOCK@0..116
       0: SVELTE_AWAIT_OPENING_BLOCK@0..53
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -189,7 +191,7 @@ HtmlRoot {
         0: SV_CURLY_SLASH@107..110 "{/" [Newline("\n")] []
         1: AWAIT_KW@110..115 "await" [] []
         2: R_CURLY@115..116 "}" [] []
-  4: EOF@116..117 "" [Newline("\n")] []
+  5: EOF@116..117 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/await_invalid_shorthand_with_clause.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/await_invalid_shorthand_with_clause.svelte.snap
@@ -21,6 +21,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteAwaitBlock {
@@ -125,7 +126,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..98
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..98
     0: SVELTE_AWAIT_BLOCK@0..98
       0: SVELTE_AWAIT_OPENING_BLOCK@0..44
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -189,7 +191,7 @@ HtmlRoot {
         0: SV_CURLY_SLASH@89..92 "{/" [Newline("\n")] []
         1: AWAIT_KW@92..97 "await" [] []
         2: R_CURLY@97..98 "}" [] []
-  4: EOF@98..99 "" [Newline("\n")] []
+  5: EOF@98..99 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/await_missing_close.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/await_missing_close.svelte.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteAwaitBlock {
@@ -83,7 +84,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..57
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..57
     0: SVELTE_AWAIT_BLOCK@0..57
       0: SVELTE_AWAIT_OPENING_BLOCK@0..57
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -120,7 +122,7 @@ HtmlRoot {
               3: R_ANGLE@56..57 ">" [] []
       1: SVELTE_AWAIT_CLAUSES_LIST@57..57
       2: (empty)
-  4: EOF@57..58 "" [Newline("\n")] []
+  5: EOF@57..58 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/await_missing_expression.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/await_missing_expression.svelte.snap
@@ -21,6 +21,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteAwaitBlock {
@@ -117,7 +118,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..81
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..81
     0: SVELTE_AWAIT_BLOCK@0..81
       0: SVELTE_AWAIT_OPENING_BLOCK@0..28
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -176,7 +178,7 @@ HtmlRoot {
         0: SV_CURLY_SLASH@72..75 "{/" [Newline("\n")] []
         1: AWAIT_KW@75..80 "await" [] []
         2: R_CURLY@80..81 "}" [] []
-  4: EOF@81..82 "" [Newline("\n")] []
+  5: EOF@81..82 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/await_unclosed.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/await_unclosed.svelte.snap
@@ -20,6 +20,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteAwaitBlock {
@@ -114,7 +115,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..80
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..80
     0: SVELTE_AWAIT_BLOCK@0..80
       0: SVELTE_AWAIT_OPENING_BLOCK@0..36
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -171,7 +173,7 @@ HtmlRoot {
                   0: P_KW@78..79 "p" [] []
                 3: R_ANGLE@79..80 ">" [] []
       2: (empty)
-  4: EOF@80..81 "" [Newline("\n")] []
+  5: EOF@80..81 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/const.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/const.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteConstBlock {
@@ -39,14 +40,15 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..38
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..38
     0: SVELTE_CONST_BLOCK@0..38
       0: SV_CURLY_AT@0..2 "{@" [] []
       1: CONST_KW@2..8 "const" [] [Whitespace(" ")]
       2: HTML_TEXT_EXPRESSION@8..38
         0: HTML_LITERAL@8..38 "area = box.width * box.height\n" [] []
       3: (empty)
-  4: EOF@38..38 "" [] []
+  5: EOF@38..38 "" [] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/const_missing_expression.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/const_missing_expression.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteEachBlock {
@@ -65,7 +66,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..49
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..49
     0: SVELTE_EACH_BLOCK@0..49
       0: SVELTE_EACH_OPENING_BLOCK@0..30
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -90,7 +92,7 @@ HtmlRoot {
         0: SV_CURLY_SLASH@41..44 "{/" [Newline("\n")] []
         1: EACH_KW@44..48 "each" [] []
         2: R_CURLY@48..49 "}" [] []
-  4: EOF@49..50 "" [Newline("\n")] []
+  5: EOF@49..50 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/debug-trailing-comma.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/debug-trailing-comma.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteDebugBlock {
@@ -43,7 +44,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..19
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..19
     0: SVELTE_DEBUG_BLOCK@0..19
       0: SV_CURLY_AT@0..2 "{@" [] []
       1: DEBUG_KW@2..8 "debug" [] [Whitespace(" ")]
@@ -53,7 +55,7 @@ HtmlRoot {
         1: COMMA@17..18 "," [] []
         2: (empty)
       3: R_CURLY@18..19 "}" [] []
-  4: EOF@19..20 "" [Newline("\n")] []
+  5: EOF@19..20 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/debug.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/debug.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteDebugBlock {
@@ -59,7 +60,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..41
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..41
     0: SVELTE_DEBUG_BLOCK@0..7
       0: SV_CURLY_AT@0..2 "{@" [] []
       1: DEBUG_KW@2..7 "debug" [] []
@@ -79,7 +81,7 @@ HtmlRoot {
         0: SVELTE_NAME@35..40
           0: IDENT@35..40 "debug" [] []
       3: R_CURLY@40..41 "}" [] []
-  4: EOF@41..42 "" [Newline("\n")] []
+  5: EOF@41..42 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/directives/animate_invalid_params.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/directives/animate_invalid_params.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteEachBlock {
@@ -113,7 +114,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..78
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..78
     0: SVELTE_EACH_BLOCK@0..78
       0: SVELTE_EACH_OPENING_BLOCK@0..27
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -166,7 +168,7 @@ HtmlRoot {
         0: SV_CURLY_SLASH@70..73 "{/" [Newline("\n")] []
         1: EACH_KW@73..77 "each" [] []
         2: R_CURLY@77..78 "}" [] []
-  4: EOF@78..79 "" [Newline("\n")] []
+  5: EOF@78..79 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/directives/animate_missing_name.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/directives/animate_missing_name.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteEachBlock {
@@ -102,7 +103,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..62
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..62
     0: SVELTE_EACH_BLOCK@0..62
       0: SVELTE_EACH_OPENING_BLOCK@0..27
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -152,7 +154,7 @@ HtmlRoot {
         0: SV_CURLY_SLASH@54..57 "{/" [Newline("\n")] []
         1: EACH_KW@57..61 "each" [] []
         2: R_CURLY@61..62 "}" [] []
-  4: EOF@62..63 "" [Newline("\n")] []
+  5: EOF@62..63 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/directives/bind_incomplete_expression.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/directives/bind_incomplete_expression.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -66,7 +67,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..22
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..22
     0: HTML_SELF_CLOSING_ELEMENT@0..22
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_TAG_NAME@1..7
@@ -86,7 +88,7 @@ HtmlRoot {
                 1: HTML_LITERAL@20..22 "/>" [] []
       3: (empty)
       4: (empty)
-  4: EOF@22..23 "" [Newline("\n")] []
+  5: EOF@22..23 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/directives/bind_invalid_syntax.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/directives/bind_invalid_syntax.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -56,7 +57,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..22
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..22
     0: HTML_SELF_CLOSING_ELEMENT@0..22
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_TAG_NAME@1..7
@@ -75,7 +77,7 @@ HtmlRoot {
           1: (empty)
       3: SLASH@20..21 "/" [] []
       4: R_ANGLE@21..22 ">" [] []
-  4: EOF@22..23 "" [Newline("\n")] []
+  5: EOF@22..23 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/directives/bind_missing_property.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/directives/bind_missing_property.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -59,7 +60,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..22
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..22
     0: HTML_SELF_CLOSING_ELEMENT@0..22
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_TAG_NAME@1..7
@@ -80,7 +82,7 @@ HtmlRoot {
                 2: R_CURLY@18..20 "}" [] [Whitespace(" ")]
       3: SLASH@20..21 "/" [] []
       4: R_ANGLE@21..22 ">" [] []
-  4: EOF@22..23 "" [Newline("\n")] []
+  5: EOF@22..23 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/directives/class_invalid_expression.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/directives/class_invalid_expression.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -76,7 +77,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..33
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..33
     0: HTML_ELEMENT@0..33
       0: HTML_OPENING_ELEMENT@0..27
         0: L_ANGLE@0..1 "<" [] []
@@ -103,7 +105,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@29..32
           0: DIV_KW@29..32 "div" [] []
         3: R_ANGLE@32..33 ">" [] []
-  4: EOF@33..34 "" [Newline("\n")] []
+  5: EOF@33..34 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/directives/class_missing_name.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/directives/class_missing_name.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlBogusElement {
@@ -72,7 +73,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..36
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..36
     0: HTML_BOGUS_ELEMENT@0..36
       0: HTML_BOGUS@0..30
         0: L_ANGLE@0..1 "<" [] []
@@ -97,7 +99,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@32..35
           0: DIV_KW@32..35 "div" [] []
         3: R_ANGLE@35..36 ">" [] []
-  4: EOF@36..37 "" [Newline("\n")] []
+  5: EOF@36..37 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/directives/directive_member_expression_invalid.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/directives/directive_member_expression_invalid.svelte.snap
@@ -22,6 +22,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -147,7 +148,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..161
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..161
     0: HTML_ELEMENT@0..57
       0: HTML_OPENING_ELEMENT@0..51
         0: L_ANGLE@0..34 "<" [Comments("<!-- trailing dot, no ..."), Newline("\n")] []
@@ -227,7 +229,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@157..160
           0: DIV_KW@157..160 "div" [] []
         3: R_ANGLE@160..161 ">" [] []
-  4: EOF@161..162 "" [Newline("\n")] []
+  5: EOF@161..162 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/directives/in_invalid_params.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/directives/in_invalid_params.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -77,7 +78,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..35
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..35
     0: HTML_ELEMENT@0..35
       0: HTML_OPENING_ELEMENT@0..29
         0: L_ANGLE@0..1 "<" [] []
@@ -105,7 +107,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@31..34
           0: DIV_KW@31..34 "div" [] []
         3: R_ANGLE@34..35 ">" [] []
-  4: EOF@35..36 "" [Newline("\n")] []
+  5: EOF@35..36 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/directives/in_missing_name.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/directives/in_missing_name.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -64,7 +65,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..22
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..22
     0: HTML_ELEMENT@0..22
       0: HTML_OPENING_ELEMENT@0..9
         0: L_ANGLE@0..1 "<" [] []
@@ -88,7 +90,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@18..21
           0: DIV_KW@18..21 "div" [] []
         3: R_ANGLE@21..22 ">" [] []
-  4: EOF@22..23 "" [Newline("\n")] []
+  5: EOF@22..23 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/directives/out_invalid_params.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/directives/out_invalid_params.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -77,7 +78,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..44
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..44
     0: HTML_ELEMENT@0..44
       0: HTML_OPENING_ELEMENT@0..38
         0: L_ANGLE@0..1 "<" [] []
@@ -105,7 +107,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@40..43
           0: DIV_KW@40..43 "div" [] []
         3: R_ANGLE@43..44 ">" [] []
-  4: EOF@44..45 "" [Newline("\n")] []
+  5: EOF@44..45 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/directives/out_missing_name.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/directives/out_missing_name.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -64,7 +65,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..23
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..23
     0: HTML_ELEMENT@0..23
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -88,7 +90,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@19..22
           0: DIV_KW@19..22 "div" [] []
         3: R_ANGLE@22..23 ">" [] []
-  4: EOF@23..24 "" [Newline("\n")] []
+  5: EOF@23..24 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/directives/style_incomplete_expression.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/directives/style_incomplete_expression.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -76,7 +77,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..35
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..35
     0: HTML_ELEMENT@0..35
       0: HTML_OPENING_ELEMENT@0..29
         0: L_ANGLE@0..1 "<" [] []
@@ -103,7 +105,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@31..34
           0: DIV_KW@31..34 "div" [] []
         3: R_ANGLE@34..35 ">" [] []
-  4: EOF@35..36 "" [Newline("\n")] []
+  5: EOF@35..36 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/directives/style_missing_property.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/directives/style_missing_property.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlBogusElement {
@@ -71,7 +72,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..31
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..31
     0: HTML_BOGUS_ELEMENT@0..31
       0: HTML_BOGUS@0..25
         0: L_ANGLE@0..1 "<" [] []
@@ -95,7 +97,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@27..30
           0: DIV_KW@27..30 "div" [] []
         3: R_ANGLE@30..31 ">" [] []
-  4: EOF@31..32 "" [Newline("\n")] []
+  5: EOF@31..32 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/directives/transition_incomplete_params.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/directives/transition_incomplete_params.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -77,7 +78,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..51
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..51
     0: HTML_ELEMENT@0..51
       0: HTML_OPENING_ELEMENT@0..45
         0: L_ANGLE@0..1 "<" [] []
@@ -105,7 +107,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@47..50
           0: DIV_KW@47..50 "div" [] []
         3: R_ANGLE@50..51 ">" [] []
-  4: EOF@51..52 "" [Newline("\n")] []
+  5: EOF@51..52 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/directives/transition_missing_name.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/directives/transition_missing_name.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -64,7 +65,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..30
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..30
     0: HTML_ELEMENT@0..30
       0: HTML_OPENING_ELEMENT@0..17
         0: L_ANGLE@0..1 "<" [] []
@@ -88,7 +90,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@26..29
           0: DIV_KW@26..29 "div" [] []
         3: R_ANGLE@29..30 ">" [] []
-  4: EOF@30..31 "" [Newline("\n")] []
+  5: EOF@30..31 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/directives/transition_modifier_only.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/directives/transition_modifier_only.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -71,7 +72,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..42
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..42
     0: HTML_ELEMENT@0..42
       0: HTML_OPENING_ELEMENT@0..24
         0: L_ANGLE@0..1 "<" [] []
@@ -99,7 +101,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@38..41
           0: DIV_KW@38..41 "div" [] []
         3: R_ANGLE@41..42 ">" [] []
-  4: EOF@42..43 "" [Newline("\n")] []
+  5: EOF@42..43 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/directives/use_invalid_expression.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/directives/use_invalid_expression.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -76,7 +77,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..32
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..32
     0: HTML_ELEMENT@0..32
       0: HTML_OPENING_ELEMENT@0..26
         0: L_ANGLE@0..1 "<" [] []
@@ -103,7 +105,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@28..31
           0: DIV_KW@28..31 "div" [] []
         3: R_ANGLE@31..32 ">" [] []
-  4: EOF@32..33 "" [Newline("\n")] []
+  5: EOF@32..33 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/directives/use_missing_name.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/directives/use_missing_name.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -64,7 +65,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..24
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..24
     0: HTML_ELEMENT@0..24
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -88,7 +90,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@20..23
           0: DIV_KW@20..23 "div" [] []
         3: R_ANGLE@23..24 ">" [] []
-  4: EOF@24..25 "" [Newline("\n")] []
+  5: EOF@24..25 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/each_missing_as.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/each_missing_as.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteBogusBlock {
@@ -80,7 +81,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..46
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..46
     0: SVELTE_BOGUS_BLOCK@0..46
       0: SVELTE_EACH_OPENING_BLOCK@0..18
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -113,7 +115,7 @@ HtmlRoot {
         0: SV_CURLY_SLASH@38..41 "{/" [Newline("\n")] []
         1: EACH_KW@41..45 "each" [] []
         2: R_CURLY@45..46 "}" [] []
-  4: EOF@46..47 "" [Newline("\n")] []
+  5: EOF@46..47 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/each_missing_binding.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/each_missing_binding.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteEachBlock {
@@ -80,7 +81,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..46
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..46
     0: SVELTE_EACH_BLOCK@0..46
       0: SVELTE_EACH_OPENING_BLOCK@0..17
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -115,7 +117,7 @@ HtmlRoot {
         0: SV_CURLY_SLASH@38..41 "{/" [Newline("\n")] []
         1: EACH_KW@41..45 "each" [] []
         2: R_CURLY@45..46 "}" [] []
-  4: EOF@46..47 "" [Newline("\n")] []
+  5: EOF@46..47 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/each_missing_closing_paren.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/each_missing_closing_paren.svelte.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteEachBlock {
@@ -68,7 +69,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..41
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..41
     0: SVELTE_EACH_BLOCK@0..41
       0: SVELTE_EACH_OPENING_BLOCK@0..33
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -95,7 +97,7 @@ HtmlRoot {
         0: SV_CURLY_SLASH@33..36 "{/" [Newline("\n")] []
         1: EACH_KW@36..40 "each" [] []
         2: R_CURLY@40..41 "}" [] []
-  4: EOF@41..42 "" [Newline("\n")] []
+  5: EOF@41..42 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/each_missing_expression.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/each_missing_expression.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteBogusBlock {
@@ -87,7 +88,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..43
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..43
     0: SVELTE_BOGUS_BLOCK@0..43
       0: HTML_BOGUS@0..15
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -124,7 +126,7 @@ HtmlRoot {
         0: SV_CURLY_SLASH@35..38 "{/" [Newline("\n")] []
         1: EACH_KW@38..42 "each" [] []
         2: R_CURLY@42..43 "}" [] []
-  4: EOF@43..44 "" [Newline("\n")] []
+  5: EOF@43..44 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/each_unclosed.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/each_unclosed.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteEachBlock {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..49
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..49
     0: SVELTE_EACH_BLOCK@0..49
       0: SVELTE_EACH_OPENING_BLOCK@0..20
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -77,7 +79,7 @@ HtmlRoot {
           0: HTML_LITERAL@20..49 "<div>{item}</div>\n{/each}\n" [Newline("\n"), Whitespace("  ")] []
       2: (empty)
       3: (empty)
-  4: EOF@49..49 "" [] []
+  5: EOF@49..49 "" [] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/html.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/html.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteHtmlBlock {
@@ -39,14 +40,15 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..15
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..15
     0: SVELTE_HTML_BLOCK@0..15
       0: SV_CURLY_AT@0..2 "{@" [] []
       1: HTML_KW@2..7 "html" [] [Whitespace(" ")]
       2: HTML_TEXT_EXPRESSION@7..15
         0: HTML_LITERAL@7..15 "'<div>'\n" [] []
       3: (empty)
-  4: EOF@15..15 "" [] []
+  5: EOF@15..15 "" [] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/if_else_if_missing_expression.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/if_else_if_missing_expression.svelte.snap
@@ -27,6 +27,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteIfBlock {
@@ -191,7 +192,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..163
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..163
     0: SVELTE_IF_BLOCK@0..77
       0: SVELTE_IF_OPENING_BLOCK@0..34
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -298,7 +300,7 @@ HtmlRoot {
         0: SV_CURLY_SLASH@157..160 "{/" [Newline("\n")] []
         1: IF_KW@160..162 "if" [] []
         2: R_CURLY@162..163 "}" [] []
-  4: EOF@163..164 "" [Newline("\n")] []
+  5: EOF@163..164 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/if_missing_expression.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/if_missing_expression.svelte.snap
@@ -23,6 +23,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteIfBlock {
@@ -117,7 +118,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..88
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..88
     0: SVELTE_IF_BLOCK@0..44
       0: SVELTE_IF_OPENING_BLOCK@0..38
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -176,7 +178,7 @@ HtmlRoot {
         0: SV_CURLY_SLASH@82..85 "{/" [Newline("\n")] []
         1: IF_KW@85..87 "if" [] []
         2: R_CURLY@87..88 "}" [] []
-  4: EOF@88..89 "" [Newline("\n")] []
+  5: EOF@88..89 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/invalid_curly_in_expression.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/invalid_curly_in_expression.svelte.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteBogusBlock {
@@ -51,7 +52,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..25
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..25
     0: SVELTE_BOGUS_BLOCK@0..25
       0: SVELTE_EACH_OPENING_BLOCK@0..17
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -65,7 +67,7 @@ HtmlRoot {
         0: SV_CURLY_SLASH@17..20 "{/" [Newline("\n")] []
         1: EACH_KW@20..24 "each" [] []
         2: R_CURLY@24..25 "}" [] []
-  4: EOF@25..26 "" [Newline("\n")] []
+  5: EOF@25..26 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/key_missing_close.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/key_missing_close.svelte.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteKeyBlock {
@@ -48,7 +49,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..28
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..28
     0: SVELTE_KEY_BLOCK@0..28
       0: SVELTE_KEY_OPENING_BLOCK@0..17
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -60,7 +62,7 @@ HtmlRoot {
         0: HTML_CONTENT@17..28
           0: HTML_LITERAL@17..28 "something" [Newline("\n"), Whitespace("\t")] []
       2: (empty)
-  4: EOF@28..29 "" [Newline("\n")] []
+  5: EOF@28..29 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/key_missing_expression.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/key_missing_expression.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteKeyBlock {
@@ -51,7 +52,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..25
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..25
     0: SVELTE_KEY_BLOCK@0..25
       0: SVELTE_KEY_OPENING_BLOCK@0..7
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -65,7 +67,7 @@ HtmlRoot {
         0: SV_CURLY_SLASH@18..21 "{/" [Newline("\n")] []
         1: KEY_KW@21..24 "key" [] []
         2: R_CURLY@24..25 "}" [] []
-  4: EOF@25..26 "" [Newline("\n")] []
+  5: EOF@25..26 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/render.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/render.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteRenderBlock {
@@ -39,14 +40,15 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..19
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..19
     0: SVELTE_RENDER_BLOCK@0..19
       0: SV_CURLY_AT@0..2 "{@" [] []
       1: RENDER_KW@2..9 "render" [] [Whitespace(" ")]
       2: HTML_TEXT_EXPRESSION@9..19
         0: HTML_LITERAL@9..19 "sum(1, 2)\n" [] []
       3: (empty)
-  4: EOF@19..19 "" [] []
+  5: EOF@19..19 "" [] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/snippet_missing_close.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/snippet_missing_close.svelte.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteSnippetBlock {
@@ -68,7 +69,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..37
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..37
     0: SVELTE_SNIPPET_BLOCK@0..37
       0: SVELTE_SNIPPET_OPENING_BLOCK@0..37
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -94,7 +96,7 @@ HtmlRoot {
                 0: P_KW@35..36 "p" [] []
               3: R_ANGLE@36..37 ">" [] []
       1: (empty)
-  4: EOF@37..38 "" [Newline("\n")] []
+  5: EOF@37..38 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/snippet_missing_expression.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/snippet_missing_expression.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteSnippetBlock {
@@ -41,7 +42,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..11
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..11
     0: SVELTE_SNIPPET_BLOCK@0..11
       0: SVELTE_SNIPPET_OPENING_BLOCK@0..11
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -50,7 +52,7 @@ HtmlRoot {
         3: R_CURLY@10..11 "}" [] []
         4: HTML_ELEMENT_LIST@11..11
       1: (empty)
-  4: EOF@11..12 "" [Newline("\n")] []
+  5: EOF@11..12 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/snippet_unclosed.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/snippet_unclosed.svelte.snap
@@ -21,6 +21,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteSnippetBlock {
@@ -83,7 +84,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..69
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..69
     0: SVELTE_SNIPPET_BLOCK@0..47
       0: SVELTE_SNIPPET_OPENING_BLOCK@0..37
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -118,7 +120,7 @@ HtmlRoot {
       2: HTML_TEXT_EXPRESSION@58..68
         0: HTML_LITERAL@58..68 "greeting()" [] []
       3: R_CURLY@68..69 "}" [] []
-  4: EOF@69..70 "" [Newline("\n")] []
+  5: EOF@69..70 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/spread.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/spread.svelte.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -69,7 +70,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..40
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..40
     0: HTML_SELF_CLOSING_ELEMENT@0..15
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_TAG_NAME@1..7
@@ -97,7 +99,7 @@ HtmlRoot {
         3: (empty)
       1: HTML_ELEMENT_LIST@40..40
       2: (empty)
-  4: EOF@40..40 "" [] []
+  5: EOF@40..40 "" [] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/template_invalid_block_type.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/template_invalid_block_type.svelte.snap
@@ -16,6 +16,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteBogusBlock {
@@ -41,13 +42,14 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..20
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..20
     0: SVELTE_BOGUS_BLOCK@0..20
       0: SV_CURLY_HASH@0..2 "{#" [] []
       1: HTML_BOGUS@2..19
         0: IDENT@2..19 "notarealblocktype" [] []
       2: R_CURLY@19..20 "}" [] []
-  4: EOF@20..20 "" [] []
+  5: EOF@20..20 "" [] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/template_missing_block_type.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/template_missing_block_type.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteBogusBlock {
@@ -37,11 +38,12 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..3
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..3
     0: SVELTE_BOGUS_BLOCK@0..3
       0: SV_CURLY_HASH@0..2 "{#" [] []
       1: R_CURLY@2..3 "}" [] []
-  4: EOF@3..4 "" [Newline("\n")] []
+  5: EOF@3..4 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/template_missing_block_type_and_closing_brace.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/template_missing_block_type_and_closing_brace.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteBogusBlock {
@@ -36,10 +37,11 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..2
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..2
     0: SVELTE_BOGUS_BLOCK@0..2
       0: SV_CURLY_HASH@0..2 "{#" [] []
-  4: EOF@2..3 "" [Newline("\n")] []
+  5: EOF@2..3 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/unterminated_js_multiline_comment.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/unterminated_js_multiline_comment.svelte.snap
@@ -20,6 +20,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -46,7 +47,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..4
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..4
     0: HTML_ELEMENT@0..4
       0: HTML_OPENING_ELEMENT@0..4
         0: L_ANGLE@0..1 "<" [] []
@@ -56,7 +58,7 @@ HtmlRoot {
         3: (empty)
       1: HTML_ELEMENT_LIST@4..4
       2: (empty)
-  4: EOF@4..50 "" [Newline("\n"), Whitespace("  "), Comments("/* block comment\n  cl ...")] []
+  5: EOF@4..50 "" [Newline("\n"), Whitespace("  "), Comments("/* block comment\n  cl ...")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/template-langs/django/issue-5450.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/template-langs/django/issue-5450.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlBogusElement {
@@ -75,7 +76,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..69
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..69
     0: HTML_BOGUS_ELEMENT@0..69
       0: HTML_OPENING_ELEMENT@0..32
         0: L_ANGLE@0..1 "<" [] []
@@ -101,7 +103,7 @@ HtmlRoot {
         4: HTML_BOGUS@42..66 "heading_level|default:2" [] [Whitespace(" ")]
         5: HTML_BOGUS@66..68 "}}" [] []
         6: R_ANGLE@68..69 ">" [] []
-  4: EOF@69..70 "" [Newline("\n")] []
+  5: EOF@69..70 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/template-langs/django/issue-8605.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/template-langs/django/issue-8605.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlBogusElement {
@@ -40,13 +41,14 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..15
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..15
     0: HTML_BOGUS_ELEMENT@0..15
       0: L_DOUBLE_CURLY@0..2 "{{" [] []
       1: HTML_TEXT_EXPRESSION@2..13
         0: HTML_LITERAL@2..13 " some_form " [] []
       2: R_DOUBLE_CURLY@13..15 "}}" [] []
-  4: EOF@15..16 "" [Newline("\n")] []
+  5: EOF@15..16 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/vue/invalid-v-bind-shorthand.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/vue/invalid-v-bind-shorthand.vue.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -62,7 +63,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..17
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..17
     0: HTML_SELF_CLOSING_ELEMENT@0..17
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_COMPONENT_NAME@1..5
@@ -81,7 +83,7 @@ HtmlRoot {
               0: HTML_STRING_LITERAL@11..15 "\"5\"" [] [Whitespace(" ")]
       3: SLASH@15..16 "/" [] []
       4: R_ANGLE@16..17 ">" [] []
-  4: EOF@17..18 "" [Newline("\n")] []
+  5: EOF@17..18 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/vue/invalid-v-on-shorthand.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/vue/invalid-v-on-shorthand.vue.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -57,7 +58,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..29
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..29
     0: HTML_SELF_CLOSING_ELEMENT@0..29
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_COMPONENT_NAME@1..5
@@ -74,7 +76,7 @@ HtmlRoot {
               0: HTML_STRING_LITERAL@13..27 "\"handleClick\"" [] [Whitespace(" ")]
       3: SLASH@27..28 "/" [] []
       4: R_ANGLE@28..29 ">" [] []
-  4: EOF@29..30 "" [Newline("\n")] []
+  5: EOF@29..30 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/vue/invalid-v-slot-shorthand.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/vue/invalid-v-slot-shorthand.vue.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -78,7 +79,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..48
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..48
     0: HTML_ELEMENT@0..48
       0: HTML_OPENING_ELEMENT@0..37
         0: L_ANGLE@0..1 "<" [] []
@@ -109,7 +111,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@39..47
           0: TEMPLATE_KW@39..47 "template" [] []
         3: R_ANGLE@47..48 ">" [] []
-  4: EOF@48..49 "" [Newline("\n")] []
+  5: EOF@48..49 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/vue/unclosed_custom_block.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/vue/unclosed_custom_block.vue.snap
@@ -22,6 +22,7 @@ This block is never closed, so the blocks after it are still parsed.
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -107,7 +108,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..139
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..139
     0: HTML_ELEMENT@0..139
       0: HTML_OPENING_ELEMENT@0..6
         0: L_ANGLE@0..1 "<" [] []
@@ -156,7 +158,7 @@ HtmlRoot {
               0: TEMPLATE_KW@130..138 "template" [] []
             3: R_ANGLE@138..139 ">" [] []
       2: (empty)
-  4: EOF@139..140 "" [Newline("\n")] []
+  5: EOF@139..140 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/vue/v-for/invalid-destructuring.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/vue/v-for/invalid-destructuring.vue.snap
@@ -24,6 +24,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -506,7 +507,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..439
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..439
     0: HTML_ELEMENT@0..439
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -835,7 +837,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@430..438
           0: TEMPLATE_KW@430..438 "template" [] []
         3: R_ANGLE@438..439 ">" [] []
-  4: EOF@439..440 "" [Newline("\n")] []
+  5: EOF@439..440 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/vue/v-for/invalid-nested-destructuring.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/vue/v-for/invalid-nested-destructuring.vue.snap
@@ -21,6 +21,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -234,7 +235,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..265
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..265
     0: HTML_ELEMENT@0..265
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -370,7 +372,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@256..264
           0: TEMPLATE_KW@256..264 "template" [] []
         3: R_ANGLE@264..265 ">" [] []
-  4: EOF@265..266 "" [Newline("\n")] []
+  5: EOF@265..266 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/vue/v-for/invalid-tuples.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/vue/v-for/invalid-tuples.vue.snap
@@ -21,6 +21,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -222,7 +223,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..183
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..183
     0: HTML_ELEMENT@0..183
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -349,7 +351,7 @@ HtmlRoot {
                 0: ERROR_TOKEN@151..183 "\">{{ value }}</div>\n</template>\n" [] []
           1: HTML_ELEMENT_LIST@183..183
       2: (empty)
-  4: EOF@183..183 "" [] []
+  5: EOF@183..183 "" [] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/vue/v-for/missing-parts.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/vue/v-for/missing-parts.vue.snap
@@ -21,6 +21,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -196,7 +197,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..143
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..143
     0: HTML_ELEMENT@0..143
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -310,7 +312,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@134..142
           0: TEMPLATE_KW@134..142 "template" [] []
         3: R_ANGLE@142..143 ">" [] []
-  4: EOF@143..144 "" [Newline("\n")] []
+  5: EOF@143..144 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/vue/v-for/unterminated.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/vue/v-for/unterminated.vue.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -65,7 +66,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..43
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..43
     0: HTML_ELEMENT@0..43
       0: HTML_OPENING_ELEMENT@0..43
         0: L_ANGLE@0..1 "<" [] []
@@ -90,7 +92,7 @@ HtmlRoot {
         3: (empty)
       1: HTML_ELEMENT_LIST@43..43
       2: (empty)
-  4: EOF@43..43 "" [] []
+  5: EOF@43..43 "" [] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/error/vue/vue_unclosed_expression.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/vue/vue_unclosed_expression.vue.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -59,7 +60,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..29
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..29
     0: HTML_ELEMENT@0..29
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -77,7 +79,7 @@ HtmlRoot {
         2: HTML_TAG_NAME@20..28
           0: TEMPLATE_KW@20..28 "template" [] []
         3: R_ANGLE@28..29 ">" [] []
-  4: EOF@29..30 "" [Newline("\n")] []
+  5: EOF@29..30 "" [Newline("\n")] []
 
 ```
 

--- a/crates/biome_html_parser/tests/html_specs/ok/angular/event-binding.component.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/angular/event-binding.component.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -65,7 +66,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..45
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..45
     0: HTML_SELF_CLOSING_ELEMENT@0..45
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_TAG_NAME@1..7
@@ -89,6 +91,6 @@ HtmlRoot {
               0: HTML_STRING_LITERAL@27..43 "\"updateField()\"" [] [Whitespace(" ")]
       3: SLASH@43..44 "/" [] []
       4: R_ANGLE@44..45 ">" [] []
-  4: EOF@45..46 "" [Newline("\n")] []
+  5: EOF@45..46 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/angular/property-binding.component.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/angular/property-binding.component.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -68,7 +69,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..48
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..48
     0: HTML_ELEMENT@0..48
       0: HTML_OPENING_ELEMENT@0..35
         0: L_ANGLE@0..1 "<" [] []
@@ -94,6 +96,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@41..47
           0: HTML_LITERAL@41..47 "button" [] []
         3: R_ANGLE@47..48 ">" [] []
-  4: EOF@48..49 "" [Newline("\n")] []
+  5: EOF@48..49 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/angular/structural-directive.component.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/angular/structural-directive.component.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -74,7 +75,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..63
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..63
     0: HTML_ELEMENT@0..63
       0: HTML_OPENING_ELEMENT@0..36
         0: L_ANGLE@0..1 "<" [] []
@@ -104,6 +106,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@61..62
           0: HTML_LITERAL@61..62 "p" [] []
         3: R_ANGLE@62..63 ">" [] []
-  4: EOF@63..64 "" [Newline("\n")] []
+  5: EOF@63..64 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/angular/template-ref.component.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/angular/template-ref.component.html.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -89,7 +90,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..91
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..91
     0: HTML_ELEMENT@0..91
       0: HTML_OPENING_ELEMENT@0..40
         0: L_ANGLE@0..1 "<" [] []
@@ -128,6 +130,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@79..90
           0: HTML_LITERAL@79..90 "ng-template" [] []
         3: R_ANGLE@90..91 ">" [] []
-  4: EOF@91..92 "" [Newline("\n")] []
+  5: EOF@91..92 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/angular/two-way-binding.component.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/angular/two-way-binding.component.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -64,7 +65,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..52
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..52
     0: HTML_ELEMENT@0..52
       0: HTML_OPENING_ELEMENT@0..38
         0: L_ANGLE@0..1 "<" [] []
@@ -88,6 +90,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@40..51
           0: HTML_LITERAL@40..51 "app-counter" [] []
         3: R_ANGLE@51..52 ">" [] []
-  4: EOF@52..53 "" [Newline("\n")] []
+  5: EOF@52..53 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/astro/all_directives.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/astro/all_directives.astro.snap
@@ -24,6 +24,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -135,7 +136,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..113
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..113
     0: HTML_SELF_CLOSING_ELEMENT@0..113
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_COMPONENT_NAME@1..10
@@ -203,6 +205,6 @@ HtmlRoot {
             2: (empty)
       3: SLASH@110..112 "/" [Newline("\n")] []
       4: R_ANGLE@112..113 ">" [] []
-  4: EOF@113..114 "" [Newline("\n")] []
+  5: EOF@113..114 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/astro/attribute_expression.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/astro/attribute_expression.astro.snap
@@ -28,6 +28,7 @@ HtmlRoot {
         },
         r_fence_token: FENCE@31..34 "---" [] [],
     },
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -101,7 +102,8 @@ HtmlRoot {
       0: HTML_LITERAL@3..31 "const foo = \"lorem ipsum\";\n" [Newline("\n")] []
     2: FENCE@31..34 "---" [] []
   2: (empty)
-  3: HTML_ELEMENT_LIST@34..73
+  3: (empty)
+  4: HTML_ELEMENT_LIST@34..73
     0: HTML_ELEMENT@34..73
       0: HTML_OPENING_ELEMENT@34..41
         0: L_ANGLE@34..36 "<" [Newline("\n")] []
@@ -140,6 +142,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@68..72
           0: HTML_KW@68..72 "html" [] []
         3: R_ANGLE@72..73 ">" [] []
-  4: EOF@73..74 "" [Newline("\n")] []
+  5: EOF@73..74 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/astro/brackets-in-text.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/astro/brackets-in-text.astro.snap
@@ -20,6 +20,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -126,7 +127,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..85
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..85
     0: HTML_ELEMENT@0..16
       0: HTML_OPENING_ELEMENT@0..5
         0: L_ANGLE@0..1 "<" [] []
@@ -191,6 +193,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@83..84
           0: P_KW@83..84 "p" [] []
         3: R_ANGLE@84..85 ">" [] []
-  4: EOF@85..86 "" [Newline("\n")] []
+  5: EOF@85..86 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/astro/comment_in_frontmatter.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/astro/comment_in_frontmatter.astro.snap
@@ -27,6 +27,7 @@ HtmlRoot {
         },
         r_fence_token: FENCE@23..26 "---" [] [],
     },
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -72,7 +73,8 @@ HtmlRoot {
       0: HTML_LITERAL@3..23 "const test = \"//\";\n" [Newline("\n")] []
     2: FENCE@23..26 "---" [] []
   2: (empty)
-  3: HTML_ELEMENT_LIST@26..45
+  3: (empty)
+  4: HTML_ELEMENT_LIST@26..45
     0: HTML_ELEMENT@26..45
       0: HTML_OPENING_ELEMENT@26..33
         0: L_ANGLE@26..29 "<" [Newline("\n"), Newline("\n")] []
@@ -92,6 +94,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@41..44
           0: DIV_KW@41..44 "div" [] []
         3: R_ANGLE@44..45 ">" [] []
-  4: EOF@45..46 "" [Newline("\n")] []
+  5: EOF@45..46 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/astro/component.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/astro/component.astro.snap
@@ -28,6 +28,7 @@ HtmlRoot {
         },
         r_fence_token: FENCE@44..47 "---" [] [],
     },
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -77,7 +78,8 @@ HtmlRoot {
       0: HTML_LITERAL@3..44 "import Base from \"$layouts/Base.astro\";\n" [Newline("\n")] []
     2: FENCE@44..47 "---" [] []
   2: (empty)
-  3: HTML_ELEMENT_LIST@47..75
+  3: (empty)
+  4: HTML_ELEMENT_LIST@47..75
     0: HTML_ELEMENT@47..75
       0: HTML_OPENING_ELEMENT@47..67
         0: L_ANGLE@47..50 "<" [Newline("\n"), Newline("\n")] []
@@ -99,6 +101,6 @@ HtmlRoot {
         2: HTML_COMPONENT_NAME@70..74
           0: HTML_COMPONENT_LITERAL@70..74 "Base" [] []
         3: R_ANGLE@74..75 ">" [] []
-  4: EOF@75..76 "" [Newline("\n")] []
+  5: EOF@75..76 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/astro/component_member.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/astro/component_member.astro.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -46,7 +47,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..28
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..28
     0: HTML_SELF_CLOSING_ELEMENT@0..28
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_MEMBER_NAME@1..26
@@ -58,6 +60,6 @@ HtmlRoot {
       2: HTML_ATTRIBUTE_LIST@26..26
       3: SLASH@26..27 "/" [] []
       4: R_ANGLE@27..28 ">" [] []
-  4: EOF@28..29 "" [Newline("\n")] []
+  5: EOF@28..29 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/astro/component_member_nested.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/astro/component_member_nested.astro.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..19
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..19
     0: HTML_SELF_CLOSING_ELEMENT@0..19
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_MEMBER_NAME@1..17
@@ -78,6 +80,6 @@ HtmlRoot {
       2: HTML_ATTRIBUTE_LIST@17..17
       3: SLASH@17..18 "/" [] []
       4: R_ANGLE@18..19 ">" [] []
-  4: EOF@19..20 "" [Newline("\n")] []
+  5: EOF@19..20 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/astro/component_with_attributes.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/astro/component_with_attributes.astro.snap
@@ -20,6 +20,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -72,7 +73,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..73
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..73
     0: HTML_SELF_CLOSING_ELEMENT@0..73
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_MEMBER_NAME@1..25
@@ -98,6 +100,6 @@ HtmlRoot {
               0: HTML_STRING_LITERAL@63..70 "\"value\"" [] []
       3: SLASH@70..72 "/" [Newline("\n")] []
       4: R_ANGLE@72..73 ">" [] []
-  4: EOF@73..74 "" [Newline("\n")] []
+  5: EOF@73..74 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/astro/directives.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/astro/directives.astro.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -111,7 +112,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..107
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..107
     0: HTML_SELF_CLOSING_ELEMENT@0..75
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_COMPONENT_NAME@1..11
@@ -166,6 +168,6 @@ HtmlRoot {
             2: (empty)
       3: SLASH@105..106 "/" [] []
       4: R_ANGLE@106..107 ">" [] []
-  4: EOF@107..108 "" [Newline("\n")] []
+  5: EOF@107..108 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/astro/empty_frontmatter.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/astro/empty_frontmatter.astro.snap
@@ -27,6 +27,7 @@ HtmlRoot {
         },
         r_fence_token: FENCE@3..7 "---" [Newline("\n")] [],
     },
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -64,7 +65,8 @@ HtmlRoot {
       0: (empty)
     2: FENCE@3..7 "---" [Newline("\n")] []
   2: (empty)
-  3: HTML_ELEMENT_LIST@7..21
+  3: (empty)
+  4: HTML_ELEMENT_LIST@7..21
     0: HTML_ELEMENT@7..21
       0: HTML_OPENING_ELEMENT@7..14
         0: L_ANGLE@7..10 "<" [Newline("\n"), Newline("\n")] []
@@ -79,6 +81,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@17..20
           0: DIV_KW@17..20 "div" [] []
         3: R_ANGLE@20..21 ">" [] []
-  4: EOF@21..22 "" [Newline("\n")] []
+  5: EOF@21..22 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/astro/fence_in_html_no_frontmatter.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/astro/fence_in_html_no_frontmatter.astro.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -54,7 +55,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..14
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..14
     0: HTML_ELEMENT@0..14
       0: HTML_OPENING_ELEMENT@0..4
         0: L_ANGLE@0..1 "<" [] []
@@ -71,6 +73,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@11..13
           0: H1_KW@11..13 "h1" [] []
         3: R_ANGLE@13..14 ">" [] []
-  4: EOF@14..15 "" [Newline("\n")] []
+  5: EOF@14..15 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/astro/fence_inside_block_comment.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/astro/fence_inside_block_comment.astro.snap
@@ -30,6 +30,7 @@ HtmlRoot {
         },
         r_fence_token: FENCE@27..30 "---" [] [],
     },
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -71,7 +72,8 @@ HtmlRoot {
       0: HTML_LITERAL@3..27 "/*\n---\n*/\nconst x = 1;\n" [Newline("\n")] []
     2: FENCE@27..30 "---" [] []
   2: (empty)
-  3: HTML_ELEMENT_LIST@30..43
+  3: (empty)
+  4: HTML_ELEMENT_LIST@30..43
     0: HTML_ELEMENT@30..43
       0: HTML_OPENING_ELEMENT@30..36
         0: L_ANGLE@30..33 "<" [Newline("\n"), Newline("\n")] []
@@ -88,6 +90,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@40..42
           0: H1_KW@40..42 "h1" [] []
         3: R_ANGLE@42..43 ">" [] []
-  4: EOF@43..44 "" [Newline("\n")] []
+  5: EOF@43..44 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/astro/fence_inside_single_line_comment.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/astro/fence_inside_single_line_comment.astro.snap
@@ -28,6 +28,7 @@ HtmlRoot {
         },
         r_fence_token: FENCE@24..27 "---" [] [],
     },
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -69,7 +70,8 @@ HtmlRoot {
       0: HTML_LITERAL@3..24 "// ---\nconst x = 1;\n" [Newline("\n")] []
     2: FENCE@24..27 "---" [] []
   2: (empty)
-  3: HTML_ELEMENT_LIST@27..40
+  3: (empty)
+  4: HTML_ELEMENT_LIST@27..40
     0: HTML_ELEMENT@27..40
       0: HTML_OPENING_ELEMENT@27..33
         0: L_ANGLE@27..30 "<" [Newline("\n"), Newline("\n")] []
@@ -86,6 +88,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@37..39
           0: H1_KW@37..39 "h1" [] []
         3: R_ANGLE@39..40 ">" [] []
-  4: EOF@40..41 "" [Newline("\n")] []
+  5: EOF@40..41 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/astro/frontmatter_in_quotes.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/astro/frontmatter_in_quotes.astro.snap
@@ -31,6 +31,7 @@ HtmlRoot {
         },
         r_fence_token: FENCE@27..30 "---" [] [],
     },
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -72,7 +73,8 @@ HtmlRoot {
       0: HTML_LITERAL@3..27 "const test = `\n\n---\n\n`\n" [Newline("\n")] []
     2: FENCE@27..30 "---" [] []
   2: (empty)
-  3: HTML_ELEMENT_LIST@30..43
+  3: (empty)
+  4: HTML_ELEMENT_LIST@30..43
     0: HTML_ELEMENT@30..43
       0: HTML_OPENING_ELEMENT@30..36
         0: L_ANGLE@30..33 "<" [Newline("\n"), Newline("\n")] []
@@ -89,6 +91,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@40..42
           0: H1_KW@40..42 "h1" [] []
         3: R_ANGLE@42..43 ">" [] []
-  4: EOF@43..44 "" [Newline("\n")] []
+  5: EOF@43..44 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/astro/issue_7837.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/astro/issue_7837.astro.snap
@@ -38,6 +38,7 @@ HtmlRoot {
         },
         r_fence_token: FENCE@356..359 "---" [] [],
     },
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -162,7 +163,8 @@ HtmlRoot {
       0: HTML_LITERAL@3..356 "import { Counter } from '@/components/counter'\nimport PageLayout from '@/components/page-layout.astro'\n\n// Welcome to Astro! Wondering what to do next? Check out the Astro documentation at https://docs.astro.build\n// Don't want to use any of this? Delete everything in this file, the `assets`, `components`, and `layouts` directories, and start fresh.\n" [Newline("\n")] []
     2: FENCE@356..359 "---" [] []
   2: (empty)
-  3: HTML_ELEMENT_LIST@359..529
+  3: (empty)
+  4: HTML_ELEMENT_LIST@359..529
     0: HTML_ELEMENT@359..529
       0: HTML_OPENING_ELEMENT@359..372
         0: L_ANGLE@359..361 "<" [Newline("\n")] []
@@ -235,6 +237,6 @@ HtmlRoot {
         2: HTML_COMPONENT_NAME@518..528
           0: HTML_COMPONENT_LITERAL@518..528 "PageLayout" [] []
         3: R_ANGLE@528..529 ">" [] []
-  4: EOF@529..530 "" [Newline("\n")] []
+  5: EOF@529..530 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/astro/issue_8882.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/astro/issue_8882.astro.snap
@@ -43,6 +43,7 @@ HtmlRoot {
         },
         r_fence_token: FENCE@348..351 "---" [] [],
     },
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -175,7 +176,8 @@ HtmlRoot {
       0: HTML_LITERAL@3..348 "/**\n * In this comment, if you add any string opening or closing, such as an apostrophe, the file will show\n * a bunch of errors. Doesn't (remove the apostrophe in the previous word to fix) that stink?\n */\nimport type { HTMLAttributes } from \"astro/types\";\ntype Props = HTMLAttributes<\"div\">;\nconst { class: className, ...rest } = Astro.props;\n" [Newline("\n")] []
     2: FENCE@348..351 "---" [] []
   2: (empty)
-  3: HTML_ELEMENT_LIST@351..530
+  3: (empty)
+  4: HTML_ELEMENT_LIST@351..530
     0: HTML_ELEMENT@351..530
       0: HTML_OPENING_ELEMENT@351..475
         0: L_ANGLE@351..354 "<" [Newline("\n"), Newline("\n")] []
@@ -252,6 +254,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@526..529
           0: DIV_KW@526..529 "div" [] []
         3: R_ANGLE@529..530 ">" [] []
-  4: EOF@530..531 "" [Newline("\n")] []
+  5: EOF@530..531 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/astro/issue_9108.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/astro/issue_9108.astro.snap
@@ -29,6 +29,7 @@ HtmlRoot {
         },
         r_fence_token: FENCE@83..86 "---" [] [],
     },
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -78,7 +79,8 @@ HtmlRoot {
       0: HTML_LITERAL@3..83 "const test = \"test'\"\nconst other = 'say \"hi\"'\nconst template = `it's a \"test\"`\n" [Newline("\n")] []
     2: FENCE@83..86 "---" [] []
   2: (empty)
-  3: HTML_ELEMENT_LIST@86..111
+  3: (empty)
+  4: HTML_ELEMENT_LIST@86..111
     0: HTML_ELEMENT@86..111
       0: HTML_OPENING_ELEMENT@86..104
         0: L_ANGLE@86..89 "<" [Newline("\n"), Newline("\n")] []
@@ -100,6 +102,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@106..110
           0: HTML_KW@106..110 "html" [] []
         3: R_ANGLE@110..111 ">" [] []
-  4: EOF@111..112 "" [Newline("\n")] []
+  5: EOF@111..112 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/astro/issue_9138.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/astro/issue_9138.astro.snap
@@ -31,6 +31,7 @@ HtmlRoot {
         },
         r_fence_token: FENCE@27..30 "---" [] [],
     },
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -72,7 +73,8 @@ HtmlRoot {
       0: HTML_LITERAL@3..27 "const test = `\n\n---\n\n`\n" [Newline("\n")] []
     2: FENCE@27..30 "---" [] []
   2: (empty)
-  3: HTML_ELEMENT_LIST@30..46
+  3: (empty)
+  4: HTML_ELEMENT_LIST@30..46
     0: HTML_ELEMENT@30..46
       0: HTML_OPENING_ELEMENT@30..36
         0: L_ANGLE@30..33 "<" [Newline("\n"), Newline("\n")] []
@@ -89,6 +91,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@43..45
           0: H1_KW@43..45 "h1" [] []
         3: R_ANGLE@45..46 ">" [] []
-  4: EOF@46..47 "" [Newline("\n")] []
+  5: EOF@46..47 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/astro/issue_9187.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/astro/issue_9187.astro.snap
@@ -29,6 +29,7 @@ HtmlRoot {
         },
         r_fence_token: FENCE@60..63 "---" [] [],
     },
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -66,7 +67,8 @@ HtmlRoot {
       0: HTML_LITERAL@3..60 "const test1 = /'/\nconst test2 = /\"/\nconst test3 = /---/\n" [Newline("\n")] []
     2: FENCE@60..63 "---" [] []
   2: (empty)
-  3: HTML_ELEMENT_LIST@63..76
+  3: (empty)
+  4: HTML_ELEMENT_LIST@63..76
     0: HTML_ELEMENT@63..76
       0: HTML_OPENING_ELEMENT@63..70
         0: L_ANGLE@63..66 "<" [Newline("\n"), Newline("\n")] []
@@ -81,6 +83,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@72..75
           0: DIV_KW@72..75 "div" [] []
         3: R_ANGLE@75..76 ">" [] []
-  4: EOF@76..77 "" [Newline("\n")] []
+  5: EOF@76..77 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/astro/issue_9696.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/astro/issue_9696.astro.snap
@@ -27,6 +27,7 @@ HtmlRoot {
         },
         r_fence_token: FENCE@23..26 "---" [] [],
     },
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -54,7 +55,8 @@ HtmlRoot {
       0: HTML_LITERAL@3..23 "const RE = /\\d{4}/\n" [Newline("\n")] []
     2: FENCE@23..26 "---" [] []
   2: (empty)
-  3: HTML_ELEMENT_LIST@26..35
+  3: (empty)
+  4: HTML_ELEMENT_LIST@26..35
     0: HTML_SELF_CLOSING_ELEMENT@26..35
       0: L_ANGLE@26..29 "<" [Newline("\n"), Newline("\n")] []
       1: HTML_TAG_NAME@29..33
@@ -62,6 +64,6 @@ HtmlRoot {
       2: HTML_ATTRIBUTE_LIST@33..33
       3: SLASH@33..34 "/" [] []
       4: R_ANGLE@34..35 ">" [] []
-  4: EOF@35..36 "" [Newline("\n")] []
+  5: EOF@35..36 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/astro/lowercase_component_member.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/astro/lowercase_component_member.astro.snap
@@ -29,6 +29,7 @@ HtmlRoot {
         },
         r_fence_token: FENCE@14..17 "---" [] [],
     },
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -159,7 +160,8 @@ HtmlRoot {
       0: HTML_LITERAL@3..14 "let Data;\n" [Newline("\n")] []
     2: FENCE@14..17 "---" [] []
   2: (empty)
-  3: HTML_ELEMENT_LIST@17..143
+  3: (empty)
+  4: HTML_ELEMENT_LIST@17..143
     0: HTML_ELEMENT@17..45
       0: HTML_OPENING_ELEMENT@17..31
         0: L_ANGLE@17..19 "<" [Newline("\n")] []
@@ -236,6 +238,6 @@ HtmlRoot {
               0: HTML_STRING_LITERAL@133..141 "\"value\"" [] [Whitespace(" ")]
       3: SLASH@141..142 "/" [] []
       4: R_ANGLE@142..143 ">" [] []
-  4: EOF@143..144 "" [Newline("\n")] []
+  5: EOF@143..144 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/astro/multiple_nested_expression.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/astro/multiple_nested_expression.astro.snap
@@ -39,6 +39,7 @@ HtmlRoot {
         },
         r_fence_token: FENCE@71..74 "---" [] [],
     },
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -109,7 +110,8 @@ HtmlRoot {
       0: HTML_LITERAL@3..71 "import { Counter } from '@/components/counter'\n\nconst show = false\n" [Newline("\n")] []
     2: FENCE@71..74 "---" [] []
   2: (empty)
-  3: HTML_ELEMENT_LIST@74..333
+  3: (empty)
+  4: HTML_ELEMENT_LIST@74..333
     0: HTML_ELEMENT@74..333
       0: HTML_OPENING_ELEMENT@74..80
         0: L_ANGLE@74..76 "<" [Newline("\n")] []
@@ -148,6 +150,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@329..332
           0: DIV_KW@329..332 "div" [] []
         3: R_ANGLE@332..333 ">" [] []
-  4: EOF@333..334 "" [Newline("\n")] []
+  5: EOF@333..334 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/astro/nested_expression.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/astro/nested_expression.astro.snap
@@ -27,6 +27,7 @@ HtmlRoot {
         },
         r_fence_token: FENCE@29..32 "---" [] [],
     },
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSingleTextExpression {
@@ -52,12 +53,13 @@ HtmlRoot {
       0: HTML_LITERAL@3..29 "const items = [1, 2, 3];\n" [Newline("\n")] []
     2: FENCE@29..32 "---" [] []
   2: (empty)
-  3: HTML_ELEMENT_LIST@32..72
+  3: (empty)
+  4: HTML_ELEMENT_LIST@32..72
     0: HTML_SINGLE_TEXT_EXPRESSION@32..72
       0: L_CURLY@32..35 "{" [Newline("\n"), Newline("\n")] []
       1: HTML_TEXT_EXPRESSION@35..71
         0: HTML_LITERAL@35..71 "items.map(item => <div>{item}</div>)" [] []
       2: R_CURLY@71..72 "}" [] []
-  4: EOF@72..73 "" [Newline("\n")] []
+  5: EOF@72..73 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/astro/no_fence.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/astro/no_fence.astro.snap
@@ -24,6 +24,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -144,7 +145,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..103
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..103
     0: HTML_ELEMENT@0..103
       0: HTML_OPENING_ELEMENT@0..6
         0: L_ANGLE@0..1 "<" [] []
@@ -219,6 +221,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@98..102
           0: HTML_KW@98..102 "html" [] []
         3: R_ANGLE@102..103 ">" [] []
-  4: EOF@103..104 "" [Newline("\n")] []
+  5: EOF@103..104 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/astro/spread.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/astro/spread.astro.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -68,7 +69,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..44
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..44
     0: HTML_SELF_CLOSING_ELEMENT@0..19
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_TAG_NAME@1..7
@@ -95,6 +97,6 @@ HtmlRoot {
           3: R_CURLY@40..42 "}" [] [Whitespace(" ")]
       3: SLASH@42..43 "/" [] []
       4: R_ANGLE@43..44 ">" [] []
-  4: EOF@44..45 "" [Newline("\n")] []
+  5: EOF@44..45 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/astro/svg_with_colon_attribute.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/astro/svg_with_colon_attribute.astro.snap
@@ -29,6 +29,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -290,7 +291,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..385
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..385
     0: HTML_ELEMENT@0..385
       0: HTML_OPENING_ELEMENT@0..116
         0: L_ANGLE@0..1 "<" [] []
@@ -452,6 +454,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@381..384
           0: SVG_KW@381..384 "svg" [] []
         3: R_ANGLE@384..385 ">" [] []
-  4: EOF@385..386 "" [Newline("\n")] []
+  5: EOF@385..386 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/astro/with_fence.astro.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/astro/with_fence.astro.snap
@@ -33,6 +33,7 @@ HtmlRoot {
         },
         r_fence_token: FENCE@33..36 "---" [] [],
     },
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -157,7 +158,8 @@ HtmlRoot {
       0: HTML_LITERAL@3..33 "const hello = \"hello world\";\n" [Newline("\n")] []
     2: FENCE@33..36 "---" [] []
   2: (empty)
-  3: HTML_ELEMENT_LIST@36..140
+  3: (empty)
+  4: HTML_ELEMENT_LIST@36..140
     0: HTML_ELEMENT@36..140
       0: HTML_OPENING_ELEMENT@36..43
         0: L_ANGLE@36..38 "<" [Newline("\n")] []
@@ -232,6 +234,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@135..139
           0: HTML_KW@135..139 "html" [] []
         3: R_ANGLE@139..140 ">" [] []
-  4: EOF@140..141 "" [Newline("\n")] []
+  5: EOF@140..141 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/attributes/attributes-unquoted.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/attributes/attributes-unquoted.html.snap
@@ -27,6 +27,7 @@ foo>bar</div>
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -313,7 +314,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..206
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..206
     0: HTML_ELEMENT@0..206
       0: HTML_OPENING_ELEMENT@0..5
         0: L_ANGLE@0..1 "<" [] []
@@ -494,6 +496,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@202..205
           0: DIV_KW@202..205 "div" [] []
         3: R_ANGLE@205..206 ">" [] []
-  4: EOF@206..207 "" [Newline("\n")] []
+  5: EOF@206..207 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/attributes/attributes.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/attributes/attributes.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -52,7 +53,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..22
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..22
     0: HTML_SELF_CLOSING_ELEMENT@0..22
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_TAG_NAME@1..5
@@ -67,6 +69,6 @@ HtmlRoot {
               0: HTML_STRING_LITERAL@9..20 "\"file.html\"" [] []
       3: SLASH@20..21 "/" [] []
       4: R_ANGLE@21..22 ">" [] []
-  4: EOF@22..23 "" [Newline("\n")] []
+  5: EOF@22..23 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/attributes/multiline-attribute-value.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/attributes/multiline-attribute-value.html.snap
@@ -18,6 +18,7 @@ bar baz">foo</div>
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -67,7 +68,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..34
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..34
     0: HTML_ELEMENT@0..34
       0: HTML_OPENING_ELEMENT@0..25
         0: L_ANGLE@0..1 "<" [] []
@@ -91,6 +93,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@30..33
           0: DIV_KW@30..33 "div" [] []
         3: R_ANGLE@33..34 ">" [] []
-  4: EOF@34..35 "" [Newline("\n")] []
+  5: EOF@34..35 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/attributes/multiline-attributes.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/attributes/multiline-attributes.html.snap
@@ -22,6 +22,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -82,7 +83,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..46
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..46
     0: HTML_ELEMENT@0..46
       0: HTML_OPENING_ELEMENT@0..34
         0: L_ANGLE@0..1 "<" [] []
@@ -113,6 +115,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@42..45
           0: DIV_KW@42..45 "div" [] []
         3: R_ANGLE@45..46 ">" [] []
-  4: EOF@46..47 "" [Newline("\n")] []
+  5: EOF@46..47 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/bom.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/bom.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: UNICODE_BOM@0..3 "\u{feff}" [] [],
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: HtmlDirective {
         l_angle_token: L_ANGLE@3..4 "<" [] [],
         excl_token: BANG@4..5 "!" [] [],
@@ -39,7 +40,8 @@ HtmlRoot {
 0: HTML_ROOT@0..14
   0: UNICODE_BOM@0..3 "\u{feff}" [] []
   1: (empty)
-  2: HTML_DIRECTIVE@3..13
+  2: (empty)
+  3: HTML_DIRECTIVE@3..13
     0: L_ANGLE@3..4 "<" [] []
     1: BANG@4..5 "!" [] []
     2: DOCTYPE_KW@5..12 "doctype" [] []
@@ -49,7 +51,7 @@ HtmlRoot {
     6: (empty)
     7: (empty)
     8: R_ANGLE@12..13 ">" [] []
-  3: HTML_ELEMENT_LIST@13..13
-  4: EOF@13..14 "" [Newline("\n")] []
+  4: HTML_ELEMENT_LIST@13..13
+  5: EOF@13..14 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/bom.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/bom.html.snap
@@ -21,6 +21,7 @@ HtmlRoot {
         l_angle_token: L_ANGLE@3..4 "<" [] [],
         excl_token: BANG@4..5 "!" [] [],
         doctype_token: DOCTYPE_KW@5..12 "doctype" [] [],
+        name_token: missing (optional),
         html_token: missing (optional),
         quirk_token: missing (optional),
         public_id_token: missing (optional),
@@ -46,7 +47,8 @@ HtmlRoot {
     4: (empty)
     5: (empty)
     6: (empty)
-    7: R_ANGLE@12..13 ">" [] []
+    7: (empty)
+    8: R_ANGLE@12..13 ">" [] []
   3: HTML_ELEMENT_LIST@13..13
   4: EOF@13..14 "" [Newline("\n")] []
 

--- a/crates/biome_html_parser/tests/html_specs/ok/brackets-in-text.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/brackets-in-text.html.snap
@@ -20,6 +20,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -126,7 +127,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..85
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..85
     0: HTML_ELEMENT@0..16
       0: HTML_OPENING_ELEMENT@0..5
         0: L_ANGLE@0..1 "<" [] []
@@ -191,6 +193,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@83..84
           0: P_KW@83..84 "p" [] []
         3: R_ANGLE@84..85 ">" [] []
-  4: EOF@85..86 "" [Newline("\n")] []
+  5: EOF@85..86 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/cdata.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/cdata.html.snap
@@ -20,6 +20,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlCdataSection {
@@ -54,7 +55,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..203
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..203
     0: HTML_CDATA_SECTION@0..19
       0: CDATA_START@0..9 "<![CDATA[" [] []
       1: HTML_LITERAL@9..16 "example" [] []
@@ -71,6 +73,6 @@ HtmlRoot {
       0: CDATA_START@151..161 "<![CDATA[" [Newline("\n")] []
       1: HTML_LITERAL@161..200 "<div attributes=\"some-attribute\"></div>" [] []
       2: CDATA_END@200..203 "]]>" [] []
-  4: EOF@203..204 "" [Newline("\n")] []
+  5: EOF@203..204 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/comment-inline.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/comment-inline.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -50,7 +51,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..33
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..33
     0: HTML_ELEMENT@0..33
       0: HTML_OPENING_ELEMENT@0..26
         0: L_ANGLE@0..1 "<" [] []
@@ -65,6 +67,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@28..32
           0: SPAN_KW@28..32 "span" [] []
         3: R_ANGLE@32..33 ">" [] []
-  4: EOF@33..34 "" [Newline("\n")] []
+  5: EOF@33..34 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/comment.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/comment.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [],
     eof_token: EOF@0..21 "" [Comments("<!-- Hello World -->"), Newline("\n")] [],
@@ -30,7 +31,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..0
-  4: EOF@0..21 "" [Comments("<!-- Hello World -->"), Newline("\n")] []
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..0
+  5: EOF@0..21 "" [Comments("<!-- Hello World -->"), Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/comment2.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/comment2.html.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -35,9 +36,10 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..24
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..24
     0: HTML_CONTENT@0..24
       0: HTML_LITERAL@0..24 "123" [Comments("<!-- Hello World -->"), Newline("\n")] []
-  4: EOF@24..25 "" [Newline("\n")] []
+  5: EOF@24..25 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/compat/non-spec-compliant-tag-name.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/compat/non-spec-compliant-tag-name.html.snap
@@ -16,6 +16,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -76,7 +77,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..106
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..106
     0: HTML_ELEMENT@0..106
       0: HTML_OPENING_ELEMENT@0..84
         0: L_ANGLE@0..1 "<" [] []
@@ -107,6 +109,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@90..105
           0: HTML_UNKNOWN_TAG@90..105 "f:link.external" [] []
         3: R_ANGLE@105..106 ">" [] []
-  4: EOF@106..106 "" [] []
+  5: EOF@106..106 "" [] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/content-blocks.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/content-blocks.html.snap
@@ -25,6 +25,7 @@ just a concept for the parser to handle.
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -45,11 +46,12 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..549
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..549
     0: HTML_CONTENT@0..199
       0: HTML_LITERAL@0..199 "This document is meant to contain 2 text blocks. This is the first text block,\nand the following will be the second text block. The content of this block is\nintentionally long so that it line breaks." [] []
     1: HTML_CONTENT@199..549
       0: HTML_LITERAL@199..549 "We define the separation of \"blocks\" of text to be 2 line breaks, or 1 empty\nline between them. This is to make it easier for users to suppress formatting\nfor specific blocks, while still preserving whitespace sensitivity. Despite\nthis, the formatter can and will combine separate blocks of content. This is\njust a concept for the parser to handle." [Newline("\n"), Newline("\n")] []
-  4: EOF@549..550 "" [Newline("\n")] []
+  5: EOF@549..550 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/dashes_in_element_content.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/dashes_in_element_content.html.snap
@@ -30,6 +30,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -305,7 +306,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..215
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..215
     0: HTML_ELEMENT@0..151
       0: HTML_OPENING_ELEMENT@0..7
         0: L_ANGLE@0..1 "<" [] []
@@ -488,6 +490,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@210..214
           0: SPAN_KW@210..214 "span" [] []
         3: R_ANGLE@214..215 ">" [] []
-  4: EOF@215..216 "" [Newline("\n")] []
+  5: EOF@215..216 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/doctype/after-processing-instruction.html
+++ b/crates/biome_html_parser/tests/html_specs/ok/doctype/after-processing-instruction.html
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<!DOCTYPE html>
+<html></html>

--- a/crates/biome_html_parser/tests/html_specs/ok/doctype/after-processing-instruction.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/doctype/after-processing-instruction.html.snap
@@ -1,0 +1,126 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+<?xml version="1.0"?>
+<!DOCTYPE html>
+<html></html>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlProcessingInstruction {
+            start_token: PI_START@0..2 "<?" [] [],
+            target: HtmlTagName {
+                value_token: HTML_LITERAL@2..6 "xml" [] [Whitespace(" ")],
+            },
+            attributes: HtmlAttributeList [
+                HtmlAttribute {
+                    name: HtmlAttributeName {
+                        value_token: HTML_LITERAL@6..13 "version" [] [],
+                    },
+                    initializer: HtmlAttributeInitializerClause {
+                        eq_token: EQ@13..14 "=" [] [],
+                        value: HtmlString {
+                            value_token: HTML_STRING_LITERAL@14..19 "\"1.0\"" [] [],
+                        },
+                    },
+                },
+            ],
+            end_token: PI_END@19..21 "?>" [] [],
+        },
+        HtmlDirective {
+            l_angle_token: L_ANGLE@21..23 "<" [Newline("\n")] [],
+            excl_token: BANG@23..24 "!" [] [],
+            doctype_token: DOCTYPE_KW@24..32 "DOCTYPE" [] [Whitespace(" ")],
+            name_token: missing (optional),
+            html_token: HTML_KW@32..36 "html" [] [],
+            quirk_token: missing (optional),
+            public_id_token: missing (optional),
+            system_id_token: missing (optional),
+            r_angle_token: R_ANGLE@36..37 ">" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@37..39 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: HTML_KW@39..43 "html" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@43..44 ">" [] [],
+            },
+            children: HtmlElementList [],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@44..45 "<" [] [],
+                slash_token: SLASH@45..46 "/" [] [],
+                name: HtmlTagName {
+                    value_token: HTML_KW@46..50 "html" [] [],
+                },
+                r_angle_token: R_ANGLE@50..51 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@51..52 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..52
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..51
+    0: HTML_PROCESSING_INSTRUCTION@0..21
+      0: PI_START@0..2 "<?" [] []
+      1: HTML_TAG_NAME@2..6
+        0: HTML_LITERAL@2..6 "xml" [] [Whitespace(" ")]
+      2: HTML_ATTRIBUTE_LIST@6..19
+        0: HTML_ATTRIBUTE@6..19
+          0: HTML_ATTRIBUTE_NAME@6..13
+            0: HTML_LITERAL@6..13 "version" [] []
+          1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@13..19
+            0: EQ@13..14 "=" [] []
+            1: HTML_STRING@14..19
+              0: HTML_STRING_LITERAL@14..19 "\"1.0\"" [] []
+      3: PI_END@19..21 "?>" [] []
+    1: HTML_DIRECTIVE@21..37
+      0: L_ANGLE@21..23 "<" [Newline("\n")] []
+      1: BANG@23..24 "!" [] []
+      2: DOCTYPE_KW@24..32 "DOCTYPE" [] [Whitespace(" ")]
+      3: (empty)
+      4: HTML_KW@32..36 "html" [] []
+      5: (empty)
+      6: (empty)
+      7: (empty)
+      8: R_ANGLE@36..37 ">" [] []
+    2: HTML_ELEMENT@37..51
+      0: HTML_OPENING_ELEMENT@37..44
+        0: L_ANGLE@37..39 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@39..43
+          0: HTML_KW@39..43 "html" [] []
+        2: HTML_ATTRIBUTE_LIST@43..43
+        3: R_ANGLE@43..44 ">" [] []
+      1: HTML_ELEMENT_LIST@44..44
+      2: HTML_CLOSING_ELEMENT@44..51
+        0: L_ANGLE@44..45 "<" [] []
+        1: SLASH@45..46 "/" [] []
+        2: HTML_TAG_NAME@46..50
+          0: HTML_KW@46..50 "html" [] []
+        3: R_ANGLE@50..51 ">" [] []
+  4: EOF@51..52 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/doctype/after-processing-instruction.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/doctype/after-processing-instruction.html.snap
@@ -19,39 +19,38 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
-    directive: missing (optional),
-    html: HtmlElementList [
-        HtmlProcessingInstruction {
-            start_token: PI_START@0..2 "<?" [] [],
-            target: HtmlTagName {
-                value_token: HTML_LITERAL@2..6 "xml" [] [Whitespace(" ")],
-            },
-            attributes: HtmlAttributeList [
-                HtmlAttribute {
-                    name: HtmlAttributeName {
-                        value_token: HTML_LITERAL@6..13 "version" [] [],
-                    },
-                    initializer: HtmlAttributeInitializerClause {
-                        eq_token: EQ@13..14 "=" [] [],
-                        value: HtmlString {
-                            value_token: HTML_STRING_LITERAL@14..19 "\"1.0\"" [] [],
-                        },
+    processing_instruction: HtmlProcessingInstruction {
+        start_token: PI_START@0..2 "<?" [] [],
+        target: HtmlTagName {
+            value_token: HTML_LITERAL@2..6 "xml" [] [Whitespace(" ")],
+        },
+        attributes: HtmlAttributeList [
+            HtmlAttribute {
+                name: HtmlAttributeName {
+                    value_token: HTML_LITERAL@6..13 "version" [] [],
+                },
+                initializer: HtmlAttributeInitializerClause {
+                    eq_token: EQ@13..14 "=" [] [],
+                    value: HtmlString {
+                        value_token: HTML_STRING_LITERAL@14..19 "\"1.0\"" [] [],
                     },
                 },
-            ],
-            end_token: PI_END@19..21 "?>" [] [],
-        },
-        HtmlDirective {
-            l_angle_token: L_ANGLE@21..23 "<" [Newline("\n")] [],
-            excl_token: BANG@23..24 "!" [] [],
-            doctype_token: DOCTYPE_KW@24..32 "DOCTYPE" [] [Whitespace(" ")],
-            name_token: missing (optional),
-            html_token: HTML_KW@32..36 "html" [] [],
-            quirk_token: missing (optional),
-            public_id_token: missing (optional),
-            system_id_token: missing (optional),
-            r_angle_token: R_ANGLE@36..37 ">" [] [],
-        },
+            },
+        ],
+        end_token: PI_END@19..21 "?>" [] [],
+    },
+    directive: HtmlDirective {
+        l_angle_token: L_ANGLE@21..23 "<" [Newline("\n")] [],
+        excl_token: BANG@23..24 "!" [] [],
+        doctype_token: DOCTYPE_KW@24..32 "DOCTYPE" [] [Whitespace(" ")],
+        name_token: missing (optional),
+        html_token: HTML_KW@32..36 "html" [] [],
+        quirk_token: missing (optional),
+        public_id_token: missing (optional),
+        system_id_token: missing (optional),
+        r_angle_token: R_ANGLE@36..37 ">" [] [],
+    },
+    html: HtmlElementList [
         HtmlElement {
             opening_element: HtmlOpeningElement {
                 l_angle_token: L_ANGLE@37..39 "<" [Newline("\n")] [],
@@ -82,32 +81,31 @@ HtmlRoot {
 0: HTML_ROOT@0..52
   0: (empty)
   1: (empty)
-  2: (empty)
-  3: HTML_ELEMENT_LIST@0..51
-    0: HTML_PROCESSING_INSTRUCTION@0..21
-      0: PI_START@0..2 "<?" [] []
-      1: HTML_TAG_NAME@2..6
-        0: HTML_LITERAL@2..6 "xml" [] [Whitespace(" ")]
-      2: HTML_ATTRIBUTE_LIST@6..19
-        0: HTML_ATTRIBUTE@6..19
-          0: HTML_ATTRIBUTE_NAME@6..13
-            0: HTML_LITERAL@6..13 "version" [] []
-          1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@13..19
-            0: EQ@13..14 "=" [] []
-            1: HTML_STRING@14..19
-              0: HTML_STRING_LITERAL@14..19 "\"1.0\"" [] []
-      3: PI_END@19..21 "?>" [] []
-    1: HTML_DIRECTIVE@21..37
-      0: L_ANGLE@21..23 "<" [Newline("\n")] []
-      1: BANG@23..24 "!" [] []
-      2: DOCTYPE_KW@24..32 "DOCTYPE" [] [Whitespace(" ")]
-      3: (empty)
-      4: HTML_KW@32..36 "html" [] []
-      5: (empty)
-      6: (empty)
-      7: (empty)
-      8: R_ANGLE@36..37 ">" [] []
-    2: HTML_ELEMENT@37..51
+  2: HTML_PROCESSING_INSTRUCTION@0..21
+    0: PI_START@0..2 "<?" [] []
+    1: HTML_TAG_NAME@2..6
+      0: HTML_LITERAL@2..6 "xml" [] [Whitespace(" ")]
+    2: HTML_ATTRIBUTE_LIST@6..19
+      0: HTML_ATTRIBUTE@6..19
+        0: HTML_ATTRIBUTE_NAME@6..13
+          0: HTML_LITERAL@6..13 "version" [] []
+        1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@13..19
+          0: EQ@13..14 "=" [] []
+          1: HTML_STRING@14..19
+            0: HTML_STRING_LITERAL@14..19 "\"1.0\"" [] []
+    3: PI_END@19..21 "?>" [] []
+  3: HTML_DIRECTIVE@21..37
+    0: L_ANGLE@21..23 "<" [Newline("\n")] []
+    1: BANG@23..24 "!" [] []
+    2: DOCTYPE_KW@24..32 "DOCTYPE" [] [Whitespace(" ")]
+    3: (empty)
+    4: HTML_KW@32..36 "html" [] []
+    5: (empty)
+    6: (empty)
+    7: (empty)
+    8: R_ANGLE@36..37 ">" [] []
+  4: HTML_ELEMENT_LIST@37..51
+    0: HTML_ELEMENT@37..51
       0: HTML_OPENING_ELEMENT@37..44
         0: L_ANGLE@37..39 "<" [Newline("\n")] []
         1: HTML_TAG_NAME@39..43
@@ -121,6 +119,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@46..50
           0: HTML_KW@46..50 "html" [] []
         3: R_ANGLE@50..51 ">" [] []
-  4: EOF@51..52 "" [Newline("\n")] []
+  5: EOF@51..52 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/doctype/basic.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/doctype/basic.html.snap
@@ -21,6 +21,7 @@ HtmlRoot {
         l_angle_token: L_ANGLE@0..1 "<" [] [],
         excl_token: BANG@1..2 "!" [] [],
         doctype_token: DOCTYPE_KW@2..10 "DOCTYPE" [] [Whitespace(" ")],
+        name_token: missing (optional),
         html_token: HTML_KW@10..14 "html" [] [],
         quirk_token: missing (optional),
         public_id_token: missing (optional),
@@ -42,11 +43,12 @@ HtmlRoot {
     0: L_ANGLE@0..1 "<" [] []
     1: BANG@1..2 "!" [] []
     2: DOCTYPE_KW@2..10 "DOCTYPE" [] [Whitespace(" ")]
-    3: HTML_KW@10..14 "html" [] []
-    4: (empty)
+    3: (empty)
+    4: HTML_KW@10..14 "html" [] []
     5: (empty)
     6: (empty)
-    7: R_ANGLE@14..15 ">" [] []
+    7: (empty)
+    8: R_ANGLE@14..15 ">" [] []
   3: HTML_ELEMENT_LIST@15..15
   4: EOF@15..16 "" [Newline("\n")] []
 

--- a/crates/biome_html_parser/tests/html_specs/ok/doctype/basic.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/doctype/basic.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: HtmlDirective {
         l_angle_token: L_ANGLE@0..1 "<" [] [],
         excl_token: BANG@1..2 "!" [] [],
@@ -39,7 +40,8 @@ HtmlRoot {
 0: HTML_ROOT@0..16
   0: (empty)
   1: (empty)
-  2: HTML_DIRECTIVE@0..15
+  2: (empty)
+  3: HTML_DIRECTIVE@0..15
     0: L_ANGLE@0..1 "<" [] []
     1: BANG@1..2 "!" [] []
     2: DOCTYPE_KW@2..10 "DOCTYPE" [] [Whitespace(" ")]
@@ -49,7 +51,7 @@ HtmlRoot {
     6: (empty)
     7: (empty)
     8: R_ANGLE@14..15 ">" [] []
-  3: HTML_ELEMENT_LIST@15..15
-  4: EOF@15..16 "" [Newline("\n")] []
+  4: HTML_ELEMENT_LIST@15..15
+  5: EOF@15..16 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/doctype/long-legacy1.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/doctype/long-legacy1.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: HtmlDirective {
         l_angle_token: L_ANGLE@0..1 "<" [] [],
         excl_token: BANG@1..2 "!" [] [],
@@ -39,7 +40,8 @@ HtmlRoot {
 0: HTML_ROOT@0..45
   0: (empty)
   1: (empty)
-  2: HTML_DIRECTIVE@0..44
+  2: (empty)
+  3: HTML_DIRECTIVE@0..44
     0: L_ANGLE@0..1 "<" [] []
     1: BANG@1..2 "!" [] []
     2: DOCTYPE_KW@2..10 "DOCTYPE" [] [Whitespace(" ")]
@@ -49,7 +51,7 @@ HtmlRoot {
     6: HTML_STRING_LITERAL@22..43 "\"about:legacy-compat\"" [] []
     7: (empty)
     8: R_ANGLE@43..44 ">" [] []
-  3: HTML_ELEMENT_LIST@44..44
-  4: EOF@44..45 "" [Newline("\n")] []
+  4: HTML_ELEMENT_LIST@44..44
+  5: EOF@44..45 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/doctype/long-legacy1.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/doctype/long-legacy1.html.snap
@@ -21,6 +21,7 @@ HtmlRoot {
         l_angle_token: L_ANGLE@0..1 "<" [] [],
         excl_token: BANG@1..2 "!" [] [],
         doctype_token: DOCTYPE_KW@2..10 "DOCTYPE" [] [Whitespace(" ")],
+        name_token: missing (optional),
         html_token: HTML_KW@10..15 "html" [] [Whitespace(" ")],
         quirk_token: HTML_LITERAL@15..22 "SYSTEM" [] [Whitespace(" ")],
         public_id_token: HTML_STRING_LITERAL@22..43 "\"about:legacy-compat\"" [] [],
@@ -42,11 +43,12 @@ HtmlRoot {
     0: L_ANGLE@0..1 "<" [] []
     1: BANG@1..2 "!" [] []
     2: DOCTYPE_KW@2..10 "DOCTYPE" [] [Whitespace(" ")]
-    3: HTML_KW@10..15 "html" [] [Whitespace(" ")]
-    4: HTML_LITERAL@15..22 "SYSTEM" [] [Whitespace(" ")]
-    5: HTML_STRING_LITERAL@22..43 "\"about:legacy-compat\"" [] []
-    6: (empty)
-    7: R_ANGLE@43..44 ">" [] []
+    3: (empty)
+    4: HTML_KW@10..15 "html" [] [Whitespace(" ")]
+    5: HTML_LITERAL@15..22 "SYSTEM" [] [Whitespace(" ")]
+    6: HTML_STRING_LITERAL@22..43 "\"about:legacy-compat\"" [] []
+    7: (empty)
+    8: R_ANGLE@43..44 ">" [] []
   3: HTML_ELEMENT_LIST@44..44
   4: EOF@44..45 "" [Newline("\n")] []
 

--- a/crates/biome_html_parser/tests/html_specs/ok/doctype/long-legacy2.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/doctype/long-legacy2.html.snap
@@ -21,6 +21,7 @@ HtmlRoot {
         l_angle_token: L_ANGLE@0..1 "<" [] [],
         excl_token: BANG@1..2 "!" [] [],
         doctype_token: DOCTYPE_KW@2..10 "DOCTYPE" [] [Whitespace(" ")],
+        name_token: missing (optional),
         html_token: HTML_KW@10..15 "html" [] [Whitespace(" ")],
         quirk_token: HTML_LITERAL@15..22 "PUBLIC" [] [Whitespace(" ")],
         public_id_token: HTML_STRING_LITERAL@22..49 "\"-//W3C//DTD HTML 4.01//EN\"" [] [],
@@ -42,11 +43,12 @@ HtmlRoot {
     0: L_ANGLE@0..1 "<" [] []
     1: BANG@1..2 "!" [] []
     2: DOCTYPE_KW@2..10 "DOCTYPE" [] [Whitespace(" ")]
-    3: HTML_KW@10..15 "html" [] [Whitespace(" ")]
-    4: HTML_LITERAL@15..22 "PUBLIC" [] [Whitespace(" ")]
-    5: HTML_STRING_LITERAL@22..49 "\"-//W3C//DTD HTML 4.01//EN\"" [] []
-    6: (empty)
-    7: R_ANGLE@49..50 ">" [] []
+    3: (empty)
+    4: HTML_KW@10..15 "html" [] [Whitespace(" ")]
+    5: HTML_LITERAL@15..22 "PUBLIC" [] [Whitespace(" ")]
+    6: HTML_STRING_LITERAL@22..49 "\"-//W3C//DTD HTML 4.01//EN\"" [] []
+    7: (empty)
+    8: R_ANGLE@49..50 ">" [] []
   3: HTML_ELEMENT_LIST@50..50
   4: EOF@50..51 "" [Newline("\n")] []
 

--- a/crates/biome_html_parser/tests/html_specs/ok/doctype/long-legacy2.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/doctype/long-legacy2.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: HtmlDirective {
         l_angle_token: L_ANGLE@0..1 "<" [] [],
         excl_token: BANG@1..2 "!" [] [],
@@ -39,7 +40,8 @@ HtmlRoot {
 0: HTML_ROOT@0..51
   0: (empty)
   1: (empty)
-  2: HTML_DIRECTIVE@0..50
+  2: (empty)
+  3: HTML_DIRECTIVE@0..50
     0: L_ANGLE@0..1 "<" [] []
     1: BANG@1..2 "!" [] []
     2: DOCTYPE_KW@2..10 "DOCTYPE" [] [Whitespace(" ")]
@@ -49,7 +51,7 @@ HtmlRoot {
     6: HTML_STRING_LITERAL@22..49 "\"-//W3C//DTD HTML 4.01//EN\"" [] []
     7: (empty)
     8: R_ANGLE@49..50 ">" [] []
-  3: HTML_ELEMENT_LIST@50..50
-  4: EOF@50..51 "" [Newline("\n")] []
+  4: HTML_ELEMENT_LIST@50..50
+  5: EOF@50..51 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/doctype/long-legacy3.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/doctype/long-legacy3.html.snap
@@ -22,6 +22,7 @@ HtmlRoot {
         l_angle_token: L_ANGLE@0..1 "<" [] [],
         excl_token: BANG@1..2 "!" [] [],
         doctype_token: DOCTYPE_KW@2..10 "DOCTYPE" [] [Whitespace(" ")],
+        name_token: missing (optional),
         html_token: HTML_KW@10..15 "HTML" [] [Whitespace(" ")],
         quirk_token: HTML_LITERAL@15..22 "PUBLIC" [] [Whitespace(" ")],
         public_id_token: HTML_STRING_LITERAL@22..58 "\"-//W3C//DTD HTML 4.01 Frameset//EN\"" [] [],
@@ -43,11 +44,12 @@ HtmlRoot {
     0: L_ANGLE@0..1 "<" [] []
     1: BANG@1..2 "!" [] []
     2: DOCTYPE_KW@2..10 "DOCTYPE" [] [Whitespace(" ")]
-    3: HTML_KW@10..15 "HTML" [] [Whitespace(" ")]
-    4: HTML_LITERAL@15..22 "PUBLIC" [] [Whitespace(" ")]
-    5: HTML_STRING_LITERAL@22..58 "\"-//W3C//DTD HTML 4.01 Frameset//EN\"" [] []
-    6: HTML_STRING_LITERAL@58..102 "\"http://www.w3.org/TR/html4/frameset.dtd\"" [Newline("\n"), Whitespace("  ")] []
-    7: R_ANGLE@102..103 ">" [] []
+    3: (empty)
+    4: HTML_KW@10..15 "HTML" [] [Whitespace(" ")]
+    5: HTML_LITERAL@15..22 "PUBLIC" [] [Whitespace(" ")]
+    6: HTML_STRING_LITERAL@22..58 "\"-//W3C//DTD HTML 4.01 Frameset//EN\"" [] []
+    7: HTML_STRING_LITERAL@58..102 "\"http://www.w3.org/TR/html4/frameset.dtd\"" [Newline("\n"), Whitespace("  ")] []
+    8: R_ANGLE@102..103 ">" [] []
   3: HTML_ELEMENT_LIST@103..103
   4: EOF@103..104 "" [Newline("\n")] []
 

--- a/crates/biome_html_parser/tests/html_specs/ok/doctype/long-legacy3.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/doctype/long-legacy3.html.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: HtmlDirective {
         l_angle_token: L_ANGLE@0..1 "<" [] [],
         excl_token: BANG@1..2 "!" [] [],
@@ -40,7 +41,8 @@ HtmlRoot {
 0: HTML_ROOT@0..104
   0: (empty)
   1: (empty)
-  2: HTML_DIRECTIVE@0..103
+  2: (empty)
+  3: HTML_DIRECTIVE@0..103
     0: L_ANGLE@0..1 "<" [] []
     1: BANG@1..2 "!" [] []
     2: DOCTYPE_KW@2..10 "DOCTYPE" [] [Whitespace(" ")]
@@ -50,7 +52,7 @@ HtmlRoot {
     6: HTML_STRING_LITERAL@22..58 "\"-//W3C//DTD HTML 4.01 Frameset//EN\"" [] []
     7: HTML_STRING_LITERAL@58..102 "\"http://www.w3.org/TR/html4/frameset.dtd\"" [Newline("\n"), Whitespace("  ")] []
     8: R_ANGLE@102..103 ">" [] []
-  3: HTML_ELEMENT_LIST@103..103
-  4: EOF@103..104 "" [Newline("\n")] []
+  4: HTML_ELEMENT_LIST@103..103
+  5: EOF@103..104 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/doctype/minimal.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/doctype/minimal.html.snap
@@ -21,6 +21,7 @@ HtmlRoot {
         l_angle_token: L_ANGLE@0..1 "<" [] [],
         excl_token: BANG@1..2 "!" [] [],
         doctype_token: DOCTYPE_KW@2..9 "DOCTYPE" [] [],
+        name_token: missing (optional),
         html_token: missing (optional),
         quirk_token: missing (optional),
         public_id_token: missing (optional),
@@ -46,7 +47,8 @@ HtmlRoot {
     4: (empty)
     5: (empty)
     6: (empty)
-    7: R_ANGLE@9..10 ">" [] []
+    7: (empty)
+    8: R_ANGLE@9..10 ">" [] []
   3: HTML_ELEMENT_LIST@10..10
   4: EOF@10..11 "" [Newline("\n")] []
 

--- a/crates/biome_html_parser/tests/html_specs/ok/doctype/minimal.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/doctype/minimal.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: HtmlDirective {
         l_angle_token: L_ANGLE@0..1 "<" [] [],
         excl_token: BANG@1..2 "!" [] [],
@@ -39,7 +40,8 @@ HtmlRoot {
 0: HTML_ROOT@0..11
   0: (empty)
   1: (empty)
-  2: HTML_DIRECTIVE@0..10
+  2: (empty)
+  3: HTML_DIRECTIVE@0..10
     0: L_ANGLE@0..1 "<" [] []
     1: BANG@1..2 "!" [] []
     2: DOCTYPE_KW@2..9 "DOCTYPE" [] []
@@ -49,7 +51,7 @@ HtmlRoot {
     6: (empty)
     7: (empty)
     8: R_ANGLE@9..10 ">" [] []
-  3: HTML_ELEMENT_LIST@10..10
-  4: EOF@10..11 "" [Newline("\n")] []
+  4: HTML_ELEMENT_LIST@10..10
+  5: EOF@10..11 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/element.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/element.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -40,7 +41,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..6
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..6
     0: HTML_SELF_CLOSING_ELEMENT@0..6
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_TAG_NAME@1..4
@@ -48,6 +50,6 @@ HtmlRoot {
       2: HTML_ATTRIBUTE_LIST@4..4
       3: SLASH@4..5 "/" [] []
       4: R_ANGLE@5..6 ">" [] []
-  4: EOF@6..7 "" [Newline("\n")] []
+  5: EOF@6..7 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/element_list.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/element_list.html.snap
@@ -39,6 +39,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -386,7 +387,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..424
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..424
     0: HTML_ELEMENT@0..424
       0: HTML_OPENING_ELEMENT@0..5
         0: L_ANGLE@0..1 "<" [] []
@@ -617,6 +619,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@420..423
           0: DIV_KW@420..423 "div" [] []
         3: R_ANGLE@423..424 ">" [] []
-  4: EOF@424..425 "" [Newline("\n")] []
+  5: EOF@424..425 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/element_list2.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/element_list2.html.snap
@@ -22,6 +22,7 @@ some text
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -118,7 +119,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..67
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..67
     0: HTML_CONTENT@0..9
       0: HTML_LITERAL@0..9 "some text" [] []
     1: HTML_ELEMENT@9..21
@@ -179,6 +181,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@63..66
           0: DIV_KW@63..66 "div" [] []
         3: R_ANGLE@66..67 ">" [] []
-  4: EOF@67..68 "" [Newline("\n")] []
+  5: EOF@67..68 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/embedded-languages/script-basic.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/embedded-languages/script-basic.html.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -56,7 +57,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..49
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..49
     0: HTML_ELEMENT@0..49
       0: HTML_OPENING_ELEMENT@0..8
         0: L_ANGLE@0..1 "<" [] []
@@ -73,6 +75,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@42..48
           0: SCRIPT_KW@42..48 "script" [] []
         3: R_ANGLE@48..49 ">" [] []
-  4: EOF@49..50 "" [Newline("\n")] []
+  5: EOF@49..50 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/embedded-languages/script-empty.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/embedded-languages/script-empty.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -50,7 +51,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..17
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..17
     0: HTML_ELEMENT@0..17
       0: HTML_OPENING_ELEMENT@0..8
         0: L_ANGLE@0..1 "<" [] []
@@ -65,6 +67,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@10..16
           0: SCRIPT_KW@10..16 "script" [] []
         3: R_ANGLE@16..17 ">" [] []
-  4: EOF@17..18 "" [Newline("\n")] []
+  5: EOF@17..18 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/embedded-languages/script-in-string.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/embedded-languages/script-in-string.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -54,7 +55,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..106
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..106
     0: HTML_ELEMENT@0..106
       0: HTML_OPENING_ELEMENT@0..8
         0: L_ANGLE@0..1 "<" [] []
@@ -71,6 +73,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@99..105
           0: SCRIPT_KW@99..105 "script" [] []
         3: R_ANGLE@105..106 ">" [] []
-  4: EOF@106..107 "" [Newline("\n")] []
+  5: EOF@106..107 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/embedded-languages/script-less-than.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/embedded-languages/script-less-than.html.snap
@@ -21,6 +21,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..67
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..67
     0: HTML_ELEMENT@0..67
       0: HTML_OPENING_ELEMENT@0..8
         0: L_ANGLE@0..1 "<" [] []
@@ -75,6 +77,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@60..66
           0: SCRIPT_KW@60..66 "script" [] []
         3: R_ANGLE@66..67 ">" [] []
-  4: EOF@67..68 "" [Newline("\n")] []
+  5: EOF@67..68 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/hello-world.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/hello-world.html.snap
@@ -30,6 +30,7 @@ HtmlRoot {
         l_angle_token: L_ANGLE@0..1 "<" [] [],
         excl_token: BANG@1..2 "!" [] [],
         doctype_token: DOCTYPE_KW@2..10 "DOCTYPE" [] [Whitespace(" ")],
+        name_token: missing (optional),
         html_token: HTML_KW@10..14 "html" [] [],
         quirk_token: missing (optional),
         public_id_token: missing (optional),
@@ -181,11 +182,12 @@ HtmlRoot {
     0: L_ANGLE@0..1 "<" [] []
     1: BANG@1..2 "!" [] []
     2: DOCTYPE_KW@2..10 "DOCTYPE" [] [Whitespace(" ")]
-    3: HTML_KW@10..14 "html" [] []
-    4: (empty)
+    3: (empty)
+    4: HTML_KW@10..14 "html" [] []
     5: (empty)
     6: (empty)
-    7: R_ANGLE@14..15 ">" [] []
+    7: (empty)
+    8: R_ANGLE@14..15 ">" [] []
   3: HTML_ELEMENT_LIST@15..155
     0: HTML_ELEMENT@15..155
       0: HTML_OPENING_ELEMENT@15..22

--- a/crates/biome_html_parser/tests/html_specs/ok/hello-world.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/hello-world.html.snap
@@ -26,6 +26,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: HtmlDirective {
         l_angle_token: L_ANGLE@0..1 "<" [] [],
         excl_token: BANG@1..2 "!" [] [],
@@ -178,7 +179,8 @@ HtmlRoot {
 0: HTML_ROOT@0..156
   0: (empty)
   1: (empty)
-  2: HTML_DIRECTIVE@0..15
+  2: (empty)
+  3: HTML_DIRECTIVE@0..15
     0: L_ANGLE@0..1 "<" [] []
     1: BANG@1..2 "!" [] []
     2: DOCTYPE_KW@2..10 "DOCTYPE" [] [Whitespace(" ")]
@@ -188,7 +190,7 @@ HtmlRoot {
     6: (empty)
     7: (empty)
     8: R_ANGLE@14..15 ">" [] []
-  3: HTML_ELEMENT_LIST@15..155
+  4: HTML_ELEMENT_LIST@15..155
     0: HTML_ELEMENT@15..155
       0: HTML_OPENING_ELEMENT@15..22
         0: L_ANGLE@15..17 "<" [Newline("\n")] []
@@ -279,6 +281,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@150..154
           0: HTML_KW@150..154 "html" [] []
         3: R_ANGLE@154..155 ">" [] []
-  4: EOF@155..156 "" [Newline("\n")] []
+  5: EOF@155..156 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keyword_directives_as_text.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keyword_directives_as_text.html.snap
@@ -27,6 +27,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -248,7 +249,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..190
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..190
     0: HTML_ELEMENT@0..17
       0: HTML_OPENING_ELEMENT@0..6
         0: L_ANGLE@0..1 "<" [] []
@@ -393,6 +395,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@188..189
           0: P_KW@188..189 "p" [] []
         3: R_ANGLE@189..190 ">" [] []
-  4: EOF@190..191 "" [Newline("\n")] []
+  5: EOF@190..191 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/as.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/as.html.snap
@@ -18,6 +18,7 @@ as text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..38
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..38
     0: HTML_CONTENT@0..15
       0: HTML_LITERAL@0..15 "as text content" [] []
     1: HTML_ELEMENT@15..38
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@36..37
           0: P_KW@36..37 "p" [] []
         3: R_ANGLE@37..38 ">" [] []
-  4: EOF@38..39 "" [Newline("\n")] []
+  5: EOF@38..39 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/attach.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/attach.html.snap
@@ -18,6 +18,7 @@ attach text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..46
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..46
     0: HTML_CONTENT@0..19
       0: HTML_LITERAL@0..19 "attach text content" [] []
     1: HTML_ELEMENT@19..46
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@44..45
           0: P_KW@44..45 "p" [] []
         3: R_ANGLE@45..46 ">" [] []
-  4: EOF@46..47 "" [Newline("\n")] []
+  5: EOF@46..47 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/await.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/await.html.snap
@@ -18,6 +18,7 @@ await text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..44
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..44
     0: HTML_CONTENT@0..18
       0: HTML_LITERAL@0..18 "await text content" [] []
     1: HTML_ELEMENT@18..44
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@42..43
           0: P_KW@42..43 "p" [] []
         3: R_ANGLE@43..44 ">" [] []
-  4: EOF@44..45 "" [Newline("\n")] []
+  5: EOF@44..45 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/bind.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/bind.html.snap
@@ -18,6 +18,7 @@ bind text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..42
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..42
     0: HTML_CONTENT@0..17
       0: HTML_LITERAL@0..17 "bind text content" [] []
     1: HTML_ELEMENT@17..42
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@40..41
           0: P_KW@40..41 "p" [] []
         3: R_ANGLE@41..42 ">" [] []
-  4: EOF@42..43 "" [Newline("\n")] []
+  5: EOF@42..43 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/catch.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/catch.html.snap
@@ -18,6 +18,7 @@ catch text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..44
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..44
     0: HTML_CONTENT@0..18
       0: HTML_LITERAL@0..18 "catch text content" [] []
     1: HTML_ELEMENT@18..44
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@42..43
           0: P_KW@42..43 "p" [] []
         3: R_ANGLE@43..44 ">" [] []
-  4: EOF@44..45 "" [Newline("\n")] []
+  5: EOF@44..45 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/class.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/class.html.snap
@@ -18,6 +18,7 @@ class text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..44
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..44
     0: HTML_CONTENT@0..18
       0: HTML_LITERAL@0..18 "class text content" [] []
     1: HTML_ELEMENT@18..44
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@42..43
           0: P_KW@42..43 "p" [] []
         3: R_ANGLE@43..44 ">" [] []
-  4: EOF@44..45 "" [Newline("\n")] []
+  5: EOF@44..45 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/client.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/client.html.snap
@@ -18,6 +18,7 @@ client text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..46
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..46
     0: HTML_CONTENT@0..19
       0: HTML_LITERAL@0..19 "client text content" [] []
     1: HTML_ELEMENT@19..46
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@44..45
           0: P_KW@44..45 "p" [] []
         3: R_ANGLE@45..46 ">" [] []
-  4: EOF@46..47 "" [Newline("\n")] []
+  5: EOF@46..47 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/const.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/const.html.snap
@@ -18,6 +18,7 @@ const text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..44
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..44
     0: HTML_CONTENT@0..18
       0: HTML_LITERAL@0..18 "const text content" [] []
     1: HTML_ELEMENT@18..44
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@42..43
           0: P_KW@42..43 "p" [] []
         3: R_ANGLE@43..44 ">" [] []
-  4: EOF@44..45 "" [Newline("\n")] []
+  5: EOF@44..45 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/debug.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/debug.html.snap
@@ -18,6 +18,7 @@ debug text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..44
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..44
     0: HTML_CONTENT@0..18
       0: HTML_LITERAL@0..18 "debug text content" [] []
     1: HTML_ELEMENT@18..44
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@42..43
           0: P_KW@42..43 "p" [] []
         3: R_ANGLE@43..44 ">" [] []
-  4: EOF@44..45 "" [Newline("\n")] []
+  5: EOF@44..45 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/define.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/define.html.snap
@@ -18,6 +18,7 @@ define text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..46
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..46
     0: HTML_CONTENT@0..19
       0: HTML_LITERAL@0..19 "define text content" [] []
     1: HTML_ELEMENT@19..46
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@44..45
           0: P_KW@44..45 "p" [] []
         3: R_ANGLE@45..46 ">" [] []
-  4: EOF@46..47 "" [Newline("\n")] []
+  5: EOF@46..47 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/doctype.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/doctype.html.snap
@@ -18,6 +18,7 @@ doctype text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..48
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..48
     0: HTML_CONTENT@0..20
       0: HTML_LITERAL@0..20 "doctype text content" [] []
     1: HTML_ELEMENT@20..48
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@46..47
           0: P_KW@46..47 "p" [] []
         3: R_ANGLE@47..48 ">" [] []
-  4: EOF@48..49 "" [Newline("\n")] []
+  5: EOF@48..49 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/each.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/each.html.snap
@@ -18,6 +18,7 @@ each text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..42
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..42
     0: HTML_CONTENT@0..17
       0: HTML_LITERAL@0..17 "each text content" [] []
     1: HTML_ELEMENT@17..42
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@40..41
           0: P_KW@40..41 "p" [] []
         3: R_ANGLE@41..42 ">" [] []
-  4: EOF@42..43 "" [Newline("\n")] []
+  5: EOF@42..43 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/else.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/else.html.snap
@@ -18,6 +18,7 @@ else text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..42
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..42
     0: HTML_CONTENT@0..17
       0: HTML_LITERAL@0..17 "else text content" [] []
     1: HTML_ELEMENT@17..42
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@40..41
           0: P_KW@40..41 "p" [] []
         3: R_ANGLE@41..42 ">" [] []
-  4: EOF@42..43 "" [Newline("\n")] []
+  5: EOF@42..43 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/false.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/false.html.snap
@@ -18,6 +18,7 @@ false text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..44
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..44
     0: HTML_CONTENT@0..18
       0: HTML_LITERAL@0..18 "false text content" [] []
     1: HTML_ELEMENT@18..44
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@42..43
           0: P_KW@42..43 "p" [] []
         3: R_ANGLE@43..44 ">" [] []
-  4: EOF@44..45 "" [Newline("\n")] []
+  5: EOF@44..45 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/html.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/html.html.snap
@@ -18,6 +18,7 @@ html text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..42
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..42
     0: HTML_CONTENT@0..17
       0: HTML_LITERAL@0..17 "html text content" [] []
     1: HTML_ELEMENT@17..42
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@40..41
           0: P_KW@40..41 "p" [] []
         3: R_ANGLE@41..42 ">" [] []
-  4: EOF@42..43 "" [Newline("\n")] []
+  5: EOF@42..43 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/if.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/if.html.snap
@@ -18,6 +18,7 @@ if text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..38
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..38
     0: HTML_CONTENT@0..15
       0: HTML_LITERAL@0..15 "if text content" [] []
     1: HTML_ELEMENT@15..38
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@36..37
           0: P_KW@36..37 "p" [] []
         3: R_ANGLE@37..38 ">" [] []
-  4: EOF@38..39 "" [Newline("\n")] []
+  5: EOF@38..39 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/in.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/in.html.snap
@@ -18,6 +18,7 @@ in text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..38
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..38
     0: HTML_CONTENT@0..15
       0: HTML_LITERAL@0..15 "in text content" [] []
     1: HTML_ELEMENT@15..38
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@36..37
           0: P_KW@36..37 "p" [] []
         3: R_ANGLE@37..38 ">" [] []
-  4: EOF@38..39 "" [Newline("\n")] []
+  5: EOF@38..39 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/is.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/is.html.snap
@@ -18,6 +18,7 @@ is text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..38
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..38
     0: HTML_CONTENT@0..15
       0: HTML_LITERAL@0..15 "is text content" [] []
     1: HTML_ELEMENT@15..38
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@36..37
           0: P_KW@36..37 "p" [] []
         3: R_ANGLE@37..38 ">" [] []
-  4: EOF@38..39 "" [Newline("\n")] []
+  5: EOF@38..39 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/key.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/key.html.snap
@@ -18,6 +18,7 @@ key text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..40
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..40
     0: HTML_CONTENT@0..16
       0: HTML_LITERAL@0..16 "key text content" [] []
     1: HTML_ELEMENT@16..40
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@38..39
           0: P_KW@38..39 "p" [] []
         3: R_ANGLE@39..40 ">" [] []
-  4: EOF@40..41 "" [Newline("\n")] []
+  5: EOF@40..41 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/null.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/null.html.snap
@@ -18,6 +18,7 @@ null text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..42
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..42
     0: HTML_CONTENT@0..17
       0: HTML_LITERAL@0..17 "null text content" [] []
     1: HTML_ELEMENT@17..42
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@40..41
           0: P_KW@40..41 "p" [] []
         3: R_ANGLE@41..42 ">" [] []
-  4: EOF@42..43 "" [Newline("\n")] []
+  5: EOF@42..43 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/of.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/of.html.snap
@@ -18,6 +18,7 @@ of text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..38
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..38
     0: HTML_CONTENT@0..15
       0: HTML_LITERAL@0..15 "of text content" [] []
     1: HTML_ELEMENT@15..38
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@36..37
           0: P_KW@36..37 "p" [] []
         3: R_ANGLE@37..38 ">" [] []
-  4: EOF@38..39 "" [Newline("\n")] []
+  5: EOF@38..39 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/out.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/out.html.snap
@@ -18,6 +18,7 @@ out text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..40
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..40
     0: HTML_CONTENT@0..16
       0: HTML_LITERAL@0..16 "out text content" [] []
     1: HTML_ELEMENT@16..40
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@38..39
           0: P_KW@38..39 "p" [] []
         3: R_ANGLE@39..40 ">" [] []
-  4: EOF@40..41 "" [Newline("\n")] []
+  5: EOF@40..41 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/render.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/render.html.snap
@@ -18,6 +18,7 @@ render text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..46
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..46
     0: HTML_CONTENT@0..19
       0: HTML_LITERAL@0..19 "render text content" [] []
     1: HTML_ELEMENT@19..46
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@44..45
           0: P_KW@44..45 "p" [] []
         3: R_ANGLE@45..46 ">" [] []
-  4: EOF@46..47 "" [Newline("\n")] []
+  5: EOF@46..47 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/server.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/server.html.snap
@@ -18,6 +18,7 @@ server text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..46
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..46
     0: HTML_CONTENT@0..19
       0: HTML_LITERAL@0..19 "server text content" [] []
     1: HTML_ELEMENT@19..46
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@44..45
           0: P_KW@44..45 "p" [] []
         3: R_ANGLE@45..46 ">" [] []
-  4: EOF@46..47 "" [Newline("\n")] []
+  5: EOF@46..47 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/set.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/set.html.snap
@@ -18,6 +18,7 @@ set text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..40
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..40
     0: HTML_CONTENT@0..16
       0: HTML_LITERAL@0..16 "set text content" [] []
     1: HTML_ELEMENT@16..40
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@38..39
           0: P_KW@38..39 "p" [] []
         3: R_ANGLE@39..40 ">" [] []
-  4: EOF@40..41 "" [Newline("\n")] []
+  5: EOF@40..41 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/snippet.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/snippet.html.snap
@@ -18,6 +18,7 @@ snippet text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..48
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..48
     0: HTML_CONTENT@0..20
       0: HTML_LITERAL@0..20 "snippet text content" [] []
     1: HTML_ELEMENT@20..48
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@46..47
           0: P_KW@46..47 "p" [] []
         3: R_ANGLE@47..48 ">" [] []
-  4: EOF@48..49 "" [Newline("\n")] []
+  5: EOF@48..49 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/style.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/style.html.snap
@@ -18,6 +18,7 @@ style text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..44
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..44
     0: HTML_CONTENT@0..18
       0: HTML_LITERAL@0..18 "style text content" [] []
     1: HTML_ELEMENT@18..44
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@42..43
           0: P_KW@42..43 "p" [] []
         3: R_ANGLE@43..44 ">" [] []
-  4: EOF@44..45 "" [Newline("\n")] []
+  5: EOF@44..45 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/then.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/then.html.snap
@@ -18,6 +18,7 @@ then text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..42
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..42
     0: HTML_CONTENT@0..17
       0: HTML_LITERAL@0..17 "then text content" [] []
     1: HTML_ELEMENT@17..42
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@40..41
           0: P_KW@40..41 "p" [] []
         3: R_ANGLE@41..42 ">" [] []
-  4: EOF@42..43 "" [Newline("\n")] []
+  5: EOF@42..43 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/transition.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/transition.html.snap
@@ -18,6 +18,7 @@ transition text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..54
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..54
     0: HTML_CONTENT@0..23
       0: HTML_LITERAL@0..23 "transition text content" [] []
     1: HTML_ELEMENT@23..54
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@52..53
           0: P_KW@52..53 "p" [] []
         3: R_ANGLE@53..54 ">" [] []
-  4: EOF@54..55 "" [Newline("\n")] []
+  5: EOF@54..55 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/true.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/true.html.snap
@@ -18,6 +18,7 @@ true text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..42
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..42
     0: HTML_CONTENT@0..17
       0: HTML_LITERAL@0..17 "true text content" [] []
     1: HTML_ELEMENT@17..42
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@40..41
           0: P_KW@40..41 "p" [] []
         3: R_ANGLE@41..42 ">" [] []
-  4: EOF@42..43 "" [Newline("\n")] []
+  5: EOF@42..43 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/use.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/keywords-as-text/use.html.snap
@@ -18,6 +18,7 @@ use text content
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..40
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..40
     0: HTML_CONTENT@0..16
       0: HTML_LITERAL@0..16 "use text content" [] []
     1: HTML_ELEMENT@16..40
@@ -77,6 +79,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@38..39
           0: P_KW@38..39 "p" [] []
         3: R_ANGLE@39..40 ">" [] []
-  4: EOF@40..41 "" [Newline("\n")] []
+  5: EOF@40..41 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/mixed-case-doctype.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/mixed-case-doctype.html.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: HtmlDirective {
         l_angle_token: L_ANGLE@0..1 "<" [] [],
         excl_token: BANG@1..2 "!" [] [],
@@ -60,7 +61,8 @@ HtmlRoot {
 0: HTML_ROOT@0..30
   0: (empty)
   1: (empty)
-  2: HTML_DIRECTIVE@0..15
+  2: (empty)
+  3: HTML_DIRECTIVE@0..15
     0: L_ANGLE@0..1 "<" [] []
     1: BANG@1..2 "!" [] []
     2: DOCTYPE_KW@2..10 "DoCtYpE" [] [Whitespace(" ")]
@@ -70,7 +72,7 @@ HtmlRoot {
     6: (empty)
     7: (empty)
     8: R_ANGLE@14..15 ">" [] []
-  3: HTML_ELEMENT_LIST@15..29
+  4: HTML_ELEMENT_LIST@15..29
     0: HTML_ELEMENT@15..29
       0: HTML_OPENING_ELEMENT@15..22
         0: L_ANGLE@15..17 "<" [Newline("\n")] []
@@ -85,6 +87,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@24..28
           0: HTML_KW@24..28 "html" [] []
         3: R_ANGLE@28..29 ">" [] []
-  4: EOF@29..30 "" [Newline("\n")] []
+  5: EOF@29..30 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/mixed-case-doctype.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/mixed-case-doctype.html.snap
@@ -22,6 +22,7 @@ HtmlRoot {
         l_angle_token: L_ANGLE@0..1 "<" [] [],
         excl_token: BANG@1..2 "!" [] [],
         doctype_token: DOCTYPE_KW@2..10 "DoCtYpE" [] [Whitespace(" ")],
+        name_token: missing (optional),
         html_token: HTML_KW@10..14 "hTmL" [] [],
         quirk_token: missing (optional),
         public_id_token: missing (optional),
@@ -63,11 +64,12 @@ HtmlRoot {
     0: L_ANGLE@0..1 "<" [] []
     1: BANG@1..2 "!" [] []
     2: DOCTYPE_KW@2..10 "DoCtYpE" [] [Whitespace(" ")]
-    3: HTML_KW@10..14 "hTmL" [] []
-    4: (empty)
+    3: (empty)
+    4: HTML_KW@10..14 "hTmL" [] []
     5: (empty)
     6: (empty)
-    7: R_ANGLE@14..15 ">" [] []
+    7: (empty)
+    8: R_ANGLE@14..15 ">" [] []
   3: HTML_ELEMENT_LIST@15..29
     0: HTML_ELEMENT@15..29
       0: HTML_OPENING_ELEMENT@15..22

--- a/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/br-followed-by-html-text.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/br-followed-by-html-text.html.snap
@@ -87,6 +87,7 @@ doctype text outside a doctype
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: HtmlDirective {
         l_angle_token: L_ANGLE@0..1 "<" [] [],
         excl_token: BANG@1..2 "!" [] [],
@@ -505,7 +506,8 @@ HtmlRoot {
 0: HTML_ROOT@0..824
   0: (empty)
   1: (empty)
-  2: HTML_DIRECTIVE@0..15
+  2: (empty)
+  3: HTML_DIRECTIVE@0..15
     0: L_ANGLE@0..1 "<" [] []
     1: BANG@1..2 "!" [] []
     2: DOCTYPE_KW@2..10 "doctype" [] [Whitespace(" ")]
@@ -515,7 +517,7 @@ HtmlRoot {
     6: (empty)
     7: (empty)
     8: R_ANGLE@14..15 ">" [] []
-  3: HTML_ELEMENT_LIST@15..823
+  4: HTML_ELEMENT_LIST@15..823
     0: HTML_ELEMENT@15..823
       0: HTML_OPENING_ELEMENT@15..32
         0: L_ANGLE@15..17 "<" [Newline("\n")] []
@@ -805,6 +807,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@818..822
           0: HTML_KW@818..822 "html" [] []
         3: R_ANGLE@822..823 ">" [] []
-  4: EOF@823..824 "" [Newline("\n")] []
+  5: EOF@823..824 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/br-followed-by-html-text.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/br-followed-by-html-text.html.snap
@@ -91,6 +91,7 @@ HtmlRoot {
         l_angle_token: L_ANGLE@0..1 "<" [] [],
         excl_token: BANG@1..2 "!" [] [],
         doctype_token: DOCTYPE_KW@2..10 "doctype" [] [Whitespace(" ")],
+        name_token: missing (optional),
         html_token: HTML_KW@10..14 "html" [] [],
         quirk_token: missing (optional),
         public_id_token: missing (optional),
@@ -508,11 +509,12 @@ HtmlRoot {
     0: L_ANGLE@0..1 "<" [] []
     1: BANG@1..2 "!" [] []
     2: DOCTYPE_KW@2..10 "doctype" [] [Whitespace(" ")]
-    3: HTML_KW@10..14 "html" [] []
-    4: (empty)
+    3: (empty)
+    4: HTML_KW@10..14 "html" [] []
     5: (empty)
     6: (empty)
-    7: R_ANGLE@14..15 ">" [] []
+    7: (empty)
+    8: R_ANGLE@14..15 ">" [] []
   3: HTML_ELEMENT_LIST@15..823
     0: HTML_ELEMENT@15..823
       0: HTML_OPENING_ELEMENT@15..32

--- a/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/br-in-span.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/br-in-span.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -66,7 +67,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..23
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..23
     0: HTML_ELEMENT@0..23
       0: HTML_OPENING_ELEMENT@0..6
         0: L_ANGLE@0..1 "<" [] []
@@ -92,6 +94,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@18..22
           0: SPAN_KW@18..22 "span" [] []
         3: R_ANGLE@22..23 ">" [] []
-  4: EOF@23..24 "" [Newline("\n")] []
+  5: EOF@23..24 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/br.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/br.html.snap
@@ -17,6 +17,7 @@ foo<br>bar
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlContent {
@@ -46,7 +47,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..10
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..10
     0: HTML_CONTENT@0..3
       0: HTML_LITERAL@0..3 "foo" [] []
     1: HTML_SELF_CLOSING_ELEMENT@3..7
@@ -58,6 +60,6 @@ HtmlRoot {
       4: R_ANGLE@6..7 ">" [] []
     2: HTML_CONTENT@7..10
       0: HTML_LITERAL@7..10 "bar" [] []
-  4: EOF@10..11 "" [Newline("\n")] []
+  5: EOF@10..11 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/casing.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/casing.html.snap
@@ -20,6 +20,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -96,7 +97,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..62
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..62
     0: HTML_ELEMENT@0..62
       0: HTML_OPENING_ELEMENT@0..6
         0: L_ANGLE@0..1 "<" [] []
@@ -139,6 +141,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@57..61
           0: HEAD_KW@57..61 "head" [] []
         3: R_ANGLE@61..62 ">" [] []
-  4: EOF@62..63 "" [Newline("\n")] []
+  5: EOF@62..63 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/meta.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/meta.html.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -74,7 +75,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..38
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..38
     0: HTML_ELEMENT@0..38
       0: HTML_OPENING_ELEMENT@0..6
         0: L_ANGLE@0..1 "<" [] []
@@ -103,6 +105,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@33..37
           0: HEAD_KW@33..37 "head" [] []
         3: R_ANGLE@37..38 ">" [] []
-  4: EOF@38..39 "" [Newline("\n")] []
+  5: EOF@38..39 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/param.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/param.html.snap
@@ -20,6 +20,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -163,7 +164,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..193
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..193
     0: HTML_ELEMENT@0..193
       0: HTML_OPENING_ELEMENT@0..90
         0: L_ANGLE@0..1 "<" [] []
@@ -248,6 +250,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@186..192
           0: OBJECT_KW@186..192 "object" [] []
         3: R_ANGLE@192..193 ">" [] []
-  4: EOF@193..194 "" [Newline("\n")] []
+  5: EOF@193..194 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/wbr.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/no-end-tags/wbr.html.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -175,7 +176,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..141
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..141
     0: HTML_ELEMENT@0..141
       0: HTML_OPENING_ELEMENT@0..3
         0: L_ANGLE@0..1 "<" [] []
@@ -282,6 +284,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@139..140
           0: P_KW@139..140 "p" [] []
         3: R_ANGLE@140..141 ">" [] []
-  4: EOF@141..142 "" [Newline("\n")] []
+  5: EOF@141..142 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/ok.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/ok.html.snap
@@ -20,6 +20,7 @@ HtmlRoot {
         l_angle_token: L_ANGLE@0..1 "<" [] [],
         excl_token: BANG@1..2 "!" [] [],
         doctype_token: DOCTYPE_KW@2..9 "doctype" [] [],
+        name_token: missing (optional),
         html_token: missing (optional),
         quirk_token: missing (optional),
         public_id_token: missing (optional),
@@ -45,7 +46,8 @@ HtmlRoot {
     4: (empty)
     5: (empty)
     6: (empty)
-    7: R_ANGLE@9..10 ">" [] []
+    7: (empty)
+    8: R_ANGLE@9..10 ">" [] []
   3: HTML_ELEMENT_LIST@10..10
   4: EOF@10..10 "" [] []
 

--- a/crates/biome_html_parser/tests/html_specs/ok/ok.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/ok.html.snap
@@ -16,6 +16,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: HtmlDirective {
         l_angle_token: L_ANGLE@0..1 "<" [] [],
         excl_token: BANG@1..2 "!" [] [],
@@ -38,7 +39,8 @@ HtmlRoot {
 0: HTML_ROOT@0..10
   0: (empty)
   1: (empty)
-  2: HTML_DIRECTIVE@0..10
+  2: (empty)
+  3: HTML_DIRECTIVE@0..10
     0: L_ANGLE@0..1 "<" [] []
     1: BANG@1..2 "!" [] []
     2: DOCTYPE_KW@2..9 "doctype" [] []
@@ -48,7 +50,7 @@ HtmlRoot {
     6: (empty)
     7: (empty)
     8: R_ANGLE@9..10 ">" [] []
-  3: HTML_ELEMENT_LIST@10..10
-  4: EOF@10..10 "" [] []
+  4: HTML_ELEMENT_LIST@10..10
+  5: EOF@10..10 "" [] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/ok2.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/ok2.html.snap
@@ -21,6 +21,7 @@ HtmlRoot {
         l_angle_token: L_ANGLE@0..1 "<" [] [],
         excl_token: BANG@1..2 "!" [] [],
         doctype_token: DOCTYPE_KW@2..10 "doctype" [] [Whitespace(" ")],
+        name_token: missing (optional),
         html_token: HTML_KW@10..14 "html" [] [],
         quirk_token: missing (optional),
         public_id_token: missing (optional),
@@ -42,11 +43,12 @@ HtmlRoot {
     0: L_ANGLE@0..1 "<" [] []
     1: BANG@1..2 "!" [] []
     2: DOCTYPE_KW@2..10 "doctype" [] [Whitespace(" ")]
-    3: HTML_KW@10..14 "html" [] []
-    4: (empty)
+    3: (empty)
+    4: HTML_KW@10..14 "html" [] []
     5: (empty)
     6: (empty)
-    7: R_ANGLE@14..15 ">" [] []
+    7: (empty)
+    8: R_ANGLE@14..15 ">" [] []
   3: HTML_ELEMENT_LIST@15..15
   4: EOF@15..16 "" [Newline("\n")] []
 

--- a/crates/biome_html_parser/tests/html_specs/ok/ok2.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/ok2.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: HtmlDirective {
         l_angle_token: L_ANGLE@0..1 "<" [] [],
         excl_token: BANG@1..2 "!" [] [],
@@ -39,7 +40,8 @@ HtmlRoot {
 0: HTML_ROOT@0..16
   0: (empty)
   1: (empty)
-  2: HTML_DIRECTIVE@0..15
+  2: (empty)
+  3: HTML_DIRECTIVE@0..15
     0: L_ANGLE@0..1 "<" [] []
     1: BANG@1..2 "!" [] []
     2: DOCTYPE_KW@2..10 "doctype" [] [Whitespace(" ")]
@@ -49,7 +51,7 @@ HtmlRoot {
     6: (empty)
     7: (empty)
     8: R_ANGLE@14..15 ">" [] []
-  3: HTML_ELEMENT_LIST@15..15
-  4: EOF@15..16 "" [Newline("\n")] []
+  4: HTML_ELEMENT_LIST@15..15
+  5: EOF@15..16 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/processing_instruction.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/processing_instruction.html.snap
@@ -21,28 +21,28 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
-    directive: missing (optional),
-    html: HtmlElementList [
-        HtmlProcessingInstruction {
-            start_token: PI_START@0..2 "<?" [] [],
-            target: HtmlTagName {
-                value_token: HTML_LITERAL@2..6 "xml" [] [Whitespace(" ")],
-            },
-            attributes: HtmlAttributeList [
-                HtmlAttribute {
-                    name: HtmlAttributeName {
-                        value_token: HTML_LITERAL@6..13 "version" [] [],
-                    },
-                    initializer: HtmlAttributeInitializerClause {
-                        eq_token: EQ@13..14 "=" [] [],
-                        value: HtmlString {
-                            value_token: HTML_STRING_LITERAL@14..20 "\"1.0\"" [] [Whitespace(" ")],
-                        },
+    processing_instruction: HtmlProcessingInstruction {
+        start_token: PI_START@0..2 "<?" [] [],
+        target: HtmlTagName {
+            value_token: HTML_LITERAL@2..6 "xml" [] [Whitespace(" ")],
+        },
+        attributes: HtmlAttributeList [
+            HtmlAttribute {
+                name: HtmlAttributeName {
+                    value_token: HTML_LITERAL@6..13 "version" [] [],
+                },
+                initializer: HtmlAttributeInitializerClause {
+                    eq_token: EQ@13..14 "=" [] [],
+                    value: HtmlString {
+                        value_token: HTML_STRING_LITERAL@14..20 "\"1.0\"" [] [Whitespace(" ")],
                     },
                 },
-            ],
-            end_token: PI_END@20..22 "?>" [] [],
-        },
+            },
+        ],
+        end_token: PI_END@20..22 "?>" [] [],
+    },
+    directive: missing (optional),
+    html: HtmlElementList [
         HtmlElement {
             opening_element: HtmlOpeningElement {
                 l_angle_token: L_ANGLE@22..25 "<" [Newline("\n"), Newline("\n")] [],
@@ -82,22 +82,22 @@ HtmlRoot {
 0: HTML_ROOT@0..53
   0: (empty)
   1: (empty)
-  2: (empty)
-  3: HTML_ELEMENT_LIST@0..52
-    0: HTML_PROCESSING_INSTRUCTION@0..22
-      0: PI_START@0..2 "<?" [] []
-      1: HTML_TAG_NAME@2..6
-        0: HTML_LITERAL@2..6 "xml" [] [Whitespace(" ")]
-      2: HTML_ATTRIBUTE_LIST@6..20
-        0: HTML_ATTRIBUTE@6..20
-          0: HTML_ATTRIBUTE_NAME@6..13
-            0: HTML_LITERAL@6..13 "version" [] []
-          1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@13..20
-            0: EQ@13..14 "=" [] []
-            1: HTML_STRING@14..20
-              0: HTML_STRING_LITERAL@14..20 "\"1.0\"" [] [Whitespace(" ")]
-      3: PI_END@20..22 "?>" [] []
-    1: HTML_ELEMENT@22..52
+  2: HTML_PROCESSING_INSTRUCTION@0..22
+    0: PI_START@0..2 "<?" [] []
+    1: HTML_TAG_NAME@2..6
+      0: HTML_LITERAL@2..6 "xml" [] [Whitespace(" ")]
+    2: HTML_ATTRIBUTE_LIST@6..20
+      0: HTML_ATTRIBUTE@6..20
+        0: HTML_ATTRIBUTE_NAME@6..13
+          0: HTML_LITERAL@6..13 "version" [] []
+        1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@13..20
+          0: EQ@13..14 "=" [] []
+          1: HTML_STRING@14..20
+            0: HTML_STRING_LITERAL@14..20 "\"1.0\"" [] [Whitespace(" ")]
+    3: PI_END@20..22 "?>" [] []
+  3: (empty)
+  4: HTML_ELEMENT_LIST@22..52
+    0: HTML_ELEMENT@22..52
       0: HTML_OPENING_ELEMENT@22..29
         0: L_ANGLE@22..25 "<" [Newline("\n"), Newline("\n")] []
         1: HTML_TAG_NAME@25..28
@@ -117,6 +117,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@48..51
           0: SVG_KW@48..51 "svg" [] []
         3: R_ANGLE@51..52 ">" [] []
-  4: EOF@52..53 "" [Newline("\n")] []
+  5: EOF@52..53 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/quote-in-child.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/quote-in-child.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -80,7 +81,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..39
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..39
     0: HTML_ELEMENT@0..39
       0: HTML_OPENING_ELEMENT@0..3
         0: L_ANGLE@0..1 "<" [] []
@@ -115,6 +117,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@37..38
           0: P_KW@37..38 "p" [] []
         3: R_ANGLE@38..39 ">" [] []
-  4: EOF@39..40 "" [Newline("\n")] []
+  5: EOF@39..40 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/special-chars.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/special-chars.html.snap
@@ -21,6 +21,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..45
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..45
     0: HTML_ELEMENT@0..45
       0: HTML_OPENING_ELEMENT@0..5
         0: L_ANGLE@0..1 "<" [] []
@@ -75,6 +77,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@41..44
           0: DIV_KW@41..44 "div" [] []
         3: R_ANGLE@44..45 ">" [] []
-  4: EOF@45..46 "" [Newline("\n")] []
+  5: EOF@45..46 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/attach.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/attach.svelte.snap
@@ -32,6 +32,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -168,7 +169,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..319
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..319
     0: HTML_ELEMENT@0..37
       0: HTML_OPENING_ELEMENT@0..28
         0: L_ANGLE@0..1 "<" [] []
@@ -253,6 +255,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@312..318
           0: CANVAS_KW@312..318 "canvas" [] []
         3: R_ANGLE@318..319 ">" [] []
-  4: EOF@319..320 "" [Newline("\n")] []
+  5: EOF@319..320 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/attribute_interpolation.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/attribute_interpolation.svelte.snap
@@ -22,6 +22,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -297,7 +298,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..208
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..208
     0: HTML_ELEMENT@0..32
       0: HTML_OPENING_ELEMENT@0..26
         0: L_ANGLE@0..1 "<" [] []
@@ -476,6 +478,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@204..207
           0: DIV_KW@204..207 "div" [] []
         3: R_ANGLE@207..208 ">" [] []
-  4: EOF@208..209 "" [Newline("\n")] []
+  5: EOF@208..209 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/attribute_interpolation_edge_cases.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/attribute_interpolation_edge_cases.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -179,7 +180,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..96
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..96
     0: HTML_ELEMENT@0..29
       0: HTML_OPENING_ELEMENT@0..23
         0: L_ANGLE@0..1 "<" [] []
@@ -280,6 +282,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@92..95
           0: DIV_KW@92..95 "div" [] []
         3: R_ANGLE@95..96 ">" [] []
-  4: EOF@96..97 "" [Newline("\n")] []
+  5: EOF@96..97 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/await_array_destructuring.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/await_array_destructuring.svelte.snap
@@ -20,6 +20,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteAwaitBlock {
@@ -129,7 +130,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..130
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..130
     0: SVELTE_AWAIT_BLOCK@0..130
       0: SVELTE_AWAIT_OPENING_BLOCK@0..121
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -197,6 +199,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@121..124 "{/" [Newline("\n")] []
         1: AWAIT_KW@124..129 "await" [] []
         2: R_CURLY@129..130 "}" [] []
-  4: EOF@130..131 "" [Newline("\n")] []
+  5: EOF@130..131 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/await_basic.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/await_basic.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteAwaitBlock {
@@ -76,7 +77,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..45
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..45
     0: SVELTE_AWAIT_BLOCK@0..45
       0: SVELTE_AWAIT_OPENING_BLOCK@0..36
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -108,6 +110,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@36..39 "{/" [Newline("\n")] []
         1: AWAIT_KW@39..44 "await" [] []
         2: R_CURLY@44..45 "}" [] []
-  4: EOF@45..46 "" [Newline("\n")] []
+  5: EOF@45..46 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/await_catch_no_then.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/await_catch_no_then.svelte.snap
@@ -21,6 +21,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteAwaitBlock {
@@ -111,7 +112,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..115
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..115
     0: SVELTE_AWAIT_BLOCK@0..115
       0: SVELTE_AWAIT_OPENING_BLOCK@0..40
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -166,6 +168,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@106..109 "{/" [Newline("\n")] []
         1: AWAIT_KW@109..114 "await" [] []
         2: R_CURLY@114..115 "}" [] []
-  4: EOF@115..116 "" [Newline("\n")] []
+  5: EOF@115..116 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/await_catch_only.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/await_catch_only.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteAwaitBlock {
@@ -88,7 +89,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..69
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..69
     0: SVELTE_AWAIT_BLOCK@0..69
       0: SVELTE_AWAIT_OPENING_BLOCK@0..60
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -128,6 +130,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@60..63 "{/" [Newline("\n")] []
         1: AWAIT_KW@63..68 "await" [] []
         2: R_CURLY@68..69 "}" [] []
-  4: EOF@69..70 "" [Newline("\n")] []
+  5: EOF@69..70 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/await_catch_only_missing_binding.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/await_catch_only_missing_binding.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteAwaitBlock {
@@ -79,7 +80,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..47
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..47
     0: SVELTE_AWAIT_BLOCK@0..47
       0: SVELTE_AWAIT_OPENING_BLOCK@0..38
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -113,6 +115,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@38..41 "{/" [Newline("\n")] []
         1: AWAIT_KW@41..46 "await" [] []
         2: R_CURLY@46..47 "}" [] []
-  4: EOF@47..48 "" [Newline("\n")] []
+  5: EOF@47..48 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/await_complex_expression.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/await_complex_expression.svelte.snap
@@ -26,6 +26,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteAwaitBlock {
@@ -208,7 +209,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..239
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..239
     0: SVELTE_AWAIT_BLOCK@0..239
       0: SVELTE_AWAIT_OPENING_BLOCK@0..80
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -327,6 +329,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@230..233 "{/" [Newline("\n")] []
         1: AWAIT_KW@233..238 "await" [] []
         2: R_CURLY@238..239 "}" [] []
-  4: EOF@239..240 "" [Newline("\n")] []
+  5: EOF@239..240 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/await_destructuring.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/await_destructuring.svelte.snap
@@ -23,6 +23,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteAwaitBlock {
@@ -172,7 +173,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..146
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..146
     0: SVELTE_AWAIT_BLOCK@0..146
       0: SVELTE_AWAIT_OPENING_BLOCK@0..137
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -268,6 +270,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@137..140 "{/" [Newline("\n")] []
         1: AWAIT_KW@140..145 "await" [] []
         2: R_CURLY@145..146 "}" [] []
-  4: EOF@146..147 "" [Newline("\n")] []
+  5: EOF@146..147 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/await_dynamic_import.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/await_dynamic_import.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteAwaitBlock {
@@ -67,7 +68,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..90
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..90
     0: SVELTE_AWAIT_BLOCK@0..90
       0: SVELTE_AWAIT_OPENING_BLOCK@0..81
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -93,6 +95,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@81..84 "{/" [Newline("\n")] []
         1: AWAIT_KW@84..89 "await" [] []
         2: R_CURLY@89..90 "}" [] []
-  4: EOF@90..91 "" [Newline("\n")] []
+  5: EOF@90..91 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/await_missing_catch_binding.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/await_missing_catch_binding.svelte.snap
@@ -23,6 +23,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteAwaitBlock {
@@ -149,7 +150,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..109
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..109
     0: SVELTE_AWAIT_BLOCK@0..109
       0: SVELTE_AWAIT_OPENING_BLOCK@0..36
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -229,6 +231,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@100..103 "{/" [Newline("\n")] []
         1: AWAIT_KW@103..108 "await" [] []
         2: R_CURLY@108..109 "}" [] []
-  4: EOF@109..110 "" [Newline("\n")] []
+  5: EOF@109..110 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/await_missing_then_binding.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/await_missing_then_binding.svelte.snap
@@ -21,6 +21,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteAwaitBlock {
@@ -110,7 +111,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..68
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..68
     0: SVELTE_AWAIT_BLOCK@0..68
       0: SVELTE_AWAIT_OPENING_BLOCK@0..36
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -164,6 +166,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@59..62 "{/" [Newline("\n")] []
         1: AWAIT_KW@62..67 "await" [] []
         2: R_CURLY@67..68 "}" [] []
-  4: EOF@68..69 "" [Newline("\n")] []
+  5: EOF@68..69 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/await_multiline.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/await_multiline.svelte.snap
@@ -33,6 +33,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteAwaitBlock {
@@ -377,7 +378,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..393
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..393
     0: SVELTE_AWAIT_BLOCK@0..393
       0: SVELTE_AWAIT_OPENING_BLOCK@0..133
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -603,6 +605,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@384..387 "{/" [Newline("\n")] []
         1: AWAIT_KW@387..392 "await" [] []
         2: R_CURLY@392..393 "}" [] []
-  4: EOF@393..394 "" [Newline("\n")] []
+  5: EOF@393..394 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/await_nested.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/await_nested.svelte.snap
@@ -32,6 +32,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteAwaitBlock {
@@ -285,7 +286,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..312
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..312
     0: SVELTE_AWAIT_BLOCK@0..312
       0: SVELTE_AWAIT_OPENING_BLOCK@0..45
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -455,6 +457,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@303..306 "{/" [Newline("\n")] []
         1: AWAIT_KW@306..311 "await" [] []
         2: R_CURLY@311..312 "}" [] []
-  4: EOF@312..313 "" [Newline("\n")] []
+  5: EOF@312..313 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/await_no_catch.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/await_no_catch.svelte.snap
@@ -21,6 +21,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteAwaitBlock {
@@ -119,7 +120,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..89
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..89
     0: SVELTE_AWAIT_BLOCK@0..89
       0: SVELTE_AWAIT_OPENING_BLOCK@0..36
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -179,6 +181,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@80..83 "{/" [Newline("\n")] []
         1: AWAIT_KW@83..88 "await" [] []
         2: R_CURLY@88..89 "}" [] []
-  4: EOF@89..90 "" [Newline("\n")] []
+  5: EOF@89..90 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/await_one_linter.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/await_one_linter.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteAwaitBlock {
@@ -129,7 +130,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..79
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..79
     0: SVELTE_AWAIT_BLOCK@0..79
       0: SVELTE_AWAIT_OPENING_BLOCK@0..28
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -201,6 +203,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@71..73 "{/" [] []
         1: AWAIT_KW@73..78 "await" [] []
         2: R_CURLY@78..79 "}" [] []
-  4: EOF@79..80 "" [Newline("\n")] []
+  5: EOF@79..80 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/await_shorthand.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/await_shorthand.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteAwaitBlock {
@@ -88,7 +89,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..66
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..66
     0: SVELTE_AWAIT_BLOCK@0..66
       0: SVELTE_AWAIT_OPENING_BLOCK@0..57
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -128,6 +130,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@57..60 "{/" [Newline("\n")] []
         1: AWAIT_KW@60..65 "await" [] []
         2: R_CURLY@65..66 "}" [] []
-  4: EOF@66..67 "" [Newline("\n")] []
+  5: EOF@66..67 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/await_shorthand_missing_binding.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/await_shorthand_missing_binding.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteAwaitBlock {
@@ -79,7 +80,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..45
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..45
     0: SVELTE_AWAIT_BLOCK@0..45
       0: SVELTE_AWAIT_OPENING_BLOCK@0..36
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -113,6 +115,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@36..39 "{/" [Newline("\n")] []
         1: AWAIT_KW@39..44 "await" [] []
         2: R_CURLY@44..45 "}" [] []
-  4: EOF@45..46 "" [Newline("\n")] []
+  5: EOF@45..46 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/brackets-in-text.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/brackets-in-text.svelte.snap
@@ -20,6 +20,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -126,7 +127,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..85
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..85
     0: HTML_ELEMENT@0..16
       0: HTML_OPENING_ELEMENT@0..5
         0: L_ANGLE@0..1 "<" [] []
@@ -191,6 +193,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@83..84
           0: P_KW@83..84 "p" [] []
         3: R_ANGLE@84..85 ">" [] []
-  4: EOF@85..86 "" [Newline("\n")] []
+  5: EOF@85..86 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/complex_expressions.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/complex_expressions.svelte.snap
@@ -23,6 +23,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteEachBlock {
@@ -146,7 +147,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..160
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..160
     0: SVELTE_EACH_BLOCK@0..84
       0: SVELTE_EACH_OPENING_BLOCK@0..50
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -223,6 +225,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@152..155 "{/" [Newline("\n")] []
         1: EACH_KW@155..159 "each" [] []
         2: R_CURLY@159..160 "}" [] []
-  4: EOF@160..161 "" [Newline("\n")] []
+  5: EOF@160..161 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/component.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/component.svelte.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -63,7 +64,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..26
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..26
     0: HTML_ELEMENT@0..26
       0: HTML_OPENING_ELEMENT@0..18
         0: L_ANGLE@0..1 "<" [] []
@@ -85,6 +87,6 @@ HtmlRoot {
         2: HTML_COMPONENT_NAME@21..25
           0: HTML_COMPONENT_LITERAL@21..25 "Base" [] []
         3: R_ANGLE@25..26 ">" [] []
-  4: EOF@26..27 "" [Newline("\n")] []
+  5: EOF@26..27 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/component_member.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/component_member.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -46,7 +47,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..28
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..28
     0: HTML_SELF_CLOSING_ELEMENT@0..28
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_MEMBER_NAME@1..26
@@ -58,6 +60,6 @@ HtmlRoot {
       2: HTML_ATTRIBUTE_LIST@26..26
       3: SLASH@26..27 "/" [] []
       4: R_ANGLE@27..28 ">" [] []
-  4: EOF@28..29 "" [Newline("\n")] []
+  5: EOF@28..29 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/component_member_nested.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/component_member_nested.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -58,7 +59,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..19
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..19
     0: HTML_SELF_CLOSING_ELEMENT@0..19
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_MEMBER_NAME@1..17
@@ -78,6 +80,6 @@ HtmlRoot {
       2: HTML_ATTRIBUTE_LIST@17..17
       3: SLASH@17..18 "/" [] []
       4: R_ANGLE@18..19 ">" [] []
-  4: EOF@19..20 "" [Newline("\n")] []
+  5: EOF@19..20 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/component_with_attributes.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/component_with_attributes.svelte.snap
@@ -20,6 +20,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -72,7 +73,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..73
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..73
     0: HTML_SELF_CLOSING_ELEMENT@0..73
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_MEMBER_NAME@1..25
@@ -98,6 +100,6 @@ HtmlRoot {
               0: HTML_STRING_LITERAL@63..70 "\"value\"" [] []
       3: SLASH@70..72 "/" [Newline("\n")] []
       4: R_ANGLE@72..73 ">" [] []
-  4: EOF@73..74 "" [Newline("\n")] []
+  5: EOF@73..74 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/const.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/const.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteConstBlock {
@@ -39,13 +40,14 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..38
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..38
     0: SVELTE_CONST_BLOCK@0..38
       0: SV_CURLY_AT@0..2 "{@" [] []
       1: CONST_KW@2..8 "const" [] [Whitespace(" ")]
       2: HTML_TEXT_EXPRESSION@8..37
         0: HTML_LITERAL@8..37 "area = box.width * box.height" [] []
       3: R_CURLY@37..38 "}" [] []
-  4: EOF@38..39 "" [Newline("\n")] []
+  5: EOF@38..39 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/debug.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/debug.svelte.snap
@@ -21,6 +21,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteDebugBlock {
@@ -89,7 +90,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..97
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..97
     0: SVELTE_DEBUG_BLOCK@0..8
       0: SV_CURLY_AT@0..2 "{@" [] []
       1: DEBUG_KW@2..7 "debug" [] []
@@ -129,6 +131,6 @@ HtmlRoot {
         0: SVELTE_NAME@92..96
           0: IDENT@92..96 "each" [] []
       3: R_CURLY@96..97 "}" [] []
-  4: EOF@97..98 "" [Newline("\n")] []
+  5: EOF@97..98 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/declaration_tags.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/declaration_tags.svelte.snap
@@ -39,6 +39,7 @@ let source = 1;
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -202,7 +203,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..351
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..351
     0: HTML_ELEMENT@0..34
       0: HTML_OPENING_ELEMENT@0..8
         0: L_ANGLE@0..1 "<" [] []
@@ -309,6 +311,6 @@ HtmlRoot {
       1: HTML_TEXT_EXPRESSION@335..350
         0: HTML_LITERAL@335..350 "var invalid = 1" [] []
       2: R_CURLY@350..351 "}" [] []
-  4: EOF@351..352 "" [Newline("\n")] []
+  5: EOF@351..352 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/animate_basic.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/animate_basic.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteEachBlock {
@@ -104,7 +105,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..66
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..66
     0: SVELTE_EACH_BLOCK@0..66
       0: SVELTE_EACH_OPENING_BLOCK@0..27
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -155,6 +157,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@58..61 "{/" [Newline("\n")] []
         1: EACH_KW@61..65 "each" [] []
         2: R_CURLY@65..66 "}" [] []
-  4: EOF@66..67 "" [Newline("\n")] []
+  5: EOF@66..67 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/animate_custom.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/animate_custom.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteEachBlock {
@@ -113,7 +114,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..87
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..87
     0: SVELTE_EACH_BLOCK@0..87
       0: SVELTE_EACH_OPENING_BLOCK@0..27
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -170,6 +172,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@79..82 "{/" [Newline("\n")] []
         1: EACH_KW@82..86 "each" [] []
         2: R_CURLY@86..87 "}" [] []
-  4: EOF@87..88 "" [Newline("\n")] []
+  5: EOF@87..88 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/animate_in_each.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/animate_in_each.svelte.snap
@@ -22,6 +22,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteEachBlock {
@@ -157,7 +158,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..181
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..181
     0: SVELTE_EACH_BLOCK@0..181
       0: SVELTE_EACH_OPENING_BLOCK@0..52
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -242,6 +244,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@173..176 "{/" [Newline("\n")] []
         1: EACH_KW@176..180 "each" [] []
         2: R_CURLY@180..181 "}" [] []
-  4: EOF@181..182 "" [Newline("\n")] []
+  5: EOF@181..182 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/animate_with_params.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/animate_with_params.svelte.snap
@@ -22,6 +22,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteEachBlock {
@@ -196,7 +197,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..199
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..199
     0: SVELTE_EACH_BLOCK@0..83
       0: SVELTE_EACH_OPENING_BLOCK@0..27
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -309,6 +311,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@191..194 "{/" [Newline("\n")] []
         1: EACH_KW@194..198 "each" [] []
         2: R_CURLY@198..199 "}" [] []
-  4: EOF@199..200 "" [Newline("\n")] []
+  5: EOF@199..200 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/bind_checked.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/bind_checked.svelte.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -114,7 +115,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..113
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..113
     0: HTML_SELF_CLOSING_ELEMENT@0..50
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_TAG_NAME@1..7
@@ -171,6 +173,6 @@ HtmlRoot {
                 2: R_CURLY@109..111 "}" [] [Whitespace(" ")]
       3: SLASH@111..112 "/" [] []
       4: R_ANGLE@112..113 ">" [] []
-  4: EOF@113..114 "" [Newline("\n")] []
+  5: EOF@113..114 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/bind_files.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/bind_files.svelte.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -120,7 +121,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..93
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..93
     0: HTML_SELF_CLOSING_ELEMENT@0..43
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_TAG_NAME@1..7
@@ -181,6 +183,6 @@ HtmlRoot {
                 2: R_CURLY@89..91 "}" [] [Whitespace(" ")]
       3: SLASH@91..92 "/" [] []
       4: R_ANGLE@92..93 ">" [] []
-  4: EOF@93..94 "" [Newline("\n")] []
+  5: EOF@93..94 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/bind_function.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/bind_function.svelte.snap
@@ -24,6 +24,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -208,7 +209,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..238
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..238
     0: HTML_SELF_CLOSING_ELEMENT@0..31
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_TAG_NAME@1..7
@@ -329,6 +331,6 @@ HtmlRoot {
                 4: R_CURLY@234..236 "}" [] [Whitespace(" ")]
       3: SLASH@236..237 "/" [] []
       4: R_ANGLE@237..238 ">" [] []
-  4: EOF@238..239 "" [Newline("\n")] []
+  5: EOF@238..239 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/bind_group.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/bind_group.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -189,7 +190,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..170
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..170
     0: HTML_SELF_CLOSING_ELEMENT@0..54
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_TAG_NAME@1..7
@@ -295,6 +297,6 @@ HtmlRoot {
               0: HTML_STRING_LITERAL@161..168 "\"mint\"" [] [Whitespace(" ")]
       3: SLASH@168..169 "/" [] []
       4: R_ANGLE@169..170 ">" [] []
-  4: EOF@170..171 "" [Newline("\n")] []
+  5: EOF@170..171 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/bind_missing_colon.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/bind_missing_colon.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -62,7 +63,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..27
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..27
     0: HTML_SELF_CLOSING_ELEMENT@0..27
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_TAG_NAME@1..7
@@ -84,6 +86,6 @@ HtmlRoot {
               2: R_CURLY@23..25 "}" [] [Whitespace(" ")]
       3: SLASH@25..26 "/" [] []
       4: R_ANGLE@26..27 ">" [] []
-  4: EOF@27..28 "" [Newline("\n")] []
+  5: EOF@27..28 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/bind_multiple_props.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/bind_multiple_props.svelte.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -182,7 +183,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..163
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..163
     0: HTML_SELF_CLOSING_ELEMENT@0..79
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_TAG_NAME@1..7
@@ -288,6 +290,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@157..162
           0: VIDEO_KW@157..162 "video" [] []
         3: R_ANGLE@162..163 ">" [] []
-  4: EOF@163..164 "" [Newline("\n")] []
+  5: EOF@163..164 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/bind_shorthand.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/bind_shorthand.svelte.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -74,7 +75,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..56
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..56
     0: HTML_SELF_CLOSING_ELEMENT@0..20
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_TAG_NAME@1..7
@@ -105,6 +107,6 @@ HtmlRoot {
             3: (empty)
       3: SLASH@54..55 "/" [] []
       4: R_ANGLE@55..56 ">" [] []
-  4: EOF@56..57 "" [Newline("\n")] []
+  5: EOF@56..57 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/bind_this.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/bind_this.svelte.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -116,7 +117,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..72
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..72
     0: HTML_ELEMENT@0..35
       0: HTML_OPENING_ELEMENT@0..22
         0: L_ANGLE@0..1 "<" [] []
@@ -175,6 +177,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@65..71
           0: CANVAS_KW@65..71 "canvas" [] []
         3: R_ANGLE@71..72 ">" [] []
-  4: EOF@72..73 "" [Newline("\n")] []
+  5: EOF@72..73 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/bind_value_basic.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/bind_value_basic.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -61,7 +62,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..27
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..27
     0: HTML_SELF_CLOSING_ELEMENT@0..27
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_TAG_NAME@1..7
@@ -83,6 +85,6 @@ HtmlRoot {
                 2: R_CURLY@23..25 "}" [] [Whitespace(" ")]
       3: SLASH@25..26 "/" [] []
       4: R_ANGLE@26..27 ">" [] []
-  4: EOF@27..28 "" [Newline("\n")] []
+  5: EOF@27..28 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/class_basic.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/class_basic.svelte.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -120,7 +121,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..100
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..100
     0: HTML_ELEMENT@0..48
       0: HTML_OPENING_ELEMENT@0..29
         0: L_ANGLE@0..1 "<" [] []
@@ -181,6 +183,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@93..99
           0: BUTTON_KW@93..99 "button" [] []
         3: R_ANGLE@99..100 ">" [] []
-  4: EOF@100..101 "" [Newline("\n")] []
+  5: EOF@100..101 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/class_kebab_case.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/class_kebab_case.svelte.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -140,7 +141,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..123
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..123
     0: HTML_ELEMENT@0..46
       0: HTML_OPENING_ELEMENT@0..30
         0: L_ANGLE@0..1 "<" [] []
@@ -215,6 +217,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@119..122
           0: DIV_KW@119..122 "div" [] []
         3: R_ANGLE@122..123 ">" [] []
-  4: EOF@123..124 "" [Newline("\n")] []
+  5: EOF@123..124 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/class_multiple.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/class_multiple.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -108,7 +109,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..77
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..77
     0: HTML_ELEMENT@0..77
       0: HTML_OPENING_ELEMENT@0..51
         0: L_ANGLE@0..1 "<" [] []
@@ -161,6 +163,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@73..76
           0: DIV_KW@73..76 "div" [] []
         3: R_ANGLE@76..77 ">" [] []
-  4: EOF@77..78 "" [Newline("\n")] []
+  5: EOF@77..78 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/class_shorthand.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/class_shorthand.svelte.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -122,7 +123,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..93
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..93
     0: HTML_ELEMENT@0..33
       0: HTML_OPENING_ELEMENT@0..18
         0: L_ANGLE@0..1 "<" [] []
@@ -185,6 +187,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@89..92
           0: DIV_KW@89..92 "div" [] []
         3: R_ANGLE@92..93 ">" [] []
-  4: EOF@93..94 "" [Newline("\n")] []
+  5: EOF@93..94 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/class_with_expression.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/class_with_expression.svelte.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -120,7 +121,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..114
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..114
     0: HTML_ELEMENT@0..55
       0: HTML_OPENING_ELEMENT@0..45
         0: L_ANGLE@0..1 "<" [] []
@@ -181,6 +183,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@107..113
           0: BUTTON_KW@107..113 "button" [] []
         3: R_ANGLE@113..114 ">" [] []
-  4: EOF@114..115 "" [Newline("\n")] []
+  5: EOF@114..115 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/directive_member_expression.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/directive_member_expression.svelte.snap
@@ -27,6 +27,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -359,7 +360,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..525
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..525
     0: HTML_ELEMENT@0..72
       0: HTML_OPENING_ELEMENT@0..57
         0: L_ANGLE@0..35 "<" [Comments("<!-- simple member ex ..."), Newline("\n")] []
@@ -574,6 +576,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@521..524
           0: DIV_KW@521..524 "div" [] []
         3: R_ANGLE@524..525 ">" [] []
-  4: EOF@525..526 "" [Newline("\n")] []
+  5: EOF@525..526 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/in_basic.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/in_basic.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -66,7 +67,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..26
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..26
     0: HTML_ELEMENT@0..26
       0: HTML_OPENING_ELEMENT@0..12
         0: L_ANGLE@0..1 "<" [] []
@@ -91,6 +93,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@22..25
           0: DIV_KW@22..25 "div" [] []
         3: R_ANGLE@25..26 ">" [] []
-  4: EOF@26..27 "" [Newline("\n")] []
+  5: EOF@26..27 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/in_global_modifier.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/in_global_modifier.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -73,7 +74,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..45
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..45
     0: HTML_ELEMENT@0..45
       0: HTML_OPENING_ELEMENT@0..19
         0: L_ANGLE@0..1 "<" [] []
@@ -102,6 +104,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@41..44
           0: DIV_KW@41..44 "div" [] []
         3: R_ANGLE@44..45 ">" [] []
-  4: EOF@45..46 "" [Newline("\n")] []
+  5: EOF@45..46 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/in_local_modifier.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/in_local_modifier.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -73,7 +74,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..43
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..43
     0: HTML_ELEMENT@0..43
       0: HTML_OPENING_ELEMENT@0..18
         0: L_ANGLE@0..1 "<" [] []
@@ -102,6 +104,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@39..42
           0: DIV_KW@39..42 "div" [] []
         3: R_ANGLE@42..43 ">" [] []
-  4: EOF@43..44 "" [Newline("\n")] []
+  5: EOF@43..44 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/in_modifier_with_params.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/in_modifier_with_params.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -82,7 +83,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..56
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..56
     0: HTML_ELEMENT@0..56
       0: HTML_OPENING_ELEMENT@0..32
         0: L_ANGLE@0..1 "<" [] []
@@ -117,6 +119,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@52..55
           0: DIV_KW@52..55 "div" [] []
         3: R_ANGLE@55..56 ">" [] []
-  4: EOF@56..57 "" [Newline("\n")] []
+  5: EOF@56..57 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/in_multiple_modifiers.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/in_multiple_modifiers.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -79,7 +80,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..49
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..49
     0: HTML_ELEMENT@0..49
       0: HTML_OPENING_ELEMENT@0..25
         0: L_ANGLE@0..1 "<" [] []
@@ -112,6 +114,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@45..48
           0: DIV_KW@45..48 "div" [] []
         3: R_ANGLE@48..49 ">" [] []
-  4: EOF@49..50 "" [Newline("\n")] []
+  5: EOF@49..50 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/in_with_params.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/in_with_params.svelte.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -120,7 +121,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..95
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..95
     0: HTML_ELEMENT@0..47
       0: HTML_OPENING_ELEMENT@0..25
         0: L_ANGLE@0..1 "<" [] []
@@ -181,6 +183,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@93..94
           0: P_KW@93..94 "p" [] []
         3: R_ANGLE@94..95 ">" [] []
-  4: EOF@95..96 "" [Newline("\n")] []
+  5: EOF@95..96 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/out_basic.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/out_basic.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -66,7 +67,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..29
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..29
     0: HTML_ELEMENT@0..29
       0: HTML_OPENING_ELEMENT@0..14
         0: L_ANGLE@0..1 "<" [] []
@@ -91,6 +93,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@25..28
           0: DIV_KW@25..28 "div" [] []
         3: R_ANGLE@28..29 ">" [] []
-  4: EOF@29..30 "" [Newline("\n")] []
+  5: EOF@29..30 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/out_combined_with_in.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/out_combined_with_in.svelte.snap
@@ -24,6 +24,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteIfBlock {
@@ -190,7 +191,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..187
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..187
     0: SVELTE_IF_BLOCK@0..187
       0: SVELTE_IF_OPENING_BLOCK@0..181
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -295,6 +297,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@181..184 "{/" [Newline("\n")] []
         1: IF_KW@184..186 "if" [] []
         2: R_CURLY@186..187 "}" [] []
-  4: EOF@187..188 "" [Newline("\n")] []
+  5: EOF@187..188 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/out_global_modifier.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/out_global_modifier.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -73,7 +74,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..48
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..48
     0: HTML_ELEMENT@0..48
       0: HTML_OPENING_ELEMENT@0..21
         0: L_ANGLE@0..1 "<" [] []
@@ -102,6 +104,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@44..47
           0: DIV_KW@44..47 "div" [] []
         3: R_ANGLE@47..48 ">" [] []
-  4: EOF@48..49 "" [Newline("\n")] []
+  5: EOF@48..49 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/out_local_modifier.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/out_local_modifier.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -73,7 +74,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..46
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..46
     0: HTML_ELEMENT@0..46
       0: HTML_OPENING_ELEMENT@0..20
         0: L_ANGLE@0..1 "<" [] []
@@ -102,6 +104,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@42..45
           0: DIV_KW@42..45 "div" [] []
         3: R_ANGLE@45..46 ">" [] []
-  4: EOF@46..47 "" [Newline("\n")] []
+  5: EOF@46..47 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/out_multiple_modifiers.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/out_multiple_modifiers.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -79,7 +80,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..51
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..51
     0: HTML_ELEMENT@0..51
       0: HTML_OPENING_ELEMENT@0..27
         0: L_ANGLE@0..1 "<" [] []
@@ -112,6 +114,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@47..50
           0: DIV_KW@47..50 "div" [] []
         3: R_ANGLE@50..51 ">" [] []
-  4: EOF@51..52 "" [Newline("\n")] []
+  5: EOF@51..52 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/out_with_params.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/out_with_params.svelte.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -120,7 +121,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..91
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..91
     0: HTML_ELEMENT@0..53
       0: HTML_OPENING_ELEMENT@0..34
         0: L_ANGLE@0..1 "<" [] []
@@ -181,6 +183,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@89..90
           0: P_KW@89..90 "p" [] []
         3: R_ANGLE@90..91 ">" [] []
-  4: EOF@91..92 "" [Newline("\n")] []
+  5: EOF@91..92 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/style_basic.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/style_basic.svelte.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -112,7 +113,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..78
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..78
     0: HTML_ELEMENT@0..37
       0: HTML_OPENING_ELEMENT@0..23
         0: L_ANGLE@0..1 "<" [] []
@@ -167,6 +169,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@76..77
           0: P_KW@76..77 "p" [] []
         3: R_ANGLE@77..78 ">" [] []
-  4: EOF@78..79 "" [Newline("\n")] []
+  5: EOF@78..79 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/style_important_modifier.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/style_important_modifier.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -71,7 +72,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..52
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..52
     0: HTML_ELEMENT@0..52
       0: HTML_OPENING_ELEMENT@0..33
         0: L_ANGLE@0..1 "<" [] []
@@ -99,6 +101,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@48..51
           0: DIV_KW@48..51 "div" [] []
         3: R_ANGLE@51..52 ">" [] []
-  4: EOF@52..53 "" [Newline("\n")] []
+  5: EOF@52..53 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/style_important_with_expression.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/style_important_with_expression.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -75,7 +76,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..60
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..60
     0: HTML_ELEMENT@0..60
       0: HTML_OPENING_ELEMENT@0..37
         0: L_ANGLE@0..1 "<" [] []
@@ -106,6 +108,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@56..59
           0: DIV_KW@56..59 "div" [] []
         3: R_ANGLE@59..60 ">" [] []
-  4: EOF@60..61 "" [Newline("\n")] []
+  5: EOF@60..61 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/style_kebab_case.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/style_kebab_case.svelte.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -128,7 +129,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..131
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..131
     0: HTML_ELEMENT@0..56
       0: HTML_OPENING_ELEMENT@0..35
         0: L_ANGLE@0..1 "<" [] []
@@ -194,6 +196,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@127..130
           0: DIV_KW@127..130 "div" [] []
         3: R_ANGLE@130..131 ">" [] []
-  4: EOF@131..132 "" [Newline("\n")] []
+  5: EOF@131..132 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/style_multiple.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/style_multiple.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -105,7 +106,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..88
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..88
     0: HTML_ELEMENT@0..88
       0: HTML_OPENING_ELEMENT@0..63
         0: L_ANGLE@0..1 "<" [] []
@@ -155,6 +157,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@84..87
           0: DIV_KW@84..87 "div" [] []
         3: R_ANGLE@87..88 ">" [] []
-  4: EOF@88..89 "" [Newline("\n")] []
+  5: EOF@88..89 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/style_multiple_with_important.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/style_multiple_with_important.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -109,7 +110,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..116
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..116
     0: HTML_ELEMENT@0..116
       0: HTML_OPENING_ELEMENT@0..91
         0: L_ANGLE@0..1 "<" [] []
@@ -162,6 +164,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@112..115
           0: DIV_KW@112..115 "div" [] []
         3: R_ANGLE@115..116 ">" [] []
-  4: EOF@116..117 "" [Newline("\n")] []
+  5: EOF@116..117 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/style_shorthand.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/style_shorthand.svelte.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -113,7 +114,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..83
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..83
     0: HTML_ELEMENT@0..32
       0: HTML_OPENING_ELEMENT@0..17
         0: L_ANGLE@0..1 "<" [] []
@@ -170,6 +172,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@81..82
           0: P_KW@81..82 "p" [] []
         3: R_ANGLE@82..83 ">" [] []
-  4: EOF@83..84 "" [Newline("\n")] []
+  5: EOF@83..84 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/style_with_expression.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/style_with_expression.svelte.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -120,7 +121,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..94
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..94
     0: HTML_ELEMENT@0..46
       0: HTML_OPENING_ELEMENT@0..27
         0: L_ANGLE@0..1 "<" [] []
@@ -181,6 +183,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@92..93
           0: P_KW@92..93 "p" [] []
         3: R_ANGLE@93..94 ">" [] []
-  4: EOF@94..95 "" [Newline("\n")] []
+  5: EOF@94..95 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/transition_basic.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/transition_basic.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -66,7 +67,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..43
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..43
     0: HTML_ELEMENT@0..43
       0: HTML_OPENING_ELEMENT@0..21
         0: L_ANGLE@0..1 "<" [] []
@@ -91,6 +93,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@39..42
           0: DIV_KW@39..42 "div" [] []
         3: R_ANGLE@42..43 ">" [] []
-  4: EOF@43..44 "" [Newline("\n")] []
+  5: EOF@43..44 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/transition_complex_params.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/transition_complex_params.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -77,7 +78,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..115
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..115
     0: HTML_ELEMENT@0..115
       0: HTML_OPENING_ELEMENT@0..87
         0: L_ANGLE@0..1 "<" [] []
@@ -108,6 +110,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@111..114
           0: DIV_KW@111..114 "div" [] []
         3: R_ANGLE@114..115 ">" [] []
-  4: EOF@115..116 "" [Newline("\n")] []
+  5: EOF@115..116 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/transition_global_modifier.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/transition_global_modifier.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -73,7 +74,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..54
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..54
     0: HTML_ELEMENT@0..54
       0: HTML_OPENING_ELEMENT@0..26
         0: L_ANGLE@0..1 "<" [] []
@@ -102,6 +104,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@52..53
           0: P_KW@52..53 "p" [] []
         3: R_ANGLE@53..54 ">" [] []
-  4: EOF@54..55 "" [Newline("\n")] []
+  5: EOF@54..55 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/transition_local_modifier.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/transition_local_modifier.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -73,7 +74,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..54
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..54
     0: HTML_ELEMENT@0..54
       0: HTML_OPENING_ELEMENT@0..25
         0: L_ANGLE@0..1 "<" [] []
@@ -102,6 +104,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@52..53
           0: P_KW@52..53 "p" [] []
         3: R_ANGLE@53..54 ">" [] []
-  4: EOF@54..55 "" [Newline("\n")] []
+  5: EOF@54..55 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/transition_modifier_with_params.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/transition_modifier_with_params.svelte.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -134,7 +135,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..131
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..131
     0: HTML_ELEMENT@0..72
       0: HTML_OPENING_ELEMENT@0..48
         0: L_ANGLE@0..1 "<" [] []
@@ -203,6 +205,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@129..130
           0: P_KW@129..130 "p" [] []
         3: R_ANGLE@130..131 ">" [] []
-  4: EOF@131..132 "" [Newline("\n")] []
+  5: EOF@131..132 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/transition_multiple_modifiers.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/transition_multiple_modifiers.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -79,7 +80,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..58
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..58
     0: HTML_ELEMENT@0..58
       0: HTML_OPENING_ELEMENT@0..34
         0: L_ANGLE@0..1 "<" [] []
@@ -112,6 +114,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@54..57
           0: DIV_KW@54..57 "div" [] []
         3: R_ANGLE@57..58 ">" [] []
-  4: EOF@58..59 "" [Newline("\n")] []
+  5: EOF@58..59 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/transition_shorthand.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/transition_shorthand.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -66,7 +67,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..47
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..47
     0: HTML_ELEMENT@0..47
       0: HTML_OPENING_ELEMENT@0..21
         0: L_ANGLE@0..1 "<" [] []
@@ -91,6 +93,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@43..46
           0: DIV_KW@43..46 "div" [] []
         3: R_ANGLE@46..47 ">" [] []
-  4: EOF@47..48 "" [Newline("\n")] []
+  5: EOF@47..48 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/transition_with_params.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/transition_with_params.svelte.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -120,7 +121,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..116
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..116
     0: HTML_ELEMENT@0..56
       0: HTML_OPENING_ELEMENT@0..41
         0: L_ANGLE@0..1 "<" [] []
@@ -181,6 +183,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@114..115
           0: P_KW@114..115 "p" [] []
         3: R_ANGLE@115..116 ">" [] []
-  4: EOF@116..117 "" [Newline("\n")] []
+  5: EOF@116..117 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/use_basic.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/use_basic.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -66,7 +67,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..31
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..31
     0: HTML_ELEMENT@0..31
       0: HTML_OPENING_ELEMENT@0..17
         0: L_ANGLE@0..1 "<" [] []
@@ -91,6 +93,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@27..30
           0: DIV_KW@27..30 "div" [] []
         3: R_ANGLE@30..31 ">" [] []
-  4: EOF@31..32 "" [Newline("\n")] []
+  5: EOF@31..32 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/use_multiple.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/use_multiple.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -99,7 +100,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..88
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..88
     0: HTML_ELEMENT@0..88
       0: HTML_OPENING_ELEMENT@0..62
         0: L_ANGLE@0..1 "<" [] []
@@ -146,6 +148,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@84..87
           0: DIV_KW@84..87 "div" [] []
         3: R_ANGLE@87..88 ">" [] []
-  4: EOF@88..89 "" [Newline("\n")] []
+  5: EOF@88..89 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/use_shorthand.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/use_shorthand.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -66,7 +67,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..44
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..44
     0: HTML_ELEMENT@0..44
       0: HTML_OPENING_ELEMENT@0..22
         0: L_ANGLE@0..1 "<" [] []
@@ -91,6 +93,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@40..43
           0: DIV_KW@40..43 "div" [] []
         3: R_ANGLE@43..44 ">" [] []
-  4: EOF@44..45 "" [Newline("\n")] []
+  5: EOF@44..45 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/use_with_param.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/directives/use_with_param.svelte.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -120,7 +121,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..92
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..92
     0: HTML_ELEMENT@0..41
       0: HTML_OPENING_ELEMENT@0..27
         0: L_ANGLE@0..1 "<" [] []
@@ -181,6 +183,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@85..91
           0: BUTTON_KW@85..91 "button" [] []
         3: R_ANGLE@91..92 ">" [] []
-  4: EOF@92..93 "" [Newline("\n")] []
+  5: EOF@92..93 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/double_curly.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/double_curly.svelte.snap
@@ -22,6 +22,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSingleTextExpression {
@@ -191,7 +192,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..180
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..180
     0: HTML_SINGLE_TEXT_EXPRESSION@0..13
       0: L_CURLY@0..1 "{" [] []
       1: HTML_TEXT_EXPRESSION@1..12
@@ -301,6 +303,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@176..179
           0: DIV_KW@176..179 "div" [] []
         3: R_ANGLE@179..180 ">" [] []
-  4: EOF@180..181 "" [Newline("\n")] []
+  5: EOF@180..181 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/dynamic-prop.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/dynamic-prop.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -70,7 +71,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..42
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..42
     0: HTML_ELEMENT@0..42
       0: HTML_OPENING_ELEMENT@0..25
         0: L_ANGLE@0..1 "<" [] []
@@ -97,6 +99,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@35..41
           0: BUTTON_KW@35..41 "button" [] []
         3: R_ANGLE@41..42 ">" [] []
-  4: EOF@42..43 "" [Newline("\n")] []
+  5: EOF@42..43 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/each_as_const.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/each_as_const.svelte.snap
@@ -35,6 +35,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteEachBlock {
@@ -349,7 +350,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..311
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..311
     0: SVELTE_EACH_BLOCK@0..59
       0: SVELTE_EACH_OPENING_BLOCK@0..35
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -564,6 +566,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@303..306 "{/" [Newline("\n")] []
         1: EACH_KW@306..310 "each" [] []
         2: R_CURLY@310..311 "}" [] []
-  4: EOF@311..312 "" [Newline("\n")] []
+  5: EOF@311..312 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/each_as_in_identifier.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/each_as_in_identifier.svelte.snap
@@ -23,6 +23,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteEachBlock {
@@ -151,7 +152,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..117
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..117
     0: SVELTE_EACH_BLOCK@0..60
       0: SVELTE_EACH_OPENING_BLOCK@0..24
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -233,6 +235,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@109..112 "{/" [Newline("\n")] []
         1: EACH_KW@112..116 "each" [] []
         2: R_CURLY@116..117 "}" [] []
-  4: EOF@117..118 "" [Newline("\n")] []
+  5: EOF@117..118 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/each_basic.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/each_basic.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteEachBlock {
@@ -86,7 +87,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..49
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..49
     0: SVELTE_EACH_BLOCK@0..49
       0: SVELTE_EACH_OPENING_BLOCK@0..21
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -125,6 +127,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@41..44 "{/" [Newline("\n")] []
         1: EACH_KW@44..48 "each" [] []
         2: R_CURLY@48..49 "}" [] []
-  4: EOF@49..50 "" [Newline("\n")] []
+  5: EOF@49..50 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/each_complex_combinations.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/each_complex_combinations.svelte.snap
@@ -29,6 +29,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteEachBlock {
@@ -261,7 +262,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..241
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..241
     0: SVELTE_EACH_BLOCK@0..104
       0: SVELTE_EACH_OPENING_BLOCK@0..34
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -415,6 +417,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@233..236 "{/" [Newline("\n")] []
         1: EACH_KW@236..240 "each" [] []
         2: R_CURLY@240..241 "}" [] []
-  4: EOF@241..242 "" [Newline("\n")] []
+  5: EOF@241..242 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/each_complex_expression.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/each_complex_expression.svelte.snap
@@ -27,6 +27,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteEachBlock {
@@ -200,7 +201,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..182
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..182
     0: SVELTE_EACH_BLOCK@0..53
       0: SVELTE_EACH_OPENING_BLOCK@0..25
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -315,6 +317,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@174..177 "{/" [Newline("\n")] []
         1: EACH_KW@177..181 "each" [] []
         2: R_CURLY@181..182 "}" [] []
-  4: EOF@182..183 "" [Newline("\n")] []
+  5: EOF@182..183 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/each_index_only.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/each_index_only.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteEachBlock {
@@ -89,7 +90,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..46
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..46
     0: SVELTE_EACH_BLOCK@0..46
       0: SVELTE_EACH_OPENING_BLOCK@0..16
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -129,6 +131,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@38..41 "{/" [Newline("\n")] []
         1: EACH_KW@41..45 "each" [] []
         2: R_CURLY@45..46 "}" [] []
-  4: EOF@46..47 "" [Newline("\n")] []
+  5: EOF@46..47 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/each_rename_binding.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/each_rename_binding.svelte.snap
@@ -31,6 +31,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteEachBlock {
@@ -348,7 +349,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..266
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..266
     0: SVELTE_EACH_BLOCK@0..76
       0: SVELTE_EACH_OPENING_BLOCK@0..55
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -564,6 +566,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@258..261 "{/" [Newline("\n")] []
         1: EACH_KW@261..265 "each" [] []
         2: R_CURLY@265..266 "}" [] []
-  4: EOF@266..267 "" [Newline("\n")] []
+  5: EOF@266..267 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/each_with_destructuring.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/each_with_destructuring.svelte.snap
@@ -35,6 +35,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteEachBlock {
@@ -412,7 +413,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..337
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..337
     0: SVELTE_EACH_BLOCK@0..63
       0: SVELTE_EACH_OPENING_BLOCK@0..29
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -671,6 +673,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@329..332 "{/" [Newline("\n")] []
         1: EACH_KW@332..336 "each" [] []
         2: R_CURLY@336..337 "}" [] []
-  4: EOF@337..338 "" [Newline("\n")] []
+  5: EOF@337..338 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/each_with_else.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/each_with_else.svelte.snap
@@ -21,6 +21,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteEachBlock {
@@ -117,7 +118,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..85
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..85
     0: SVELTE_EACH_BLOCK@0..85
       0: SVELTE_EACH_OPENING_BLOCK@0..21
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -176,6 +178,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@77..80 "{/" [Newline("\n")] []
         1: EACH_KW@80..84 "each" [] []
         2: R_CURLY@84..85 "}" [] []
-  4: EOF@85..86 "" [Newline("\n")] []
+  5: EOF@85..86 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/each_with_index.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/each_with_index.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteEachBlock {
@@ -101,7 +102,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..57
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..57
     0: SVELTE_EACH_BLOCK@0..57
       0: SVELTE_EACH_OPENING_BLOCK@0..24
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -150,6 +152,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@49..52 "{/" [Newline("\n")] []
         1: EACH_KW@52..56 "each" [] []
         2: R_CURLY@56..57 "}" [] []
-  4: EOF@57..58 "" [Newline("\n")] []
+  5: EOF@57..58 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/each_with_index_and_key.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/each_with_index_and_key.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteEachBlock {
@@ -107,7 +108,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..72
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..72
     0: SVELTE_EACH_BLOCK@0..72
       0: SVELTE_EACH_OPENING_BLOCK@0..34
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -160,6 +162,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@64..67 "{/" [Newline("\n")] []
         1: EACH_KW@67..71 "each" [] []
         2: R_CURLY@71..72 "}" [] []
-  4: EOF@72..73 "" [Newline("\n")] []
+  5: EOF@72..73 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/each_with_key.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/each_with_key.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteEachBlock {
@@ -92,7 +93,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..64
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..64
     0: SVELTE_EACH_BLOCK@0..64
       0: SVELTE_EACH_OPENING_BLOCK@0..31
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -135,6 +137,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@56..59 "{/" [Newline("\n")] []
         1: EACH_KW@59..63 "each" [] []
         2: R_CURLY@63..64 "}" [] []
-  4: EOF@64..65 "" [Newline("\n")] []
+  5: EOF@64..65 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/each_with_method_call_key.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/each_with_method_call_key.svelte.snap
@@ -23,6 +23,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteEachBlock {
@@ -160,7 +161,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..145
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..145
     0: SVELTE_EACH_BLOCK@0..78
       0: SVELTE_EACH_OPENING_BLOCK@0..52
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -248,6 +250,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@137..140 "{/" [Newline("\n")] []
         1: EACH_KW@140..144 "each" [] []
         2: R_CURLY@144..145 "}" [] []
-  4: EOF@145..146 "" [Newline("\n")] []
+  5: EOF@145..146 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/html.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/html.svelte.snap
@@ -21,6 +21,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -82,7 +83,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..77
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..77
     0: HTML_ELEMENT@0..37
       0: HTML_OPENING_ELEMENT@0..9
         0: L_ANGLE@0..1 "<" [] []
@@ -117,6 +119,6 @@ HtmlRoot {
       2: HTML_TEXT_EXPRESSION@68..76
         0: HTML_LITERAL@68..76 "'</div>'" [] []
       3: R_CURLY@76..77 "}" [] []
-  4: EOF@77..78 "" [Newline("\n")] []
+  5: EOF@77..78 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/if.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/if.svelte.snap
@@ -29,6 +29,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteIfBlock {
@@ -211,7 +212,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..244
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..244
     0: SVELTE_IF_BLOCK@0..56
       0: SVELTE_IF_OPENING_BLOCK@0..50
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -332,6 +334,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@238..241 "{/" [Newline("\n")] []
         1: IF_KW@241..243 "if" [] []
         2: R_CURLY@243..244 "}" [] []
-  4: EOF@244..245 "" [Newline("\n")] []
+  5: EOF@244..245 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/if_else.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/if_else.svelte.snap
@@ -22,6 +22,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteIfBlock {
@@ -107,7 +108,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..100
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..100
     0: SVELTE_IF_BLOCK@0..100
       0: SVELTE_IF_OPENING_BLOCK@0..68
         0: SV_CURLY_HASH@0..21 "{#" [Comments("<!-- if / else -->"), Newline("\n")] []
@@ -158,6 +160,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@94..97 "{/" [Newline("\n")] []
         1: IF_KW@97..99 "if" [] []
         2: R_CURLY@99..100 "}" [] []
-  4: EOF@100..101 "" [Newline("\n")] []
+  5: EOF@100..101 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/if_else_if_else.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/if_else_if_else.svelte.snap
@@ -24,6 +24,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteIfBlock {
@@ -144,7 +145,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..167
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..167
     0: SVELTE_IF_BLOCK@0..167
       0: SVELTE_IF_OPENING_BLOCK@0..78
         0: SV_CURLY_HASH@0..31 "{#" [Comments("<!-- if / else-if / e ..."), Newline("\n")] []
@@ -219,6 +221,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@161..164 "{/" [Newline("\n")] []
         1: IF_KW@164..166 "if" [] []
         2: R_CURLY@166..167 "}" [] []
-  4: EOF@167..168 "" [Newline("\n")] []
+  5: EOF@167..168 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/js_comments_in_component_tags.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/js_comments_in_component_tags.svelte.snap
@@ -31,6 +31,7 @@ prop="value"
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -156,7 +157,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..247
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..247
     0: HTML_SELF_CLOSING_ELEMENT@0..46
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_COMPONENT_NAME@1..10
@@ -231,6 +233,6 @@ HtmlRoot {
               0: HTML_STRING_LITERAL@237..244 "\"value\"" [] []
       3: SLASH@244..246 "/" [Newline("\n")] []
       4: R_ANGLE@246..247 ">" [] []
-  4: EOF@247..248 "" [Newline("\n")] []
+  5: EOF@247..248 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/js_comments_in_tag.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/js_comments_in_tag.svelte.snap
@@ -49,6 +49,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -285,7 +286,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..512
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..512
     0: HTML_ELEMENT@0..74
       0: HTML_OPENING_ELEMENT@0..57
         0: L_ANGLE@0..1 "<" [] []
@@ -433,6 +435,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@508..511
           0: DIV_KW@508..511 "div" [] []
         3: R_ANGLE@511..512 ">" [] []
-  4: EOF@512..513 "" [Newline("\n")] []
+  5: EOF@512..513 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/key.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/key.svelte.snap
@@ -23,6 +23,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteKeyBlock {
@@ -77,7 +78,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..65
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..65
     0: SVELTE_KEY_BLOCK@0..35
       0: SVELTE_KEY_OPENING_BLOCK@0..17
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -106,6 +108,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@58..61 "{/" [Newline("\n")] []
         1: KEY_KW@61..64 "key" [] []
         2: R_CURLY@64..65 "}" [] []
-  4: EOF@65..66 "" [Newline("\n")] []
+  5: EOF@65..66 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/keyword_directives_as_text.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/keyword_directives_as_text.svelte.snap
@@ -27,6 +27,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -248,7 +249,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..190
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..190
     0: HTML_ELEMENT@0..17
       0: HTML_OPENING_ELEMENT@0..6
         0: L_ANGLE@0..1 "<" [] []
@@ -393,6 +395,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@188..189
           0: P_KW@188..189 "p" [] []
         3: R_ANGLE@189..190 ">" [] []
-  4: EOF@190..191 "" [Newline("\n")] []
+  5: EOF@190..191 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/lowercase_component_member.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/lowercase_component_member.svelte.snap
@@ -22,6 +22,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -194,7 +195,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..163
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..163
     0: HTML_ELEMENT@0..25
       0: HTML_OPENING_ELEMENT@0..12
         0: L_ANGLE@0..1 "<" [] []
@@ -304,6 +306,6 @@ HtmlRoot {
               0: HTML_STRING_LITERAL@153..161 "\"value\"" [] [Whitespace(" ")]
       3: SLASH@161..162 "/" [] []
       4: R_ANGLE@162..163 ">" [] []
-  4: EOF@163..164 "" [Newline("\n")] []
+  5: EOF@163..164 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/render.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/render.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteRenderBlock {
@@ -39,13 +40,14 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..19
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..19
     0: SVELTE_RENDER_BLOCK@0..19
       0: SV_CURLY_AT@0..2 "{@" [] []
       1: RENDER_KW@2..9 "render" [] [Whitespace(" ")]
       2: HTML_TEXT_EXPRESSION@9..18
         0: HTML_LITERAL@9..18 "sum(1, 2)" [] []
       3: R_CURLY@18..19 "}" [] []
-  4: EOF@19..20 "" [Newline("\n")] []
+  5: EOF@19..20 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/shorthand-prop.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/shorthand-prop.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -62,7 +63,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..36
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..36
     0: HTML_ELEMENT@0..36
       0: HTML_OPENING_ELEMENT@0..19
         0: L_ANGLE@0..1 "<" [] []
@@ -84,6 +86,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@29..35
           0: BUTTON_KW@29..35 "button" [] []
         3: R_ANGLE@35..36 ">" [] []
-  4: EOF@36..37 "" [Newline("\n")] []
+  5: EOF@36..37 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/shorthand-spread-props.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/shorthand-spread-props.svelte.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -63,7 +64,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..36
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..36
     0: HTML_ELEMENT@0..36
       0: HTML_OPENING_ELEMENT@0..19
         0: L_ANGLE@0..1 "<" [] []
@@ -86,6 +88,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@29..35
           0: BUTTON_KW@29..35 "button" [] []
         3: R_ANGLE@35..36 ">" [] []
-  4: EOF@36..37 "" [Newline("\n")] []
+  5: EOF@36..37 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/snippet_array_destructuring.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/snippet_array_destructuring.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteSnippetBlock {
@@ -90,7 +91,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..64
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..64
     0: SVELTE_SNIPPET_BLOCK@0..64
       0: SVELTE_SNIPPET_OPENING_BLOCK@0..53
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -131,6 +133,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@53..56 "{/" [Newline("\n")] []
         1: SNIPPET_KW@56..63 "snippet" [] []
         2: R_CURLY@63..64 "}" [] []
-  4: EOF@64..65 "" [Newline("\n")] []
+  5: EOF@64..65 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/snippet_basic.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/snippet_basic.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteSnippetBlock {
@@ -73,7 +74,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..48
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..48
     0: SVELTE_SNIPPET_BLOCK@0..48
       0: SVELTE_SNIPPET_OPENING_BLOCK@0..37
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -102,6 +104,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@37..40 "{/" [Newline("\n")] []
         1: SNIPPET_KW@40..47 "snippet" [] []
         2: R_CURLY@47..48 "}" [] []
-  4: EOF@48..49 "" [Newline("\n")] []
+  5: EOF@48..49 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/snippet_default_values.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/snippet_default_values.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteSnippetBlock {
@@ -83,7 +84,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..70
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..70
     0: SVELTE_SNIPPET_BLOCK@0..70
       0: SVELTE_SNIPPET_OPENING_BLOCK@0..59
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -119,6 +121,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@59..62 "{/" [Newline("\n")] []
         1: SNIPPET_KW@62..69 "snippet" [] []
         2: R_CURLY@69..70 "}" [] []
-  4: EOF@70..71 "" [Newline("\n")] []
+  5: EOF@70..71 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/snippet_destructuring.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/snippet_destructuring.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteSnippetBlock {
@@ -90,7 +91,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..76
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..76
     0: SVELTE_SNIPPET_BLOCK@0..76
       0: SVELTE_SNIPPET_OPENING_BLOCK@0..65
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -131,6 +133,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@65..68 "{/" [Newline("\n")] []
         1: SNIPPET_KW@68..75 "snippet" [] []
         2: R_CURLY@75..76 "}" [] []
-  4: EOF@76..77 "" [Newline("\n")] []
+  5: EOF@76..77 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/snippet_multiple.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/snippet_multiple.svelte.snap
@@ -23,6 +23,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteSnippetBlock {
@@ -117,7 +118,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..96
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..96
     0: SVELTE_SNIPPET_BLOCK@0..48
       0: SVELTE_SNIPPET_OPENING_BLOCK@0..37
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -174,6 +176,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@85..88 "{/" [Newline("\n")] []
         1: SNIPPET_KW@88..95 "snippet" [] []
         2: R_CURLY@95..96 "}" [] []
-  4: EOF@96..97 "" [Newline("\n")] []
+  5: EOF@96..97 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/snippet_nested.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/snippet_nested.svelte.snap
@@ -23,6 +23,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteSnippetBlock {
@@ -114,7 +115,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..111
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..111
     0: SVELTE_SNIPPET_BLOCK@0..111
       0: SVELTE_SNIPPET_OPENING_BLOCK@0..100
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -169,6 +171,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@100..103 "{/" [Newline("\n")] []
         1: SNIPPET_KW@103..110 "snippet" [] []
         2: R_CURLY@110..111 "}" [] []
-  4: EOF@111..112 "" [Newline("\n")] []
+  5: EOF@111..112 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/snippet_recursive.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/snippet_recursive.svelte.snap
@@ -23,6 +23,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteSnippetBlock {
@@ -129,7 +130,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..101
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..101
     0: SVELTE_SNIPPET_BLOCK@0..101
       0: SVELTE_SNIPPET_OPENING_BLOCK@0..90
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -195,6 +197,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@90..93 "{/" [Newline("\n")] []
         1: SNIPPET_KW@93..100 "snippet" [] []
         2: R_CURLY@100..101 "}" [] []
-  4: EOF@101..102 "" [Newline("\n")] []
+  5: EOF@101..102 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/snippet_with_params.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/snippet_with_params.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         SvelteSnippetBlock {
@@ -90,7 +91,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..72
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..72
     0: SVELTE_SNIPPET_BLOCK@0..72
       0: SVELTE_SNIPPET_OPENING_BLOCK@0..61
         0: SV_CURLY_HASH@0..2 "{#" [] []
@@ -131,6 +133,6 @@ HtmlRoot {
         0: SV_CURLY_SLASH@61..64 "{/" [Newline("\n")] []
         1: SNIPPET_KW@64..71 "snippet" [] []
         2: R_CURLY@71..72 "}" [] []
-  4: EOF@72..73 "" [Newline("\n")] []
+  5: EOF@72..73 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/spread.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/spread.svelte.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -87,7 +88,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..74
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..74
     0: HTML_SELF_CLOSING_ELEMENT@0..18
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_TAG_NAME@1..7
@@ -127,6 +129,6 @@ HtmlRoot {
           3: R_CURLY@70..72 "}" [] [Whitespace(" ")]
       3: SLASH@72..73 "/" [] []
       4: R_ANGLE@73..74 ">" [] []
-  4: EOF@74..75 "" [Newline("\n")] []
+  5: EOF@74..75 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/svelte_expressions.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/svelte_expressions.svelte.snap
@@ -21,6 +21,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -85,7 +86,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..66
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..66
     0: HTML_ELEMENT@0..42
       0: HTML_OPENING_ELEMENT@0..8
         0: L_ANGLE@0..1 "<" [] []
@@ -121,6 +123,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@61..65
           0: SPAN_KW@61..65 "span" [] []
         3: R_ANGLE@65..66 ">" [] []
-  4: EOF@66..67 "" [Newline("\n")] []
+  5: EOF@66..67 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svelte/svg_with_colon_attribute.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svelte/svg_with_colon_attribute.svelte.snap
@@ -29,6 +29,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -290,7 +291,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..385
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..385
     0: HTML_ELEMENT@0..385
       0: HTML_OPENING_ELEMENT@0..116
         0: L_ANGLE@0..1 "<" [] []
@@ -452,6 +454,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@381..384
           0: SVG_KW@381..384 "svg" [] []
         3: R_ANGLE@384..385 ">" [] []
-  4: EOF@385..386 "" [Newline("\n")] []
+  5: EOF@385..386 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svg/doctype-with-declaration.svg
+++ b/crates/biome_html_parser/tests/html_specs/ok/svg/doctype-with-declaration.svg
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<!DOCTYPE svg PUBLIC "a" "b">
+<svg></svg>

--- a/crates/biome_html_parser/tests/html_specs/ok/svg/doctype-with-declaration.svg.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svg/doctype-with-declaration.svg.snap
@@ -19,39 +19,38 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
-    directive: missing (optional),
-    html: HtmlElementList [
-        HtmlProcessingInstruction {
-            start_token: PI_START@0..2 "<?" [] [],
-            target: HtmlTagName {
-                value_token: HTML_LITERAL@2..6 "xml" [] [Whitespace(" ")],
-            },
-            attributes: HtmlAttributeList [
-                HtmlAttribute {
-                    name: HtmlAttributeName {
-                        value_token: HTML_LITERAL@6..13 "version" [] [],
-                    },
-                    initializer: HtmlAttributeInitializerClause {
-                        eq_token: EQ@13..14 "=" [] [],
-                        value: HtmlString {
-                            value_token: HTML_STRING_LITERAL@14..19 "\"1.0\"" [] [],
-                        },
+    processing_instruction: HtmlProcessingInstruction {
+        start_token: PI_START@0..2 "<?" [] [],
+        target: HtmlTagName {
+            value_token: HTML_LITERAL@2..6 "xml" [] [Whitespace(" ")],
+        },
+        attributes: HtmlAttributeList [
+            HtmlAttribute {
+                name: HtmlAttributeName {
+                    value_token: HTML_LITERAL@6..13 "version" [] [],
+                },
+                initializer: HtmlAttributeInitializerClause {
+                    eq_token: EQ@13..14 "=" [] [],
+                    value: HtmlString {
+                        value_token: HTML_STRING_LITERAL@14..19 "\"1.0\"" [] [],
                     },
                 },
-            ],
-            end_token: PI_END@19..21 "?>" [] [],
-        },
-        HtmlDirective {
-            l_angle_token: L_ANGLE@21..23 "<" [Newline("\n")] [],
-            excl_token: BANG@23..24 "!" [] [],
-            doctype_token: DOCTYPE_KW@24..32 "DOCTYPE" [] [Whitespace(" ")],
-            name_token: HTML_LITERAL@32..36 "svg" [] [Whitespace(" ")],
-            html_token: missing (optional),
-            quirk_token: HTML_LITERAL@36..43 "PUBLIC" [] [Whitespace(" ")],
-            public_id_token: HTML_STRING_LITERAL@43..47 "\"a\"" [] [Whitespace(" ")],
-            system_id_token: HTML_STRING_LITERAL@47..50 "\"b\"" [] [],
-            r_angle_token: R_ANGLE@50..51 ">" [] [],
-        },
+            },
+        ],
+        end_token: PI_END@19..21 "?>" [] [],
+    },
+    directive: HtmlDirective {
+        l_angle_token: L_ANGLE@21..23 "<" [Newline("\n")] [],
+        excl_token: BANG@23..24 "!" [] [],
+        doctype_token: DOCTYPE_KW@24..32 "DOCTYPE" [] [Whitespace(" ")],
+        name_token: HTML_LITERAL@32..36 "svg" [] [Whitespace(" ")],
+        html_token: missing (optional),
+        quirk_token: HTML_LITERAL@36..43 "PUBLIC" [] [Whitespace(" ")],
+        public_id_token: HTML_STRING_LITERAL@43..47 "\"a\"" [] [Whitespace(" ")],
+        system_id_token: HTML_STRING_LITERAL@47..50 "\"b\"" [] [],
+        r_angle_token: R_ANGLE@50..51 ">" [] [],
+    },
+    html: HtmlElementList [
         HtmlElement {
             opening_element: HtmlOpeningElement {
                 l_angle_token: L_ANGLE@51..53 "<" [Newline("\n")] [],
@@ -82,32 +81,31 @@ HtmlRoot {
 0: HTML_ROOT@0..64
   0: (empty)
   1: (empty)
-  2: (empty)
-  3: HTML_ELEMENT_LIST@0..63
-    0: HTML_PROCESSING_INSTRUCTION@0..21
-      0: PI_START@0..2 "<?" [] []
-      1: HTML_TAG_NAME@2..6
-        0: HTML_LITERAL@2..6 "xml" [] [Whitespace(" ")]
-      2: HTML_ATTRIBUTE_LIST@6..19
-        0: HTML_ATTRIBUTE@6..19
-          0: HTML_ATTRIBUTE_NAME@6..13
-            0: HTML_LITERAL@6..13 "version" [] []
-          1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@13..19
-            0: EQ@13..14 "=" [] []
-            1: HTML_STRING@14..19
-              0: HTML_STRING_LITERAL@14..19 "\"1.0\"" [] []
-      3: PI_END@19..21 "?>" [] []
-    1: HTML_DIRECTIVE@21..51
-      0: L_ANGLE@21..23 "<" [Newline("\n")] []
-      1: BANG@23..24 "!" [] []
-      2: DOCTYPE_KW@24..32 "DOCTYPE" [] [Whitespace(" ")]
-      3: HTML_LITERAL@32..36 "svg" [] [Whitespace(" ")]
-      4: (empty)
-      5: HTML_LITERAL@36..43 "PUBLIC" [] [Whitespace(" ")]
-      6: HTML_STRING_LITERAL@43..47 "\"a\"" [] [Whitespace(" ")]
-      7: HTML_STRING_LITERAL@47..50 "\"b\"" [] []
-      8: R_ANGLE@50..51 ">" [] []
-    2: HTML_ELEMENT@51..63
+  2: HTML_PROCESSING_INSTRUCTION@0..21
+    0: PI_START@0..2 "<?" [] []
+    1: HTML_TAG_NAME@2..6
+      0: HTML_LITERAL@2..6 "xml" [] [Whitespace(" ")]
+    2: HTML_ATTRIBUTE_LIST@6..19
+      0: HTML_ATTRIBUTE@6..19
+        0: HTML_ATTRIBUTE_NAME@6..13
+          0: HTML_LITERAL@6..13 "version" [] []
+        1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@13..19
+          0: EQ@13..14 "=" [] []
+          1: HTML_STRING@14..19
+            0: HTML_STRING_LITERAL@14..19 "\"1.0\"" [] []
+    3: PI_END@19..21 "?>" [] []
+  3: HTML_DIRECTIVE@21..51
+    0: L_ANGLE@21..23 "<" [Newline("\n")] []
+    1: BANG@23..24 "!" [] []
+    2: DOCTYPE_KW@24..32 "DOCTYPE" [] [Whitespace(" ")]
+    3: HTML_LITERAL@32..36 "svg" [] [Whitespace(" ")]
+    4: (empty)
+    5: HTML_LITERAL@36..43 "PUBLIC" [] [Whitespace(" ")]
+    6: HTML_STRING_LITERAL@43..47 "\"a\"" [] [Whitespace(" ")]
+    7: HTML_STRING_LITERAL@47..50 "\"b\"" [] []
+    8: R_ANGLE@50..51 ">" [] []
+  4: HTML_ELEMENT_LIST@51..63
+    0: HTML_ELEMENT@51..63
       0: HTML_OPENING_ELEMENT@51..57
         0: L_ANGLE@51..53 "<" [Newline("\n")] []
         1: HTML_TAG_NAME@53..56
@@ -121,6 +119,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@59..62
           0: SVG_KW@59..62 "svg" [] []
         3: R_ANGLE@62..63 ">" [] []
-  4: EOF@63..64 "" [Newline("\n")] []
+  5: EOF@63..64 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svg/doctype-with-declaration.svg.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svg/doctype-with-declaration.svg.snap
@@ -1,0 +1,126 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+<?xml version="1.0"?>
+<!DOCTYPE svg PUBLIC "a" "b">
+<svg></svg>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlProcessingInstruction {
+            start_token: PI_START@0..2 "<?" [] [],
+            target: HtmlTagName {
+                value_token: HTML_LITERAL@2..6 "xml" [] [Whitespace(" ")],
+            },
+            attributes: HtmlAttributeList [
+                HtmlAttribute {
+                    name: HtmlAttributeName {
+                        value_token: HTML_LITERAL@6..13 "version" [] [],
+                    },
+                    initializer: HtmlAttributeInitializerClause {
+                        eq_token: EQ@13..14 "=" [] [],
+                        value: HtmlString {
+                            value_token: HTML_STRING_LITERAL@14..19 "\"1.0\"" [] [],
+                        },
+                    },
+                },
+            ],
+            end_token: PI_END@19..21 "?>" [] [],
+        },
+        HtmlDirective {
+            l_angle_token: L_ANGLE@21..23 "<" [Newline("\n")] [],
+            excl_token: BANG@23..24 "!" [] [],
+            doctype_token: DOCTYPE_KW@24..32 "DOCTYPE" [] [Whitespace(" ")],
+            name_token: HTML_LITERAL@32..36 "svg" [] [Whitespace(" ")],
+            html_token: missing (optional),
+            quirk_token: HTML_LITERAL@36..43 "PUBLIC" [] [Whitespace(" ")],
+            public_id_token: HTML_STRING_LITERAL@43..47 "\"a\"" [] [Whitespace(" ")],
+            system_id_token: HTML_STRING_LITERAL@47..50 "\"b\"" [] [],
+            r_angle_token: R_ANGLE@50..51 ">" [] [],
+        },
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@51..53 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: SVG_KW@53..56 "svg" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@56..57 ">" [] [],
+            },
+            children: HtmlElementList [],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@57..58 "<" [] [],
+                slash_token: SLASH@58..59 "/" [] [],
+                name: HtmlTagName {
+                    value_token: SVG_KW@59..62 "svg" [] [],
+                },
+                r_angle_token: R_ANGLE@62..63 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@63..64 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..64
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: HTML_ELEMENT_LIST@0..63
+    0: HTML_PROCESSING_INSTRUCTION@0..21
+      0: PI_START@0..2 "<?" [] []
+      1: HTML_TAG_NAME@2..6
+        0: HTML_LITERAL@2..6 "xml" [] [Whitespace(" ")]
+      2: HTML_ATTRIBUTE_LIST@6..19
+        0: HTML_ATTRIBUTE@6..19
+          0: HTML_ATTRIBUTE_NAME@6..13
+            0: HTML_LITERAL@6..13 "version" [] []
+          1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@13..19
+            0: EQ@13..14 "=" [] []
+            1: HTML_STRING@14..19
+              0: HTML_STRING_LITERAL@14..19 "\"1.0\"" [] []
+      3: PI_END@19..21 "?>" [] []
+    1: HTML_DIRECTIVE@21..51
+      0: L_ANGLE@21..23 "<" [Newline("\n")] []
+      1: BANG@23..24 "!" [] []
+      2: DOCTYPE_KW@24..32 "DOCTYPE" [] [Whitespace(" ")]
+      3: HTML_LITERAL@32..36 "svg" [] [Whitespace(" ")]
+      4: (empty)
+      5: HTML_LITERAL@36..43 "PUBLIC" [] [Whitespace(" ")]
+      6: HTML_STRING_LITERAL@43..47 "\"a\"" [] [Whitespace(" ")]
+      7: HTML_STRING_LITERAL@47..50 "\"b\"" [] []
+      8: R_ANGLE@50..51 ">" [] []
+    2: HTML_ELEMENT@51..63
+      0: HTML_OPENING_ELEMENT@51..57
+        0: L_ANGLE@51..53 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@53..56
+          0: SVG_KW@53..56 "svg" [] []
+        2: HTML_ATTRIBUTE_LIST@56..56
+        3: R_ANGLE@56..57 ">" [] []
+      1: HTML_ELEMENT_LIST@57..57
+      2: HTML_CLOSING_ELEMENT@57..63
+        0: L_ANGLE@57..58 "<" [] []
+        1: SLASH@58..59 "/" [] []
+        2: HTML_TAG_NAME@59..62
+          0: SVG_KW@59..62 "svg" [] []
+        3: R_ANGLE@62..63 ">" [] []
+  4: EOF@63..64 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/svg/doctype.svg
+++ b/crates/biome_html_parser/tests/html_specs/ok/svg/doctype.svg
@@ -1,0 +1,2 @@
+<!DOCTYPE svg PUBLIC "a" "b">
+<svg></svg>

--- a/crates/biome_html_parser/tests/html_specs/ok/svg/doctype.svg.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svg/doctype.svg.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: HtmlDirective {
         l_angle_token: L_ANGLE@0..1 "<" [] [],
         excl_token: BANG@1..2 "!" [] [],
@@ -60,7 +61,8 @@ HtmlRoot {
 0: HTML_ROOT@0..42
   0: (empty)
   1: (empty)
-  2: HTML_DIRECTIVE@0..29
+  2: (empty)
+  3: HTML_DIRECTIVE@0..29
     0: L_ANGLE@0..1 "<" [] []
     1: BANG@1..2 "!" [] []
     2: DOCTYPE_KW@2..10 "DOCTYPE" [] [Whitespace(" ")]
@@ -70,7 +72,7 @@ HtmlRoot {
     6: HTML_STRING_LITERAL@21..25 "\"a\"" [] [Whitespace(" ")]
     7: HTML_STRING_LITERAL@25..28 "\"b\"" [] []
     8: R_ANGLE@28..29 ">" [] []
-  3: HTML_ELEMENT_LIST@29..41
+  4: HTML_ELEMENT_LIST@29..41
     0: HTML_ELEMENT@29..41
       0: HTML_OPENING_ELEMENT@29..35
         0: L_ANGLE@29..31 "<" [Newline("\n")] []
@@ -85,6 +87,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@37..40
           0: SVG_KW@37..40 "svg" [] []
         3: R_ANGLE@40..41 ">" [] []
-  4: EOF@41..42 "" [Newline("\n")] []
+  5: EOF@41..42 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svg/doctype.svg.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svg/doctype.svg.snap
@@ -1,0 +1,90 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```html
+<!DOCTYPE svg PUBLIC "a" "b">
+<svg></svg>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    directive: HtmlDirective {
+        l_angle_token: L_ANGLE@0..1 "<" [] [],
+        excl_token: BANG@1..2 "!" [] [],
+        doctype_token: DOCTYPE_KW@2..10 "DOCTYPE" [] [Whitespace(" ")],
+        name_token: HTML_LITERAL@10..14 "svg" [] [Whitespace(" ")],
+        html_token: missing (optional),
+        quirk_token: HTML_LITERAL@14..21 "PUBLIC" [] [Whitespace(" ")],
+        public_id_token: HTML_STRING_LITERAL@21..25 "\"a\"" [] [Whitespace(" ")],
+        system_id_token: HTML_STRING_LITERAL@25..28 "\"b\"" [] [],
+        r_angle_token: R_ANGLE@28..29 ">" [] [],
+    },
+    html: HtmlElementList [
+        HtmlElement {
+            opening_element: HtmlOpeningElement {
+                l_angle_token: L_ANGLE@29..31 "<" [Newline("\n")] [],
+                name: HtmlTagName {
+                    value_token: SVG_KW@31..34 "svg" [] [],
+                },
+                attributes: HtmlAttributeList [],
+                r_angle_token: R_ANGLE@34..35 ">" [] [],
+            },
+            children: HtmlElementList [],
+            closing_element: HtmlClosingElement {
+                l_angle_token: L_ANGLE@35..36 "<" [] [],
+                slash_token: SLASH@36..37 "/" [] [],
+                name: HtmlTagName {
+                    value_token: SVG_KW@37..40 "svg" [] [],
+                },
+                r_angle_token: R_ANGLE@40..41 ">" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@41..42 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..42
+  0: (empty)
+  1: (empty)
+  2: HTML_DIRECTIVE@0..29
+    0: L_ANGLE@0..1 "<" [] []
+    1: BANG@1..2 "!" [] []
+    2: DOCTYPE_KW@2..10 "DOCTYPE" [] [Whitespace(" ")]
+    3: HTML_LITERAL@10..14 "svg" [] [Whitespace(" ")]
+    4: (empty)
+    5: HTML_LITERAL@14..21 "PUBLIC" [] [Whitespace(" ")]
+    6: HTML_STRING_LITERAL@21..25 "\"a\"" [] [Whitespace(" ")]
+    7: HTML_STRING_LITERAL@25..28 "\"b\"" [] []
+    8: R_ANGLE@28..29 ">" [] []
+  3: HTML_ELEMENT_LIST@29..41
+    0: HTML_ELEMENT@29..41
+      0: HTML_OPENING_ELEMENT@29..35
+        0: L_ANGLE@29..31 "<" [Newline("\n")] []
+        1: HTML_TAG_NAME@31..34
+          0: SVG_KW@31..34 "svg" [] []
+        2: HTML_ATTRIBUTE_LIST@34..34
+        3: R_ANGLE@34..35 ">" [] []
+      1: HTML_ELEMENT_LIST@35..35
+      2: HTML_CLOSING_ELEMENT@35..41
+        0: L_ANGLE@35..36 "<" [] []
+        1: SLASH@36..37 "/" [] []
+        2: HTML_TAG_NAME@37..40
+          0: SVG_KW@37..40 "svg" [] []
+        3: R_ANGLE@40..41 ">" [] []
+  4: EOF@41..42 "" [Newline("\n")] []
+
+```

--- a/crates/biome_html_parser/tests/html_specs/ok/svg/dot.svg.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svg/dot.svg.snap
@@ -20,6 +20,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -199,7 +200,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..180
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..180
     0: HTML_ELEMENT@0..180
       0: HTML_OPENING_ELEMENT@0..62
         0: L_ANGLE@0..1 "<" [] []
@@ -307,6 +309,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@176..179
           0: SVG_KW@176..179 "svg" [] []
         3: R_ANGLE@179..180 ">" [] []
-  4: EOF@180..181 "" [Newline("\n")] []
+  5: EOF@180..181 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/svg/elements.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/svg/elements.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -98,7 +99,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..35
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..35
     0: HTML_ELEMENT@0..28
       0: HTML_OPENING_ELEMENT@0..5
         0: L_ANGLE@0..1 "<" [] []
@@ -148,6 +150,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@33..34
           0: A_KW@33..34 "a" [] []
         3: R_ANGLE@34..35 ">" [] []
-  4: EOF@35..36 "" [Newline("\n")] []
+  5: EOF@35..36 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/text_keywords.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/text_keywords.html.snap
@@ -32,6 +32,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -414,7 +415,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..318
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..318
     0: HTML_ELEMENT@0..24
       0: HTML_OPENING_ELEMENT@0..6
         0: L_ANGLE@0..1 "<" [] []
@@ -671,6 +673,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@313..317
           0: SPAN_KW@313..317 "span" [] []
         3: R_ANGLE@317..318 ">" [] []
-  4: EOF@318..319 "" [Newline("\n")] []
+  5: EOF@318..319 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/unicode-escape-attribute.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/unicode-escape-attribute.html.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -63,7 +64,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..110
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..110
     0: HTML_ELEMENT@0..110
       0: HTML_OPENING_ELEMENT@0..104
         0: L_ANGLE@0..85 "<" [Comments("<!-- valid because we ..."), Newline("\n")] []
@@ -85,6 +87,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@106..109
           0: DIV_KW@106..109 "div" [] []
         3: R_ANGLE@109..110 ">" [] []
-  4: EOF@110..111 "" [Newline("\n")] []
+  5: EOF@110..111 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/brackets-in-text.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/brackets-in-text.vue.snap
@@ -22,6 +22,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -148,7 +149,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..112
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..112
     0: HTML_ELEMENT@0..112
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -227,6 +229,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@103..111
           0: TEMPLATE_KW@103..111 "template" [] []
         3: R_ANGLE@111..112 ">" [] []
-  4: EOF@112..113 "" [Newline("\n")] []
+  5: EOF@112..113 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/component.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/component.vue.snap
@@ -20,6 +20,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -85,7 +86,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..51
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..51
     0: HTML_ELEMENT@0..51
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -121,6 +123,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@42..50
           0: TEMPLATE_KW@42..50 "template" [] []
         3: R_ANGLE@50..51 ">" [] []
-  4: EOF@51..52 "" [Newline("\n")] []
+  5: EOF@51..52 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/component_member.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/component_member.vue.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -68,7 +69,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..53
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..53
     0: HTML_ELEMENT@0..53
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -94,6 +96,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@44..52
           0: TEMPLATE_KW@44..52 "template" [] []
         3: R_ANGLE@52..53 ">" [] []
-  4: EOF@53..54 "" [Newline("\n")] []
+  5: EOF@53..54 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/component_member_nested.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/component_member_nested.vue.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -80,7 +81,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..44
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..44
     0: HTML_ELEMENT@0..44
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -114,6 +116,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@35..43
           0: TEMPLATE_KW@35..43 "template" [] []
         3: R_ANGLE@43..44 ">" [] []
-  4: EOF@44..45 "" [Newline("\n")] []
+  5: EOF@44..45 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/component_member_simple.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/component_member_simple.vue.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -46,7 +47,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..28
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..28
     0: HTML_SELF_CLOSING_ELEMENT@0..28
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_MEMBER_NAME@1..26
@@ -58,6 +60,6 @@ HtmlRoot {
       2: HTML_ATTRIBUTE_LIST@26..26
       3: SLASH@26..27 "/" [] []
       4: R_ANGLE@27..28 ">" [] []
-  4: EOF@28..29 "" [Newline("\n")] []
+  5: EOF@28..29 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/component_with_attributes.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/component_with_attributes.vue.snap
@@ -21,6 +21,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -82,7 +83,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..82
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..82
     0: HTML_ELEMENT@0..82
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -115,6 +117,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@73..81
           0: TEMPLATE_KW@73..81 "template" [] []
         3: R_ANGLE@81..82 ">" [] []
-  4: EOF@82..83 "" [Newline("\n")] []
+  5: EOF@82..83 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/custom_blocks.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/custom_blocks.vue.snap
@@ -40,6 +40,7 @@ const foo = "</"
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -248,7 +249,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..339
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..339
     0: HTML_ELEMENT@0..51
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -380,6 +382,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@335..338
           0: DIV_KW@335..338 "div" [] []
         3: R_ANGLE@338..339 ">" [] []
-  4: EOF@339..340 "" [Newline("\n")] []
+  5: EOF@339..340 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/custom_blocks_lang.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/custom_blocks_lang.vue.snap
@@ -59,6 +59,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -639,7 +640,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..652
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..652
     0: HTML_ELEMENT@0..39
       0: HTML_OPENING_ELEMENT@0..21
         0: L_ANGLE@0..1 "<" [] []
@@ -1013,6 +1015,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@643..651
           0: TEMPLATE_KW@643..651 "template" [] []
         3: R_ANGLE@651..652 ">" [] []
-  4: EOF@652..653 "" [Newline("\n")] []
+  5: EOF@652..653 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/dynamic-slot-arg.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/dynamic-slot-arg.vue.snap
@@ -39,6 +39,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -281,7 +282,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..345
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..345
     0: HTML_ELEMENT@0..115
       0: HTML_OPENING_ELEMENT@0..97
         0: L_ANGLE@0..1 "<" [] []
@@ -440,6 +442,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@336..344
           0: TEMPLATE_KW@336..344 "template" [] []
         3: R_ANGLE@344..345 ">" [] []
-  4: EOF@345..346 "" [Newline("\n")] []
+  5: EOF@345..346 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/event-with-colon.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/event-with-colon.vue.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -54,7 +55,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..37
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..37
     0: HTML_SELF_CLOSING_ELEMENT@0..37
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_COMPONENT_NAME@1..5
@@ -71,6 +73,6 @@ HtmlRoot {
               0: HTML_STRING_LITERAL@24..35 "\"onUpdate\"" [] [Whitespace(" ")]
       3: SLASH@35..36 "/" [] []
       4: R_ANGLE@36..37 ">" [] []
-  4: EOF@37..38 "" [Newline("\n")] []
+  5: EOF@37..38 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/generic-directives/arg-modifiers-no-value.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/generic-directives/arg-modifiers-no-value.vue.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -163,7 +164,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..91
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..91
     0: HTML_ELEMENT@0..21
       0: HTML_OPENING_ELEMENT@0..17
         0: L_ANGLE@0..1 "<" [] []
@@ -253,6 +255,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@89..90
           0: P_KW@89..90 "p" [] []
         3: R_ANGLE@90..91 ">" [] []
-  4: EOF@91..92 "" [Newline("\n")] []
+  5: EOF@91..92 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/generic-directives/arg-no-modifiers-no-value.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/generic-directives/arg-no-modifiers-no-value.vue.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -148,7 +149,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..79
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..79
     0: HTML_ELEMENT@0..17
       0: HTML_OPENING_ELEMENT@0..13
         0: L_ANGLE@0..1 "<" [] []
@@ -229,6 +231,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@77..78
           0: P_KW@77..78 "p" [] []
         3: R_ANGLE@78..79 ">" [] []
-  4: EOF@79..80 "" [Newline("\n")] []
+  5: EOF@79..80 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/generic-directives/directive-only.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/generic-directives/directive-only.vue.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -133,7 +134,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..67
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..67
     0: HTML_ELEMENT@0..13
       0: HTML_OPENING_ELEMENT@0..9
         0: L_ANGLE@0..1 "<" [] []
@@ -205,6 +207,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@65..66
           0: P_KW@65..66 "p" [] []
         3: R_ANGLE@66..67 ">" [] []
-  4: EOF@67..68 "" [Newline("\n")] []
+  5: EOF@67..68 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/generic-directives/modifiers-no-arg-no-value.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/generic-directives/modifiers-no-arg-no-value.vue.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -148,7 +149,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..79
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..79
     0: HTML_ELEMENT@0..17
       0: HTML_OPENING_ELEMENT@0..13
         0: L_ANGLE@0..1 "<" [] []
@@ -229,6 +231,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@77..78
           0: P_KW@77..78 "p" [] []
         3: R_ANGLE@78..79 ">" [] []
-  4: EOF@79..80 "" [Newline("\n")] []
+  5: EOF@79..80 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/interpolation.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/interpolation.vue.snap
@@ -32,6 +32,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -173,7 +174,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..309
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..309
     0: HTML_ELEMENT@0..309
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -263,6 +265,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@300..308
           0: TEMPLATE_KW@300..308 "template" [] []
         3: R_ANGLE@308..309 ">" [] []
-  4: EOF@309..310 "" [Newline("\n")] []
+  5: EOF@309..310 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/issue-10622.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/issue-10622.vue.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -99,7 +100,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..49
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..49
     0: HTML_ELEMENT@0..21
       0: HTML_OPENING_ELEMENT@0..15
         0: L_ANGLE@0..1 "<" [] []
@@ -147,6 +149,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@45..48
           0: DIV_KW@45..48 "div" [] []
         3: R_ANGLE@48..49 ">" [] []
-  4: EOF@49..50 "" [Newline("\n")] []
+  5: EOF@49..50 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/issue-8174.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/issue-8174.vue.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlSelfClosingElement {
@@ -99,7 +100,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..83
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..83
     0: HTML_SELF_CLOSING_ELEMENT@0..46
       0: L_ANGLE@0..1 "<" [] []
       1: HTML_COMPONENT_NAME@1..11
@@ -147,6 +149,6 @@ HtmlRoot {
               0: HTML_STRING_LITERAL@75..81 "\"123\"" [] [Whitespace(" ")]
       3: SLASH@81..82 "/" [] []
       4: R_ANGLE@82..83 ">" [] []
-  4: EOF@83..84 "" [Newline("\n")] []
+  5: EOF@83..84 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/issue-8765.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/issue-8765.vue.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -108,7 +109,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..67
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..67
     0: HTML_ELEMENT@0..33
       0: HTML_OPENING_ELEMENT@0..27
         0: L_ANGLE@0..1 "<" [] []
@@ -161,6 +163,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@63..66
           0: DIV_KW@63..66 "div" [] []
         3: R_ANGLE@66..67 ">" [] []
-  4: EOF@67..68 "" [Newline("\n")] []
+  5: EOF@67..68 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/modifier.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/modifier.vue.snap
@@ -18,6 +18,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -93,7 +94,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..60
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..60
     0: HTML_ELEMENT@0..60
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -136,6 +138,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@51..59
           0: TEMPLATE_KW@51..59 "template" [] []
         3: R_ANGLE@59..60 ">" [] []
-  4: EOF@60..60 "" [] []
+  5: EOF@60..60 "" [] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/modifiers-all-variants.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/modifiers-all-variants.vue.snap
@@ -20,6 +20,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -173,7 +174,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..105
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..105
     0: HTML_ELEMENT@0..105
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -269,6 +271,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@96..104
           0: TEMPLATE_KW@96..104 "template" [] []
         3: R_ANGLE@104..105 ">" [] []
-  4: EOF@105..105 "" [] []
+  5: EOF@105..105 "" [] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/multiple_expressions.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/multiple_expressions.vue.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -66,7 +67,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..39
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..39
     0: HTML_ELEMENT@0..39
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -90,6 +92,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@30..38
           0: TEMPLATE_KW@30..38 "template" [] []
         3: R_ANGLE@38..39 ">" [] []
-  4: EOF@39..40 "" [Newline("\n")] []
+  5: EOF@39..40 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/svg_with_colon_attribute.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/svg_with_colon_attribute.vue.snap
@@ -31,6 +31,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -312,7 +313,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..418
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..418
     0: HTML_ELEMENT@0..418
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -488,6 +490,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@409..417
           0: TEMPLATE_KW@409..417 "template" [] []
         3: R_ANGLE@417..418 ">" [] []
-  4: EOF@418..419 "" [Newline("\n")] []
+  5: EOF@418..419 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/unocss-attributify.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/unocss-attributify.vue.snap
@@ -28,6 +28,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -108,7 +109,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..368
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..368
     0: HTML_ELEMENT@0..368
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -153,6 +155,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@359..367
           0: TEMPLATE_KW@359..367 "template" [] []
         3: R_ANGLE@367..368 ">" [] []
-  4: EOF@368..369 "" [Newline("\n")] []
+  5: EOF@368..369 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/v-bind-dynamic.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/v-bind-dynamic.vue.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -80,7 +81,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..44
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..44
     0: HTML_ELEMENT@0..44
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -114,6 +116,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@35..43
           0: TEMPLATE_KW@35..43 "template" [] []
         3: R_ANGLE@43..44 ">" [] []
-  4: EOF@44..45 "" [Newline("\n")] []
+  5: EOF@44..45 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/v-bind-mixed.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/v-bind-mixed.vue.snap
@@ -37,6 +37,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -319,7 +320,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..575
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..575
     0: HTML_ELEMENT@0..575
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -508,6 +510,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@566..574
           0: TEMPLATE_KW@566..574 "template" [] []
         3: R_ANGLE@574..575 ">" [] []
-  4: EOF@575..575 "" [] []
+  5: EOF@575..575 "" [] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/v-bind-shorthand.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/v-bind-shorthand.vue.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -88,7 +89,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..45
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..45
     0: HTML_ELEMENT@0..45
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -127,6 +129,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@36..44
           0: TEMPLATE_KW@36..44 "template" [] []
         3: R_ANGLE@44..45 ">" [] []
-  4: EOF@45..46 "" [Newline("\n")] []
+  5: EOF@45..46 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/v-bind.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/v-bind.vue.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -89,7 +90,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..51
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..51
     0: HTML_ELEMENT@0..51
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -129,6 +131,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@42..50
           0: TEMPLATE_KW@42..50 "template" [] []
         3: R_ANGLE@50..51 ">" [] []
-  4: EOF@51..52 "" [Newline("\n")] []
+  5: EOF@51..52 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/v-dynamic-chains.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/v-dynamic-chains.vue.snap
@@ -65,6 +65,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -721,7 +722,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..1440
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..1440
     0: HTML_ELEMENT@0..1440
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -1164,6 +1166,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@1431..1439
           0: TEMPLATE_KW@1431..1439 "template" [] []
         3: R_ANGLE@1439..1440 ">" [] []
-  4: EOF@1440..1441 "" [Newline("\n")] []
+  5: EOF@1440..1441 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/v-else-if.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/v-else-if.vue.snap
@@ -47,6 +47,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -698,7 +699,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..830
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..830
     0: HTML_ELEMENT@0..830
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -1144,6 +1146,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@821..829
           0: TEMPLATE_KW@821..829 "template" [] []
         3: R_ANGLE@829..830 ">" [] []
-  4: EOF@830..830 "" [] []
+  5: EOF@830..830 "" [] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/v-else.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/v-else.vue.snap
@@ -20,6 +20,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -141,7 +142,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..97
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..97
     0: HTML_ELEMENT@0..97
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -215,6 +217,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@88..96
           0: TEMPLATE_KW@88..96 "template" [] []
         3: R_ANGLE@96..97 ">" [] []
-  4: EOF@97..98 "" [Newline("\n")] []
+  5: EOF@97..98 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/v-for-single-quote-and-of.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/v-for-single-quote-and-of.vue.snap
@@ -34,6 +34,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -387,7 +388,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..606
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..606
     0: HTML_ELEMENT@0..606
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -621,6 +623,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@597..605
           0: TEMPLATE_KW@597..605 "template" [] []
         3: R_ANGLE@605..606 ">" [] []
-  4: EOF@606..607 "" [Newline("\n")] []
+  5: EOF@606..607 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/v-for.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/v-for.vue.snap
@@ -61,6 +61,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -1224,7 +1225,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..1404
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..1404
     0: HTML_ELEMENT@0..1404
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -2023,6 +2025,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@1395..1403
           0: TEMPLATE_KW@1395..1403 "template" [] []
         3: R_ANGLE@1403..1404 ">" [] []
-  4: EOF@1404..1405 "" [Newline("\n")] []
+  5: EOF@1404..1405 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/v-for/destructuring.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/v-for/destructuring.vue.snap
@@ -21,6 +21,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -283,7 +284,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..241
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..241
     0: HTML_ELEMENT@0..241
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -457,6 +459,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@232..240
           0: TEMPLATE_KW@232..240 "template" [] []
         3: R_ANGLE@240..241 ">" [] []
-  4: EOF@241..242 "" [Newline("\n")] []
+  5: EOF@241..242 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/v-for/expressions.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/v-for/expressions.vue.snap
@@ -24,6 +24,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -352,7 +353,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..388
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..388
     0: HTML_ELEMENT@0..388
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -571,6 +573,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@379..387
           0: TEMPLATE_KW@379..387 "template" [] []
         3: R_ANGLE@387..388 ">" [] []
-  4: EOF@388..389 "" [Newline("\n")] []
+  5: EOF@388..389 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/v-for/iterable-expressions.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/v-for/iterable-expressions.vue.snap
@@ -21,6 +21,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -202,7 +203,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..172
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..172
     0: HTML_ELEMENT@0..172
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -319,6 +321,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@163..171
           0: TEMPLATE_KW@163..171 "template" [] []
         3: R_ANGLE@171..172 ">" [] []
-  4: EOF@172..173 "" [Newline("\n")] []
+  5: EOF@172..173 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/v-for/nested-destructuring.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/v-for/nested-destructuring.vue.snap
@@ -24,6 +24,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -753,7 +754,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..811
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..811
     0: HTML_ELEMENT@0..811
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -1251,6 +1253,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@802..810
           0: TEMPLATE_KW@802..810 "template" [] []
         3: R_ANGLE@810..811 ">" [] []
-  4: EOF@811..812 "" [Newline("\n")] []
+  5: EOF@811..812 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/v-for/quotes-and-of.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/v-for/quotes-and-of.vue.snap
@@ -21,6 +21,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -223,7 +224,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..179
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..179
     0: HTML_ELEMENT@0..179
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -355,6 +357,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@170..178
           0: TEMPLATE_KW@170..178 "template" [] []
         3: R_ANGLE@178..179 ">" [] []
-  4: EOF@179..180 "" [Newline("\n")] []
+  5: EOF@179..180 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/v-for/simple.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/v-for/simple.vue.snap
@@ -21,6 +21,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -202,7 +203,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..148
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..148
     0: HTML_ELEMENT@0..148
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -319,6 +321,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@139..147
           0: TEMPLATE_KW@139..147 "template" [] []
         3: R_ANGLE@147..148 ">" [] []
-  4: EOF@148..149 "" [Newline("\n")] []
+  5: EOF@148..149 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/v-for/tuple.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/v-for/tuple.vue.snap
@@ -22,6 +22,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -336,7 +337,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..288
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..288
     0: HTML_ELEMENT@0..288
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -547,6 +549,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@279..287
           0: TEMPLATE_KW@279..287 "template" [] []
         3: R_ANGLE@287..288 ">" [] []
-  4: EOF@288..289 "" [Newline("\n")] []
+  5: EOF@288..289 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/v-for/with-directives.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/v-for/with-directives.vue.snap
@@ -23,6 +23,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -289,7 +290,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..273
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..273
     0: HTML_ELEMENT@0..273
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -464,6 +466,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@264..272
           0: TEMPLATE_KW@264..272 "template" [] []
         3: R_ANGLE@272..273 ">" [] []
-  4: EOF@273..274 "" [Newline("\n")] []
+  5: EOF@273..274 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/v-html-text.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/v-html-text.vue.snap
@@ -36,6 +36,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -676,7 +677,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..636
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..636
     0: HTML_ELEMENT@0..636
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -1116,6 +1118,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@627..635
           0: TEMPLATE_KW@627..635 "template" [] []
         3: R_ANGLE@635..636 ">" [] []
-  4: EOF@636..636 "" [] []
+  5: EOF@636..636 "" [] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/v-if.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/v-if.vue.snap
@@ -20,6 +20,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -119,7 +120,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..83
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..83
     0: HTML_ELEMENT@0..83
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -179,6 +181,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@74..82
           0: TEMPLATE_KW@74..82 "template" [] []
         3: R_ANGLE@82..83 ">" [] []
-  4: EOF@83..84 "" [Newline("\n")] []
+  5: EOF@83..84 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/v-mixed-complex.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/v-mixed-complex.vue.snap
@@ -42,6 +42,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -522,7 +523,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..783
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..783
     0: HTML_ELEMENT@0..783
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -845,6 +847,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@774..782
           0: TEMPLATE_KW@774..782 "template" [] []
         3: R_ANGLE@782..783 ">" [] []
-  4: EOF@783..783 "" [] []
+  5: EOF@783..783 "" [] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/v-model-mixed.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/v-model-mixed.vue.snap
@@ -56,6 +56,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -803,7 +804,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..1319
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..1319
     0: HTML_ELEMENT@0..1319
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -1309,6 +1311,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@1310..1318
           0: TEMPLATE_KW@1310..1318 "template" [] []
         3: R_ANGLE@1318..1319 ">" [] []
-  4: EOF@1319..1319 "" [] []
+  5: EOF@1319..1319 "" [] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/v-on-mixed.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/v-on-mixed.vue.snap
@@ -40,6 +40,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -635,7 +636,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..872
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..872
     0: HTML_ELEMENT@0..872
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -1035,6 +1037,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@863..871
           0: TEMPLATE_KW@863..871 "template" [] []
         3: R_ANGLE@871..872 ">" [] []
-  4: EOF@872..872 "" [] []
+  5: EOF@872..872 "" [] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/v-on-shorthand.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/v-on-shorthand.vue.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -86,7 +87,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..65
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..65
     0: HTML_ELEMENT@0..65
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -124,6 +126,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@56..64
           0: TEMPLATE_KW@56..64 "template" [] []
         3: R_ANGLE@64..65 ">" [] []
-  4: EOF@65..66 "" [Newline("\n")] []
+  5: EOF@65..66 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/v-slot-shorthand.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/v-slot-shorthand.vue.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -124,7 +125,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..108
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..108
     0: HTML_ELEMENT@0..29
       0: HTML_OPENING_ELEMENT@0..18
         0: L_ANGLE@0..1 "<" [] []
@@ -190,6 +192,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@99..107
           0: TEMPLATE_KW@99..107 "template" [] []
         3: R_ANGLE@107..108 ">" [] []
-  4: EOF@108..109 "" [Newline("\n")] []
+  5: EOF@108..109 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/vue_expressions.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/vue_expressions.vue.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -60,7 +61,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..31
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..31
     0: HTML_ELEMENT@0..31
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -80,6 +82,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@22..30
           0: TEMPLATE_KW@22..30 "template" [] []
         3: R_ANGLE@30..31 ">" [] []
-  4: EOF@31..32 "" [Newline("\n")] []
+  5: EOF@31..32 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/vue/vue_expressions_escaped.vue.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/vue/vue_expressions_escaped.vue.snap
@@ -19,6 +19,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlElement {
@@ -56,7 +57,8 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..37
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..37
     0: HTML_ELEMENT@0..37
       0: HTML_OPENING_ELEMENT@0..10
         0: L_ANGLE@0..1 "<" [] []
@@ -73,6 +75,6 @@ HtmlRoot {
         2: HTML_TAG_NAME@28..36
           0: TEMPLATE_KW@28..36 "template" [] []
         3: R_ANGLE@36..37 ">" [] []
-  4: EOF@37..38 "" [Newline("\n")] []
+  5: EOF@37..38 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_parser/tests/html_specs/ok/with-text-expressions/issue-8605.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/with-text-expressions/issue-8605.html.snap
@@ -17,6 +17,7 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     frontmatter: missing (optional),
+    processing_instruction: missing (optional),
     directive: missing (optional),
     html: HtmlElementList [
         HtmlDoubleTextExpression {
@@ -38,12 +39,13 @@ HtmlRoot {
   0: (empty)
   1: (empty)
   2: (empty)
-  3: HTML_ELEMENT_LIST@0..15
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..15
     0: HTML_DOUBLE_TEXT_EXPRESSION@0..15
       0: L_DOUBLE_CURLY@0..2 "{{" [] []
       1: HTML_TEXT_EXPRESSION@2..13
         0: HTML_LITERAL@2..13 " some_form " [] []
       2: R_DOUBLE_CURLY@13..15 "}}" [] []
-  4: EOF@15..16 "" [Newline("\n")] []
+  5: EOF@15..16 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_syntax/src/element_ext.rs
+++ b/crates/biome_html_syntax/src/element_ext.rs
@@ -41,7 +41,6 @@ impl AnyHtmlElement {
         match self {
             Self::AnyHtmlContent(_)
             | Self::HtmlBogusElement(_)
-            | Self::HtmlDirective(_)
             | Self::HtmlSelfClosingElement(_)
             | Self::HtmlProcessingInstruction(_)
             | Self::HtmlCdataSection(_) => false,
@@ -53,7 +52,6 @@ impl AnyHtmlElement {
         match self {
             Self::AnyHtmlContent(_)
             | Self::HtmlBogusElement(_)
-            | Self::HtmlDirective(_)
             | Self::HtmlSelfClosingElement(_)
             | Self::HtmlProcessingInstruction(_)
             | Self::HtmlCdataSection(_) => false,
@@ -72,10 +70,7 @@ impl AnyHtmlElement {
                 element.find_attribute_by_name(name_to_lookup)
             }
             // Other variants don't have attributes
-            Self::AnyHtmlContent(_)
-            | Self::HtmlBogusElement(_)
-            | Self::HtmlCdataSection(_)
-            | Self::HtmlDirective(_) => None,
+            Self::AnyHtmlContent(_) | Self::HtmlBogusElement(_) | Self::HtmlCdataSection(_) => None,
         }
     }
 

--- a/crates/biome_html_syntax/src/element_ext.rs
+++ b/crates/biome_html_syntax/src/element_ext.rs
@@ -41,6 +41,7 @@ impl AnyHtmlElement {
         match self {
             Self::AnyHtmlContent(_)
             | Self::HtmlBogusElement(_)
+            | Self::HtmlDirective(_)
             | Self::HtmlSelfClosingElement(_)
             | Self::HtmlProcessingInstruction(_)
             | Self::HtmlCdataSection(_) => false,
@@ -52,6 +53,7 @@ impl AnyHtmlElement {
         match self {
             Self::AnyHtmlContent(_)
             | Self::HtmlBogusElement(_)
+            | Self::HtmlDirective(_)
             | Self::HtmlSelfClosingElement(_)
             | Self::HtmlProcessingInstruction(_)
             | Self::HtmlCdataSection(_) => false,
@@ -70,7 +72,10 @@ impl AnyHtmlElement {
                 element.find_attribute_by_name(name_to_lookup)
             }
             // Other variants don't have attributes
-            Self::AnyHtmlContent(_) | Self::HtmlBogusElement(_) | Self::HtmlCdataSection(_) => None,
+            Self::AnyHtmlContent(_)
+            | Self::HtmlBogusElement(_)
+            | Self::HtmlCdataSection(_)
+            | Self::HtmlDirective(_) => None,
         }
     }
 

--- a/crates/biome_html_syntax/src/generated/nodes.rs
+++ b/crates/biome_html_syntax/src/generated/nodes.rs
@@ -1048,6 +1048,7 @@ impl HtmlDirective {
             l_angle_token: self.l_angle_token(),
             excl_token: self.excl_token(),
             doctype_token: self.doctype_token(),
+            name_token: self.name_token(),
             html_token: self.html_token(),
             quirk_token: self.quirk_token(),
             public_id_token: self.public_id_token(),
@@ -1064,20 +1065,23 @@ impl HtmlDirective {
     pub fn doctype_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 2usize)
     }
-    pub fn html_token(&self) -> Option<SyntaxToken> {
+    pub fn name_token(&self) -> Option<SyntaxToken> {
         support::token(&self.syntax, 3usize)
     }
-    pub fn quirk_token(&self) -> Option<SyntaxToken> {
+    pub fn html_token(&self) -> Option<SyntaxToken> {
         support::token(&self.syntax, 4usize)
     }
-    pub fn public_id_token(&self) -> Option<SyntaxToken> {
+    pub fn quirk_token(&self) -> Option<SyntaxToken> {
         support::token(&self.syntax, 5usize)
     }
-    pub fn system_id_token(&self) -> Option<SyntaxToken> {
+    pub fn public_id_token(&self) -> Option<SyntaxToken> {
         support::token(&self.syntax, 6usize)
     }
+    pub fn system_id_token(&self) -> Option<SyntaxToken> {
+        support::token(&self.syntax, 7usize)
+    }
     pub fn r_angle_token(&self) -> SyntaxResult<SyntaxToken> {
-        support::required_token(&self.syntax, 7usize)
+        support::required_token(&self.syntax, 8usize)
     }
 }
 impl Serialize for HtmlDirective {
@@ -1093,6 +1097,7 @@ pub struct HtmlDirectiveFields {
     pub l_angle_token: SyntaxResult<SyntaxToken>,
     pub excl_token: SyntaxResult<SyntaxToken>,
     pub doctype_token: SyntaxResult<SyntaxToken>,
+    pub name_token: Option<SyntaxToken>,
     pub html_token: Option<SyntaxToken>,
     pub quirk_token: Option<SyntaxToken>,
     pub public_id_token: Option<SyntaxToken>,
@@ -5116,6 +5121,7 @@ pub enum AnyHtmlElement {
     AnyHtmlContent(AnyHtmlContent),
     HtmlBogusElement(HtmlBogusElement),
     HtmlCdataSection(HtmlCdataSection),
+    HtmlDirective(HtmlDirective),
     HtmlElement(HtmlElement),
     HtmlProcessingInstruction(HtmlProcessingInstruction),
     HtmlSelfClosingElement(HtmlSelfClosingElement),
@@ -5136,6 +5142,12 @@ impl AnyHtmlElement {
     pub fn as_html_cdata_section(&self) -> Option<&HtmlCdataSection> {
         match &self {
             Self::HtmlCdataSection(item) => Some(item),
+            _ => None,
+        }
+    }
+    pub fn as_html_directive(&self) -> Option<&HtmlDirective> {
+        match &self {
+            Self::HtmlDirective(item) => Some(item),
             _ => None,
         }
     }
@@ -7036,6 +7048,10 @@ impl std::fmt::Debug for HtmlDirective {
                 .field(
                     "doctype_token",
                     &support::DebugSyntaxResult(self.doctype_token()),
+                )
+                .field(
+                    "name_token",
+                    &support::DebugOptionalElement(self.name_token()),
                 )
                 .field(
                     "html_token",
@@ -12223,6 +12239,11 @@ impl From<HtmlCdataSection> for AnyHtmlElement {
         Self::HtmlCdataSection(node)
     }
 }
+impl From<HtmlDirective> for AnyHtmlElement {
+    fn from(node: HtmlDirective) -> Self {
+        Self::HtmlDirective(node)
+    }
+}
 impl From<HtmlElement> for AnyHtmlElement {
     fn from(node: HtmlElement) -> Self {
         Self::HtmlElement(node)
@@ -12243,6 +12264,7 @@ impl AstNode for AnyHtmlElement {
     const KIND_SET: SyntaxKindSet<Language> = AnyHtmlContent::KIND_SET
         .union(HtmlBogusElement::KIND_SET)
         .union(HtmlCdataSection::KIND_SET)
+        .union(HtmlDirective::KIND_SET)
         .union(HtmlElement::KIND_SET)
         .union(HtmlProcessingInstruction::KIND_SET)
         .union(HtmlSelfClosingElement::KIND_SET);
@@ -12250,6 +12272,7 @@ impl AstNode for AnyHtmlElement {
         match kind {
             HTML_BOGUS_ELEMENT
             | HTML_CDATA_SECTION
+            | HTML_DIRECTIVE
             | HTML_ELEMENT
             | HTML_PROCESSING_INSTRUCTION
             | HTML_SELF_CLOSING_ELEMENT => true,
@@ -12261,6 +12284,7 @@ impl AstNode for AnyHtmlElement {
         let res = match syntax.kind() {
             HTML_BOGUS_ELEMENT => Self::HtmlBogusElement(HtmlBogusElement { syntax }),
             HTML_CDATA_SECTION => Self::HtmlCdataSection(HtmlCdataSection { syntax }),
+            HTML_DIRECTIVE => Self::HtmlDirective(HtmlDirective { syntax }),
             HTML_ELEMENT => Self::HtmlElement(HtmlElement { syntax }),
             HTML_PROCESSING_INSTRUCTION => {
                 Self::HtmlProcessingInstruction(HtmlProcessingInstruction { syntax })
@@ -12281,6 +12305,7 @@ impl AstNode for AnyHtmlElement {
         match self {
             Self::HtmlBogusElement(it) => it.syntax(),
             Self::HtmlCdataSection(it) => it.syntax(),
+            Self::HtmlDirective(it) => it.syntax(),
             Self::HtmlElement(it) => it.syntax(),
             Self::HtmlProcessingInstruction(it) => it.syntax(),
             Self::HtmlSelfClosingElement(it) => it.syntax(),
@@ -12291,6 +12316,7 @@ impl AstNode for AnyHtmlElement {
         match self {
             Self::HtmlBogusElement(it) => it.into_syntax(),
             Self::HtmlCdataSection(it) => it.into_syntax(),
+            Self::HtmlDirective(it) => it.into_syntax(),
             Self::HtmlElement(it) => it.into_syntax(),
             Self::HtmlProcessingInstruction(it) => it.into_syntax(),
             Self::HtmlSelfClosingElement(it) => it.into_syntax(),
@@ -12304,6 +12330,7 @@ impl std::fmt::Debug for AnyHtmlElement {
             Self::AnyHtmlContent(it) => std::fmt::Debug::fmt(it, f),
             Self::HtmlBogusElement(it) => std::fmt::Debug::fmt(it, f),
             Self::HtmlCdataSection(it) => std::fmt::Debug::fmt(it, f),
+            Self::HtmlDirective(it) => std::fmt::Debug::fmt(it, f),
             Self::HtmlElement(it) => std::fmt::Debug::fmt(it, f),
             Self::HtmlProcessingInstruction(it) => std::fmt::Debug::fmt(it, f),
             Self::HtmlSelfClosingElement(it) => std::fmt::Debug::fmt(it, f),
@@ -12316,6 +12343,7 @@ impl From<AnyHtmlElement> for SyntaxNode {
             AnyHtmlElement::AnyHtmlContent(it) => it.into_syntax(),
             AnyHtmlElement::HtmlBogusElement(it) => it.into_syntax(),
             AnyHtmlElement::HtmlCdataSection(it) => it.into_syntax(),
+            AnyHtmlElement::HtmlDirective(it) => it.into_syntax(),
             AnyHtmlElement::HtmlElement(it) => it.into_syntax(),
             AnyHtmlElement::HtmlProcessingInstruction(it) => it.into_syntax(),
             AnyHtmlElement::HtmlSelfClosingElement(it) => it.into_syntax(),

--- a/crates/biome_html_syntax/src/generated/nodes.rs
+++ b/crates/biome_html_syntax/src/generated/nodes.rs
@@ -1392,6 +1392,7 @@ impl HtmlRoot {
         HtmlRootFields {
             bom_token: self.bom_token(),
             frontmatter: self.frontmatter(),
+            processing_instruction: self.processing_instruction(),
             directive: self.directive(),
             html: self.html(),
             eof_token: self.eof_token(),
@@ -1403,14 +1404,17 @@ impl HtmlRoot {
     pub fn frontmatter(&self) -> Option<AnyAstroFrontmatterElement> {
         support::node(&self.syntax, 1usize)
     }
-    pub fn directive(&self) -> Option<HtmlDirective> {
+    pub fn processing_instruction(&self) -> Option<HtmlProcessingInstruction> {
         support::node(&self.syntax, 2usize)
     }
+    pub fn directive(&self) -> Option<HtmlDirective> {
+        support::node(&self.syntax, 3usize)
+    }
     pub fn html(&self) -> HtmlElementList {
-        support::list(&self.syntax, 3usize)
+        support::list(&self.syntax, 4usize)
     }
     pub fn eof_token(&self) -> SyntaxResult<SyntaxToken> {
-        support::required_token(&self.syntax, 4usize)
+        support::required_token(&self.syntax, 5usize)
     }
 }
 impl Serialize for HtmlRoot {
@@ -1425,6 +1429,7 @@ impl Serialize for HtmlRoot {
 pub struct HtmlRootFields {
     pub bom_token: Option<SyntaxToken>,
     pub frontmatter: Option<AnyAstroFrontmatterElement>,
+    pub processing_instruction: Option<HtmlProcessingInstruction>,
     pub directive: Option<HtmlDirective>,
     pub html: HtmlElementList,
     pub eof_token: SyntaxResult<SyntaxToken>,
@@ -5121,7 +5126,6 @@ pub enum AnyHtmlElement {
     AnyHtmlContent(AnyHtmlContent),
     HtmlBogusElement(HtmlBogusElement),
     HtmlCdataSection(HtmlCdataSection),
-    HtmlDirective(HtmlDirective),
     HtmlElement(HtmlElement),
     HtmlProcessingInstruction(HtmlProcessingInstruction),
     HtmlSelfClosingElement(HtmlSelfClosingElement),
@@ -5142,12 +5146,6 @@ impl AnyHtmlElement {
     pub fn as_html_cdata_section(&self) -> Option<&HtmlCdataSection> {
         match &self {
             Self::HtmlCdataSection(item) => Some(item),
-            _ => None,
-        }
-    }
-    pub fn as_html_directive(&self) -> Option<&HtmlDirective> {
-        match &self {
-            Self::HtmlDirective(item) => Some(item),
             _ => None,
         }
     }
@@ -7444,6 +7442,10 @@ impl std::fmt::Debug for HtmlRoot {
                 .field(
                     "frontmatter",
                     &support::DebugOptionalElement(self.frontmatter()),
+                )
+                .field(
+                    "processing_instruction",
+                    &support::DebugOptionalElement(self.processing_instruction()),
                 )
                 .field(
                     "directive",
@@ -12239,11 +12241,6 @@ impl From<HtmlCdataSection> for AnyHtmlElement {
         Self::HtmlCdataSection(node)
     }
 }
-impl From<HtmlDirective> for AnyHtmlElement {
-    fn from(node: HtmlDirective) -> Self {
-        Self::HtmlDirective(node)
-    }
-}
 impl From<HtmlElement> for AnyHtmlElement {
     fn from(node: HtmlElement) -> Self {
         Self::HtmlElement(node)
@@ -12264,7 +12261,6 @@ impl AstNode for AnyHtmlElement {
     const KIND_SET: SyntaxKindSet<Language> = AnyHtmlContent::KIND_SET
         .union(HtmlBogusElement::KIND_SET)
         .union(HtmlCdataSection::KIND_SET)
-        .union(HtmlDirective::KIND_SET)
         .union(HtmlElement::KIND_SET)
         .union(HtmlProcessingInstruction::KIND_SET)
         .union(HtmlSelfClosingElement::KIND_SET);
@@ -12272,7 +12268,6 @@ impl AstNode for AnyHtmlElement {
         match kind {
             HTML_BOGUS_ELEMENT
             | HTML_CDATA_SECTION
-            | HTML_DIRECTIVE
             | HTML_ELEMENT
             | HTML_PROCESSING_INSTRUCTION
             | HTML_SELF_CLOSING_ELEMENT => true,
@@ -12284,7 +12279,6 @@ impl AstNode for AnyHtmlElement {
         let res = match syntax.kind() {
             HTML_BOGUS_ELEMENT => Self::HtmlBogusElement(HtmlBogusElement { syntax }),
             HTML_CDATA_SECTION => Self::HtmlCdataSection(HtmlCdataSection { syntax }),
-            HTML_DIRECTIVE => Self::HtmlDirective(HtmlDirective { syntax }),
             HTML_ELEMENT => Self::HtmlElement(HtmlElement { syntax }),
             HTML_PROCESSING_INSTRUCTION => {
                 Self::HtmlProcessingInstruction(HtmlProcessingInstruction { syntax })
@@ -12305,7 +12299,6 @@ impl AstNode for AnyHtmlElement {
         match self {
             Self::HtmlBogusElement(it) => it.syntax(),
             Self::HtmlCdataSection(it) => it.syntax(),
-            Self::HtmlDirective(it) => it.syntax(),
             Self::HtmlElement(it) => it.syntax(),
             Self::HtmlProcessingInstruction(it) => it.syntax(),
             Self::HtmlSelfClosingElement(it) => it.syntax(),
@@ -12316,7 +12309,6 @@ impl AstNode for AnyHtmlElement {
         match self {
             Self::HtmlBogusElement(it) => it.into_syntax(),
             Self::HtmlCdataSection(it) => it.into_syntax(),
-            Self::HtmlDirective(it) => it.into_syntax(),
             Self::HtmlElement(it) => it.into_syntax(),
             Self::HtmlProcessingInstruction(it) => it.into_syntax(),
             Self::HtmlSelfClosingElement(it) => it.into_syntax(),
@@ -12330,7 +12322,6 @@ impl std::fmt::Debug for AnyHtmlElement {
             Self::AnyHtmlContent(it) => std::fmt::Debug::fmt(it, f),
             Self::HtmlBogusElement(it) => std::fmt::Debug::fmt(it, f),
             Self::HtmlCdataSection(it) => std::fmt::Debug::fmt(it, f),
-            Self::HtmlDirective(it) => std::fmt::Debug::fmt(it, f),
             Self::HtmlElement(it) => std::fmt::Debug::fmt(it, f),
             Self::HtmlProcessingInstruction(it) => std::fmt::Debug::fmt(it, f),
             Self::HtmlSelfClosingElement(it) => std::fmt::Debug::fmt(it, f),
@@ -12343,7 +12334,6 @@ impl From<AnyHtmlElement> for SyntaxNode {
             AnyHtmlElement::AnyHtmlContent(it) => it.into_syntax(),
             AnyHtmlElement::HtmlBogusElement(it) => it.into_syntax(),
             AnyHtmlElement::HtmlCdataSection(it) => it.into_syntax(),
-            AnyHtmlElement::HtmlDirective(it) => it.into_syntax(),
             AnyHtmlElement::HtmlElement(it) => it.into_syntax(),
             AnyHtmlElement::HtmlProcessingInstruction(it) => it.into_syntax(),
             AnyHtmlElement::HtmlSelfClosingElement(it) => it.into_syntax(),

--- a/crates/biome_html_syntax/src/generated/nodes_mut.rs
+++ b/crates/biome_html_syntax/src/generated/nodes_mut.rs
@@ -588,22 +588,28 @@ impl HtmlRoot {
             once(element.map(|element| element.into_syntax().into())),
         ))
     }
-    pub fn with_directive(self, element: Option<HtmlDirective>) -> Self {
+    pub fn with_processing_instruction(self, element: Option<HtmlProcessingInstruction>) -> Self {
         Self::unwrap_cast(self.syntax.splice_slots(
             2usize..=2usize,
+            once(element.map(|element| element.into_syntax().into())),
+        ))
+    }
+    pub fn with_directive(self, element: Option<HtmlDirective>) -> Self {
+        Self::unwrap_cast(self.syntax.splice_slots(
+            3usize..=3usize,
             once(element.map(|element| element.into_syntax().into())),
         ))
     }
     pub fn with_html(self, element: HtmlElementList) -> Self {
         Self::unwrap_cast(
             self.syntax
-                .splice_slots(3usize..=3usize, once(Some(element.into_syntax().into()))),
+                .splice_slots(4usize..=4usize, once(Some(element.into_syntax().into()))),
         )
     }
     pub fn with_eof_token(self, element: SyntaxToken) -> Self {
         Self::unwrap_cast(
             self.syntax
-                .splice_slots(4usize..=4usize, once(Some(element.into()))),
+                .splice_slots(5usize..=5usize, once(Some(element.into()))),
         )
     }
 }

--- a/crates/biome_html_syntax/src/generated/nodes_mut.rs
+++ b/crates/biome_html_syntax/src/generated/nodes_mut.rs
@@ -418,34 +418,40 @@ impl HtmlDirective {
                 .splice_slots(2usize..=2usize, once(Some(element.into()))),
         )
     }
-    pub fn with_html_token(self, element: Option<SyntaxToken>) -> Self {
+    pub fn with_name_token(self, element: Option<SyntaxToken>) -> Self {
         Self::unwrap_cast(
             self.syntax
                 .splice_slots(3usize..=3usize, once(element.map(|element| element.into()))),
         )
     }
-    pub fn with_quirk_token(self, element: Option<SyntaxToken>) -> Self {
+    pub fn with_html_token(self, element: Option<SyntaxToken>) -> Self {
         Self::unwrap_cast(
             self.syntax
                 .splice_slots(4usize..=4usize, once(element.map(|element| element.into()))),
         )
     }
-    pub fn with_public_id_token(self, element: Option<SyntaxToken>) -> Self {
+    pub fn with_quirk_token(self, element: Option<SyntaxToken>) -> Self {
         Self::unwrap_cast(
             self.syntax
                 .splice_slots(5usize..=5usize, once(element.map(|element| element.into()))),
         )
     }
-    pub fn with_system_id_token(self, element: Option<SyntaxToken>) -> Self {
+    pub fn with_public_id_token(self, element: Option<SyntaxToken>) -> Self {
         Self::unwrap_cast(
             self.syntax
                 .splice_slots(6usize..=6usize, once(element.map(|element| element.into()))),
         )
     }
+    pub fn with_system_id_token(self, element: Option<SyntaxToken>) -> Self {
+        Self::unwrap_cast(
+            self.syntax
+                .splice_slots(7usize..=7usize, once(element.map(|element| element.into()))),
+        )
+    }
     pub fn with_r_angle_token(self, element: SyntaxToken) -> Self {
         Self::unwrap_cast(
             self.syntax
-                .splice_slots(7usize..=7usize, once(Some(element.into()))),
+                .splice_slots(8usize..=8usize, once(Some(element.into()))),
         )
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs
@@ -22,6 +22,7 @@ declare_lint_rule! {
     /// Check out React documentation for [explanation on the why does React need keys.](https://react.dev/learn/rendering-lists#why-does-react-need-keys)
     ///
     /// This rule is intended for use in both React and Qwik applications to prevent missing key props in JSX elements inside iterators.
+    /// It does not report diagnostics in Astro files.
     ///
     /// ## Examples
     ///

--- a/crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs
@@ -11,6 +11,7 @@ use biome_js_syntax::{
     JsCallArgumentList, JsCallArguments, JsCallExpression, JsFunctionBody, JsNewExpression,
     JsObjectExpression, JsStatementList, JsxAttributeList, JsxExpressionChild, JsxTagExpression,
 };
+use biome_languages::JsFileSource;
 use biome_rowan::{AstNode, AstNodeList, AstSeparatedList, TextRange, declare_node_union};
 use biome_rule_options::use_jsx_key_in_iterable::UseJsxKeyInIterableOptions;
 
@@ -87,6 +88,12 @@ impl Rule for UseJsxKeyInIterable {
         let node = ctx.query();
         let model = ctx.model();
         let options = ctx.options();
+        let file_source = ctx.source_type::<JsFileSource>();
+
+        if file_source.as_embedding_kind().is_astro() {
+            return vec![].into_boxed_slice();
+        }
+
         match node {
             UseJsxKeyInIterableQuery::JsArrayExpression(node) => {
                 handle_collections(node, model, options)
@@ -429,10 +436,9 @@ fn handle_jsx_child(
                     ranges.push(open_node.range());
                 }
             }
-            AnyJsxChild::JsxSelfClosingElement(node)
-                if !has_key_attribute(&node.attributes()) => {
-                    ranges.push(node.range());
-                }
+            AnyJsxChild::JsxSelfClosingElement(node) if !has_key_attribute(&node.attributes()) => {
+                ranges.push(node.range());
+            }
             AnyJsxChild::JsxExpressionChild(node) => {
                 let expr = node.expression()?;
                 if let Some(child_ranges) =
@@ -441,10 +447,9 @@ fn handle_jsx_child(
                     ranges.extend(child_ranges);
                 }
             }
-            AnyJsxChild::JsxFragment(node)
-                if options.check_shorthand_fragments() => {
-                    ranges.push(node.range())
-                }
+            AnyJsxChild::JsxFragment(node) if options.check_shorthand_fragments() => {
+                ranges.push(node.range())
+            }
             _ => {}
         }
     }

--- a/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/valid.astro
+++ b/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/valid.astro
@@ -1,0 +1,2 @@
+<!-- should not generate diagnostics -->
+<ul>{items.map((item) => <li>{item}</li>)}</ul>

--- a/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/valid.astro.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useJsxKeyInIterable/valid.astro.snap
@@ -1,0 +1,10 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.astro
+---
+# Input
+```astro
+<!-- should not generate diagnostics -->
+<ul>{items.map((item) => <li>{item}</li>)}</ul>
+
+```

--- a/xtask/codegen/html.ungram
+++ b/xtask/codegen/html.ungram
@@ -48,6 +48,7 @@ VueBogusDirectiveArgument = SyntaxElement*
 HtmlRoot =
 	bom: 'UNICODE_BOM'?
 	frontmatter: AnyAstroFrontmatterElement?
+	processing_instruction: HtmlProcessingInstruction?
 	directive: HtmlDirective?
 	html: HtmlElementList
 	eof: 'EOF'
@@ -74,7 +75,6 @@ HtmlElementList = AnyHtmlElement*
 AnyHtmlElement =
 	HtmlSelfClosingElement
 	| HtmlElement
-	| HtmlDirective
 	| AnyHtmlContent
 	| HtmlCdataSection
 	| HtmlProcessingInstruction

--- a/xtask/codegen/html.ungram
+++ b/xtask/codegen/html.ungram
@@ -52,12 +52,13 @@ HtmlRoot =
 	html: HtmlElementList
 	eof: 'EOF'
 
-// <!DOCTYPE html>
-// ^^^^^^^^^^^^^^^
+// <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN">
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 HtmlDirective =
 	'<'
 	'!'
 	doctype: 'doctype'
+	name: 'html_literal'?
 	html: 'html'?
 	quirk: 'html_literal'?
 	public_id: 'html_string_literal'?
@@ -73,6 +74,7 @@ HtmlElementList = AnyHtmlElement*
 AnyHtmlElement =
 	HtmlSelfClosingElement
 	| HtmlElement
+	| HtmlDirective
 	| AnyHtmlContent
 	| HtmlCdataSection
 	| HtmlProcessingInstruction


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

- Fixes a bug in our parser where `"PUBLIC"` wasn't correctly parsed in the doctype element.
- Fixes a bug where a JSX rule triggered for Astro files. That rule isn't valid in Astro.

Implemented via AI coding agent.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added new tests

<!-- What demonstrates that your implementation is correct? -->

## Docs

N/A

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
