### PR TITLE
fix(grit): handle metavariables inside quoted strings

### DIFF
--- a/.changeset/true-books-deny.md
+++ b/.changeset/true-books-deny.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6426](https://github.com/biomejs/biome/issues/6426): GritQL plugins now match and rewrite metavariables embedded in quoted strings.

--- a/crates/biome_grit_patterns/src/grit_query.rs
+++ b/crates/biome_grit_patterns/src/grit_query.rs
@@ -852,6 +852,33 @@ mod tests {
     }
 
     #[test]
+    fn rewrites_metavariables_inside_quoted_strings() {
+        let query = compile_js_query(
+            r#"`"$value"` where {
+                $token = "my-old-css-variable",
+                $replacement = "my-new-css-variable",
+                $value <: r`(.*)(.*)-\\[--$token\\](.*)`($prefix, $class, $suffix) => `$prefix$class-[--$replacement]$suffix`
+            }"#,
+        );
+        let code = r#"const value = "bg-[--my-old-css-variable] text-sm";"#;
+        let expected = r#"const value = "bg-[--my-new-css-variable] text-sm";"#;
+
+        let results = [
+            query.execute(make_js_file(code)).expect("execute failed"),
+            query
+                .execute_optimized(make_js_file(code))
+                .expect("optimized failed"),
+        ];
+
+        for result in results {
+            let [GritQueryEffect::Rewrite(rewrite)] = result.effects.as_slice() else {
+                panic!("expected one rewrite effect, got {:?}", result.effects);
+            };
+            assert_eq!(rewrite.rewritten.content, expected);
+        }
+    }
+
+    #[test]
     fn execute_optimized_no_matches_when_pattern_absent() {
         let query = compile_js_query("`console.log($msg)`");
         let code = "const x = 42;";

--- a/crates/biome_grit_patterns/src/pattern_compiler/snippet_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/snippet_compiler.rs
@@ -298,11 +298,12 @@ fn implicit_metavariable_regex(
     let mut last = 0;
     let mut regex_string = String::new();
     let mut variables: Vec<Variable> = vec![];
+    let node_start = node.start_byte() as usize;
     for m in variable_regex.find_iter(source) {
         regex_string.push_str(&regex::escape(&source[last..m.start()]));
-        let range = ByteRange::new(m.start(), m.end());
-        last = range.end;
+        last = m.end();
         let name = m.as_str();
+        let range = ByteRange::new(node_start + m.start(), node_start + m.end());
         let variable = text_to_var(name, range, context_range, range_map, context).ok()?;
         match variable {
             SnippetValue::Dots => return None,
@@ -386,13 +387,9 @@ fn node_sub_variables(node: &GritTargetNode, lang: &GritTargetLanguage) -> Vec<B
 
     let source = node.text();
     let variable_regex = lang.replaced_metavariable_regex();
+    let start_byte = node.start_byte() as usize;
     for m in variable_regex.find_iter(source) {
-        let var_range = ByteRange::new(m.start(), m.end());
-        let start_byte = node.start_byte() as usize;
-        let end_byte = node.end_byte() as usize;
-        if var_range.start >= start_byte && var_range.end <= end_byte {
-            ranges.push(var_range);
-        }
+        ranges.push(ByteRange::new(start_byte + m.start(), start_byte + m.end()));
     }
 
     ranges


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Frankly, my intuition of how grit works internally is not great, so I'm not sure if this is the right way to fix this.

fixes #6426

This is gpt 5.6 sol's explanation of the bug:

The bug was caused by mixing two kinds of byte positions.

  For this GritQL snippet:

```
  `"$value"`
```

  Biome temporarily changes $value to µvalue, then parses:

```
  "µvalue"
```

  The parser may wrap that text in extra JavaScript so it can understand the snippet. That means the string node
  might begin at byte 20 in the wrapped source.

  Inside the string node, the regex finds µvalue at bytes 1..8. Those positions are relative to the string itself:

```
  "µvalue"
   ^^^^^^^
   1.....8
```

  The old code treated 1..8 as positions in the complete wrapped source. Elsewhere, Biome expected the absolute
  range 21..28. Since 1..8 and 21..28 did not match, Biome lost track of the metavariable and treated "µvalue" as
  literal text.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->


<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
tests

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
