### PR TITLE
chore(wasm): enable JS plugins via `unstable` feature

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -38,3 +38,8 @@ new-crate             = "run -p xtask_codegen -- new-crate"
 
 [profile.release]
 lto = true
+
+# getrandom 0.3 (pulled in by boa_engine) requires an explicit backend on wasm,
+# in addition to its `wasm_js` cargo feature (enabled in biome_js_runtime).
+[target.wasm32-unknown-unknown]
+rustflags = ["--cfg", 'getrandom_backend="wasm_js"']

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,6 +1149,7 @@ dependencies = [
  "biome_text_size",
  "boa_engine",
  "camino",
+ "getrandom 0.3.2",
  "rustc-hash 2.1.3",
 ]
 

--- a/crates/biome_js_runtime/Cargo.toml
+++ b/crates/biome_js_runtime/Cargo.toml
@@ -22,5 +22,8 @@ boa_engine        = { workspace = true }
 camino            = { workspace = true }
 rustc-hash        = { workspace = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.3.2", features = ["wasm_js"] }
+
 [lints]
 workspace = true

--- a/crates/biome_plugin_loader/src/thread_local.rs
+++ b/crates/biome_plugin_loader/src/thread_local.rs
@@ -90,9 +90,45 @@ mod platform {
     }
 }
 
+#[cfg(target_arch = "wasm32")]
+mod platform {
+    use std::cell::Cell;
+    use std::marker::PhantomData;
+
+    /// Fallback for targets without native TLS, i.e. `wasm32-unknown-unknown`,
+    /// which only ever runs on a single thread.
+    pub(super) struct Key<T> {
+        inner: Cell<*mut T>,
+        _phantom: PhantomData<fn() -> T>,
+    }
+
+    // SAFETY: this fallback is only compiled for single-threaded targets, so
+    // the cell can never actually be accessed from more than one thread.
+    unsafe impl<T> Send for Key<T> {}
+    unsafe impl<T> Sync for Key<T> {}
+
+    impl<T> Key<T> {
+        pub(super) unsafe fn new() -> Self {
+            Self {
+                inner: Cell::new(std::ptr::null_mut()),
+                _phantom: PhantomData,
+            }
+        }
+
+        pub(super) unsafe fn get(&self) -> *mut T {
+            self.inner.get()
+        }
+
+        pub(super) unsafe fn set(&self, value: *mut T) {
+            self.inner.set(value);
+        }
+    }
+}
+
 /// Thread-local storage.
 /// It uses [`Fiber Local Storage`](https://learn.microsoft.com/en-us/windows/win32/procthread/fibers#fiber-local-storage) on Windows,
-/// or [`pthread_setspecific(3)`](https://linux.die.net/man/3/pthread_setspecific) on Unix.
+/// [`pthread_setspecific(3)`](https://linux.die.net/man/3/pthread_setspecific) on Unix,
+/// or a plain [`Cell`](std::cell::Cell) on single-threaded targets such as WASM.
 /// Note that the inner value is not dropped on thread exit to avoid double-free after another
 /// [`std::thread_local`] is dropped.
 pub(crate) struct ThreadLocalCell<T> {

--- a/crates/biome_wasm/Cargo.toml
+++ b/crates/biome_wasm/Cargo.toml
@@ -46,11 +46,12 @@ schemars           = { workspace = true }
 
 [features]
 default                      = ["console_error_panic_hook"]
+js_plugin                    = ["biome_service/js_plugin"]
 lang_md                      = ["biome_service/lang_md"]
 lang_scss                    = ["biome_service/lang_scss"]
 lang_yaml                    = ["biome_service/lang_yaml"]
 report_scss_exclusive_syntax = ["biome_service/report_scss_exclusive_syntax"]
-unstable                     = ["lang_md", "lang_scss", "lang_yaml", "report_scss_exclusive_syntax"]
+unstable                     = ["js_plugin", "lang_md", "lang_scss", "lang_yaml", "report_scss_exclusive_syntax"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

Enables the `js_plugin` feature in the `biome_wasm` crate if the `unstable` feature is enabled. Our playground will be able to use JS plugins.

The `js_plugin` feature contains the Boa engine. I concerned about the file size, turns out it didn't grow much than I expected (It's still big 😅):

| Before | After | Δ |
| --- | --- | --- |
| 45,891,054 bytes | 53,005,199 bytes | +7,114,145 bytes (~ 7 MB) |

## Test Plan

I tried `just build-wasm-web --features=unstable` locally to confirm it succeeds.

## Docs

N/A