### PR TITLE
fix(noUnusedVariables): handle generic parameters in function overloads

### DIFF
--- a/.changeset/honest-terms-design.md
+++ b/.changeset/honest-terms-design.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11214](https://github.com/biomejs/biome/issues/11214): [`noUnusedVariables`](https://biomejs.dev/linter/rules/no-unused-variables/) no longer reports type parameters declared by non-default function overload signatures that have an implementation.

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_variables.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_variables.rs
@@ -11,8 +11,9 @@ use biome_js_syntax::declaration_ext::is_in_ambient_context;
 use biome_js_syntax::{
     AnyJsExpression, JsCallExpression, JsClassExpression, JsForStatement, JsFunctionExpression,
     JsIdentifierExpression, JsModuleItemList, JsSequenceExpression, JsSyntaxKind, JsSyntaxNode,
-    JsVariableDeclarator, TsConditionalType, TsDeclarationModule, TsInferType,
-    TsInterfaceDeclaration, TsTypeAliasDeclaration,
+    JsVariableDeclarator, TsConditionalType, TsDeclarationModule, TsDeclareFunctionDeclaration,
+    TsInferType, TsInterfaceDeclaration, TsTypeAliasDeclaration, TsTypeParameterList,
+    TsTypeParameters,
 };
 use biome_languages::JsFileSource;
 use biome_languages::javascript::JsEmbeddingKind;
@@ -320,7 +321,7 @@ impl Rule for NoUnusedVariables {
             {
                 return None;
             }
-            suggested_fix_if_unused(binding, ctx.options())
+            suggested_fix_if_unused(model, binding, ctx.options())
         } else {
             None
         }
@@ -433,6 +434,52 @@ fn is_rest_spread_sibling(decl: &AnyJsBindingDeclaration) -> bool {
     }
 }
 
