### PR TITLE
feat(tailwind): add the stylesheet configuration

### DIFF
--- a/crates/biome_analyze/src/context.rs
+++ b/crates/biome_analyze/src/context.rs
@@ -1,4 +1,4 @@
-use crate::options::{JsxRuntime, PreferredIndentation, PreferredQuote};
+use crate::options::{JsxRuntime, PreferredIndentation, PreferredQuote, TailwindOptions};
 use crate::{FromServices, Queryable, Rule, RuleKey, ServiceBag, registry::RuleRoot};
 use crate::{GroupCategory, RuleCategory, RuleGroup, RuleMetadata};
 use biome_diagnostics::{Error, Result};
@@ -23,6 +23,7 @@ pub struct RuleContext<'a, R: Rule> {
     jsx_factory: Option<&'a str>,
     jsx_fragment_factory: Option<&'a str>,
     working_directory: Option<&'a Utf8Path>,
+    tailwind: &'a TailwindOptions,
 }
 
 impl<'a, R> RuleContext<'a, R>
@@ -44,6 +45,7 @@ where
         jsx_factory: Option<&'a str>,
         jsx_fragment_factory: Option<&'a str>,
         working_directory: Option<&'a Utf8Path>,
+        tailwind: &'a TailwindOptions,
     ) -> Result<Self, Error> {
         let rule_key = RuleKey::rule::<R>();
         Ok(Self {
@@ -61,6 +63,7 @@ where
             jsx_factory,
             jsx_fragment_factory,
             working_directory,
+            tailwind,
         })
     }
 
@@ -186,6 +189,11 @@ where
     /// The file path of the current file
     pub fn file_path(&self) -> &Utf8Path {
         self.file_path
+    }
+
+    /// The top-level `tailwind` configuration.
+    pub fn tailwind(&self) -> &TailwindOptions {
+        self.tailwind
     }
 
     pub fn working_directory(&self) -> Option<&Utf8Path> {

--- a/crates/biome_analyze/src/options.rs
+++ b/crates/biome_analyze/src/options.rs
@@ -245,20 +245,33 @@ impl AnalyzerOptions {
     }
 }
 
-/// User-provided names that Tailwind-aware analyzer queries use to identify class strings.
-#[derive(Clone, Debug, Eq, PartialEq)]
+/// User-provided names that Tailwind-aware analyzer queries use to identify class strings,
+/// and the project stylesheet Tailwind-aware rules read.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct TailwindOptions {
     attributes: Option<Arc<[Box<str>]>>,
     functions: Option<Arc<[Box<str>]>>,
+    stylesheet: Option<Arc<str>>,
 }
 
 impl TailwindOptions {
-    /// Creates analyzer options from optional replacement lists.
-    pub fn new(attributes: Option<Box<[Box<str>]>>, functions: Option<Box<[Box<str>]>>) -> Self {
+    /// Creates analyzer options from optional replacement lists and stylesheet path.
+    pub fn new(
+        attributes: Option<Box<[Box<str>]>>,
+        functions: Option<Box<[Box<str>]>>,
+        stylesheet: Option<Box<str>>,
+    ) -> Self {
         Self {
             attributes: attributes.map(Arc::from),
             functions: functions.map(Arc::from),
+            stylesheet: stylesheet.map(Arc::from),
         }
+    }
+
+    /// Returns the configured path of the project's Tailwind CSS entry stylesheet,
+    /// relative to the package root of the linted file.
+    pub fn stylesheet(&self) -> Option<&str> {
+        self.stylesheet.as_deref()
     }
 
     /// Returns the configured attribute replacement list, or `None` when language defaults apply.
@@ -269,12 +282,6 @@ impl TailwindOptions {
     /// Returns the configured function replacement list, or `None` when defaults apply.
     pub fn functions(&self) -> Option<&[Box<str>]> {
         self.functions.as_deref()
-    }
-}
-
-impl Default for TailwindOptions {
-    fn default() -> Self {
-        Self::new(None, None)
     }
 }
 

--- a/crates/biome_analyze/src/registry.rs
+++ b/crates/biome_analyze/src/registry.rs
@@ -424,6 +424,7 @@ impl<L: Language + Default> RegistryRule<L> {
                 jsx_factory,
                 jsx_fragment_factory,
                 working_directory,
+                params.options.tailwind(),
             )?;
 
             let rule_timer = crate::profiling::start_rule::<R>();

--- a/crates/biome_analyze/src/signals.rs
+++ b/crates/biome_analyze/src/signals.rs
@@ -529,6 +529,7 @@ where
             self.options.jsx_factory(),
             self.options.jsx_fragment_factory(),
             self.options.working_directory.as_deref(),
+            self.options.tailwind(),
         )
         .ok()?;
 
@@ -584,6 +585,7 @@ where
             self.options.jsx_factory(),
             self.options.jsx_fragment_factory(),
             self.options.working_directory.as_deref(),
+            self.options.tailwind(),
         )
         .ok();
         let mut actions = Vec::new();
