### PR TITLE
fix(service): preserve embedded references in stateless processing

### DIFF
--- a/.changeset/cuddly-boxes-end.md
+++ b/.changeset/cuddly-boxes-end.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11389](https://github.com/biomejs/biome/issues/11389): Files passed through `--stdin-file-path` now use full HTML support for Astro, Svelte, and Vue when it is enabled.

--- a/crates/biome_cli/tests/cases/mod.rs
+++ b/crates/biome_cli/tests/cases/mod.rs
@@ -46,6 +46,7 @@ mod reporter_sarif;
 mod reporter_summary;
 mod reporter_terminal;
 mod rules_via_dependencies;
+mod stdin_full_support;
 mod suppressions;
 mod tailwind_directives;
 mod type_inference_profile;

--- a/crates/biome_cli/tests/cases/stdin_full_support.rs
+++ b/crates/biome_cli/tests/cases/stdin_full_support.rs
@@ -1,0 +1,149 @@
+use crate::run_cli;
+use crate::snap_test::markup_to_string;
+use biome_console::{BufferConsole, markup};
+use biome_fs::MemoryFileSystem;
+use bpaf::Args;
+
+const CONFIG: &str = r#"{
+    "html": {
+        "experimentalFullSupportEnabled": true,
+        "formatter": { "enabled": true }
+    },
+    "linter": {
+        "rules": { "style": { "useImportType": "on" } }
+    }
+}"#;
+
+const CASES: &[(&str, &str)] = &[
+    (
+        "+page.svelte",
+        r#"<script lang="ts">
+import Modal from "./Modal.svelte"
+let myModal: Modal
+</script>
+<Modal bind:this={myModal} />"#,
+    ),
+    (
+        "Component.vue",
+        r#"<script setup lang="ts">
+import Modal from "./Modal.vue"
+let myModal: Modal
+</script>
+<template><Modal ref="myModal" /></template>"#,
+    ),
+    (
+        "Component.astro",
+        r#"---
+import Modal from "./Modal.astro"
+let myModal: Modal
+---
+<Modal />"#,
+    ),
+];
+
+#[test]
+fn stdin_full_support_uses_framework_markup_references() {
+    for &(path, input) in CASES {
+        let fs = MemoryFileSystem::default();
+        fs.insert("biome.json".into(), CONFIG.as_bytes());
+        let mut console = BufferConsole::default();
+        console.in_buffer.push(input.to_string());
+
+        let (_, result) = run_cli(
+            fs,
+            &mut console,
+            Args::from(
+                [
+                    "check",
+                    "--write",
+                    "--formatter-enabled=false",
+                    "--stdin-file-path",
+                    path,
+                ]
+                .as_slice(),
+            ),
+        );
+
+        assert!(result.is_ok(), "run_cli returned {result:?} for {path}");
+        let message = console
+            .out_buffer
+            .first()
+            .unwrap_or_else(|| panic!("Console should have written a message for {path}"));
+        let content = markup_to_string(markup! {
+            {message.content}
+        });
+        assert!(content.contains("import Modal from"), "{path}: {content}");
+        assert!(
+            !content.contains("import type Modal from"),
+            "{path}: {content}"
+        );
+    }
+}
+
+#[test]
+fn stdin_full_support_uses_vue_custom_directive_references() {
+    let fs = MemoryFileSystem::default();
+    fs.insert("biome.json".into(), CONFIG.as_bytes());
+    let mut console = BufferConsole::default();
+    console.in_buffer.push(
+        r#"<script setup>
+import vClickOutside from "./v-click-outside.js"
+</script>
+<template><div v-click-outside /></template>"#
+            .to_string(),
+    );
+
+    let (_, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(
+            [
+                "lint",
+                "--write",
+                "--unsafe",
+                "--only=correctness/noUnusedImports",
+                "--stdin-file-path",
+                "Component.vue",
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+    let message = console
+        .out_buffer
+        .first()
+        .expect("Console should have written a message");
+    let content = markup_to_string(markup! {
+        {message.content}
+    });
+    assert!(content.contains("import vClickOutside from"), "{content}");
+}
+
+#[test]
+fn stdin_full_support_formats_vue_markup() {
+    let fs = MemoryFileSystem::default();
+    fs.insert("biome.json".into(), CONFIG.as_bytes());
+    let mut console = BufferConsole::default();
+    console.in_buffer.push(
+        r#"<script setup>const value=1;</script>
+<template><div class="foo">{{ value }}</div></template>"#
+            .to_string(),
+    );
+
+    let (_, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["format", "--stdin-file-path", "Component.vue"].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+    let message = console
+        .out_buffer
+        .first()
+        .expect("Console should have written a message");
+    let content = markup_to_string(markup! {
+        {message.content}
+    });
+    assert!(content.contains("<template>\n"), "{content}");
+}

--- a/crates/biome_embeds/src/data.rs
+++ b/crates/biome_embeds/src/data.rs
@@ -1,0 +1,102 @@
+use crate::bindings::EmbeddedBinding;
+use crate::references::{
+    EmbeddedTypeReference, EmbeddedValueReference, is_potential_vue_directive_reference,
+    svelte_store_reference_name, vue_directive_name_matches_reference_name,
+};
+
+/// Bindings and references collected across a host document and its embedded
+/// language snippets.
+///
+/// Binding and ordinary reference queries compare identifier text exactly.
+/// Framework-specific queries apply Svelte store and Vue custom-directive
+/// naming rules.
+#[derive(Debug, Default)]
+pub struct EmbeddedData {
+    /// Bindings created in embedded documents
+    bindings: Vec<EmbeddedBinding>,
+    /// Refernces that are used as values
+    value_references: Vec<EmbeddedValueReference>,
+    /// References that are only used in type contexts
+    type_references: Vec<EmbeddedTypeReference>,
+}
+
+impl EmbeddedData {
+    pub(crate) fn new(
+        bindings: Vec<EmbeddedBinding>,
+        value_references: Vec<EmbeddedValueReference>,
+        type_references: Vec<EmbeddedTypeReference>,
+    ) -> Self {
+        Self {
+            bindings,
+            value_references,
+            type_references,
+        }
+    }
+
+    /// Returns whether a collected binding has the identifier text `name`.
+    pub fn contains_binding(&self, name: &str) -> bool {
+        self.bindings
+            .iter()
+            .any(|binding| binding.text.text() == name)
+    }
+
+    /// Returns whether a collected value reference has the identifier text
+    /// `name`.
+    pub fn is_used_as_value(&self, name: &str) -> bool {
+        self.value_references
+            .iter()
+            .any(|reference| reference.text.text() == name)
+    }
+
+    /// Returns whether a collected type reference has the identifier text
+    /// `name`.
+    pub fn is_used_as_type(&self, name: &str) -> bool {
+        self.type_references
+            .iter()
+            .any(|reference| reference.text.text() == name)
+    }
+
+    /// Returns whether a collected value or type reference has the identifier
+    /// text `name`.
+    pub fn is_used(&self, name: &str) -> bool {
+        self.is_used_as_value(name) || self.is_used_as_type(name)
+    }
+
+    /// Returns whether a Svelte value reference uses the store named `name`
+    /// through its `$`-prefixed auto-subscription.
+    pub fn is_svelte_store_used(&self, name: &str) -> bool {
+        self.value_references.iter().any(|reference| {
+            svelte_store_reference_name(reference.text.text())
+                .is_some_and(|store_name| store_name == name)
+        })
+    }
+
+    /// Returns whether a collected Vue custom-directive reference resolves to
+    /// the JavaScript binding named `name`.
+    pub fn is_vue_directive_used(&self, name: &str) -> bool {
+        is_potential_vue_directive_reference(name)
+            && self.value_references.iter().any(|reference| {
+                vue_directive_name_matches_reference_name(reference.text.text(), name)
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use biome_rowan::{RawSyntaxKind, TextRange, TokenText};
+
+    #[test]
+    fn is_vue_directive_used_finds_custom_directive() {
+        let data = EmbeddedData::new(
+            Vec::new(),
+            vec![EmbeddedValueReference {
+                range: TextRange::default(),
+                text: TokenText::new_raw(RawSyntaxKind(0), "v-click-outside"),
+            }],
+            Vec::new(),
+        );
+
+        assert!(data.is_vue_directive_used("vClickOutside"));
+    }
+}

--- a/crates/biome_embeds/src/lib.rs
+++ b/crates/biome_embeds/src/lib.rs
@@ -1,3 +1,7 @@
 pub mod bindings;
+mod data;
 pub mod references;
 pub(crate) mod visitor;
+
+pub use data::EmbeddedData;
+pub use visitor::{EmbeddedSnippet, collect_embedded_data};

--- a/crates/biome_embeds/src/references.rs
+++ b/crates/biome_embeds/src/references.rs
@@ -99,7 +99,7 @@ pub fn is_svelte_store_reference_used(
         })
 }
 
-fn svelte_store_reference_name(reference_name: &str) -> Option<&str> {
+pub(crate) fn svelte_store_reference_name(reference_name: &str) -> Option<&str> {
     // These are special Svelte runes that are not valid store names, so we should ignore them.
     const SVELTE_RUNES: [&str; 7] = [
         "$bindable",
@@ -154,7 +154,7 @@ pub fn is_vue_directive_reference_used(
 
 /// Returns `true` if `reference_name` starts with `v` followed by an uppercase letter
 /// or digit, which is the naming convention for Vue custom directives (e.g. `vHighlight`).
-fn is_potential_vue_directive_reference(reference_name: &str) -> bool {
+pub(crate) fn is_potential_vue_directive_reference(reference_name: &str) -> bool {
     matches!(
         reference_name.as_bytes(),
         [b'v', b'A'..=b'Z' | b'0'..=b'9', ..]
@@ -164,7 +164,10 @@ fn is_potential_vue_directive_reference(reference_name: &str) -> bool {
 /// Returns `true` if `directive_name` starts with `v-` and its camelCase
 /// form matches `reference_name` (e.g. `v-highlight` matches `vHighlight`),
 /// without allocating.
-fn vue_directive_name_matches_reference_name(directive_name: &str, reference_name: &str) -> bool {
+pub(crate) fn vue_directive_name_matches_reference_name(
+    directive_name: &str,
+    reference_name: &str,
+) -> bool {
     if !directive_name.starts_with("v-") {
         return false;
     }

--- a/crates/biome_embeds/src/visitor.rs
+++ b/crates/biome_embeds/src/visitor.rs
@@ -1,4 +1,5 @@
 use crate::bindings::EmbeddedBinding;
+use crate::data::EmbeddedData;
 use crate::references::{EmbeddedTypeReference, EmbeddedValueReference};
 use biome_db::ParsedSource;
 use biome_html_syntax::{
@@ -20,9 +21,58 @@ use biome_js_syntax::{
 };
 use biome_languages::html::HtmlVariant;
 use biome_languages::javascript::{JsEmbeddingKind, SvelteEmbeddingKind};
-use biome_languages::{HtmlFileSource, JsFileSource, LanguageDb};
+use biome_languages::{DocumentFileSource, HtmlFileSource, JsFileSource, LanguageDb};
+use biome_parser::AnyParse;
 use biome_rowan::{AstNode, AstSeparatedList, TextRange, TokenText, WalkEvent};
 use std::collections::VecDeque;
+
+/// A parsed embedded-language snippet, its source language, and its location
+/// in the host document.
+pub struct EmbeddedSnippet<'a> {
+    parse: &'a AnyParse,
+    content_range: TextRange,
+    file_source: DocumentFileSource,
+}
+
+impl<'a> EmbeddedSnippet<'a> {
+    /// Creates a snippet whose `content_range` uses host-document offsets and
+    /// whose `file_source` describes `parse`.
+    pub fn new(
+        parse: &'a AnyParse,
+        content_range: TextRange,
+        file_source: DocumentFileSource,
+    ) -> Self {
+        Self {
+            parse,
+            content_range,
+            file_source,
+        }
+    }
+}
+
+/// Collects bindings and references that cross language boundaries in a host
+/// document and its embedded snippets.
+///
+/// `host_source` must describe `host_parse`. Each snippet must satisfy the
+/// contract of [`EmbeddedSnippet::new`].
+pub fn collect_embedded_data<'a>(
+    host_source: DocumentFileSource,
+    host_parse: &AnyParse,
+    snippets: Vec<EmbeddedSnippet<'a>>,
+) -> EmbeddedData {
+    let bindings = collect_embedded_bindings(host_source, host_parse, &snippets);
+    let references = collect_embedded_references(host_source, host_parse, &snippets);
+
+    EmbeddedData::new(
+        bindings,
+        references
+            .as_ref()
+            .map_or_else(Vec::new, build_value_references),
+        references
+            .as_ref()
+            .map_or_else(Vec::new, build_type_references),
+    )
+}
 
 #[derive(Debug, Default, Clone, Copy)]
 enum EmbeddedBlockKind {
@@ -65,11 +115,36 @@ pub fn embedded_bindings_from_source(
     let Some(host_source) = db.source_from_index(file.document_source_index(db)) else {
         return Vec::new();
     };
+    let snippets = file
+        .snippets(db)
+        .iter()
+        .filter_map(|snippet| {
+            let file_source = db.source_from_index(snippet.document_source_index(db))?;
+            Some(EmbeddedSnippet::new(
+                snippet.parsed(db),
+                snippet.content_range(db),
+                file_source,
+            ))
+        })
+        .collect::<Vec<_>>();
+
+    vec![collect_embedded_bindings(
+        host_source,
+        file.parsed(db),
+        &snippets,
+    )]
+}
+
+fn collect_embedded_bindings(
+    host_source: DocumentFileSource,
+    host_parse: &AnyParse,
+    snippets: &[EmbeddedSnippet],
+) -> Vec<EmbeddedBinding> {
     let Some(host_file_source) = host_source.to_html_file_source() else {
         return Vec::new();
     };
 
-    let html_root: HtmlRoot = file.parsed(db).tree();
+    let html_root: HtmlRoot = host_parse.tree();
     let mut builder = EmbeddedBindingsBuilder::new();
 
     if host_file_source.is_vue() {
@@ -78,39 +153,34 @@ pub fn embedded_bindings_from_source(
         builder.visit_svelte_html_root(&html_root);
     }
 
-    for snippet in file.snippets(db) {
-        let Some(file_source) = db.source_from_index(snippet.document_source_index(db)) else {
-            continue;
-        };
-        let Some(js_file_source) = file_source.to_js_file_source() else {
+    for snippet in snippets {
+        let Some(js_file_source) = snippet.file_source.to_js_file_source() else {
             continue;
         };
 
         if js_file_source.is_embedded_source()
             || host_file_source.is_svelte()
-            || is_script_element_snippet(&html_root, snippet.content_range(db))
+            || is_script_element_snippet(&html_root, snippet.content_range)
         {
             let block_kind = block_kind_from_js_source(&js_file_source)
-                .or_else(|| block_kind_for_snippet(&html_root, snippet.content_range(db)));
+                .or_else(|| block_kind_for_snippet(&html_root, snippet.content_range));
             builder.visit_js_source_snippet(
-                &snippet.parsed(db).tree(),
+                &snippet.parse.tree(),
                 &host_file_source,
                 block_kind.as_ref(),
             );
         }
     }
 
-    vec![
-        builder
-            .js_bindings
-            .into_iter()
-            .map(|(range, text, source)| EmbeddedBinding {
-                range,
-                text,
-                source,
-            })
-            .collect(),
-    ]
+    builder
+        .js_bindings
+        .into_iter()
+        .map(|(range, text, source)| EmbeddedBinding {
+            range,
+            text,
+            source,
+        })
+        .collect()
 }
 
 #[salsa::tracked(returns(ref))]
@@ -118,17 +188,11 @@ pub fn embedded_references_from_source(
     db: &dyn LanguageDb,
     file: ParsedSource,
 ) -> Vec<Vec<EmbeddedValueReference>> {
-    let Some(builder) = collect_embedded_references(db, file) else {
+    let Some(builder) = collect_embedded_references_from_source(db, file) else {
         return Vec::new();
     };
 
-    vec![
-        builder
-            .value_references
-            .into_iter()
-            .map(|(range, text)| EmbeddedValueReference { range, text })
-            .collect(),
-    ]
+    vec![build_value_references(&builder)]
 }
 
 #[salsa::tracked(returns(ref))]
@@ -136,35 +200,47 @@ pub fn embedded_type_references_from_source(
     db: &dyn LanguageDb,
     file: ParsedSource,
 ) -> Vec<Vec<EmbeddedTypeReference>> {
-    let Some(builder) = collect_embedded_references(db, file) else {
+    let Some(builder) = collect_embedded_references_from_source(db, file) else {
         return Vec::new();
     };
 
-    vec![
-        builder
-            .type_references
-            .into_iter()
-            .map(|(range, text)| EmbeddedTypeReference { range, text })
-            .collect(),
-    ]
+    vec![build_type_references(&builder)]
 }
 
-fn collect_embedded_references(
+fn collect_embedded_references_from_source(
     db: &dyn LanguageDb,
     file: ParsedSource,
 ) -> Option<EmbeddedReferencesBuilder> {
     let host_source = db.source_from_index(file.document_source_index(db))?;
+    let snippets = file
+        .snippets(db)
+        .iter()
+        .filter_map(|snippet| {
+            let file_source = db.source_from_index(snippet.document_source_index(db))?;
+            Some(EmbeddedSnippet::new(
+                snippet.parsed(db),
+                snippet.content_range(db),
+                file_source,
+            ))
+        })
+        .collect::<Vec<_>>();
+
+    collect_embedded_references(host_source, file.parsed(db), &snippets)
+}
+
+fn collect_embedded_references(
+    host_source: DocumentFileSource,
+    host_parse: &AnyParse,
+    snippets: &[EmbeddedSnippet],
+) -> Option<EmbeddedReferencesBuilder> {
     let is_svelte = host_source
         .to_html_file_source()
         .is_some_and(|s| s.is_svelte());
 
     let mut builder = EmbeddedReferencesBuilder::new();
 
-    for snippet in file.snippets(db) {
-        let Some(file_source) = db.source_from_index(snippet.document_source_index(db)) else {
-            continue;
-        };
-        let Some(js_file_source) = file_source.to_js_file_source() else {
+    for snippet in snippets {
+        let Some(js_file_source) = snippet.file_source.to_js_file_source() else {
             continue;
         };
         // Templates always; for Svelte also the sibling `<script>` blocks.
@@ -172,18 +248,40 @@ fn collect_embedded_references(
         // one module and share a top-level scope, so a binding used only in
         // the other block must still count as used.
         if !js_file_source.is_embedded_source() || is_svelte {
-            builder.visit_non_source_snippet(&snippet.parsed(db).tree(), &js_file_source);
+            builder.visit_non_source_snippet(&snippet.parse.tree(), &js_file_source);
         }
     }
 
     if let Some(html_file_source) = host_source.to_html_file_source()
         && html_file_source.supports_components()
     {
-        let html_root: HtmlRoot = file.parsed(db).tree();
+        let html_root: HtmlRoot = host_parse.tree();
         builder.visit_html_root(&html_root, &html_file_source);
     }
 
     Some(builder)
+}
+
+fn build_value_references(builder: &EmbeddedReferencesBuilder) -> Vec<EmbeddedValueReference> {
+    builder
+        .value_references
+        .iter()
+        .map(|(range, text)| EmbeddedValueReference {
+            range: *range,
+            text: text.clone(),
+        })
+        .collect()
+}
+
+fn build_type_references(builder: &EmbeddedReferencesBuilder) -> Vec<EmbeddedTypeReference> {
+    builder
+        .type_references
+        .iter()
+        .map(|(range, text)| EmbeddedTypeReference {
+            range: *range,
+            text: text.clone(),
+        })
+        .collect()
 }
 
 fn block_kind_from_js_source(source: &JsFileSource) -> Option<EmbeddedBlockKind> {

--- a/crates/biome_js_analyze/src/lib.rs
+++ b/crates/biome_js_analyze/src/lib.rs
@@ -19,6 +19,7 @@ use biome_analyze::{
 };
 use biome_aria::AriaRoles;
 use biome_diagnostics::Error as DiagnosticError;
+use biome_embeds::EmbeddedData;
 use biome_js_semantic::SemanticModel;
 use biome_js_syntax::{AnyJsRoot, JsLanguage};
 use biome_languages::{JsFileSource, LanguageDb};
@@ -60,6 +61,7 @@ pub static METADATA: LazyLock<MetadataRegistry> = LazyLock::new(|| {
 pub struct JsAnalyzerServices<'a> {
     module_db: Option<Rc<dyn ModuleDb>>,
     language_db: Option<Rc<dyn LanguageDb>>,
+    embedded_data: Option<Arc<EmbeddedData>>,
     project_layout: Arc<ProjectLayout>,
     source_type: JsFileSource,
     semantic_model: Option<&'a SemanticModel>,
@@ -76,6 +78,7 @@ impl From<(Rc<dyn ModuleDb>, Arc<ProjectLayout>, JsFileSource)> for JsAnalyzerSe
         Self {
             module_db: Some(module_db),
             language_db: None,
+            embedded_data: None,
             project_layout,
             source_type,
             semantic_model: None,
@@ -88,6 +91,7 @@ impl From<&AnyJsRoot> for JsAnalyzerServices<'_> {
         Self {
             module_db: None,
             language_db: None,
+            embedded_data: None,
             project_layout: Arc::new(ProjectLayout::default()),
             source_type: JsFileSource::default(),
             semantic_model: None,
@@ -113,6 +117,11 @@ impl<'a> JsAnalyzerServices<'a> {
 
     pub fn with_language_db(mut self, language_db: Rc<dyn LanguageDb>) -> Self {
         self.language_db = Some(language_db);
+        self
+    }
+
+    pub fn with_embedded_data(mut self, embedded_data: Option<Arc<EmbeddedData>>) -> Self {
+        self.embedded_data = embedded_data;
         self
     }
 
@@ -174,6 +183,7 @@ where
     let JsAnalyzerServices {
         module_db,
         language_db: embedded_db,
+        embedded_data,
         project_layout,
         source_type,
         semantic_model,
@@ -239,7 +249,9 @@ where
     services.insert_service(file_path);
     services.insert_service(type_resolver);
     services.insert_service(project_layout);
-    if let Some(embedded_db) = embedded_db {
+    if let Some(embedded_data) = embedded_data {
+        services.insert_service(EmbeddedService::from_data(embedded_data));
+    } else if let Some(embedded_db) = embedded_db {
         services.insert_service(EmbeddedService::new(embedded_db, options.file_path.clone()));
     }
     // If a pre-built model is available (workspace open_file/change_file path),

--- a/crates/biome_js_analyze/src/services/embedded.rs
+++ b/crates/biome_js_analyze/src/services/embedded.rs
@@ -1,4 +1,5 @@
 use biome_analyze::{FromServices, RuleKey, RuleMetadata, ServiceBag, ServicesDiagnostic};
+use biome_embeds::EmbeddedData;
 use biome_embeds::bindings::{
     InternedBindingText, InternedBindingTokenText, get_binding_by_name, get_binding_by_text,
 };
@@ -10,63 +11,98 @@ use biome_languages::LanguageDb;
 use biome_rowan::TokenText;
 use camino::Utf8PathBuf;
 use std::rc::Rc;
+use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct EmbeddedService {
-    db: Rc<dyn LanguageDb>,
-    path: Utf8PathBuf,
+    source: EmbeddedSource,
+}
+
+#[derive(Clone)]
+enum EmbeddedSource {
+    Workspace {
+        db: Rc<dyn LanguageDb>,
+        path: Utf8PathBuf,
+    },
+    Interned(Arc<EmbeddedData>),
 }
 
 impl EmbeddedService {
     pub(crate) fn new(db: Rc<dyn LanguageDb>, path: Utf8PathBuf) -> Self {
-        Self { db, path }
+        Self {
+            source: EmbeddedSource::Workspace { db, path },
+        }
+    }
+
+    pub(crate) fn from_data(data: Arc<EmbeddedData>) -> Self {
+        Self {
+            source: EmbeddedSource::Interned(data),
+        }
     }
 
     pub(crate) fn contains_binding(&self, binding: TokenText) -> bool {
-        get_binding_by_name(
-            self.db.as_ref(),
-            InternedBindingTokenText::new(self.db.as_ref(), self.path.clone(), binding),
-        )
-        .is_some()
+        match &self.source {
+            EmbeddedSource::Workspace { db, path } => get_binding_by_name(
+                db.as_ref(),
+                InternedBindingTokenText::new(db.as_ref(), path.clone(), binding),
+            )
+            .is_some(),
+            EmbeddedSource::Interned(data) => data.contains_binding(binding.text()),
+        }
     }
 
     pub(crate) fn contains_binding_text(&self, binding: &str) -> bool {
-        get_binding_by_text(
-            self.db.as_ref(),
-            InternedBindingText::new(self.db.as_ref(), self.path.clone(), binding.to_string()),
-        )
-        .is_some()
+        match &self.source {
+            EmbeddedSource::Workspace { db, path } => get_binding_by_text(
+                db.as_ref(),
+                InternedBindingText::new(db.as_ref(), path.clone(), binding.to_string()),
+            )
+            .is_some(),
+            EmbeddedSource::Interned(data) => data.contains_binding(binding),
+        }
     }
 
     pub(crate) fn is_used_as_value(&self, identifier: TokenText) -> bool {
-        is_value_reference_used(
-            self.db.as_ref(),
-            InternedReference::new(self.db.as_ref(), self.path.clone(), identifier),
-        )
+        match &self.source {
+            EmbeddedSource::Workspace { db, path } => is_value_reference_used(
+                db.as_ref(),
+                InternedReference::new(db.as_ref(), path.clone(), identifier),
+            ),
+            EmbeddedSource::Interned(data) => data.is_used_as_value(identifier.text()),
+        }
     }
 
     pub(crate) fn is_used_as_type(&self, identifier: TokenText) -> bool {
-        is_type_reference_used(
-            self.db.as_ref(),
-            InternedReference::new(self.db.as_ref(), self.path.clone(), identifier),
-        )
+        match &self.source {
+            EmbeddedSource::Workspace { db, path } => is_type_reference_used(
+                db.as_ref(),
+                InternedReference::new(db.as_ref(), path.clone(), identifier),
+            ),
+            EmbeddedSource::Interned(data) => data.is_used_as_type(identifier.text()),
+        }
     }
 
     pub(crate) fn is_used(&self, identifier: TokenText) -> bool {
-        is_reference_used(
-            self.db.as_ref(),
-            InternedReference::new(self.db.as_ref(), self.path.clone(), identifier),
-        )
+        match &self.source {
+            EmbeddedSource::Workspace { db, path } => is_reference_used(
+                db.as_ref(),
+                InternedReference::new(db.as_ref(), path.clone(), identifier),
+            ),
+            EmbeddedSource::Interned(data) => data.is_used(identifier.text()),
+        }
     }
 
     /// Svelte stores are a special case. The `$` prefix is used to "dereference" the store and get its value.
     ///
     /// See also: https://svelte.dev/docs/svelte/stores
     pub(crate) fn is_svelte_store_used(&self, identifier: TokenText) -> bool {
-        is_svelte_store_reference_used(
-            self.db.as_ref(),
-            InternedReference::new(self.db.as_ref(), self.path.clone(), identifier),
-        )
+        match &self.source {
+            EmbeddedSource::Workspace { db, path } => is_svelte_store_reference_used(
+                db.as_ref(),
+                InternedReference::new(db.as_ref(), path.clone(), identifier),
+            ),
+            EmbeddedSource::Interned(data) => data.is_svelte_store_used(identifier.text()),
+        }
     }
 
     /// Vue custom directives are a special case. The template spells them in
@@ -75,10 +111,13 @@ impl EmbeddedService {
     ///
     /// See also: https://vuejs.org/guide/reusability/custom-directives.html
     pub(crate) fn is_vue_directive_used(&self, identifier: TokenText) -> bool {
-        is_vue_directive_reference_used(
-            self.db.as_ref(),
-            InternedReference::new(self.db.as_ref(), self.path.clone(), identifier),
-        )
+        match &self.source {
+            EmbeddedSource::Workspace { db, path } => is_vue_directive_reference_used(
+                db.as_ref(),
+                InternedReference::new(db.as_ref(), path.clone(), identifier),
+            ),
+            EmbeddedSource::Interned(data) => data.is_vue_directive_used(identifier.text()),
+        }
     }
 }
 

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -1230,28 +1230,18 @@ fn js_analyzer_services_for_fix<'a>(
     params: &FixAllParams,
     source_type: JsFileSource,
 ) -> JsAnalyzerServices<'a> {
-    #[cfg(feature = "module_graph")]
-    {
-        js_analyzer_services(
-            root,
-            &params.workspace_db,
-            params.module_db.clone(),
-            params.project_layout.clone(),
-            source_type,
-        )
-        .with_semantic_model(semantic_model)
-    }
-
-    #[cfg(not(feature = "module_graph"))]
-    js_analyzer_services(
+    let services = js_analyzer_services(
         root,
         &params.workspace_db,
         #[cfg(feature = "module_graph")]
         params.module_db.clone(),
         params.project_layout.clone(),
         source_type,
-    )
-    .with_semantic_model(semantic_model)
+    );
+    #[cfg(feature = "html_embeds")]
+    let services = services.with_embedded_data(params.embedded_data.clone());
+
+    services.with_semantic_model(semantic_model)
 }
 
 pub(crate) fn lint(params: LintParams) -> LintResults {
@@ -1310,6 +1300,8 @@ pub(crate) fn lint(params: LintParams) -> LintResults {
         params.project_layout.clone(),
         files_source,
     );
+    #[cfg(feature = "html_embeds")]
+    let services = services.with_embedded_data(params.embedded_data.clone());
     let services = services.with_semantic_model(&semantic_model);
 
     let (_, analyze_diagnostics) = analyze(

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -65,6 +65,8 @@ use biome_css_analyze::METADATA as css_metadata;
 use biome_css_syntax::CssLanguage;
 use biome_db::{AnyParsedSource, ParsedSnippet, ParsedSource};
 use biome_diagnostics::{Applicability, Diagnostic, DiagnosticExt, Error, Severity, category};
+#[cfg(feature = "html_embeds")]
+use biome_embeds::EmbeddedData;
 use biome_formatter::Printed;
 use biome_fs::BiomePath;
 #[cfg(feature = "lang_graphql")]
@@ -128,6 +130,8 @@ pub struct FixAllParams<'a> {
     pub(crate) settings: &'a SettingsWithEditor<'a>,
     pub(crate) biome_path: &'a BiomePath,
     pub(crate) workspace_db: WorkspaceDb,
+    #[cfg(feature = "html_embeds")]
+    pub(crate) embedded_data: Option<Arc<EmbeddedData>>,
     #[cfg(feature = "module_graph")]
     pub(crate) module_db: Rc<dyn ModuleDb>,
     pub(crate) project_layout: Arc<ProjectLayout>,
@@ -461,6 +465,8 @@ pub(crate) struct LintParams<'a> {
     pub(crate) skip: &'a [AnalyzerSelector],
     pub(crate) categories: RuleCategories,
     pub(crate) workspace_db: WorkspaceDb,
+    #[cfg(feature = "html_embeds")]
+    pub(crate) embedded_data: Option<Arc<EmbeddedData>>,
     #[cfg(feature = "module_graph")]
     pub(crate) module_db: Rc<dyn ModuleDb>,
     pub(crate) project_layout: Arc<ProjectLayout>,

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -62,6 +62,8 @@ use biome_diagnostics::print_diagnostic_to_string;
 use biome_diagnostics::{
     Diagnostic, DiagnosticExt, Error, Severity, serde::Diagnostic as SerdeDiagnostic,
 };
+#[cfg(feature = "html_embeds")]
+use biome_embeds::{EmbeddedData, EmbeddedSnippet, collect_embedded_data};
 use biome_formatter::Printed;
 use biome_fs::{BiomePath, ConfigName, PathKind, normalize_path};
 #[cfg(all(feature = "module_graph", feature = "lang_html"))]
@@ -188,6 +190,39 @@ impl ProcessFileState {
             }
             ParsedOrigin::Interned { snippets, .. } => SnippetsIterator::Interned(snippets.iter()),
         }
+    }
+
+    #[cfg(feature = "html_embeds")]
+    fn collect_embedded_data(&self) -> Option<Arc<EmbeddedData>> {
+        let ParsedOrigin::Interned {
+            parse, snippets, ..
+        } = &self.parsed
+        else {
+            return None;
+        };
+
+        Some(Arc::new(collect_embedded_data(
+            self.file_source,
+            parse,
+            snippets
+                .iter()
+                .filter_map(|snippet| {
+                    let ParsedSnippetOrigin::Interned {
+                        parse,
+                        content,
+                        file_source,
+                    } = snippet
+                    else {
+                        return None;
+                    };
+                    Some(EmbeddedSnippet::new(
+                        parse,
+                        content.content_range,
+                        *file_source,
+                    ))
+                })
+                .collect(),
+        )))
     }
 
     fn has_errors(&self) -> bool {
@@ -1169,7 +1204,7 @@ impl WorkspaceServerWithDb<'_> {
         let file_source = language.unwrap_or(file_source);
 
         let mut snippet_cache = NodeCache::default();
-        let snippets = if DocumentFileSource::can_contain_embeds(
+        let embedded_snippets = if DocumentFileSource::can_contain_embeds(
             path.as_path(),
             settings.as_ref().experimental_full_html_support_enabled(),
         ) {
@@ -1182,16 +1217,18 @@ impl WorkspaceServerWithDb<'_> {
             )?
         } else {
             Vec::new()
-        }
-        .into_iter()
-        .map(
-            |(parse, content, file_source)| ParsedSnippetOrigin::Interned {
-                parse,
-                content,
-                file_source,
-            },
-        )
-        .collect();
+        };
+
+        let snippets = embedded_snippets
+            .into_iter()
+            .map(
+                |(parse, content, file_source)| ParsedSnippetOrigin::Interned {
+                    parse,
+                    content,
+                    file_source,
+                },
+            )
+            .collect();
 
         Ok(ProcessFileState {
             parsed: ParsedOrigin::interned_document(any_parse, snippets),
@@ -1274,6 +1311,8 @@ impl WorkspaceServerWithDb<'_> {
             suppression_reason,
             inline_config,
         } = params;
+        #[cfg(feature = "html_embeds")]
+        let embedded_data = state.collect_embedded_data();
         let (working_directory, settings, query_context) = self
             .project_get_settings_query(&state.db, project_key, &path, inline_config)
             .ok_or_else(WorkspaceError::no_project)?;
@@ -1321,6 +1360,8 @@ impl WorkspaceServerWithDb<'_> {
                     settings: &settings,
                     biome_path: &path,
                     workspace_db: state.db.clone(),
+                    #[cfg(feature = "html_embeds")]
+                    embedded_data: embedded_data.clone(),
                     #[cfg(feature = "module_graph")]
                     module_db: module_db.clone(),
                     project_layout: self.project_layout.clone(),
@@ -1414,6 +1455,8 @@ impl WorkspaceServerWithDb<'_> {
             settings: &settings,
             biome_path: &path,
             workspace_db: state.db.clone(),
+            #[cfg(feature = "html_embeds")]
+            embedded_data,
             #[cfg(feature = "module_graph")]
             module_db,
             project_layout: self.project_layout.clone(),
@@ -1522,6 +1565,8 @@ impl WorkspaceServerWithDb<'_> {
             || categories.is_assist())
             && let Some(lint) = capabilities.analyzer.lint
         {
+            #[cfg(feature = "html_embeds")]
+            let embedded_data = state.collect_embedded_data();
             let plugins = cfg_select! {
                 feature = "plugins" => {
                     if categories.is_lint() {
@@ -1550,6 +1595,8 @@ impl WorkspaceServerWithDb<'_> {
                 language: state.file_source,
                 categories,
                 workspace_db: state.db.clone(),
+                #[cfg(feature = "html_embeds")]
+                embedded_data: embedded_data.clone(),
                 #[cfg(feature = "module_graph")]
                 module_db: module_db.clone(),
                 project_layout: self.project_layout.clone(),
@@ -1587,6 +1634,8 @@ impl WorkspaceServerWithDb<'_> {
                     language: file_source,
                     categories,
                     workspace_db: state.db.clone(),
+                    #[cfg(feature = "html_embeds")]
+                    embedded_data: embedded_data.clone(),
                     #[cfg(feature = "module_graph")]
                     module_db: module_db.clone(),
                     project_layout: self.project_layout.clone(),


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This PR makes sure that html full support is respected when files are piped in via stdin.

My clanker explains it as:

> Stateless processing parsed embedded snippets but didn’t register them, so cross-snippet references were missed. The fix registers them in an operation-local database view, enabling full HTML analysis without modifying shared workspace state.

fixes #11389

implemented by gpt 5.6 sol
<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
added cli tests

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
