### PR TITLE
fix(lint/css): treat math as a generic font family

### DIFF
--- a/.changeset/math-generic-font-family.md
+++ b/.changeset/math-generic-font-family.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11229](https://github.com/biomejs/biome/issues/11229): The [`useGenericFontNames`](https://biomejs.dev/linter/rules/use-generic-font-names/) rule now treats `math` as a valid generic font family.

--- a/crates/biome_css_analyze/tests/specs/a11y/useGenericFontNames/valid.css
+++ b/crates/biome_css_analyze/tests/specs/a11y/useGenericFontNames/valid.css
@@ -10,7 +10,7 @@ b { font-family: unset; }
 b { font-family: serif; }
 b { font-family: sans-serif; }
 b { font-family: math; }
-b { font-family: STIX Two Math, math; }
+b { font-family: "STIX Two Math", math; }
 b { font-family: Courier, monospace; }
 b { font: 1em/1.5 "Whatever Fanciness", cursive; }
 a { font-family: Helvetica Neue, sans-serif, Apple Color Emoji; }

--- a/crates/biome_css_analyze/tests/specs/a11y/useGenericFontNames/valid.css
+++ b/crates/biome_css_analyze/tests/specs/a11y/useGenericFontNames/valid.css
@@ -9,6 +9,8 @@ b { font-family: initial; }
 b { font-family: unset; }
 b { font-family: serif; }
 b { font-family: sans-serif; }
+b { font-family: math; }
+b { font-family: STIX Two Math, math; }
 b { font-family: Courier, monospace; }
 b { font: 1em/1.5 "Whatever Fanciness", cursive; }
 a { font-family: Helvetica Neue, sans-serif, Apple Color Emoji; }

--- a/crates/biome_css_analyze/tests/specs/a11y/useGenericFontNames/valid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/a11y/useGenericFontNames/valid.css.snap
@@ -16,7 +16,7 @@ b { font-family: unset; }
 b { font-family: serif; }
 b { font-family: sans-serif; }
 b { font-family: math; }
-b { font-family: STIX Two Math, math; }
+b { font-family: "STIX Two Math", math; }
 b { font-family: Courier, monospace; }
 b { font: 1em/1.5 "Whatever Fanciness", cursive; }
 a { font-family: Helvetica Neue, sans-serif, Apple Color Emoji; }

--- a/crates/biome_css_analyze/tests/specs/a11y/useGenericFontNames/valid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/a11y/useGenericFontNames/valid.css.snap
@@ -15,6 +15,8 @@ b { font-family: initial; }
 b { font-family: unset; }
 b { font-family: serif; }
 b { font-family: sans-serif; }
+b { font-family: math; }
+b { font-family: STIX Two Math, math; }
 b { font-family: Courier, monospace; }
 b { font: 1em/1.5 "Whatever Fanciness", cursive; }
 a { font-family: Helvetica Neue, sans-serif, Apple Color Emoji; }

--- a/crates/biome_css_syntax/src/keywords/mod.rs
+++ b/crates/biome_css_syntax/src/keywords/mod.rs
@@ -14,9 +14,10 @@ pub const SYSTEM_FAMILY_NAME_KEYWORDS: [&str; 6] = [
     "status-bar",
 ];
 
-pub const FONT_FAMILY_KEYWORDS: [&str; 10] = [
+pub const FONT_FAMILY_KEYWORDS: [&str; 11] = [
     "cursive",
     "fantasy",
+    "math",
     "monospace",
     "sans-serif",
     "serif",


### PR DESCRIPTION
## Summary

Fixes #11229.

`math` is a CSS Fonts Level 4 generic font family, but `useGenericFontNames` did not treat it as one, so declarations like `font-family: math` were incorrectly flagged as missing a generic fallback.

This adds `math` to `FONT_FAMILY_KEYWORDS` (kept sorted for `binary_search`) and covers it in the rule’s valid fixtures.

## Test Plan

- [x] `cargo test -p biome_css_syntax -- test_font_family_keywords_sorted`
- [x] `cargo test -p biome_css_analyze -- use_generic_font_names`

## Docs

No website docs PR needed; the rule now accepts the standard `math` keyword via the shared keyword list.

## AI assistance

AI assistance was used to navigate the codebase and draft the change. The fix, tests, and PR text were reviewed and verified by me before submission.