### PR TITLE
feat(tailwind): add top-level detection configuration

### DIFF
--- a/crates/biome_analyze/src/options.rs
+++ b/crates/biome_analyze/src/options.rs
@@ -83,6 +83,9 @@ pub struct AnalyzerConfiguration {
     /// The JSX fragment factory function identifier (e.g., "Fragment")
     /// Only applies when jsx_runtime is ReactClassic.
     jsx_fragment_factory: Option<Box<str>>,
+
+    /// Configures which attributes and functions contain Tailwind classes.
+    tailwind: TailwindOptions,
 }
 
 impl AnalyzerConfiguration {
@@ -128,6 +131,11 @@ impl AnalyzerConfiguration {
         preferred_indentation: PreferredIndentation,
     ) -> Self {
         self.preferred_indentation = preferred_indentation;
+        self
+    }
+
+    pub fn with_tailwind(mut self, tailwind: TailwindOptions) -> Self {
+        self.tailwind = tailwind;
         self
     }
 }
@@ -230,6 +238,43 @@ impl AnalyzerOptions {
 
     pub fn preferred_indentation(&self) -> PreferredIndentation {
         self.configuration.preferred_indentation
+    }
+
+    pub fn tailwind(&self) -> &TailwindOptions {
+        &self.configuration.tailwind
+    }
+}
+
+/// User-provided names that Tailwind-aware analyzer queries use to identify class strings.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TailwindOptions {
+    attributes: Option<Arc<[Box<str>]>>,
+    functions: Option<Arc<[Box<str>]>>,
+}
+
+impl TailwindOptions {
+    /// Creates analyzer options from optional replacement lists.
+    pub fn new(attributes: Option<Box<[Box<str>]>>, functions: Option<Box<[Box<str>]>>) -> Self {
+        Self {
+            attributes: attributes.map(Arc::from),
+            functions: functions.map(Arc::from),
+        }
+    }
+
+    /// Returns the configured attribute replacement list, or `None` when language defaults apply.
+    pub fn attributes(&self) -> Option<&[Box<str>]> {
+        self.attributes.as_deref()
+    }
+
+    /// Returns the configured function replacement list, or `None` when defaults apply.
+    pub fn functions(&self) -> Option<&[Box<str>]> {
+        self.functions.as_deref()
+    }
+}
+
+impl Default for TailwindOptions {
+    fn default() -> Self {
+        Self::new(None, None)
     }
 }
 

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -27,6 +27,7 @@ pub mod json;
 pub mod markdown;
 pub mod max_size;
 mod overrides;
+pub mod tailwind;
 pub mod vcs;
 #[cfg(feature = "lang_yaml")]
 pub mod yaml;
@@ -57,6 +58,7 @@ pub use crate::markdown::MarkdownConfiguration;
 #[cfg(all(feature = "cli", feature = "lang_md"))]
 pub use crate::markdown::markdown_configuration;
 use crate::max_size::MaxSize;
+pub use crate::tailwind::TailwindConfiguration;
 use crate::vcs::VcsConfiguration;
 #[cfg(feature = "cli")]
 use crate::vcs::vcs_configuration;