@@ -708,6 +710,7 @@ where
             self.options.jsx_factory(),
             self.options.jsx_fragment_factory(),
             self.options.working_directory.as_deref(),
+            self.options.tailwind(),
         )
         .ok();
         if let Some(ctx) = ctx {

--- a/crates/biome_configuration/src/tailwind.rs
+++ b/crates/biome_configuration/src/tailwind.rs
@@ -19,10 +19,22 @@ pub struct TailwindConfiguration {
     /// `cnb`, and `ctl`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub functions: Option<Box<[Box<str>]>>,
+
+    /// Path to the project's Tailwind CSS entry stylesheet, relative to the root of
+    /// the package that contains the linted file.
+    ///
+    /// When set, Tailwind-aware rules read the `@theme`, `@utility`, and
+    /// `@custom-variant` directives of that file and of the stylesheets it imports.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stylesheet: Option<Box<str>>,
 }
 
 impl From<TailwindConfiguration> for TailwindOptions {
     fn from(configuration: TailwindConfiguration) -> Self {
-        Self::new(configuration.attributes, configuration.functions)
+        Self::new(
+            configuration.attributes,
+            configuration.functions,
+            configuration.stylesheet,
+        )
     }
 }

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -397,6 +397,14 @@ Defaults to `clsx`, `tw`, `twMerge`, `twJoin`, `cva`, `tv`, `cn`, `cc`,
 `cnb`, and `ctl`. 
 	 */
 	functions?: string[];
+	/**
+	* Path to the project's Tailwind CSS entry stylesheet, relative to the root of
+the package that contains the linted file.
+
+When set, Tailwind-aware rules read the `@theme`, `@utility`, and
+`@custom-variant` directives of that file and of the stylesheets it imports. 
+	 */
+	stylesheet?: string;
 }
 /**
  * Settings for integrating Biome with version control.

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -14881,6 +14881,10 @@
 					"description": "Function and tagged-template names whose arguments contain Tailwind classes.\n\nDefaults to `clsx`, `tw`, `twMerge`, `twJoin`, `cva`, `tv`, `cn`, `cc`,\n`cnb`, and `ctl`.",
 					"type": ["array", "null"],
 					"items": { "type": "string" }
+				},
+				"stylesheet": {
+					"description": "Path to the project's Tailwind CSS entry stylesheet, relative to the root of\nthe package that contains the linted file.\n\nWhen set, Tailwind-aware rules read the `@theme`, `@utility`, and\n`@custom-variant` directives of that file and of the stylesheets it imports.",
+					"type": ["string", "null"]
 				}
 			},
 			"additionalProperties": false


### PR DESCRIPTION
## Summary

Adds `tailwind.stylesheet` to the top-level Tailwind configuration: the path of the project's Tailwind CSS entry stylesheet, relative to the package root of the linted file (mirrors `tailwindStylesheet` in prettier-plugin-tailwindcss). It reaches rules through a new `RuleContext::tailwind()` accessor, alongside the `attributes`/`functions` this branch already exposes to the syntax service.

This is the configuration half of what was #11396, split out per the review discussion there so it merges into #11386 rather than with the v4 sorter switchover. It has no dependency on #11396 and can merge before or after it. `useSortedClasses` starts reading it in a follow-up on `next` once both are in.

AI tools were used to identify the next step and brainstorm idiomatic solutions, as in the previous PRs in this series.

## Test Plan

Compiles and existing tests pass on this branch; schema and TypeScript bindings regenerated (`just gen-bindings`). The behavior is exercised by the follow-up's rule specs and stylesheet fixtures.

## Docs

Documented on the configuration field. No changeset here; the follow-up that makes the option do something carries it.