+fn is_implemented_overload_type_parameter(
+    model: &SemanticModel,
+    type_parameter: &JsSyntaxNode,
+) -> bool {
+    let Some(signature) = type_parameter
+        .parent()
+        .and_then(TsTypeParameterList::cast)
+        .and_then(|list| list.parent::<TsTypeParameters>())
+        .and_then(|parameters| parameters.parent::<TsDeclareFunctionDeclaration>())
+    else {
+        return false;
+    };
+    let Some(id) = signature
+        .id()
+        .ok()
+        .and_then(|id| id.as_js_identifier_binding().cloned())
+    else {
+        return false;
+    };
+    let Some(scope) = model.scope_hoisted_to(id.syntax()) else {
+        return false;
+    };
+    let signature_range = id.syntax().text_trimmed_range();
+
+    scope.overload_sets().into_iter().any(|set| {
+        let Some((implementation, signatures)) = set.split_last() else {
+            return false;
+        };
+        let Some(implementation) = model.binding_by_id(*implementation) else {
+            return false;
+        };
+        if !matches!(
+            implementation.tree().declaration(),
+            Some(AnyJsBindingDeclaration::JsFunctionDeclaration(_))
+        ) {
+            return false;
+        }
+
+        signatures.iter().any(|id| {
+            model.binding_by_id(*id).is_some_and(|binding| {
+                binding.syntax().text_trimmed_range() == signature_range
+            })
+        })
+    })
+}
+
 fn suggestion_for_binding(binding: &AnyJsIdentifierBinding) -> Option<SuggestedFix> {
     if binding.is_under_object_pattern_binding()? {
         Some(SuggestedFix::NoSuggestion)
@@ -444,6 +491,7 @@ fn suggestion_for_binding(binding: &AnyJsIdentifierBinding) -> Option<SuggestedF
 // It is ok in some Typescripts constructs for a parameter to be unused.
 // Returning None means is ok to be unused
 fn suggested_fix_if_unused(
+    model: &SemanticModel,
     binding: &AnyJsIdentifierBinding,
     options: &NoUnusedVariablesOptions,
 ) -> Option<SuggestedFix> {
@@ -502,7 +550,9 @@ fn suggested_fix_if_unused(
 
         // Type parameters are never ok to be unused unless they are declared in an ambient context
         node @ AnyJsBindingDeclaration::TsTypeParameter(_) => {
-            if is_in_ambient_context(node.syntax()) {
+            if is_in_ambient_context(node.syntax())
+                || is_implemented_overload_type_parameter(model, node.syntax())
+            {
                 None
             } else {
                 Some(SuggestedFix::PrefixUnderscore)

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_variables.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_variables.rs
@@ -548,7 +548,8 @@ fn suggested_fix_if_unused(
         // Bindings under catch are never ok to be unused
         AnyJsBindingDeclaration::JsCatchDeclaration(_) => Some(SuggestedFix::PrefixUnderscore),
 
-        // Type parameters are never ok to be unused unless they are declared in an ambient context
+        // Type parameters are only ok to be unused in ambient contexts or implemented overload
+        // signatures.
         node @ AnyJsBindingDeclaration::TsTypeParameter(_) => {
             if is_in_ambient_context(node.syntax())
                 || is_implemented_overload_type_parameter(model, node.syntax())

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidOverloadTypeParam.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidOverloadTypeParam.ts
@@ -1,0 +1,7 @@
+/* should generate diagnostics */
+function orphan<T>(): void;
+function orphan(value: string): void;
+
+function withCallback(callback: <T>() => void): void;
+function withCallback(callback: () => void): void {}
+withCallback(() => {});

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidOverloadTypeParam.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidOverloadTypeParam.ts.snap
@@ -1,0 +1,66 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidOverloadTypeParam.ts
+---
+# Input
+```ts
+/* should generate diagnostics */
+function orphan<T>(): void;
+function orphan(value: string): void;
+
+function withCallback(callback: <T>() => void): void;
+function withCallback(callback: () => void): void {}
+withCallback(() => {});
+
+```
+
+# Diagnostics
+```
+invalidOverloadTypeParam.ts:2:17 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This type parameter T is unused.
+  
+    1 │ /* should generate diagnostics */
+  > 2 │ function orphan<T>(): void;
+      │                 ^
+    3 │ function orphan(value: string): void;
+    4 │ 
+  
+  i Unused variables are often the result of typos, incomplete refactors, or other sources of bugs.
+  
+  i Unsafe fix: If this is intentional, prepend T with an underscore.
+  
+    1 1 │   /* should generate diagnostics */
+    2   │ - function·orphan<T>():·void;
+      2 │ + function·orphan<_T>():·void;
+    3 3 │   function orphan(value: string): void;
+    4 4 │   
+  
+
+```
+
+```
+invalidOverloadTypeParam.ts:5:34 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This type parameter T is unused.
+  
+    3 │ function orphan(value: string): void;
+    4 │ 
+  > 5 │ function withCallback(callback: <T>() => void): void;
+      │                                  ^
+    6 │ function withCallback(callback: () => void): void {}
+    7 │ withCallback(() => {});
+  
+  i Unused variables are often the result of typos, incomplete refactors, or other sources of bugs.
+  
+  i Unsafe fix: If this is intentional, prepend T with an underscore.
+  
+    3 3 │   function orphan(value: string): void;
+    4 4 │   
+    5   │ - function·withCallback(callback:·<T>()·=>·void):·void;
+      5 │ + function·withCallback(callback:·<_T>()·=>·void):·void;
+    6 6 │   function withCallback(callback: () => void): void {}
+    7 7 │   withCallback(() => {});
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validOverloadTypeParam.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validOverloadTypeParam.ts
@@ -1,0 +1,10 @@
+/* should not generate diagnostics */
+declare function returnAny(): any;
+
+function someFn<MyGeneric>(): void;
+function someFn<MyGeneric>(): void {
+	const value: MyGeneric = returnAny();
+	console.log(value);
+}
+
+someFn();

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validOverloadTypeParam.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validOverloadTypeParam.ts.snap
@@ -1,0 +1,18 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validOverloadTypeParam.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+declare function returnAny(): any;
+
+function someFn<MyGeneric>(): void;
+function someFn<MyGeneric>(): void {
+	const value: MyGeneric = returnAny();
+	console.log(value);
+}
+
+someFn();
+
+```


### PR DESCRIPTION
## Summary

Fixes #11214.

`noUnusedVariables` incorrectly reported generic type parameters declared in TypeScript function overload signatures.

This change prevents false positives for named, non-default-export function overloads that have an implementation body.

## Behavior

After this change:

- Generic parameters in overload signatures of named, non-default-export functions with an implementation are no longer reported.
- Declaration-only overloads without an implementation are still reported.
- Unused generic parameters inside nested function types or callbacks are still reported.

## Test Plan

Added:

- A valid regression test for function overloads with an implementation.
- A negative test for declaration-only overloads.
- A negative test for unused generic parameters in nested callback types.

Validation performed:

```sh
cargo test -p biome_js_analyze --no-fail-fast
cargo lint
just gen-rules
just gen-configuration
just lint-rules
```

## Docs

A patch changeset is included. No additional documentation changes are required.

## AI disclosure

Codex assisted with issue analysis, implementation, and testing. I reviewed the resulting diff and validation results.