@@ -185,6 +187,11 @@ pub struct Configuration {
     #[cfg_attr(feature = "cli", bpaf(external(linter_configuration), optional))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub linter: Option<LinterConfiguration>,
+
+    /// Configures how Biome recognizes Tailwind class strings.
+    #[cfg_attr(feature = "cli", bpaf(hide, pure(Default::default())))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tailwind: Option<TailwindConfiguration>,
 
     /// Configuration specific to JavaScript.
     #[cfg(feature = "lang_js")]

--- a/crates/biome_configuration/src/tailwind.rs
+++ b/crates/biome_configuration/src/tailwind.rs
@@ -1,0 +1,28 @@
+use biome_analyze::options::TailwindOptions;
+use biome_deserialize_macros::{Deserializable, Merge};
+use serde::{Deserialize, Serialize};
+
+/// Configures how Biome recognizes Tailwind class strings.
+#[derive(Clone, Debug, Default, Deserialize, Deserializable, Eq, Merge, PartialEq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields, default)]
+pub struct TailwindConfiguration {
+    /// Attribute names whose values contain Tailwind classes.
+    ///
+    /// Defaults to `class` for HTML and to `class` and `className` for JSX.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attributes: Option<Box<[Box<str>]>>,
+
+    /// Function and tagged-template names whose arguments contain Tailwind classes.
+    ///
+    /// Defaults to `clsx`, `tw`, `twMerge`, `twJoin`, `cva`, `tv`, `cn`, `cc`,
+    /// `cnb`, and `ctl`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub functions: Option<Box<[Box<str>]>>,
+}
+
+impl From<TailwindConfiguration> for TailwindOptions {
+    fn from(configuration: TailwindConfiguration) -> Self {
+        Self::new(configuration.attributes, configuration.functions)
+    }
+}

--- a/crates/biome_html_analyze/src/lint/nursery/use_tailwind_shorthand_classes.rs
+++ b/crates/biome_html_analyze/src/lint/nursery/use_tailwind_shorthand_classes.rs
@@ -42,6 +42,17 @@ declare_lint_rule! {
     /// <div class="size-4"></div>
     /// ```
     ///
+    /// Configure the recognized attributes with the top-level `tailwind` configuration.
+    /// Specified arrays replace the defaults.
+    ///
+    /// ```json
+    /// {
+    ///     "tailwind": {
+    ///         "attributes": ["class", "classList"]
+    ///     }
+    /// }
+    /// ```
+    ///
     /// ## Known limitations
     ///
     /// This rule currently doesn't check bare strings inside framework-specific class collections,

--- a/crates/biome_html_analyze/tests/specs/nursery/useTailwindShorthandClasses/custom-attribute.html
+++ b/crates/biome_html_analyze/tests/specs/nursery/useTailwindShorthandClasses/custom-attribute.html
@@ -1,1 +1,2 @@
+<!-- should generate diagnostics -->
 <div data-classes="px-2 py-2"></div>

--- a/crates/biome_html_analyze/tests/specs/nursery/useTailwindShorthandClasses/custom-attribute.html.snap
+++ b/crates/biome_html_analyze/tests/specs/nursery/useTailwindShorthandClasses/custom-attribute.html.snap
@@ -4,6 +4,41 @@ expression: custom-attribute.html
 ---
 # Input
 ```html
+<!-- should generate diagnostics -->
 <div data-classes="px-2 py-2"></div>
+
+```
+
+# Diagnostics
+```
+custom-attribute.html:2:20 lint/nursery/useTailwindShorthandClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
+
+  × These Tailwind classes can be replaced with a shorthand class.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <div data-classes="px-2 py-2"></div>
+      │                    ^^^^
+    3 │ 
+  
+  i Compressible utility used here.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <div data-classes="px-2 py-2"></div>
+      │                         ^^^^
+    3 │ 
+  
+  i Using fewer classes reduces duplication and improves readability.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/11342 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Unsafe fix: Use the Tailwind shorthand classes.
+  
+    1 1 │   <!-- should generate diagnostics -->
+    2   │ - <div·data-classes="px-2·py-2"></div>
+      2 │ + <div·data-classes="p-2"></div>
+    3 3 │   
+  
 
 ```

--- a/crates/biome_html_analyze/tests/specs/nursery/useTailwindShorthandClasses/custom-attribute.options.json
+++ b/crates/biome_html_analyze/tests/specs/nursery/useTailwindShorthandClasses/custom-attribute.options.json
@@ -1,0 +1,13 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"tailwind": {
+		"attributes": ["data-classes"]
+	},
+	"linter": {
+		"rules": {
+			"nursery": {
+				"useTailwindShorthandClasses": "error"
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/src/lint/nursery/use_tailwind_shorthand_classes.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_tailwind_shorthand_classes.rs
@@ -61,6 +61,17 @@ declare_lint_rule! {
     /// - `ctl`
     ///
     /// Tagged template members like `tw.div` are also checked when their base function name is recognized.
+    /// Configure the recognized attributes and functions with the top-level `tailwind` configuration.
+    /// Specified arrays replace the defaults.
+    ///
+    /// ```json
+    /// {
+    ///     "tailwind": {
+    ///         "attributes": ["class", "className", "classList"],
+    ///         "functions": ["clsx", "tw"]
+    ///     }
+    /// }
+    /// ```
     ///
     /// ## Known limitations
     ///

--- a/crates/biome_js_analyze/src/shared/any_class_string_like.rs
+++ b/crates/biome_js_analyze/src/shared/any_class_string_like.rs
@@ -4,6 +4,7 @@
 //! various AST nodes that can contain CSS class strings (string literals,
 //! JSX strings, template chunks, etc.).
 
+use biome_analyze::options::TailwindOptions;
 use biome_js_syntax::{
     AnyJsExpression, JsCallArguments, JsCallExpression, JsLiteralMemberName,
     JsStringLiteralExpression, JsSyntaxNode, JsTemplateChunkElement, JsTemplateExpression,
@@ -70,12 +71,12 @@ impl ClassStringOptions for NoTailwindArbitraryValueOptions {
 }
 
 impl TailwindClassStringHost for AnyClassStringLike {
-    fn tailwind_class_string(&self) -> Option<TailwindClassString> {
+    fn tailwind_class_string(&self, options: &TailwindOptions) -> Option<TailwindClassString> {
         match self {
-            Self::JsStringLiteralExpression(node) => node.tailwind_class_string(),
-            Self::JsxString(node) => node.tailwind_class_string(),
-            Self::JsTemplateChunkElement(node) => node.tailwind_class_string(),
-            Self::JsLiteralMemberName(node) => node.tailwind_class_string(),
+            Self::JsStringLiteralExpression(node) => node.tailwind_class_string(options),
+            Self::JsxString(node) => node.tailwind_class_string(options),
+            Self::JsTemplateChunkElement(node) => node.tailwind_class_string(options),
+            Self::JsLiteralMemberName(node) => node.tailwind_class_string(options),
         }
     }
 }

--- a/crates/biome_js_analyze/tests/specs/nursery/useTailwindShorthandClasses/with-functions.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/useTailwindShorthandClasses/with-functions.jsx
@@ -1,3 +1,6 @@
-const button = cn("px-2 py-2");
+/* should generate diagnostics */
+const button = cx("px-2 py-2");
 
 const card = tw.div`overflow-hidden text-ellipsis whitespace-nowrap`;
+
+const spaced = tw /* comment */ .div`px-2 py-2`;

--- a/crates/biome_js_analyze/tests/specs/nursery/useTailwindShorthandClasses/with-functions.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useTailwindShorthandClasses/with-functions.jsx.snap
@@ -4,29 +4,34 @@ expression: with-functions.jsx
 ---
 # Input
 ```jsx
-const button = cn("px-2 py-2");
+/* should generate diagnostics */
+const button = cx("px-2 py-2");
 
 const card = tw.div`overflow-hidden text-ellipsis whitespace-nowrap`;
+
+const spaced = tw /* comment */ .div`px-2 py-2`;
 
 ```
 
 # Diagnostics
 ```
-with-functions.jsx:1:20 lint/nursery/useTailwindShorthandClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━
+with-functions.jsx:2:20 lint/nursery/useTailwindShorthandClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i These Tailwind classes can be replaced with a shorthand class.
   
-  > 1 │ const button = cn("px-2 py-2");
+    1 │ /* should generate diagnostics */
+  > 2 │ const button = cx("px-2 py-2");
       │                    ^^^^
-    2 │ 
-    3 │ const card = tw.div`overflow-hidden text-ellipsis whitespace-nowrap`;
+    3 │ 
+    4 │ const card = tw.div`overflow-hidden text-ellipsis whitespace-nowrap`;
   
   i Compressible utility used here.
   
-  > 1 │ const button = cn("px-2 py-2");
+    1 │ /* should generate diagnostics */
+  > 2 │ const button = cx("px-2 py-2");
       │                         ^^^^
-    2 │ 
-    3 │ const card = tw.div`overflow-hidden text-ellipsis whitespace-nowrap`;
+    3 │ 
+    4 │ const card = tw.div`overflow-hidden text-ellipsis whitespace-nowrap`;
   
   i Using fewer classes reduces duplication and improves readability.
   
@@ -36,40 +41,44 @@ with-functions.jsx:1:20 lint/nursery/useTailwindShorthandClasses  FIXABLE  ━�
   
   i Unsafe fix: Use the Tailwind shorthand classes.
   
-    1   │ - const·button·=·cn("px-2·py-2");
-      1 │ + const·button·=·cn("p-2");
-    2 2 │   
-    3 3 │   const card = tw.div`overflow-hidden text-ellipsis whitespace-nowrap`;
+    1 1 │   /* should generate diagnostics */
+    2   │ - const·button·=·cx("px-2·py-2");
+      2 │ + const·button·=·cx("p-2");
+    3 3 │   
+    4 4 │   const card = tw.div`overflow-hidden text-ellipsis whitespace-nowrap`;
   
 
 ```
 
 ```
-with-functions.jsx:3:21 lint/nursery/useTailwindShorthandClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━
+with-functions.jsx:4:21 lint/nursery/useTailwindShorthandClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i These Tailwind classes can be replaced with a shorthand class.
   
-    1 │ const button = cn("px-2 py-2");
-    2 │ 
-  > 3 │ const card = tw.div`overflow-hidden text-ellipsis whitespace-nowrap`;
+    2 │ const button = cx("px-2 py-2");
+    3 │ 
+  > 4 │ const card = tw.div`overflow-hidden text-ellipsis whitespace-nowrap`;
       │                     ^^^^^^^^^^^^^^^
-    4 │ 
+    5 │ 
+    6 │ const spaced = tw /* comment */ .div`px-2 py-2`;
   
   i Compressible utility used here.
   
-    1 │ const button = cn("px-2 py-2");
-    2 │ 
-  > 3 │ const card = tw.div`overflow-hidden text-ellipsis whitespace-nowrap`;
+    2 │ const button = cx("px-2 py-2");
+    3 │ 
+  > 4 │ const card = tw.div`overflow-hidden text-ellipsis whitespace-nowrap`;
       │                                     ^^^^^^^^^^^^^
-    4 │ 
+    5 │ 
+    6 │ const spaced = tw /* comment */ .div`px-2 py-2`;
   
   i Compressible utility used here.
   
-    1 │ const button = cn("px-2 py-2");
-    2 │ 
-  > 3 │ const card = tw.div`overflow-hidden text-ellipsis whitespace-nowrap`;
+    2 │ const button = cx("px-2 py-2");
+    3 │ 
+  > 4 │ const card = tw.div`overflow-hidden text-ellipsis whitespace-nowrap`;
       │                                                   ^^^^^^^^^^^^^^^^^
-    4 │ 
+    5 │ 
+    6 │ const spaced = tw /* comment */ .div`px-2 py-2`;
   
   i Using fewer classes reduces duplication and improves readability.
   
@@ -79,11 +88,48 @@ with-functions.jsx:3:21 lint/nursery/useTailwindShorthandClasses  FIXABLE  ━�
   
   i Unsafe fix: Use the Tailwind shorthand classes.
   
-    1 1 │   const button = cn("px-2 py-2");
-    2 2 │   
-    3   │ - const·card·=·tw.div`overflow-hidden·text-ellipsis·whitespace-nowrap`;
-      3 │ + const·card·=·tw.div`truncate`;
-    4 4 │   
+    2 2 │   const button = cx("px-2 py-2");
+    3 3 │   
+    4   │ - const·card·=·tw.div`overflow-hidden·text-ellipsis·whitespace-nowrap`;
+      4 │ + const·card·=·tw.div`truncate`;
+    5 5 │   
+    6 6 │   const spaced = tw /* comment */ .div`px-2 py-2`;
+  
+
+```
+
+```
+with-functions.jsx:6:38 lint/nursery/useTailwindShorthandClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i These Tailwind classes can be replaced with a shorthand class.
+  
+    4 │ const card = tw.div`overflow-hidden text-ellipsis whitespace-nowrap`;
+    5 │ 
+  > 6 │ const spaced = tw /* comment */ .div`px-2 py-2`;
+      │                                      ^^^^
+    7 │ 
+  
+  i Compressible utility used here.
+  
+    4 │ const card = tw.div`overflow-hidden text-ellipsis whitespace-nowrap`;
+    5 │ 
+  > 6 │ const spaced = tw /* comment */ .div`px-2 py-2`;
+      │                                           ^^^^
+    7 │ 
+  
+  i Using fewer classes reduces duplication and improves readability.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/11342 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Unsafe fix: Use the Tailwind shorthand classes.
+  
+    4 4 │   const card = tw.div`overflow-hidden text-ellipsis whitespace-nowrap`;
+    5 5 │   
+    6   │ - const·spaced·=·tw·/*·comment·*/·.div`px-2·py-2`;
+      6 │ + const·spaced·=·tw·/*·comment·*/·.div`p-2`;
+    7 7 │   
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/useTailwindShorthandClasses/with-functions.options.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/useTailwindShorthandClasses/with-functions.options.json
@@ -1,0 +1,13 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"tailwind": {
+		"functions": ["cx", "tw"]
+	},
+	"linter": {
+		"rules": {
+			"nursery": {
+				"useTailwindShorthandClasses": "error"
+			}
+		}
+	}
+}

--- a/crates/biome_service/src/file_handlers/html.rs
+++ b/crates/biome_service/src/file_handlers/html.rs
@@ -234,8 +234,9 @@ impl ServiceLanguage for HtmlLanguage {
         _file_source: &super::DocumentFileSource,
         suppression_reason: Option<&str>,
     ) -> AnalyzerOptions {
-        let configuration =
-            AnalyzerConfiguration::default().with_rules(to_analyzer_rules(global, path.as_path()));
+        let configuration = AnalyzerConfiguration::default()
+            .with_rules(to_analyzer_rules(global, path.as_path()))
+            .with_tailwind(global.tailwind.clone());
 
         AnalyzerOptions::default()
             .with_file_path(path.as_path())

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -479,6 +479,7 @@ impl ServiceLanguage for JsLanguage {
         let configuration = configuration
             .with_rules(to_analyzer_rules(global, path.as_path()))
             .with_globals(globals)
+            .with_tailwind(global.tailwind.clone())
             .with_preferred_quote(preferred_quote)
             .with_preferred_jsx_quote(preferred_jsx_quote)
             .with_preferred_indentation(preferred_indentation);

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -1,6 +1,6 @@
 use crate::workspace::{FeatureKind, ScanKind};
 use crate::{WorkspaceError, is_dir};
-use biome_analyze::{AnalyzerOptions, AnalyzerRules};
+use biome_analyze::{AnalyzerOptions, AnalyzerRules, options::TailwindOptions};
 #[cfg(feature = "lang_css")]
 use biome_configuration::CssConfiguration;
 #[cfg(feature = "lang_js")]
@@ -98,6 +98,9 @@ pub struct Settings {
     /// The VCS settings of the project
     pub vcs_settings: VcsSettings,
 
+    /// Settings used to recognize Tailwind class strings.
+    pub tailwind: TailwindOptions,
+
     // TODO: remove once HTML full support is stable
     #[cfg(feature = "lang_html")]
     pub experimental_full_html_support: Option<ExperimentalFullSupportEnabled>,
@@ -181,6 +184,10 @@ impl Settings {
                     .map(|p| p.as_path().to_path_buf()),
                 linter,
             )?;
+        }
+
+        if let Some(tailwind) = configuration.tailwind {
+            self.tailwind = tailwind.into();
         }
 
         // assist part

--- a/crates/biome_tailwind_logic/src/syntax_service.rs
+++ b/crates/biome_tailwind_logic/src/syntax_service.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 use biome_analyze::{
     AddVisitor, DiagnosticSignal, FromServices, Phase, Phases, QueryMatch, Queryable, RuleCategory,
     RuleKey, RuleMetadata, ServiceBag, ServicesDiagnostic, SignalEntry, SignalRuleKey, Visitor,
-    VisitorContext,
+    VisitorContext, options::TailwindOptions,
 };
 use biome_console::markup;
 use biome_diagnostics::{Diagnostic, MessageAndDescription, panic::catch_unwind};
@@ -168,7 +168,7 @@ fn parse_with_inner(
 }
 
 pub trait TailwindClassStringHost: AstNode {
-    fn tailwind_class_string(&self) -> Option<TailwindClassString>;
+    fn tailwind_class_string(&self, options: &TailwindOptions) -> Option<TailwindClassString>;
 }
 
 #[derive(Clone)]
@@ -177,11 +177,14 @@ pub struct TailwindSyntax<N> {
     parse: Rc<TailwindParse>,
 }
 
-pub struct TailwindSyntaxMatch<L: Language>(SyntaxNode<L>);
+pub struct TailwindSyntaxMatch<L: Language> {
+    node: SyntaxNode<L>,
+    class_string: TailwindClassString,
+}
 
 impl<L: Language + 'static> QueryMatch for TailwindSyntaxMatch<L> {
     fn text_range(&self) -> TextRange {
-        self.0.text_trimmed_range()
+        self.node.text_trimmed_range()
     }
 }
 
@@ -254,18 +257,17 @@ where
     }
 
     fn unwrap_match(services: &ServiceBag, node: &Self::Input) -> Self::Output {
-        let node = N::unwrap_cast(node.0.clone());
-        let class_string = node
-            .tailwind_class_string()
-            // SAFETY: The visitor emits matches only for nodes that host a Tailwind class string.
-            .expect("TailwindSyntaxVisitor only emits Tailwind class strings");
+        let ast_node = N::unwrap_cast(node.node.clone());
         let parse = services
             .get_service::<TwSyntaxService>()
             // SAFETY: TailwindSyntaxServices requires this service before the rule can run.
             .expect("TwSyntaxService service is not registered")
-            .parse_for_query(&class_string);
+            .parse_for_query(&node.class_string);
 
-        Self { node, parse }
+        Self {
+            node: ast_node,
+            parse,
+        }
     }
 }
 
@@ -320,7 +322,7 @@ where
         let Some(ast_node) = N::cast_ref(node) else {
             return;
         };
-        let Some(class_string) = ast_node.tailwind_class_string() else {
+        let Some(class_string) = ast_node.tailwind_class_string(ctx.options.tailwind()) else {
             return;
         };
         let Some(service) = ctx.services.get_service::<TwSyntaxService>() else {
@@ -340,7 +342,10 @@ where
         if parsed.should_emit_diagnostics {
             emit_parse_diagnostics(&mut ctx, &class_string, parsed.parse.diagnostics());
         }
-        ctx.match_query(TailwindSyntaxMatch(node.clone()));
+        ctx.match_query(TailwindSyntaxMatch {
+            node: node.clone(),
+            class_string,
+        });
     }
 }
 
@@ -368,12 +373,113 @@ fn emit_parse_diagnostics<L: Language>(
     }
 }
 
+fn matches_function_pattern(pattern: &str, name: &str) -> bool {
+    let mut pattern_parts = pattern.split('.');
+    let mut name_parts = name.split('.');
+    let all_parts_match = pattern_parts
+        .by_ref()
+        .zip(name_parts.by_ref())
+        .all(|(pattern, name)| pattern == "*" || pattern == name);
+    all_parts_match && pattern_parts.next().is_none() && name_parts.next().is_none()
+}
+
 const DEFAULT_FUNCTIONS: [&str; 10] = [
     "clsx", "tw", "twMerge", "twJoin", "cva", "tv", "cn", "cc", "cnb", "ctl",
 ];
 
-fn is_default_function(name: &str) -> bool {
-    DEFAULT_FUNCTIONS.contains(&name)
+fn is_tailwind_function(options: &TailwindOptions, name: &str) -> bool {
+    if let Some(functions) = options.functions() {
+        functions
+            .iter()
+            .any(|pattern| matches_function_pattern(pattern, name))
+    } else {
+        DEFAULT_FUNCTIONS
+            .iter()
+            .any(|pattern| matches_function_pattern(pattern, name))
+    }
+}
+
+fn matches_static_member_function_pattern(
+    pattern: &str,
+    static_member_expression: &JsStaticMemberExpression,
+) -> bool {
+    let mut current = static_member_expression.clone();
+
+    if !pattern.contains('.') {
+        loop {
+            let Ok(object) = current.object() else {
+                return false;
+            };
+            if let Some(identifier) = object.as_js_identifier_expression() {
+                let Ok(name) = identifier.name() else {
+                    return false;
+                };
+                let Ok(name) = name.name() else {
+                    return false;
+                };
+                return pattern == "*" || pattern == name.text();
+            }
+            let Some(static_member) = object.as_js_static_member_expression() else {
+                return false;
+            };
+            current = static_member.clone();
+        }
+    }
+
+    let mut pattern_parts = pattern.rsplit('.');
+    loop {
+        let Some(pattern_part) = pattern_parts.next() else {
+            return false;
+        };
+        let Ok(member) = current.member() else {
+            return false;
+        };
+        let Some(member) = member.as_js_name() else {
+            return false;
+        };
+        let Ok(member) = member.value_token() else {
+            return false;
+        };
+        if pattern_part != "*" && pattern_part != member.text_trimmed() {
+            return false;
+        }
+
+        let Ok(object) = current.object() else {
+            return false;
+        };
+        if let Some(identifier) = object.as_js_identifier_expression() {
+            let Ok(name) = identifier.name() else {
+                return false;
+            };
+            let Ok(name) = name.name() else {
+                return false;
+            };
+            let Some(pattern_part) = pattern_parts.next() else {
+                return false;
+            };
+            return (pattern_part == "*" || pattern_part == name.text())
+                && pattern_parts.next().is_none();
+        }
+        let Some(static_member) = object.as_js_static_member_expression() else {
+            return false;
+        };
+        current = static_member.clone();
+    }
+}
+
+fn is_tailwind_static_member_function(
+    options: &TailwindOptions,
+    static_member_expression: &JsStaticMemberExpression,
+) -> bool {
+    if let Some(functions) = options.functions() {
+        functions.iter().any(|pattern| {
+            matches_static_member_function_pattern(pattern, static_member_expression)
+        })
+    } else {
+        DEFAULT_FUNCTIONS.iter().any(|pattern| {
+            matches_static_member_function_pattern(pattern, static_member_expression)
+        })
+    }
 }
 
 fn get_callee_name(call_expression: &JsCallExpression) -> Option<TokenText> {
@@ -387,25 +493,28 @@ fn get_callee_name(call_expression: &JsCallExpression) -> Option<TokenText> {
         .ok()
 }
 
-fn is_call_expression_of_default_function(call_expression: &JsCallExpression) -> bool {
-    get_callee_name(call_expression).is_some_and(|name| is_default_function(name.text()))
+fn is_call_expression_of_configured_function(
+    call_expression: &JsCallExpression,
+    options: &TailwindOptions,
+) -> bool {
+    if let Some(name) = get_callee_name(call_expression) {
+        return is_tailwind_function(options, name.text());
+    }
+
+    let Ok(callee) = call_expression.callee() else {
+        return false;
+    };
+    let Some(callee) = callee.as_js_static_member_expression() else {
+        return false;
+    };
+    is_tailwind_static_member_function(options, callee)
 }
 
-fn is_static_member_expression_of_default_function(
+fn is_static_member_expression_of_configured_function(
     static_member_expression: &JsStaticMemberExpression,
-) -> Option<bool> {
-    let mut current = static_member_expression.object().ok()?;
-    loop {
-        if let Some(identifier) = current.as_js_identifier_expression() {
-            let name = identifier.name().ok()?.name().ok()?;
-            return Some(is_default_function(name.text()));
-        }
-        if let Some(static_member) = current.as_js_static_member_expression() {
-            current = static_member.object().ok()?;
-            continue;
-        }
-        return Some(false);
-    }
+    options: &TailwindOptions,
+) -> bool {
+    is_tailwind_static_member_function(options, static_member_expression)
 }
 
 fn get_jsx_attribute_name(attribute: &JsxAttribute) -> Option<TokenText> {
@@ -420,24 +529,35 @@ fn get_jsx_attribute_name(attribute: &JsxAttribute) -> Option<TokenText> {
     )
 }
 
-fn is_class_attribute_name(name: &str) -> bool {
-    matches!(name, "class" | "className")
+fn is_configured_attribute(options: &TailwindOptions, name: &str) -> bool {
+    options.attributes().map_or_else(
+        || matches!(name, "class" | "className"),
+        |attributes| {
+            attributes
+                .iter()
+                .any(|attribute| attribute.as_ref() == name)
+        },
+    )
 }
 
-fn inspect_string_literal(node: &SyntaxNode<JsLanguage>) -> Option<bool> {
+fn inspect_string_literal(
+    node: &SyntaxNode<JsLanguage>,
+    options: &TailwindOptions,
+) -> Option<bool> {
     let mut in_arguments = false;
     for ancestor in node.ancestors().skip(1) {
         if let Some(jsx_attribute) = JsxAttribute::cast_ref(&ancestor) {
             let Some(attribute_name) = get_jsx_attribute_name(&jsx_attribute) else {
                 continue;
             };
-            if is_class_attribute_name(attribute_name.text()) {
+            if is_configured_attribute(options, attribute_name.text()) {
                 return Some(true);
             }
         }
 
         if let Some(call_expression) = JsCallExpression::cast_ref(&ancestor) {
-            return in_arguments.then(|| is_call_expression_of_default_function(&call_expression));
+            return in_arguments
+                .then(|| is_call_expression_of_configured_function(&call_expression, options));
         }
 
         if JsCallArguments::can_cast(ancestor.kind()) {
@@ -462,8 +582,8 @@ fn tailwind_class_string(
 }
 
 impl TailwindClassStringHost for JsStringLiteralExpression {
-    fn tailwind_class_string(&self) -> Option<TailwindClassString> {
-        if !inspect_string_literal(self.syntax()).unwrap_or(false) {
+    fn tailwind_class_string(&self, options: &TailwindOptions) -> Option<TailwindClassString> {
+        if !inspect_string_literal(self.syntax(), options).unwrap_or(false) {
             return None;
         }
         tailwind_class_string(
@@ -476,8 +596,8 @@ impl TailwindClassStringHost for JsStringLiteralExpression {
 }
 
 impl TailwindClassStringHost for JsLiteralMemberName {
-    fn tailwind_class_string(&self) -> Option<TailwindClassString> {
-        if !inspect_string_literal(self.syntax()).unwrap_or(false) {
+    fn tailwind_class_string(&self, options: &TailwindOptions) -> Option<TailwindClassString> {
+        if !inspect_string_literal(self.syntax(), options).unwrap_or(false) {
             return None;
         }
         tailwind_class_string(
@@ -490,14 +610,14 @@ impl TailwindClassStringHost for JsLiteralMemberName {
 }
 
 impl TailwindClassStringHost for JsxString {
-    fn tailwind_class_string(&self) -> Option<TailwindClassString> {
+    fn tailwind_class_string(&self, options: &TailwindOptions) -> Option<TailwindClassString> {
         let jsx_attribute = self
             .syntax()
             .ancestors()
             .skip(1)
             .find_map(JsxAttribute::cast)?;
         let name = get_jsx_attribute_name(&jsx_attribute)?;
-        if !is_class_attribute_name(name.text()) {
+        if !is_configured_attribute(options, name.text()) {
             return None;
         }
         tailwind_class_string(
@@ -510,14 +630,14 @@ impl TailwindClassStringHost for JsxString {
 }
 
 impl TailwindClassStringHost for JsTemplateChunkElement {
-    fn tailwind_class_string(&self) -> Option<TailwindClassString> {
+    fn tailwind_class_string(&self, options: &TailwindOptions) -> Option<TailwindClassString> {
         for ancestor in self.syntax().ancestors().skip(1) {
             if let Some(template_expression) = JsTemplateExpression::cast_ref(&ancestor) {
                 if let Some(AnyJsExpression::JsIdentifierExpression(tag)) =
                     template_expression.tag()
                 {
                     let name = tag.name().ok()?.name().ok()?;
-                    if is_default_function(name.text()) {
+                    if is_tailwind_function(options, name.text()) {
                         return Some(tailwind_class_string(
                             self.template_chunk_token().ok()?.token_text(),
                             self.template_chunk_token()
@@ -530,7 +650,7 @@ impl TailwindClassStringHost for JsTemplateChunkElement {
                 }
                 if let Some(AnyJsExpression::JsStaticMemberExpression(tag)) =
                     template_expression.tag()
-                    && is_static_member_expression_of_default_function(&tag).unwrap_or(false)
+                    && is_static_member_expression_of_configured_function(&tag, options)
                 {
                     return Some(tailwind_class_string(
                         self.template_chunk_token().ok()?.token_text(),
@@ -545,7 +665,7 @@ impl TailwindClassStringHost for JsTemplateChunkElement {
                 let Some(attribute_name) = get_jsx_attribute_name(&jsx_attribute) else {
                     continue;
                 };
-                if is_class_attribute_name(attribute_name.text()) {
+                if is_configured_attribute(options, attribute_name.text()) {
                     return Some(tailwind_class_string(
                         self.template_chunk_token().ok()?.token_text(),
                         self.template_chunk_token()
@@ -563,9 +683,17 @@ impl TailwindClassStringHost for JsTemplateChunkElement {
 }
 
 impl TailwindClassStringHost for HtmlAttribute {
-    fn tailwind_class_string(&self) -> Option<TailwindClassString> {
+    fn tailwind_class_string(&self, options: &TailwindOptions) -> Option<TailwindClassString> {
         let name = self.name().ok()?.value_token().ok()?;
-        if !name.text_trimmed().eq_ignore_ascii_case("class") {
+        let is_tailwind_attribute = options.attributes().map_or_else(
+            || name.text_trimmed().eq_ignore_ascii_case("class"),
+            |attributes| {
+                attributes
+                    .iter()
+                    .any(|attribute| attribute.as_ref().eq_ignore_ascii_case(name.text_trimmed()))
+            },
+        );
+        if !is_tailwind_attribute {
             return None;
         }
         let html_string = self.html_string()?;

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -78,6 +78,10 @@ project. By default, this is `true`.
 	 */
 	root?: Bool;
 	/**
+	 * Configures how Biome recognizes Tailwind class strings.
+	 */
+	tailwind?: TailwindConfiguration;
+	/**
 	 * The version control integration configuration.
 	 */
 	vcs?: VcsConfiguration;
@@ -376,6 +380,24 @@ match these patterns.
 export type Overrides = OverridePattern[];
 export type Plugins = PluginConfiguration[];
 export type Bool = boolean;
+/**
+ * Configures how Biome recognizes Tailwind class strings.
+ */
+export interface TailwindConfiguration {
+	/**
+	* Attribute names whose values contain Tailwind classes.
+
+Defaults to `class` for HTML and to `class` and `className` for JSX. 
+	 */
+	attributes?: string[];
+	/**
+	* Function and tagged-template names whose arguments contain Tailwind classes.
+
+Defaults to `clsx`, `tw`, `twMerge`, `twJoin`, `cva`, `tv`, `cn`, `cc`,
+`cnb`, and `ctl`. 
+	 */
+	functions?: string[];
+}
 /**
  * Settings for integrating Biome with version control.
  */

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -67,6 +67,10 @@
 			"description": "Indicates whether this configuration file is at the root of a Biome\nproject. By default, this is `true`.",
 			"anyOf": [{ "$ref": "#/$defs/Bool" }, { "type": "null" }]
 		},
+		"tailwind": {
+			"description": "Configures how Biome recognizes Tailwind class strings.",
+			"anyOf": [{ "$ref": "#/$defs/TailwindConfiguration" }, { "type": "null" }]
+		},
 		"vcs": {
 			"description": "The version control integration configuration.",
 			"anyOf": [{ "$ref": "#/$defs/VcsConfiguration" }, { "type": "null" }]
@@ -14860,6 +14864,23 @@
 						{ "$ref": "#/$defs/UseStrictModeConfiguration" },
 						{ "type": "null" }
 					]
+				}
+			},
+			"additionalProperties": false
+		},
+		"TailwindConfiguration": {
+			"description": "Configures how Biome recognizes Tailwind class strings.",
+			"type": "object",
+			"properties": {
+				"attributes": {
+					"description": "Attribute names whose values contain Tailwind classes.\n\nDefaults to `class` for HTML and to `class` and `className` for JSX.",
+					"type": ["array", "null"],
+					"items": { "type": "string" }
+				},
+				"functions": {
+					"description": "Function and tagged-template names whose arguments contain Tailwind classes.\n\nDefaults to `clsx`, `tw`, `twMerge`, `twJoin`, `cva`, `tv`, `cn`, `cc`,\n`cnb`, and `ctl`.",
+					"type": ["array", "null"],
+					"items": { "type": "string" }
 				}
 			},
 			"additionalProperties": false


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
    Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
    Please provide enough information so that others can review your PR.
    Once created, your PR will be automatically labeled according to changed files.
    Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This adds top level configuration for tailwind. The goal is to allow users to define, in one place, configuration that applies to all tailwind rules. For now, its just configuration for where to look for tailwind classes.

implemented by gpt 5.6 sol

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
TODO

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>