### PR TITLE
feat(js_plugin): support TypeScript plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,7 +1143,10 @@ version = "0.0.1"
 dependencies = [
  "biome_analyze",
  "biome_diagnostics",
+ "biome_js_parser",
  "biome_js_syntax",
+ "biome_js_transform",
+ "biome_languages",
  "biome_resolver",
  "biome_rowan",
  "biome_text_size",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ biome_js_analyze             = { path = "./crates/biome_js_analyze", version = "
 biome_js_factory             = { path = "./crates/biome_js_factory", version = "0.5.7" }
 biome_js_formatter           = { path = "./crates/biome_js_formatter", version = "0.5.7" }
 biome_js_parser              = { path = "./crates/biome_js_parser", version = "0.5.7" }
+biome_js_transform           = { path = "./crates/biome_js_transform", version = "0.5.7" }
 biome_js_runtime             = { path = "./crates/biome_js_runtime", version = "0.0.1" }
 biome_js_semantic            = { path = "./crates/biome_js_semantic", version = "0.5.7" }
 biome_js_syntax              = { path = "./crates/biome_js_syntax", version = "0.5.7" }

--- a/crates/biome_js_runtime/Cargo.toml
+++ b/crates/biome_js_runtime/Cargo.toml
@@ -12,15 +12,18 @@ categories.workspace = true
 publish              = true
 
 [dependencies]
-biome_analyze     = { workspace = true }
-biome_diagnostics = { workspace = true }
-biome_js_syntax   = { workspace = true }
-biome_resolver    = { workspace = true }
-biome_rowan       = { workspace = true }
-biome_text_size   = { workspace = true }
-boa_engine        = { workspace = true }
-camino            = { workspace = true }
-rustc-hash        = { workspace = true }
+biome_analyze      = { workspace = true }
+biome_diagnostics  = { workspace = true }
+biome_js_parser    = { workspace = true }
+biome_js_syntax    = { workspace = true }
+biome_js_transform = { workspace = true }
+biome_languages    = { workspace = true, features = ["lang_js"] }
+biome_resolver     = { workspace = true }
+biome_rowan        = { workspace = true }
+biome_text_size    = { workspace = true }
+boa_engine         = { workspace = true }
+camino             = { workspace = true }
+rustc-hash         = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.3.2", features = ["wasm_js"] }

--- a/crates/biome_js_runtime/src/context.rs
+++ b/crates/biome_js_runtime/src/context.rs
@@ -16,6 +16,7 @@ use biome_resolver::FsWithResolverProxy;
 use crate::JsModuleLoader;
 use crate::ast::JsAstNode;
 use crate::plugin_api::JsPluginApi;
+use crate::source::read_module_source;
 
 pub struct JsExecContext {
     ctx: Context,
@@ -64,9 +65,7 @@ impl JsExecContext {
     pub fn import_module(&mut self, path: impl AsRef<Utf8Path>) -> JsResult<Module> {
         let ctx = &mut self.ctx;
         let path = path.as_ref();
-        let source = self.fs.read_file_from_path(path).map_err(|err| {
-            JsNativeError::error().with_message(format!("Failed to read {path}: {err}"))
-        })?;
+        let source = read_module_source(&self.fs, path)?;
         let source = Source::from_bytes(source.as_bytes()).with_path(path.as_std_path());
         let module = Module::parse(source, None, ctx)?;
 

--- a/crates/biome_js_runtime/src/lib.rs
+++ b/crates/biome_js_runtime/src/lib.rs
@@ -2,6 +2,7 @@ mod ast;
 mod context;
 mod module_loader;
 mod plugin_api;
+mod source;
 
 pub use context::{JsExecContext, JsPluginRule};
 pub use module_loader::JsModuleLoader;

--- a/crates/biome_js_runtime/src/module_loader.rs
+++ b/crates/biome_js_runtime/src/module_loader.rs
@@ -9,6 +9,8 @@ use rustc_hash::FxHashMap;
 
 use biome_resolver::{FsWithResolverProxy, ResolveOptions, resolve};
 
+use crate::source::read_module_source;
+
 pub struct JsModuleLoader {
     fs: Arc<dyn FsWithResolverProxy>,
     builtins: RefCell<FxHashMap<JsString, Module>>,
@@ -60,22 +62,16 @@ impl ModuleLoader for JsModuleLoader {
                     return Ok(module);
                 }
 
-                let source = self.fs.read_file_from_path(&path);
-                match source {
-                    Ok(source) => {
-                        let source = source.as_bytes();
-                        let source = Source::from_bytes(source).with_path(path.as_std_path());
-                        let module = Module::parse(source, None, &mut context.borrow_mut());
+                let source = read_module_source(&self.fs, &path)?;
+                let source = Source::from_bytes(source.as_bytes()).with_path(path.as_std_path());
+                let module = Module::parse(source, None, &mut context.borrow_mut());
 
-                        // Insert the parsed module into the cache.
-                        if let Ok(module) = &module {
-                            self.modules.borrow_mut().insert(path, module.clone());
-                        }
-
-                        module
-                    }
-                    Err(err) => Err(JsNativeError::error().with_message(err.to_string()).into()),
+                // Insert the parsed module into the cache.
+                if let Ok(module) = &module {
+                    self.modules.borrow_mut().insert(path, module.clone());
                 }
+
+                module
             }
             Err(err) => Err(JsNativeError::error().with_message(err.to_string()).into()),
         }

--- a/crates/biome_js_runtime/src/source.rs
+++ b/crates/biome_js_runtime/src/source.rs
@@ -1,0 +1,124 @@
+use std::slice;
+use std::sync::Arc;
+
+use boa_engine::{JsNativeError, JsResult};
+use camino::Utf8Path;
+
+use biome_analyze::{AnalysisFilter, AnalyzerOptions, ControlFlow, Never, RuleFilter};
+use biome_diagnostics::PrintDescription;
+use biome_js_parser::JsParserOptions;
+use biome_languages::JsFileSource;
+use biome_resolver::FsWithResolverProxy;
+
+/// Reads the ECMAScript source of the module at `path`.
+///
+/// TypeScript modules are transpiled by erasing their types, so plugins can be written in
+/// TypeScript. Only *erasable* syntax is supported: constructs generating runtime code, like
+/// `enum` or `namespace`, are reported as an error.
+pub(crate) fn read_module_source(
+    fs: &Arc<dyn FsWithResolverProxy>,
+    path: &Utf8Path,
+) -> JsResult<String> {
+    let source = fs.read_file_from_path(path).map_err(|err| {
+        JsNativeError::error().with_message(format!("Failed to read {path}: {err}"))
+    })?;
+
+    let source_type = JsFileSource::try_from(path).unwrap_or_else(|_| JsFileSource::js_module());
+    if !source_type.is_typescript() {
+        return Ok(source);
+    }
+
+    strip_types(&source, source_type).map_err(|message| {
+        JsNativeError::syntax()
+            .with_message(format!("{path}: {message}"))
+            .into()
+    })
+}
+
+/// Erases the TypeScript-only syntax of `source` by running the `stripTypes` transformation.
+///
+/// The output has the same length as the input: erased syntax is replaced with whitespace, so
+/// positions are preserved and the module needs no source map.
+fn strip_types(source: &str, source_type: JsFileSource) -> Result<String, String> {
+    let parsed = biome_js_parser::parse(source, source_type, JsParserOptions::default());
+    if parsed.has_errors() {
+        return Err("failed to parse the TypeScript source".to_string());
+    }
+
+    let rule = RuleFilter::Rule("transformations", "stripTypes");
+    let filter = AnalysisFilter {
+        enabled_rules: Some(slice::from_ref(&rule)),
+        ..AnalysisFilter::default()
+    };
+
+    let mut output = source.as_bytes().to_vec();
+    let mut errors = Vec::new();
+
+    let (_, analyzer_errors) = biome_js_transform::transform(
+        &parsed.tree(),
+        filter,
+        &AnalyzerOptions::default(),
+        source_type,
+        |signal| {
+            if let Some(diagnostic) = signal.diagnostic() {
+                errors.push(PrintDescription(&diagnostic).to_string());
+            }
+
+            // Each transformation rewrites the whole source, blanking out the range it erases.
+            // Since the length is preserved, the transformations are merged bytewise.
+            for transformation in signal.transformations() {
+                let stripped = transformation.mutation.commit().to_string();
+                for ((byte, original), stripped) in
+                    output.iter_mut().zip(source.bytes()).zip(stripped.bytes())
+                {
+                    if stripped != original {
+                        *byte = stripped;
+                    }
+                }
+            }
+
+            ControlFlow::<Never>::Continue(())
+        },
+    );
+
+    errors.extend(
+        analyzer_errors
+            .iter()
+            .map(|error| PrintDescription(error).to_string()),
+    );
+
+    if !errors.is_empty() {
+        return Err(errors.join("\n"));
+    }
+
+    Ok(String::from_utf8(output).expect("erasing types must keep the source valid UTF-8"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_types_erases_every_type() {
+        let source = "type A = number;\nfunction f(a: A): A {\n  return a as A;\n}\n";
+
+        let stripped = strip_types(source, JsFileSource::ts()).expect("types are erasable");
+
+        assert_eq!(
+            stripped,
+            "                \nfunction f(a   )    {\n  return a     ;\n}\n"
+        );
+        assert_eq!(stripped.len(), source.len());
+    }
+
+    #[test]
+    fn strip_types_reports_syntax_generating_runtime_code() {
+        let error = strip_types("enum Foo { Lorem }", JsFileSource::ts())
+            .expect_err("`enum` can't be erased");
+
+        assert_eq!(
+            error,
+            "enum declarations cannot be stripped because they generate runtime code."
+        );
+    }
+}

--- a/crates/biome_js_runtime/src/source.rs
+++ b/crates/biome_js_runtime/src/source.rs
@@ -5,7 +5,7 @@ use boa_engine::{JsNativeError, JsResult};
 use camino::Utf8Path;
 
 use biome_analyze::{AnalysisFilter, AnalyzerOptions, ControlFlow, Never, RuleFilter};
-use biome_diagnostics::PrintDescription;
+use biome_diagnostics::{Error, PrintDescription};
 use biome_js_parser::JsParserOptions;
 use biome_languages::JsFileSource;
 use biome_resolver::FsWithResolverProxy;
@@ -28,7 +28,13 @@ pub(crate) fn read_module_source(
         return Ok(source);
     }
 
-    strip_types(&source, source_type).map_err(|message| {
+    strip_types(&source, source_type).map_err(|errors| {
+        let message = errors
+            .iter()
+            .map(|error| PrintDescription(error).to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
         JsNativeError::syntax()
             .with_message(format!("{path}: {message}"))
             .into()
@@ -39,10 +45,14 @@ pub(crate) fn read_module_source(
 ///
 /// The output has the same length as the input: erased syntax is replaced with whitespace, so
 /// positions are preserved and the module needs no source map.
-fn strip_types(source: &str, source_type: JsFileSource) -> Result<String, String> {
+fn strip_types(source: &str, source_type: JsFileSource) -> Result<String, Vec<Error>> {
     let parsed = biome_js_parser::parse(source, source_type, JsParserOptions::default());
     if parsed.has_errors() {
-        return Err("failed to parse the TypeScript source".to_string());
+        return Err(parsed
+            .into_diagnostics()
+            .into_iter()
+            .map(Error::from)
+            .collect());
     }
 
     let rule = RuleFilter::Rule("transformations", "stripTypes");
@@ -61,7 +71,7 @@ fn strip_types(source: &str, source_type: JsFileSource) -> Result<String, String
         source_type,
         |signal| {
             if let Some(diagnostic) = signal.diagnostic() {
-                errors.push(PrintDescription(&diagnostic).to_string());
+                errors.push(Error::from(diagnostic));
             }
 
             // Each transformation rewrites the whole source, blanking out the range it erases.
@@ -81,14 +91,10 @@ fn strip_types(source: &str, source_type: JsFileSource) -> Result<String, String
         },
     );
 
-    errors.extend(
-        analyzer_errors
-            .iter()
-            .map(|error| PrintDescription(error).to_string()),
-    );
+    errors.extend(analyzer_errors);
 
     if !errors.is_empty() {
-        return Err(errors.join("\n"));
+        return Err(errors);
     }
 
     Ok(String::from_utf8(output).expect("erasing types must keep the source valid UTF-8"))
@@ -113,12 +119,15 @@ mod tests {
 
     #[test]
     fn strip_types_reports_syntax_generating_runtime_code() {
-        let error = strip_types("enum Foo { Lorem }", JsFileSource::ts())
+        let errors = strip_types("enum Foo { Lorem }", JsFileSource::ts())
             .expect_err("`enum` can't be erased");
 
         assert_eq!(
-            error,
-            "enum declarations cannot be stripped because they generate runtime code."
+            errors
+                .iter()
+                .map(|error| PrintDescription(error).to_string())
+                .collect::<Vec<_>>(),
+            ["enum declarations cannot be stripped because they generate runtime code."]
         );
     }
 }

--- a/crates/biome_js_transform/Cargo.toml
+++ b/crates/biome_js_transform/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 license.workspace    = true
 keywords.workspace   = true
 categories.workspace = true
-publish              = false
+publish              = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/biome_plugin_loader/src/analyzer_js_plugin.rs
+++ b/crates/biome_plugin_loader/src/analyzer_js_plugin.rs
@@ -222,17 +222,19 @@ mod tests {
     }
 
     fn load_test_plugin_from_source(
+        path: &str,
         source: &str,
         includes: Option<&[NormalizedGlob]>,
     ) -> AnalyzerJsPlugin {
         let fs = MemoryFileSystem::default();
-        fs.insert("/plugin.js".into(), source);
+        fs.insert(path.into(), source);
         let fs = Arc::new(fs) as Arc<dyn FsWithResolverProxy>;
-        AnalyzerJsPlugin::load(fs, "/plugin.js".into(), includes).unwrap()
+        AnalyzerJsPlugin::load(fs, path.into(), includes).unwrap()
     }
 
     fn load_test_plugin(includes: Option<&[NormalizedGlob]>) -> AnalyzerJsPlugin {
         load_test_plugin_from_source(
+            "/plugin.js",
             r#"import { ast, defineRule, registerDiagnostic } from "@biomejs/plugin-api";
             export const useMyPlugin = defineRule({
                 query: ast("JS_MODULE"),
@@ -278,6 +280,7 @@ mod tests {
     #[test]
     fn passes_the_matched_node_to_run() {
         let plugin = load_test_plugin_from_source(
+            "/plugin.js",
             r#"import { ast, defineRule, registerDiagnostic } from "@biomejs/plugin-api";
             export const useMyPlugin = defineRule({
                 query: ast("JS_MODULE"),
@@ -319,6 +322,7 @@ mod tests {
     #[test]
     fn queries_the_kinds_declared_by_the_rules() {
         let plugin = load_test_plugin_from_source(
+            "/plugin.js",
             r#"import { ast, defineRule } from "@biomejs/plugin-api";
             export const rule1 = defineRule({
                 query: ast("JS_VARIABLE_STATEMENT", "JS_CALL_EXPRESSION"),
@@ -407,7 +411,7 @@ mod tests {
             JsParserOptions::default(),
         );
 
-        let plugin = load_test_plugin_from_source(source, None);
+        let plugin = load_test_plugin_from_source("/plugin.js", source, None);
         let result = plugin.evaluate(parse.syntax().into(), "/file.js".into());
 
         snap_diagnostics(
@@ -442,7 +446,7 @@ mod tests {
             JsParserOptions::default(),
         );
 
-        let plugin = load_test_plugin_from_source(source, None);
+        let plugin = load_test_plugin_from_source("/plugin.js", source, None);
         let content_rendered: String = parse
             .syntax()
             .descendants()
@@ -457,6 +461,60 @@ mod tests {
             .collect();
 
         snap_diagnostics("dispatches_nodes_to_the_matching_rules", content_rendered);
+    }
+
+    /// Plugins can be written in TypeScript: the types are erased before the module is
+    /// evaluated by the engine.
+    #[test]
+    fn evaluate_typescript_plugin() {
+        let plugin = load_test_plugin_from_source(
+            "/plugin.ts",
+            r#"import { ast, defineRule, registerDiagnostic } from "@biomejs/plugin-api";
+            import type { AnyJsRoot, Severity } from "@biomejs/plugin-api";
+            export const useMyPlugin = defineRule({
+                query: ast("JS_MODULE"),
+                run(root: AnyJsRoot): void {
+                    registerDiagnostic(root, "information" satisfies Severity, "Hello, TypeScript!");
+                },
+            });"#,
+            None,
+        );
+        let parse = biome_js_parser::parse(
+            "let foo;",
+            JsFileSource::js_module(),
+            JsParserOptions::default(),
+        );
+
+        let result = plugin.evaluate(parse.syntax().into(), "/file.js".into());
+
+        let [entry] = result.entries.as_slice() else {
+            panic!("expected a single diagnostic, got {result:?}");
+        };
+        assert_eq!(
+            PrintDescription(&entry.diagnostic).to_string(),
+            "Hello, TypeScript!"
+        );
+    }
+
+    /// TypeScript syntax that generates runtime code can't be erased, so loading fails instead
+    /// of silently evaluating broken code.
+    #[test]
+    fn reject_typescript_plugin_with_unerasable_syntax() {
+        let fs = MemoryFileSystem::default();
+        fs.insert(
+            "/plugin.ts".into(),
+            r#"enum Severity { Information }
+            export default function useMyPlugin() {}"#,
+        );
+
+        let fs = Arc::new(fs) as Arc<dyn FsWithResolverProxy>;
+        let error = AnalyzerJsPlugin::load(fs, "/plugin.ts".into(), None)
+            .expect_err("`enum` can't be erased");
+
+        snap_diagnostics(
+            "reject_typescript_plugin_with_unerasable_syntax",
+            print_diagnostic_to_string(&Error::from(error)),
+        );
     }
 
     #[test]

--- a/crates/biome_plugin_loader/src/lib.rs
+++ b/crates/biome_plugin_loader/src/lib.rs
@@ -70,7 +70,7 @@ impl BiomePlugin {
         #[cfg(feature = "js_plugin")]
         if plugin_path
             .extension()
-            .is_some_and(|extension| extension == "js" || extension == "mjs")
+            .is_some_and(|extension| matches!(extension, "js" | "mjs" | "ts" | "mts"))
         {
             let plugin = AnalyzerJsPlugin::load(fs.clone(), &plugin_path, includes)?;
             return Ok((
@@ -230,6 +230,27 @@ mod test {
         let fs = Arc::new(fs) as Arc<dyn FsWithResolverProxy>;
         let (plugin, _) = BiomePlugin::load(fs, "./my-plugin.grit", Utf8Path::new("/"), None)
             .expect("Couldn't load plugin");
+        assert_eq!(plugin.analyzer_plugins.len(), 1);
+    }
+
+    #[cfg(feature = "js_plugin")]
+    #[test]
+    fn load_single_rule_ts_plugin() {
+        let fs = MemoryFileSystem::default();
+        fs.insert(
+            "/my-plugin.ts".into(),
+            r#"import { ast, defineRule } from "@biomejs/plugin-api";
+            import type { AnyJsRoot } from "@biomejs/plugin-api";
+            export const useMyPlugin = defineRule({
+                query: ast("JS_MODULE"),
+                run(root: AnyJsRoot): void {},
+            });"#,
+        );
+
+        let fs = Arc::new(fs) as Arc<dyn FsWithResolverProxy>;
+        let (plugin, _) = BiomePlugin::load(fs, "./my-plugin.ts", Utf8Path::new("/"), None)
+            .expect("Couldn't load plugin");
+
         assert_eq!(plugin.analyzer_plugins.len(), 1);
     }
 

--- a/crates/biome_plugin_loader/src/snapshots/reject_typescript_plugin_with_unerasable_syntax.snap
+++ b/crates/biome_plugin_loader/src/snapshots/reject_typescript_plugin_with_unerasable_syntax.snap
@@ -1,0 +1,7 @@
+---
+source: crates/biome_plugin_loader/src/analyzer_js_plugin.rs
+expression: content
+---
+plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Failed to compile the JS plugin: SyntaxError: /plugin.ts: enum declarations cannot be stripped because they generate runtime code.

--- a/crates/biome_service/src/workspace/server.tests.rs
+++ b/crates/biome_service/src/workspace/server.tests.rs
@@ -4065,3 +4065,90 @@ const x = 1;
         "cursor before an embedded script should not resolve to any definition"
     );
 }
+
+#[test]
+#[cfg(feature = "js_plugin")]
+fn typescript_plugin_reports_diagnostics_through_the_workspace() {
+    use biome_plugin_loader::{PluginConfiguration, Plugins};
+
+    const PLUGIN_PATH: &str = "/project/plugin.ts";
+    const PLUGIN_SOURCE: &str = r#"import { ast, defineRule, registerDiagnostic } from "@biomejs/plugin-api";
+import type { AnyJsRoot, Severity } from "@biomejs/plugin-api";
+
+export const noTopLevelVar = defineRule({
+    query: ast("JS_MODULE"),
+    run(root: AnyJsRoot): void {
+        for (const item of root.items) {
+            if (
+                item.kind === "JS_VARIABLE_STATEMENT" &&
+                item.declaration?.kindToken === "var"
+            ) {
+                registerDiagnostic(
+                    item,
+                    "warning" satisfies Severity,
+                    "Use let or const instead of a top-level var declaration.",
+                );
+            }
+        }
+    },
+});"#;
+    const FILE_PATH: &str = "/project/file.ts";
+    const FILE_CONTENT: &str = "var foo: number = 1;\nexport const bar: string = `${foo}`;\n";
+
+    let fs = MemoryFileSystem::default();
+    fs.insert(Utf8PathBuf::from(PLUGIN_PATH), PLUGIN_SOURCE);
+    fs.insert(Utf8PathBuf::from(FILE_PATH), FILE_CONTENT);
+
+    let (workspace, project_key) = setup_workspace_and_open_project(fs, "/project");
+
+    workspace
+        .update_settings(UpdateSettingsParams {
+            project_key,
+            workspace_directory: Some(BiomePath::new("/project")),
+            configuration: Configuration {
+                plugins: Some(Plugins(vec![PluginConfiguration::Path(
+                    "plugin.ts".to_string(),
+                )])),
+                ..Default::default()
+            },
+            extended_configurations: vec![],
+            module_graph_resolution_kind: ModuleGraphResolutionKind::None,
+        })
+        .unwrap();
+
+    workspace
+        .open_file(OpenFileParams {
+            project_key,
+            path: BiomePath::new(FILE_PATH),
+            content: FileContent::FromServer,
+            document_file_source: None,
+            persist_node_cache: false,
+            inline_config: None,
+            editor_features: None,
+        })
+        .unwrap();
+
+    let result = workspace
+        .pull_diagnostics(PullDiagnosticsParams {
+            project_key,
+            path: BiomePath::new(FILE_PATH),
+            categories: RuleCategories::default(),
+            only: vec![],
+            skip: vec![],
+            enabled_rules: vec![],
+            include_code_fix: false,
+            inline_config: None,
+            max_diagnostics: None,
+            diagnostic_level: Severity::Hint,
+            enforce_assist: false,
+        })
+        .unwrap();
+
+    assert_eq!(result.parse_errors, 0);
+
+    let diagnostics = format!("{:?}", result.diagnostics);
+    assert!(
+        diagnostics.contains("top-level var declaration"),
+        "Expected a diagnostic from the TypeScript plugin, got: {diagnostics}"
+    );
+}

--- a/plugins/plugin.ts
+++ b/plugins/plugin.ts
@@ -1,8 +1,13 @@
-import { ast, defineRule, registerDiagnostic } from "@biomejs/plugin-api";
+import {
+	type AnyJsRoot,
+	ast,
+	defineRule,
+	registerDiagnostic,
+} from "@biomejs/plugin-api";
 
 export const noTopLevelVar = defineRule({
 	query: ast("JS_MODULE", "JS_SCRIPT", "TS_DECLARATION_MODULE"),
-	run(root) {
+	run(root: AnyJsRoot) {
 		const statements = root.kind === "JS_SCRIPT" ? root.statements : root.items;
 
 		for (const statement of statements) {


### PR DESCRIPTION
## Summary

> [!WARNING]
> This PR depends on #11417.

> [!NOTE]
> **AI Assistance Disclosure**: I used Claude Agent (Fable 5) for authoring this pull request. I have reviewed all the changes before submitting.

This pull request introduces support for TypeScript files in JS plugins. Upon loading a plugin, Biome transforms it using the `biome_js_transform` crate. Note that only erasable syntax is supported in the transformation; see #11417 for details.

## Test Plan

Added some snapshot and unit tests.

## Docs

N/A. JS plugins are still behind a feature flag.
