### PR TITLE
fix(useStrictMode): ignore Vue event handlers

### DIFF
--- a/.changeset/eager-pears-give.md
+++ b/.changeset/eager-pears-give.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11207](https://github.com/biomejs/biome/issues/11207): [`useStrictMode`](https://biomejs.dev/linter/rules/use-strict-mode/) no longer reports Vue event handlers such as `@click="count++"`.

--- a/crates/biome_js_analyze/src/lint/suspicious/use_strict_mode.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/use_strict_mode.rs
@@ -6,6 +6,7 @@ use biome_analyze::{
 use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_factory::make::{js_directive, js_directive_list, token};
+use biome_languages::JsFileSource;
 use biome_js_syntax::{JsScript, JsSyntaxKind, JsSyntaxToken, T};
 use biome_rowan::{AstNode, AstNodeList, BatchMutationExt, TriviaPieceKind};
 use biome_rule_options::use_strict_mode::UseStrictModeOptions;
@@ -53,6 +54,14 @@ impl Rule for UseStrictMode {
     type Options = UseStrictModeOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        if ctx
+            .source_type::<JsFileSource>()
+            .as_embedding_kind()
+            .is_vue_event_handler()
+        {
+            return None;
+        }
+
         let node = ctx.query();
 
         if node.directives().is_empty() && node.statements().is_empty() {

--- a/crates/biome_js_analyze/tests/specs/suspicious/useStrictMode/valid-vue-event-handler.vue
+++ b/crates/biome_js_analyze/tests/specs/suspicious/useStrictMode/valid-vue-event-handler.vue
@@ -1,0 +1,5 @@
+<!-- should not generate diagnostics -->
+<template>
+  <button @click="count++">Increment</button>
+  <button v-on:click="count++">Increment</button>
+</template>

--- a/crates/biome_js_analyze/tests/specs/suspicious/useStrictMode/valid-vue-event-handler.vue.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/useStrictMode/valid-vue-event-handler.vue.snap
@@ -1,0 +1,13 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid-vue-event-handler.vue
+---
+# Input
+```vue
+<!-- should not generate diagnostics -->
+<template>
+  <button @click="count++">Increment</button>
+  <button v-on:click="count++">Increment</button>
+</template>
+
+```


### PR DESCRIPTION
## Summary

Fixes #11207.

`useStrictMode` incorrectly reported Vue event handlers, which may contain inline statements and are not standalone scripts. This change makes the rule ignore Vue event handlers while preserving its existing behavior for regular JavaScript.

## Test Plan

Added regression tests covering both Vue event directive syntaxes:

- `@click="count++"`
- `v-on:click="count++"`

## Docs

No additional documentation is needed. This user-visible lint behavior fix is documented by the included patch changeset.

Codex assisted with issue triage, code analysis, implementation, and testing. I personally reviewed the diff and verification results.
