### PR TITLE
refactor(analyze): avoid boxed rule state strings

### DIFF
--- a/crates/biome_css_analyze/src/lint/suspicious/no_shorthand_property_overrides.rs
+++ b/crates/biome_css_analyze/src/lint/suspicious/no_shorthand_property_overrides.rs
@@ -1,5 +1,3 @@
-#![expect(clippy::disallowed_methods, reason = "This rule stores property syntax that can span multiple tokens.")]
-
 use crate::utils::{get_longhand_sub_properties, get_reset_to_initial_properties, vender_prefix};
 use biome_analyze::{
     AddVisitor, Phases, QueryMatch, Queryable, Rule, RuleDiagnostic, RuleSource, ServiceBag,
@@ -8,7 +6,7 @@ use biome_analyze::{
 use biome_console::markup;
 use biome_css_syntax::{AnyCssDeclarationName, CssGenericProperty, CssLanguage, CssSyntaxKind};
 use biome_diagnostics::Severity;
-use biome_rowan::{AstNode, Language, SyntaxNode, TextRange, WalkEvent};
+use biome_rowan::{AstNode, Language, SyntaxNode, TextRange, TokenText, WalkEvent};
 use biome_rule_options::no_shorthand_property_overrides::NoShorthandPropertyOverridesOptions;
 
 declare_lint_rule! {
@@ -47,12 +45,13 @@ declare_lint_rule! {
 #[derive(Clone)]
 pub struct NoDeclarationBlockShorthandPropertyOverridesQuery {
     property_node: AnyCssDeclarationName,
-    override_property: Box<str>,
+    target_property: TokenText,
+    override_property: TokenText,
 }
 
 pub struct NoDeclarationBlockShorthandPropertyOverridesState {
-    target_property: Box<str>,
-    override_property: Box<str>,
+    target_property: TokenText,
+    override_property: TokenText,
     span: TextRange,
 }
 
@@ -66,7 +65,7 @@ impl Rule for NoShorthandPropertyOverrides {
         let query = ctx.query();
 
         Some(NoDeclarationBlockShorthandPropertyOverridesState {
-            target_property: query.property_node.to_trimmed_text().into(),
+            target_property: query.target_property.clone(),
             override_property: query.override_property.clone(),
             span: query.text_range(),
         })
@@ -78,7 +77,7 @@ impl Rule for NoShorthandPropertyOverrides {
                 rule_category!(),
                 state.span,
                 markup! {
-                    "This shorthand property "<Emphasis>{state.target_property}</Emphasis>" overrides the earlier "<Emphasis>{state.override_property}</Emphasis>" declaration."
+                    "This shorthand property "<Emphasis>{state.target_property.text()}</Emphasis>" overrides the earlier "<Emphasis>{state.override_property.text()}</Emphasis>" declaration."
                 },
             )
             .note(markup! {
@@ -128,9 +127,8 @@ fn get_override_props(property: &str) -> Vec<&str> {
     merged
 }
 
-#[derive(Default)]
 struct PriorProperty {
-    original: Box<str>,
+    original: TokenText,
     lowercase: Box<str>,
 }
 
@@ -155,8 +153,8 @@ impl Visitor for NoDeclarationBlockShorthandPropertyOverridesVisitor {
                 CssSyntaxKind::CSS_GENERIC_PROPERTY => {
                     if let Some(prop_node) = CssGenericProperty::cast_ref(node)
                         .and_then(|property_node| property_node.name().ok())
+                        && let Some(prop) = prop_node.identifier_text()
                     {
-                        let prop = prop_node.to_trimmed_text();
                         #[expect(clippy::disallowed_methods)]
                         let prop_lowercase = prop.to_lowercase();
 
@@ -175,6 +173,7 @@ impl Visitor for NoDeclarationBlockShorthandPropertyOverridesVisitor {
                                 ctx.match_query(
                                     NoDeclarationBlockShorthandPropertyOverridesQuery {
                                         property_node: prop_node.clone(),
+                                        target_property: prop.clone(),
                                         override_property: prior_prop.original.clone(),
                                     },
                                 );
@@ -182,7 +181,7 @@ impl Visitor for NoDeclarationBlockShorthandPropertyOverridesVisitor {
                         });
 
                         self.prior_props_in_block.push(PriorProperty {
-                            original: prop.into(),
+                            original: prop,
                             lowercase: prop_lowercase.into(),
                         });
                     }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_unknown_attribute.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_unknown_attribute.rs
@@ -5,7 +5,7 @@ use biome_diagnostics::Severity;
 use biome_js_syntax::AnyJsxAttributeName;
 use biome_js_syntax::{AnyJsxElementName, JsxAttribute, jsx_ext::AnyJsxElement};
 use biome_package::PackageJson;
-use biome_rowan::{AstNode, TokenText};
+use biome_rowan::{AstNode, Text, TokenText};
 use biome_rule_options::no_unknown_attribute::NoUnknownAttributeOptions;
 use camino::Utf8PathBuf;
 use rustc_hash::FxHashMap;
@@ -88,14 +88,14 @@ declare_lint_rule! {
 
 pub enum NoUnknownAttributeState {
     UnknownProp {
-        name: Box<str>,
+        name: Text,
     },
     UnknownPropWithStandardName {
-        name: Box<str>,
-        standard_name: Box<str>,
+        name: Text,
+        standard_name: &'static str,
     },
     InvalidPropOnTag {
-        name: Box<str>,
+        name: &'static str,
         tag_name: TokenText,
         allowed_tags: &'static [&'static str],
     },
@@ -127,13 +127,13 @@ impl Rule for NoUnknownAttribute {
         {
             return None;
         }
-        let name = if let Some(element) = DOM_PROPERTIES_IGNORE_CASE
+        let name: &str = if let Some(element) = DOM_PROPERTIES_IGNORE_CASE
             .iter()
             .find(|element| element.eq_ignore_ascii_case(&node_name))
         {
             element
         } else {
-            &node_name.text()
+            node_name.text()
         };
 
         let parent = node.syntax().parent()?.parent()?;
@@ -166,12 +166,10 @@ impl Rule for NoUnknownAttribute {
             return None;
         }
 
-        let allowed_tags = ATTRIBUTE_TAGS_LOOKUP.get(name);
-
-        if let Some(allowed_tags) = allowed_tags {
+        if let Some((&name, &allowed_tags)) = ATTRIBUTE_TAGS_LOOKUP.get_key_value(name) {
             if !allowed_tags.contains(&tag_name.trim()) {
                 return Some(NoUnknownAttributeState::InvalidPropOnTag {
-                    name: (*name).into(),
+                    name,
                     tag_name,
                     allowed_tags,
                 });
@@ -180,17 +178,17 @@ impl Rule for NoUnknownAttribute {
         }
 
         if let Some(standard_name) = get_standard_name(ctx, name) {
-            if standard_name != *name {
+            if standard_name != name {
                 return Some(NoUnknownAttributeState::UnknownPropWithStandardName {
-                    name: (*name).into(),
-                    standard_name: standard_name.into(),
+                    name: node_name,
+                    standard_name,
                 });
             }
             return None;
         }
 
         Some(NoUnknownAttributeState::UnknownProp {
-            name: (*name).into(),
+            name: node_name,
         })
     }
 
@@ -202,7 +200,7 @@ impl Rule for NoUnknownAttribute {
                     rule_category!(),
                     node.range(),
                     markup! {
-                        "The property '"{name}"' is not a valid DOM attribute."
+                        "The property '"{name.text()}"' is not a valid DOM attribute."
                     },
                 )
                 .note(markup! {
@@ -220,14 +218,14 @@ impl Rule for NoUnknownAttribute {
                     rule_category!(),
                     node.range(),
                     markup! {
-                        "Property '"{name}"' is not a valid React prop name."
+                        "Property '"{name.text()}"' is not a valid React prop name."
                     },
                 )
                 .note(markup! {
                     "React uses camelCased props, while HTML uses kebab-cased attributes."
                 })
                 .note(markup! {
-                        "Use '"{standard_name}"' instead of '"{name}"' for React components."
+                        "Use '"{standard_name}"' instead of '"{name.text()}"' for React components."
                 }),
             ),
             NoUnknownAttributeState::InvalidPropOnTag {


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
A simple refactor for a couple rules to avoid forced string allocations in rule state.

If benches show an improvement I'll include a changeset.

implemented by gpt 5.6 sol

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
green ci, no snapshot changes

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
