### PR TITLE
fix(useSimplifiedLogicExpression): suppress auto-fix for expr || false and expr && true

### DIFF
--- a/.changeset/fix-use-simplified-logic-expression-unsafe.md
+++ b/.changeset/fix-use-simplified-logic-expression-unsafe.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11351](https://github.com/biomejs/biome/issues/11351): [`useSimplifiedLogicExpression`](https://biomejs.dev/linter/rules/use-simplified-logic-expression/) now correctly marks the fix for `expr || false` and `expr && true` as unsafe. Previously the fix was marked safe, but it can change runtime behavior when the non-literal operand is not strictly boolean (e.g. `boolean | undefined`).

--- a/crates/biome_js_analyze/src/lint/complexity/use_simplified_logic_expression.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_simplified_logic_expression.rs
@@ -1,7 +1,7 @@
 use crate::JsRuleAction;
 use biome_analyze::{Ast, FixKind, Rule, RuleDiagnostic, context::RuleContext, declare_lint_rule};
 use biome_console::markup;
-use biome_diagnostics::Severity;
+use biome_diagnostics::{Applicability, Severity};
 use biome_js_factory::make;
 use biome_js_syntax::{
     AnyJsExpression, AnyJsLiteralExpression, JsBooleanLiteralExpression, JsLogicalExpression,
@@ -62,8 +62,13 @@ declare_lint_rule! {
 
 impl Rule for UseSimplifiedLogicExpression {
     type Query = Ast<JsLogicalExpression>;
-    /// First element of tuple is if the expression is simplified by [De Morgan's Law](https://en.wikipedia.org/wiki/De_Morgan%27s_laws) rule, the second element is the expression to replace.
-    type State = (bool, AnyJsExpression);
+    /// `(is_de_morgan, replacement_expression, is_safe)`
+    ///
+    /// - `is_de_morgan`: whether the simplification applies De Morgan's law
+    /// - `replacement_expression`: the expression to substitute for the logical expression
+    /// - `is_safe`: when `false`, the fix is `MaybeIncorrect` because the non-literal operand
+    ///   may not be boolean (e.g. `x || false` where `x: boolean | undefined`)
+    type State = (bool, AnyJsExpression, bool);
     type Signals = Option<Self::State>;
     type Options = UseSimplifiedLogicExpressionOptions;
 
@@ -80,26 +85,33 @@ impl Rule for UseSimplifiedLogicExpression {
                     )
                 ) =>
             {
-                return Some((false, right));
+                return Some((false, right, true));
             }
             biome_js_syntax::JsLogicalOperator::LogicalOr => {
                 if let AnyJsExpression::AnyJsLiteralExpression(
                     AnyJsLiteralExpression::JsBooleanLiteralExpression(literal),
                 ) = left
                 {
-                    return simplify_or_expression(literal, right).map(|expr| (false, expr));
+                    // `false || expr` → `expr` and `true || expr` → `true` are always safe.
+                    return simplify_or_expression(literal, right)
+                        .map(|expr| (false, expr, true));
                 }
 
                 if let AnyJsExpression::AnyJsLiteralExpression(
                     AnyJsLiteralExpression::JsBooleanLiteralExpression(literal),
                 ) = right
                 {
-                    return simplify_or_expression(literal, left).map(|expr| (false, expr));
+                    // `expr || true` → `true` is always safe (returns the literal, not expr).
+                    // `expr || false` → `expr` is only safe when `expr` is boolean; without
+                    // type information we cannot verify this, so the fix is MaybeIncorrect.
+                    let is_safe = literal_value(&literal)? != false;
+                    return simplify_or_expression(literal, left)
+                        .map(|expr| (false, expr, is_safe));
                 }
 
                 if could_apply_de_morgan(node).unwrap_or(false) {
                     return simplify_de_morgan(node)
-                        .map(|expr| (true, AnyJsExpression::JsUnaryExpression(expr)));
+                        .map(|expr| (true, AnyJsExpression::JsUnaryExpression(expr), true));
                 }
             }
             biome_js_syntax::JsLogicalOperator::LogicalAnd => {
@@ -107,19 +119,26 @@ impl Rule for UseSimplifiedLogicExpression {
                     AnyJsLiteralExpression::JsBooleanLiteralExpression(literal),
                 ) = left
                 {
-                    return simplify_and_expression(literal, right).map(|expr| (false, expr));
+                    // `true && expr` → `expr` and `false && expr` → `false` are always safe.
+                    return simplify_and_expression(literal, right)
+                        .map(|expr| (false, expr, true));
                 }
 
                 if let AnyJsExpression::AnyJsLiteralExpression(
                     AnyJsLiteralExpression::JsBooleanLiteralExpression(literal),
                 ) = right
                 {
-                    return simplify_and_expression(literal, left).map(|expr| (false, expr));
+                    // `expr && false` → `false` is always safe (returns the literal, not expr).
+                    // `expr && true` → `expr` is only safe when `expr` is boolean; without
+                    // type information we cannot verify this, so the fix is MaybeIncorrect.
+                    let is_safe = literal_value(&literal)? != true;
+                    return simplify_and_expression(literal, left)
+                        .map(|expr| (false, expr, is_safe));
                 }
 
                 if could_apply_de_morgan(node).unwrap_or(false) {
                     return simplify_de_morgan(node)
-                        .map(|expr| (true, AnyJsExpression::JsUnaryExpression(expr)));
+                        .map(|expr| (true, AnyJsExpression::JsUnaryExpression(expr), true));
                 }
             }
             _ => return None,
@@ -144,7 +163,7 @@ impl Rule for UseSimplifiedLogicExpression {
         let node = ctx.query();
         let mut mutation = ctx.root().begin();
 
-        let (is_simplified_by_de_morgan, expr) = state;
+        let (is_simplified_by_de_morgan, expr, is_safe) = state;
 
         mutation.replace_node(
             AnyJsExpression::JsLogicalExpression(node.clone()),
@@ -157,12 +176,26 @@ impl Rule for UseSimplifiedLogicExpression {
             "Discard redundant terms from the logical expression."
         };
 
+        let applicability = if *is_safe {
+            Applicability::Always
+        } else {
+            Applicability::MaybeIncorrect
+        };
+
         Some(JsRuleAction::new(
             ctx.metadata().action_category(ctx.category(), ctx.group()),
-            ctx.metadata().applicability(),
+            applicability,
             markup! { ""{message}"" }.to_owned(),
             mutation,
         ))
+    }
+}
+
+fn literal_value(literal: &JsBooleanLiteralExpression) -> Option<bool> {
+    match literal.value_token().ok()?.kind() {
+        T![true] => Some(true),
+        T![false] => Some(false),
+        _ => None,
     }
 }
 
@@ -205,11 +238,7 @@ fn keep_expression_if_literal(
     expression: AnyJsExpression,
     expected_value: bool,
 ) -> Option<AnyJsExpression> {
-    let eval_value = match literal.value_token().ok()?.kind() {
-        T![true] => true,
-        T![false] => false,
-        _ => return None,
-    };
+    let eval_value = literal_value(&literal)?;
     if eval_value == expected_value {
         Some(expression)
     } else {

--- a/crates/biome_js_analyze/src/lint/complexity/use_simplified_logic_expression.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_simplified_logic_expression.rs
@@ -1,7 +1,7 @@
 use crate::JsRuleAction;
 use biome_analyze::{Ast, FixKind, Rule, RuleDiagnostic, context::RuleContext, declare_lint_rule};
 use biome_console::markup;
-use biome_diagnostics::{Applicability, Severity};
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{
     AnyJsExpression, AnyJsLiteralExpression, JsBooleanLiteralExpression, JsLogicalExpression,
@@ -176,15 +176,16 @@ impl Rule for UseSimplifiedLogicExpression {
             "Discard redundant terms from the logical expression."
         };
 
-        let applicability = if *is_safe {
-            Applicability::Always
-        } else {
-            Applicability::MaybeIncorrect
-        };
+        if !is_safe {
+            // Without type information we cannot verify that the non-literal operand is
+            // boolean, so we suppress the auto-fix to avoid silently changing runtime
+            // behaviour (e.g. `x || false` where `x: boolean | undefined`).
+            return None;
+        }
 
         Some(JsRuleAction::new(
             ctx.metadata().action_category(ctx.category(), ctx.group()),
-            applicability,
+            ctx.metadata().applicability(),
             markup! { ""{message}"" }.to_owned(),
             mutation,
         ))

--- a/crates/biome_js_analyze/tests/specs/complexity/useSimplifiedLogicExpression/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/complexity/useSimplifiedLogicExpression/invalid.js
@@ -5,4 +5,4 @@ const nonNullExp = 123;
 const r3 = null ?? nonNullExp;
 const boolExpr1 = true;
 const boolExpr2 = false;
-const r4 = /*1*/ !boolExpr1 /*2*/  || /*3*/ !boolExpr2 /*4*/ 
+const r4 = /*1*/ !boolExpr1 /*2*/  || /*3*/ !boolExpr2 /*4*/

--- a/crates/biome_js_analyze/tests/specs/complexity/useSimplifiedLogicExpression/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useSimplifiedLogicExpression/invalid.js.snap
@@ -11,7 +11,7 @@ const nonNullExp = 123;
 const r3 = null ?? nonNullExp;
 const boolExpr1 = true;
 const boolExpr2 = false;
-const r4 = /*1*/ !boolExpr1 /*2*/  || /*3*/ !boolExpr2 /*4*/ 
+const r4 = /*1*/ !boolExpr1 /*2*/  || /*3*/ !boolExpr2 /*4*/
 
 ```
 
@@ -78,7 +78,7 @@ invalid.js:8:18 lint/complexity/useSimplifiedLogicExpression  FIXABLE  ━━━
   
     6 │ const boolExpr1 = true;
     7 │ const boolExpr2 = false;
-  > 8 │ const r4 = /*1*/ !boolExpr1 /*2*/  || /*3*/ !boolExpr2 /*4*/·
+  > 8 │ const r4 = /*1*/ !boolExpr1 /*2*/  || /*3*/ !boolExpr2 /*4*/
       │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     9 │ 
   
@@ -86,8 +86,8 @@ invalid.js:8:18 lint/complexity/useSimplifiedLogicExpression  FIXABLE  ━━━
   
     6 6 │   const boolExpr1 = true;
     7 7 │   const boolExpr2 = false;
-    8   │ - const·r4·=·/*1*/·!boolExpr1·/*2*/··||·/*3*/·!boolExpr2·/*4*/·
-      8 │ + const·r4·=·/*1*/·!(boolExpr1·/*2*/··&&·/*3*/·boolExpr2·/*4*/·)·/*4*/·
+    8   │ - const·r4·=·/*1*/·!boolExpr1·/*2*/··||·/*3*/·!boolExpr2·/*4*/
+      8 │ + const·r4·=·/*1*/·!(boolExpr1·/*2*/··&&·/*3*/·boolExpr2·/*4*/)·/*4*/
     9 9 │   
   
 

--- a/crates/biome_js_analyze/tests/specs/complexity/useSimplifiedLogicExpression/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/complexity/useSimplifiedLogicExpression/invalid.ts
@@ -1,0 +1,7 @@
+// should generate diagnostics
+// expr || false and expr && true produce diagnostics with unsafe fixes
+// because the non-literal operand may not be boolean (e.g. boolean | undefined).
+var x: boolean | undefined;
+var y: boolean;
+y = x || false;
+y = x && true;

--- a/crates/biome_js_analyze/tests/specs/complexity/useSimplifiedLogicExpression/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useSimplifiedLogicExpression/invalid.ts.snap
@@ -1,0 +1,53 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid.ts
+---
+# Input
+```ts
+// should generate diagnostics
+// expr || false and expr && true produce diagnostics with unsafe fixes
+// because the non-literal operand may not be boolean (e.g. boolean | undefined).
+var x: boolean | undefined;
+var y: boolean;
+y = x || false;
+y = x && true;
+
+```
+
+# Diagnostics
+```
+invalid.ts:6:5 lint/complexity/useSimplifiedLogicExpression  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Logical expression contains unnecessary complexity.
+  
+    4 │ var x: boolean | undefined;
+    5 │ var y: boolean;
+  > 6 │ y = x || false;
+      │     ^^^^^^^^^^
+    7 │ y = x && true;
+    8 │ 
+  
+  i Unsafe fix: Discard redundant terms from the logical expression.
+  
+    6 │ y·=·x·||·false;
+      │      --------- 
+
+```
+
+```
+invalid.ts:7:5 lint/complexity/useSimplifiedLogicExpression  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Logical expression contains unnecessary complexity.
+  
+    5 │ var y: boolean;
+    6 │ y = x || false;
+  > 7 │ y = x && true;
+      │     ^^^^^^^^^
+    8 │ 
+  
+  i Unsafe fix: Discard redundant terms from the logical expression.
+  
+    7 │ y·=·x·&&·true;
+      │      -------- 
+
+```

--- a/crates/biome_js_analyze/tests/specs/complexity/useSimplifiedLogicExpression/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useSimplifiedLogicExpression/invalid.ts.snap
@@ -16,7 +16,7 @@ y = x && true;
 
 # Diagnostics
 ```
-invalid.ts:6:5 lint/complexity/useSimplifiedLogicExpression  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:6:5 lint/complexity/useSimplifiedLogicExpression ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Logical expression contains unnecessary complexity.
   
@@ -27,15 +27,11 @@ invalid.ts:6:5 lint/complexity/useSimplifiedLogicExpression  FIXABLE  ━━━�
     7 │ y = x && true;
     8 │ 
   
-  i Unsafe fix: Discard redundant terms from the logical expression.
-  
-    6 │ y·=·x·||·false;
-      │      --------- 
 
 ```
 
 ```
-invalid.ts:7:5 lint/complexity/useSimplifiedLogicExpression  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:7:5 lint/complexity/useSimplifiedLogicExpression ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Logical expression contains unnecessary complexity.
   
@@ -45,9 +41,5 @@ invalid.ts:7:5 lint/complexity/useSimplifiedLogicExpression  FIXABLE  ━━━�
       │     ^^^^^^^^^
     8 │ 
   
-  i Unsafe fix: Discard redundant terms from the logical expression.
-  
-    7 │ y·=·x·&&·true;
-      │      -------- 
 
 ```


### PR DESCRIPTION
## Summary

Fixes #11351.

`useSimplifiedLogicExpression` was offering a **Safe fix** for `expr || false → expr` and `expr && true → expr`, but these simplifications are only correct when `expr` is strictly boolean. Without type information we cannot verify this, so the auto-fix can silently change runtime behaviour:

```ts
var x: boolean | undefined;
var y: boolean;
y = x || false; // y = false when x is undefined
y = x;          // y = undefined when x is undefined — different!
```

### Approach

Instead of mixing fix applicabilities (which Biome's rule design doesn't support), the auto-fix is **suppressed entirely** for the two problematic patterns:

- `expr || false` — diagnostic fires, no fix offered
- `expr && true` — diagnostic fires, no fix offered

All other patterns keep their existing **Safe fix**:
- `false || expr` → `expr` ✅ safe (identity law)
- `true || expr` → `true` ✅ safe
- `expr || true` → `true` ✅ safe (returns literal)
- `true && expr` → `expr` ✅ safe (identity law)
- `false && expr` → `false` ✅ safe
- `expr && false` → `false` ✅ safe (returns literal)
- De Morgan rewrites ✅ safe (logically equivalent)

### Changes

- `run()` now tracks `is_safe` (third element in `State`) for each pattern.
- `action()` returns `None` when `is_safe == false`, suppressing the fix.
- Removed unused `Applicability` import.
- Added `invalid.ts` test with `x: boolean | undefined` showing the diagnostic fires but no fix is offered.

## Test plan

- `cargo test -p biome_js_analyze` passes (3 tests: valid.js, invalid.js, invalid.ts all ok)
- Snapshot confirms no `FIXABLE` label or fix suggestion for `x || false` and `x && true`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)