### PR TITLE
chore: fix typos in two comments

### DIFF
--- a/crates/biome_formatter/src/buffer.rs
+++ b/crates/biome_formatter/src/buffer.rs
@@ -791,7 +791,7 @@ where
         let elements = buffer.elements();
 
         let recorded = if self.start > elements.len() {
-            // May happen if buffer was rewinded.
+            // May happen if buffer was rewound.
             &[]
         } else {
             &elements[self.start..]

--- a/crates/biome_js_syntax/src/static_value.rs
+++ b/crates/biome_js_syntax/src/static_value.rs
@@ -73,7 +73,7 @@ impl StaticValue {
         }
     }
 
-    /// Return teh range of the static value.
+    /// Return the range of the static value.
     ///
     /// ## Examples
     ///


### PR DESCRIPTION
Two comment-only spelling fixes:

- `Return teh range` -> `Return the range` (`crates/biome_js_syntax/src/static_value.rs`)
- `buffer was rewinded` -> `buffer was rewound` (`crates/biome_formatter/src/buffer.rs`)

No code or behaviour changes, so no changeset.