### PR TITLE
refactor(deserialize): type-erased visitor for reduce binary size

### DIFF
--- a/crates/biome_cli/src/execute/migrate/eslint_eslint.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_eslint.rs
@@ -518,7 +518,9 @@ impl Deserializable for Rules {
             fn visit_map(
                 self,
                 ctx: &mut dyn DeserializationContext,
-                members: &mut dyn ExactSizeIterator<Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>>,
+                members: &mut dyn ExactSizeIterator<
+                    Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>,
+                >,
                 _range: biome_rowan::TextRange,
                 name: &str,
             ) -> Option<Self::Output> {

--- a/crates/biome_cli/src/execute/migrate/eslint_eslint.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_eslint.rs
@@ -129,7 +129,7 @@ impl AsRef<str> for IgnorePattern {
 }
 impl biome_deserialize::Deserializable for IgnorePattern {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -182,7 +182,7 @@ impl GlobalConf {
 }
 impl Deserializable for GlobalConf {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl biome_deserialize::DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -247,7 +247,7 @@ impl<T> IntoIterator for ShorthandVec<T> {
 }
 impl<T: Deserializable> Deserializable for ShorthandVec<T> {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -288,7 +288,7 @@ impl<T> From<Vec<T>> for NestableVec<T> {
 }
 impl<T: Deserializable> Deserializable for NestableVec<T> {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -311,8 +311,8 @@ impl<T: Deserializable> DeserializationVisitor for NestableVecVisitor<T> {
     const EXPECTED_TYPE: DeserializableTypes = DeserializableTypes::ARRAY;
     fn visit_array(
         self,
-        ctx: &mut impl DeserializationContext,
-        items: impl Iterator<Item = Option<impl DeserializableValue>>,
+        ctx: &mut dyn DeserializationContext,
+        items: &mut dyn ExactSizeIterator<Item = Option<Box<dyn DeserializableValue>>>,
         _range: TextRange,
         name: &str,
     ) -> Option<Self::Output> {
@@ -369,7 +369,7 @@ impl<T: Default, U: Default> RuleConf<T, U> {
 }
 impl<T: Deserializable + 'static, U: Deserializable + 'static> Deserializable for RuleConf<T, U> {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl biome_deserialize::DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -381,8 +381,8 @@ impl<T: Deserializable + 'static, U: Deserializable + 'static> Deserializable fo
             const EXPECTED_TYPE: DeserializableTypes = DeserializableTypes::ARRAY;
             fn visit_array(
                 self,
-                ctx: &mut impl DeserializationContext,
-                values: impl Iterator<Item = Option<impl DeserializableValue>>,
+                ctx: &mut dyn DeserializationContext,
+                values: &mut dyn ExactSizeIterator<Item = Option<Box<dyn DeserializableValue>>>,
                 range: TextRange,
                 _name: &str,
             ) -> Option<Self::Output> {
@@ -480,7 +480,7 @@ enum NumberOrString {
 }
 impl Deserializable for NumberOrString {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl biome_deserialize::DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -507,7 +507,7 @@ impl Deref for Rules {
 }
 impl Deserializable for Rules {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl biome_deserialize::DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -517,13 +517,8 @@ impl Deserializable for Rules {
             const EXPECTED_TYPE: DeserializableTypes = DeserializableTypes::MAP;
             fn visit_map(
                 self,
-                ctx: &mut impl DeserializationContext,
-                members: impl Iterator<
-                    Item = Option<(
-                        impl biome_deserialize::DeserializableValue,
-                        impl biome_deserialize::DeserializableValue,
-                    )>,
-                >,
+                ctx: &mut dyn DeserializationContext,
+                members: &mut dyn ExactSizeIterator<Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>>,
                 _range: biome_rowan::TextRange,
                 name: &str,
             ) -> Option<Self::Output> {
@@ -663,7 +658,7 @@ impl MaxNestedCallbacksOptions {
 
 impl Deserializable for MaxNestedCallbacksOptions {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -795,7 +790,7 @@ impl NoRestrictedGlobal {
 }
 impl Deserializable for NoRestrictedGlobal {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {

--- a/crates/biome_cli/src/execute/migrate/eslint_eslint.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_eslint.rs
@@ -1,6 +1,6 @@
 use biome_deserialize::{
     Deserializable, DeserializableType, DeserializableTypes, DeserializableValue,
-    DeserializationContext, DeserializationDiagnostic, DeserializationVisitor, Merge,
+    DeserializationContext, DeserializationDiagnostic, DeserializationVisitor, MapMembers, Merge,
 };
 use biome_deserialize_macros::Deserializable;
 use biome_rowan::TextRange;
@@ -518,9 +518,7 @@ impl Deserializable for Rules {
             fn visit_map(
                 self,
                 ctx: &mut dyn DeserializationContext,
-                members: &mut dyn ExactSizeIterator<
-                    Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>,
-                >,
+                members: &mut MapMembers<'_>,
                 _range: biome_rowan::TextRange,
                 name: &str,
             ) -> Option<Self::Output> {

--- a/crates/biome_cli/src/execute/migrate/eslint_typescript.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_typescript.rs
@@ -538,7 +538,7 @@ impl NamingConventionSelection {
 pub(crate) struct Anything;
 impl Deserializable for Anything {
     fn deserialize(
-        _ctx: &mut impl biome_deserialize::DeserializationContext,
+        _ctx: &mut dyn biome_deserialize::DeserializationContext,
         _value: &impl biome_deserialize::DeserializableValue,
         _name: &str,
     ) -> Option<Self> {

--- a/crates/biome_configuration/src/analyzer/linter/mod.rs
+++ b/crates/biome_configuration/src/analyzer/linter/mod.rs
@@ -48,7 +48,7 @@ pub struct LinterConfiguration {
 impl DeserializableValidator for LinterConfiguration {
     fn validate(
         &mut self,
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         _name: &str,
         range: TextRange,
     ) -> bool {

--- a/crates/biome_configuration/src/analyzer/mod.rs
+++ b/crates/biome_configuration/src/analyzer/mod.rs
@@ -28,7 +28,7 @@ pub enum RuleConfiguration<T: Default + Merge> {
 }
 impl<T: Default + Merge + Deserializable> Deserializable for RuleConfiguration<T> {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         rule_name: &str,
     ) -> Option<Self> {
@@ -137,7 +137,7 @@ impl<T: Default + Merge> Default for RuleFixConfiguration<T> {
 }
 impl<T: Default + Merge + Deserializable> Deserializable for RuleFixConfiguration<T> {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         rule_name: &str,
     ) -> Option<Self> {
@@ -305,7 +305,7 @@ pub enum RuleAssistConfiguration<T: Default> {
 }
 impl<T: Default + Deserializable> Deserializable for RuleAssistConfiguration<T> {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -1196,7 +1196,7 @@ where
 
 impl<G: Deserializable> Deserializable for SeverityOrGroup<G> {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {

--- a/crates/biome_configuration/src/analyzer/presets.rs
+++ b/crates/biome_configuration/src/analyzer/presets.rs
@@ -70,7 +70,7 @@ impl PresetConfig {
 
 impl Deserializable for PresetConfig {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -80,7 +80,7 @@ impl Deserializable for PresetConfig {
             const EXPECTED_TYPE: DeserializableTypes = DeserializableTypes::STR;
             fn visit_str(
                 self,
-                ctx: &mut impl DeserializationContext,
+                ctx: &mut dyn DeserializationContext,
                 value: Text,
                 range: TextRange,
                 _name: &str,

--- a/crates/biome_configuration/src/bool.rs
+++ b/crates/biome_configuration/src/bool.rs
@@ -44,7 +44,7 @@ impl<const D: bool> FromStr for Bool<D> {
 
 impl<const D: bool> Deserializable for Bool<D> {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {

--- a/crates/biome_configuration/src/extends.rs
+++ b/crates/biome_configuration/src/extends.rs
@@ -36,7 +36,7 @@ impl Default for Extends {
 
 impl Deserializable for Extends {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -265,7 +265,7 @@ pub struct Configuration {
 impl DeserializableValidator for Configuration {
     fn validate(
         &mut self,
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         _name: &str,
         range: TextRange,
     ) -> bool {
@@ -540,7 +540,7 @@ static SCHEMA_REGEX: LazyLock<Regex> =
 
 impl Deserializable for Schema {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -551,7 +551,7 @@ impl Deserializable for Schema {
 
             fn visit_str(
                 self,
-                ctx: &mut impl DeserializationContext,
+                ctx: &mut dyn DeserializationContext,
                 value: Text,
                 range: TextRange,
                 _name: &str,
@@ -674,7 +674,7 @@ pub struct FilesConfiguration {
 impl FilesConfiguration {
     fn deserialize_field(
         &mut self,
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         name: &str,
         value: &impl DeserializableValue,
         range: TextRange,
@@ -742,7 +742,7 @@ impl FilesConfiguration {
 
 impl biome_deserialize::Deserializable for FilesConfiguration {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -752,10 +752,8 @@ impl biome_deserialize::Deserializable for FilesConfiguration {
             const EXPECTED_TYPE: DeserializableTypes = DeserializableTypes::MAP;
             fn visit_map(
                 self,
-                ctx: &mut impl DeserializationContext,
-                members: impl Iterator<
-                    Item = Option<(impl DeserializableValue, impl DeserializableValue)>,
-                >,
+                ctx: &mut dyn DeserializationContext,
+                members: &mut dyn ExactSizeIterator<Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>>,
                 _range: TextRange,
                 _name: &str,
             ) -> Option<Self::Output> {

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -753,7 +753,9 @@ impl biome_deserialize::Deserializable for FilesConfiguration {
             fn visit_map(
                 self,
                 ctx: &mut dyn DeserializationContext,
-                members: &mut dyn ExactSizeIterator<Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>>,
+                members: &mut dyn ExactSizeIterator<
+                    Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>,
+                >,
                 _range: TextRange,
                 _name: &str,
             ) -> Option<Self::Output> {

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -71,7 +71,8 @@ use biome_console::fmt::{Display, Formatter};
 use biome_console::{KeyValuePair, markup};
 use biome_deserialize::{
     Deserializable, DeserializableTypes, DeserializableValidator, DeserializableValue,
-    DeserializationContext, DeserializationDiagnostic, DeserializationVisitor, Text, TextRange,
+    DeserializationContext, DeserializationDiagnostic, DeserializationVisitor, MapMembers, Text,
+    TextRange,
 };
 use biome_deserialize_macros::{Deserializable, Merge};
 use biome_diagnostics::Severity;
@@ -753,9 +754,7 @@ impl biome_deserialize::Deserializable for FilesConfiguration {
             fn visit_map(
                 self,
                 ctx: &mut dyn DeserializationContext,
-                members: &mut dyn ExactSizeIterator<
-                    Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>,
-                >,
+                members: &mut MapMembers<'_>,
                 _range: TextRange,
                 _name: &str,
             ) -> Option<Self::Output> {

--- a/crates/biome_configuration/src/max_size.rs
+++ b/crates/biome_configuration/src/max_size.rs
@@ -30,7 +30,7 @@ impl FromStr for MaxSize {
 
 impl Deserializable for MaxSize {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {

--- a/crates/biome_configuration/src/overrides.rs
+++ b/crates/biome_configuration/src/overrides.rs
@@ -103,7 +103,7 @@ impl OverrideGlobs {
 }
 impl biome_deserialize::Deserializable for OverrideGlobs {
     fn deserialize(
-        ctx: &mut impl biome_deserialize::DeserializationContext,
+        ctx: &mut dyn biome_deserialize::DeserializationContext,
         value: &impl biome_deserialize::DeserializableValue,
         name: &str,
     ) -> Option<Self> {

--- a/crates/biome_configuration/src/vcs.rs
+++ b/crates/biome_configuration/src/vcs.rs
@@ -89,7 +89,7 @@ impl VcsConfiguration {
 impl DeserializableValidator for VcsConfiguration {
     fn validate(
         &mut self,
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         _name: &str,
         range: biome_rowan::TextRange,
     ) -> bool {

--- a/crates/biome_deserialize/README.md
+++ b/crates/biome_deserialize/README.md
@@ -193,7 +193,7 @@ impl FromStr for Day {
 
 impl Deserializable for Day {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -248,7 +248,7 @@ enum Union {
 
 impl Deserializable for Union {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -296,7 +296,7 @@ The full example:
 ```rust
 impl Deserializable for Union {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -315,7 +315,7 @@ impl DeserializationVisitor for UnionVisitor {
     // Because we expect a `bool` or a `str`, we have to implement the associated method `visit_bool`.
     fn visit_bool(
         self,
-        _ctx: &mut impl DeserializationContext,
+        _ctx: &mut dyn DeserializationContext,
         value: bool,
         range: TextRange,
         _name: &str,
@@ -326,7 +326,7 @@ impl DeserializationVisitor for UnionVisitor {
     // Because we expect a `bool` or a `str`, we have to implement the associated method `visit_str`.
     fn visit_str(
         self,
-        _ctx: &mut impl DeserializationContext,
+        _ctx: &mut dyn DeserializationContext,
         value: Text,
         range: TextRange,
         _name: &str,
@@ -355,7 +355,7 @@ pub enum Variant { A, B }
 
 impl Deserializable for Variant {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -400,7 +400,7 @@ pub enum Variant { A, B }
 
 impl Deserializable for Variant {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -460,7 +460,7 @@ pub struct Person { name: String, age: u8 }
 
 impl Deserializable for Person {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -481,7 +481,7 @@ impl DeserializationVisitor for PersonVisitor {
     // Because we expect a `map`, we have to implement the associated method `visit_map`.
     fn visit_map(
         self,
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         // Iterator of key-value pairs.
         members: impl Iterator<Item = Option<(impl DeserializableValue, impl DeserializableValue)>>,
         // range of the map in the source text.

--- a/crates/biome_deserialize/src/impls.rs
+++ b/crates/biome_deserialize/src/impls.rs
@@ -17,7 +17,7 @@ use std::{
 
 impl Deserializable for Text {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -27,7 +27,7 @@ impl Deserializable for Text {
             const EXPECTED_TYPE: DeserializableTypes = DeserializableTypes::STR;
             fn visit_str(
                 self,
-                _ctx: &mut impl DeserializationContext,
+                _ctx: &mut dyn DeserializationContext,
                 value: Text,
                 _range: TextRange,
                 _name: &str,
@@ -61,7 +61,7 @@ impl std::fmt::Display for TextNumber {
 }
 impl Deserializable for TextNumber {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -71,7 +71,7 @@ impl Deserializable for TextNumber {
             const EXPECTED_TYPE: DeserializableTypes = DeserializableTypes::NUMBER;
             fn visit_number(
                 self,
-                _ctx: &mut impl DeserializationContext,
+                _ctx: &mut dyn DeserializationContext,
                 value: TextNumber,
                 _range: TextRange,
                 _name: &str,
@@ -85,7 +85,7 @@ impl Deserializable for TextNumber {
 
 impl Deserializable for () {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -100,7 +100,7 @@ impl Deserializable for () {
 
 impl Deserializable for bool {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -110,7 +110,7 @@ impl Deserializable for bool {
             const EXPECTED_TYPE: DeserializableTypes = DeserializableTypes::BOOL;
             fn visit_bool(
                 self,
-                _ctx: &mut impl DeserializationContext,
+                _ctx: &mut dyn DeserializationContext,
                 value: bool,
                 _range: TextRange,
                 _name: &str,
@@ -124,7 +124,7 @@ impl Deserializable for bool {
 
 impl Deserializable for f32 {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -142,7 +142,7 @@ impl Deserializable for f32 {
 
 impl Deserializable for f64 {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -160,7 +160,7 @@ impl Deserializable for f64 {
 
 impl Deserializable for i8 {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -179,7 +179,7 @@ impl Deserializable for i8 {
 
 impl Deserializable for i16 {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -198,7 +198,7 @@ impl Deserializable for i16 {
 
 impl Deserializable for i32 {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -217,7 +217,7 @@ impl Deserializable for i32 {
 
 impl Deserializable for isize {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -236,7 +236,7 @@ impl Deserializable for isize {
 
 impl Deserializable for i64 {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -255,7 +255,7 @@ impl Deserializable for i64 {
 
 impl Deserializable for u8 {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -274,7 +274,7 @@ impl Deserializable for u8 {
 
 impl Deserializable for u16 {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -293,7 +293,7 @@ impl Deserializable for u16 {
 
 impl Deserializable for u32 {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -312,7 +312,7 @@ impl Deserializable for u32 {
 
 impl Deserializable for usize {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -331,7 +331,7 @@ impl Deserializable for usize {
 
 impl Deserializable for u64 {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -350,7 +350,7 @@ impl Deserializable for u64 {
 
 impl Deserializable for NonZeroU8 {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -369,7 +369,7 @@ impl Deserializable for NonZeroU8 {
 
 impl Deserializable for NonZeroU16 {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -388,7 +388,7 @@ impl Deserializable for NonZeroU16 {
 
 impl Deserializable for NonZeroU32 {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -407,7 +407,7 @@ impl Deserializable for NonZeroU32 {
 
 impl Deserializable for NonZeroUsize {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -426,7 +426,7 @@ impl Deserializable for NonZeroUsize {
 
 impl Deserializable for NonZeroU64 {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -445,7 +445,7 @@ impl Deserializable for NonZeroU64 {
 
 impl Deserializable for String {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -455,7 +455,7 @@ impl Deserializable for String {
 
 impl Deserializable for Box<str> {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -465,7 +465,7 @@ impl Deserializable for Box<str> {
 
 impl Deserializable for PathBuf {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -475,7 +475,7 @@ impl Deserializable for PathBuf {
 
 impl<T: Deserializable> Deserializable for Box<T> {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -485,7 +485,7 @@ impl<T: Deserializable> Deserializable for Box<T> {
 
 impl<T: Deserializable> Deserializable for Option<T> {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -499,7 +499,7 @@ impl<T: Deserializable> Deserializable for Option<T> {
 
 impl<T: Deserializable> Deserializable for Vec<T> {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -509,8 +509,8 @@ impl<T: Deserializable> Deserializable for Vec<T> {
             const EXPECTED_TYPE: DeserializableTypes = DeserializableTypes::ARRAY;
             fn visit_array(
                 self,
-                ctx: &mut impl DeserializationContext,
-                values: impl ExactSizeIterator<Item = Option<impl DeserializableValue>>,
+                ctx: &mut dyn DeserializationContext,
+                values: &mut dyn ExactSizeIterator<Item = Option<Box<dyn DeserializableValue>>>,
                 _range: TextRange,
                 _name: &str,
             ) -> Option<Self::Output> {
@@ -527,7 +527,7 @@ impl<T: Deserializable> Deserializable for Vec<T> {
 
 impl<T: Deserializable> Deserializable for Box<[T]> {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -538,7 +538,7 @@ impl<T: Deserializable> Deserializable for Box<[T]> {
 #[cfg(feature = "smallvec")]
 impl<T: Deserializable, const L: usize> Deserializable for smallvec::SmallVec<[T; L]> {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -548,8 +548,8 @@ impl<T: Deserializable, const L: usize> Deserializable for smallvec::SmallVec<[T
             const EXPECTED_TYPE: DeserializableTypes = DeserializableTypes::ARRAY;
             fn visit_array(
                 self,
-                ctx: &mut impl DeserializationContext,
-                values: impl ExactSizeIterator<Item = Option<impl DeserializableValue>>,
+                ctx: &mut dyn DeserializationContext,
+                values: &mut dyn ExactSizeIterator<Item = Option<Box<dyn DeserializableValue>>>,
                 _range: TextRange,
                 _name: &str,
             ) -> Option<Self::Output> {
@@ -566,7 +566,7 @@ impl<T: Deserializable, const L: usize> Deserializable for smallvec::SmallVec<[T
 
 impl<T: Deserializable + Eq + Hash, S: BuildHasher + Default> Deserializable for HashSet<T, S> {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -578,8 +578,8 @@ impl<T: Deserializable + Eq + Hash, S: BuildHasher + Default> Deserializable for
             const EXPECTED_TYPE: DeserializableTypes = DeserializableTypes::ARRAY;
             fn visit_array(
                 self,
-                ctx: &mut impl DeserializationContext,
-                values: impl ExactSizeIterator<Item = Option<impl DeserializableValue>>,
+                ctx: &mut dyn DeserializationContext,
+                values: &mut dyn ExactSizeIterator<Item = Option<Box<dyn DeserializableValue>>>,
                 _range: TextRange,
                 _name: &str,
             ) -> Option<Self::Output> {
@@ -596,7 +596,7 @@ impl<T: Deserializable + Eq + Hash, S: BuildHasher + Default> Deserializable for
 
 impl<T: Ord + Deserializable> Deserializable for BTreeSet<T> {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -606,8 +606,8 @@ impl<T: Ord + Deserializable> Deserializable for BTreeSet<T> {
             const EXPECTED_TYPE: DeserializableTypes = DeserializableTypes::ARRAY;
             fn visit_array(
                 self,
-                ctx: &mut impl DeserializationContext,
-                values: impl ExactSizeIterator<Item = Option<impl DeserializableValue>>,
+                ctx: &mut dyn DeserializationContext,
+                values: &mut dyn ExactSizeIterator<Item = Option<Box<dyn DeserializableValue>>>,
                 _range: TextRange,
                 _name: &str,
             ) -> Option<Self::Output> {
@@ -625,7 +625,7 @@ impl<T: Ord + Deserializable> Deserializable for BTreeSet<T> {
 #[cfg(feature = "indexmap")]
 impl<T: Hash + Eq + Deserializable> Deserializable for indexmap::IndexSet<T> {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -635,8 +635,8 @@ impl<T: Hash + Eq + Deserializable> Deserializable for indexmap::IndexSet<T> {
             const EXPECTED_TYPE: DeserializableTypes = DeserializableTypes::ARRAY;
             fn visit_array(
                 self,
-                ctx: &mut impl DeserializationContext,
-                values: impl ExactSizeIterator<Item = Option<impl DeserializableValue>>,
+                ctx: &mut dyn DeserializationContext,
+                values: &mut dyn ExactSizeIterator<Item = Option<Box<dyn DeserializableValue>>>,
                 _range: TextRange,
                 _name: &str,
             ) -> Option<Self::Output> {
@@ -655,7 +655,7 @@ impl<K: Hash + Eq + Deserializable, V: Deserializable, S: Default + BuildHasher>
     for HashMap<K, V, S>
 {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -667,9 +667,9 @@ impl<K: Hash + Eq + Deserializable, V: Deserializable, S: Default + BuildHasher>
             const EXPECTED_TYPE: DeserializableTypes = DeserializableTypes::MAP;
             fn visit_map(
                 self,
-                ctx: &mut impl DeserializationContext,
-                members: impl ExactSizeIterator<
-                    Item = Option<(impl DeserializableValue, impl DeserializableValue)>,
+                ctx: &mut dyn DeserializationContext,
+                members: &mut dyn ExactSizeIterator<
+                    Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>,
                 >,
                 _range: TextRange,
                 _name: &str,
@@ -692,7 +692,7 @@ impl<K: Hash + Eq + Deserializable, V: Deserializable, S: Default + BuildHasher>
 
 impl<K: Ord + Deserializable, V: Deserializable> Deserializable for BTreeMap<K, V> {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -702,9 +702,9 @@ impl<K: Ord + Deserializable, V: Deserializable> Deserializable for BTreeMap<K, 
             const EXPECTED_TYPE: DeserializableTypes = DeserializableTypes::MAP;
             fn visit_map(
                 self,
-                ctx: &mut impl DeserializationContext,
-                members: impl ExactSizeIterator<
-                    Item = Option<(impl DeserializableValue, impl DeserializableValue)>,
+                ctx: &mut dyn DeserializationContext,
+                members: &mut dyn ExactSizeIterator<
+                    Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>,
                 >,
                 _range: TextRange,
                 _name: &str,
@@ -729,7 +729,7 @@ impl<K: Hash + Eq + Deserializable, V: Deserializable, S: Default + BuildHasher>
     for indexmap::IndexMap<K, V, S>
 {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -741,9 +741,9 @@ impl<K: Hash + Eq + Deserializable, V: Deserializable, S: Default + BuildHasher>
             const EXPECTED_TYPE: DeserializableTypes = DeserializableTypes::MAP;
             fn visit_map(
                 self,
-                ctx: &mut impl DeserializationContext,
-                members: impl ExactSizeIterator<
-                    Item = Option<(impl DeserializableValue, impl DeserializableValue)>,
+                ctx: &mut dyn DeserializationContext,
+                members: &mut dyn ExactSizeIterator<
+                    Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>,
                 >,
                 _range: TextRange,
                 _name: &str,
@@ -767,7 +767,7 @@ impl<K: Hash + Eq + Deserializable, V: Deserializable, S: Default + BuildHasher>
 #[cfg(feature = "camino")]
 impl Deserializable for camino::Utf8PathBuf {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {

--- a/crates/biome_deserialize/src/impls.rs
+++ b/crates/biome_deserialize/src/impls.rs
@@ -3,7 +3,7 @@
 //! Tests of these implementations are available in [biome_deserialize::json::tests] module.
 use crate::{
     Deserializable, DeserializableValue, DeserializationContext, DeserializationDiagnostic,
-    DeserializationVisitor, diagnostics::DeserializableTypes,
+    DeserializationVisitor, MapMembers, diagnostics::DeserializableTypes,
 };
 use biome_rowan::{Text, TextRange, TokenText};
 use std::{
@@ -668,9 +668,7 @@ impl<K: Hash + Eq + Deserializable, V: Deserializable, S: Default + BuildHasher>
             fn visit_map(
                 self,
                 ctx: &mut dyn DeserializationContext,
-                members: &mut dyn ExactSizeIterator<
-                    Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>,
-                >,
+                members: &mut MapMembers<'_>,
                 _range: TextRange,
                 _name: &str,
             ) -> Option<Self::Output> {
@@ -703,9 +701,7 @@ impl<K: Ord + Deserializable, V: Deserializable> Deserializable for BTreeMap<K, 
             fn visit_map(
                 self,
                 ctx: &mut dyn DeserializationContext,
-                members: &mut dyn ExactSizeIterator<
-                    Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>,
-                >,
+                members: &mut MapMembers<'_>,
                 _range: TextRange,
                 _name: &str,
             ) -> Option<Self::Output> {
@@ -742,9 +738,7 @@ impl<K: Hash + Eq + Deserializable, V: Deserializable, S: Default + BuildHasher>
             fn visit_map(
                 self,
                 ctx: &mut dyn DeserializationContext,
-                members: &mut dyn ExactSizeIterator<
-                    Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>,
-                >,
+                members: &mut MapMembers<'_>,
                 _range: TextRange,
                 _name: &str,
             ) -> Option<Self::Output> {

--- a/crates/biome_deserialize/src/json.rs
+++ b/crates/biome_deserialize/src/json.rs
@@ -1,7 +1,8 @@
 //! Implementation of [DeserializableValue] for the JSON data format.
 use crate::{
     DefaultDeserializationContext, Deserializable, DeserializableValue, DeserializationContext,
-    DeserializationVisitor, Deserialized, TextNumber, diagnostics::DeserializableType,
+    DeserializationVisitor, Deserialized, ErasedDeserializationVisitor, TextNumber,
+    diagnostics::DeserializableType,
 };
 use biome_diagnostics::{DiagnosticExt, Error};
 use biome_json_parser::{JsonParserOptions, parse_json};
@@ -84,40 +85,45 @@ impl DeserializableValue for AnyJsonValue {
         AstNode::range(self)
     }
 
-    fn deserialize<V: DeserializationVisitor>(
+    fn deserialize_erased(
         &self,
-        ctx: &mut impl DeserializationContext,
-        visitor: V,
+        ctx: &mut dyn DeserializationContext,
+        visitor: &mut dyn ErasedDeserializationVisitor,
         name: &str,
-    ) -> Option<V::Output> {
+    ) {
         let range = AstNode::range(self);
         match self {
             Self::JsonArrayValue(array) => {
-                let items = array.elements().iter().map(|x| x.ok());
-                visitor.visit_array(ctx, items, range, name)
+                let mut items = array.elements().iter().map(|x| {
+                    x.ok()
+                        .map(|item| Box::new(item) as Box<dyn DeserializableValue>)
+                });
+                visitor.visit_array(ctx, &mut items, range, name)
             }
             Self::JsonBogusValue(_) => {
                 // The parser should emit an error about this node
                 // No need to emit another diagnostic.
-                None
             }
             Self::JsonMetavariable(_) => {
                 // Metavariables are for GritQL pattern matching only
                 // They can't be deserialized.
-                None
             }
             Self::JsonBooleanValue(value) => {
-                let value = value.value_token().ok()?;
+                let Ok(value) = value.value_token() else {
+                    return;
+                };
                 visitor.visit_bool(ctx, value.kind() == T![true], range, name)
             }
             Self::JsonNullValue(_) => visitor.visit_null(ctx, range, name),
             Self::JsonNumberValue(value) => {
-                let value = value.value_token().ok()?;
+                let Ok(value) = value.value_token() else {
+                    return;
+                };
                 let token_text = value.token_text_trimmed();
                 visitor.visit_number(ctx, TextNumber(token_text), range, name)
             }
             Self::JsonObjectValue(object) => {
-                let members = object.json_member_list().iter().map(|member| {
+                let mut members = object.json_member_list().iter().map(|member| {
                     let member = member.ok()?;
                     // Extract JsonMemberName from AnyJsonMemberName
                     let name = match member.name().ok()? {
@@ -125,13 +131,18 @@ impl DeserializableValue for AnyJsonValue {
                         // Metavariables and bogus nodes can't be deserialized
                         _ => return None,
                     };
-                    Some((name, member.value().ok()?))
+                    Some((
+                        Box::new(name) as Box<dyn DeserializableValue>,
+                        Box::new(member.value().ok()?) as Box<dyn DeserializableValue>,
+                    ))
                 });
-                visitor.visit_map(ctx, members, range, name)
+                visitor.visit_map(ctx, &mut members, range, name)
             }
             Self::JsonStringValue(value) => {
-                let value = unescape_json_string(value.inner_string_text().ok()?);
-                visitor.visit_str(ctx, value, range, name)
+                let Ok(text) = value.inner_string_text() else {
+                    return;
+                };
+                visitor.visit_str(ctx, unescape_json_string(text), range, name)
             }
         }
     }
@@ -153,7 +164,7 @@ impl DeserializableValue for AnyJsonValue {
 #[cfg(feature = "serde")]
 impl Deserializable for serde_json::Value {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -163,7 +174,7 @@ impl Deserializable for serde_json::Value {
             const EXPECTED_TYPE: crate::DeserializableTypes = crate::DeserializableTypes::all();
             fn visit_null(
                 self,
-                _ctx: &mut impl DeserializationContext,
+                _ctx: &mut dyn DeserializationContext,
                 _range: biome_rowan::TextRange,
                 _name: &str,
             ) -> Option<Self::Output> {
@@ -172,7 +183,7 @@ impl Deserializable for serde_json::Value {
 
             fn visit_bool(
                 self,
-                _ctx: &mut impl DeserializationContext,
+                _ctx: &mut dyn DeserializationContext,
                 value: bool,
                 _range: biome_rowan::TextRange,
                 _name: &str,
@@ -182,7 +193,7 @@ impl Deserializable for serde_json::Value {
 
             fn visit_number(
                 self,
-                ctx: &mut impl DeserializationContext,
+                ctx: &mut dyn DeserializationContext,
                 value: TextNumber,
                 _range: biome_rowan::TextRange,
                 _name: &str,
@@ -198,7 +209,7 @@ impl Deserializable for serde_json::Value {
 
             fn visit_str(
                 self,
-                _ctx: &mut impl DeserializationContext,
+                _ctx: &mut dyn DeserializationContext,
                 value: Text,
                 _range: biome_rowan::TextRange,
                 _name: &str,
@@ -208,8 +219,8 @@ impl Deserializable for serde_json::Value {
 
             fn visit_array(
                 self,
-                ctx: &mut impl DeserializationContext,
-                values: impl Iterator<Item = Option<impl DeserializableValue>>,
+                ctx: &mut dyn DeserializationContext,
+                values: &mut dyn ExactSizeIterator<Item = Option<Box<dyn DeserializableValue>>>,
                 _range: biome_rowan::TextRange,
                 _name: &str,
             ) -> Option<Self::Output> {
@@ -222,9 +233,9 @@ impl Deserializable for serde_json::Value {
 
             fn visit_map(
                 self,
-                ctx: &mut impl DeserializationContext,
-                members: impl Iterator<
-                    Item = Option<(impl DeserializableValue, impl DeserializableValue)>,
+                ctx: &mut dyn DeserializationContext,
+                members: &mut dyn ExactSizeIterator<
+                    Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>,
                 >,
                 _range: biome_rowan::TextRange,
                 _name: &str,
@@ -251,14 +262,16 @@ impl DeserializableValue for JsonMemberName {
         AstNode::range(self)
     }
 
-    fn deserialize<V: DeserializationVisitor>(
+    fn deserialize_erased(
         &self,
-        ctx: &mut impl DeserializationContext,
-        visitor: V,
+        ctx: &mut dyn DeserializationContext,
+        visitor: &mut dyn ErasedDeserializationVisitor,
         name: &str,
-    ) -> Option<V::Output> {
-        let value = unescape_json_string(self.inner_string_text().ok()?);
-        visitor.visit_str(ctx, value, AstNode::range(self), name)
+    ) {
+        let Ok(text) = self.inner_string_text() else {
+            return;
+        };
+        visitor.visit_str(ctx, unescape_json_string(text), AstNode::range(self), name)
     }
 
     fn visitable_type(&self) -> Option<DeserializableType> {
@@ -370,7 +383,7 @@ mod tests {
         }
         impl Deserializable for Name {
             fn deserialize(
-                ctx: &mut impl DeserializationContext,
+                ctx: &mut dyn DeserializationContext,
                 _value: &impl DeserializableValue,
                 name: &str,
             ) -> Option<Self> {

--- a/crates/biome_deserialize/src/json.rs
+++ b/crates/biome_deserialize/src/json.rs
@@ -1,7 +1,7 @@
 //! Implementation of [DeserializableValue] for the JSON data format.
 use crate::{
     DefaultDeserializationContext, Deserializable, DeserializableValue, DeserializationContext,
-    DeserializationVisitor, Deserialized, ErasedDeserializationVisitor, TextNumber,
+    DeserializationVisitor, Deserialized, ErasedDeserializationVisitor, MapMembers, TextNumber,
     diagnostics::DeserializableType,
 };
 use biome_diagnostics::{DiagnosticExt, Error};
@@ -234,9 +234,7 @@ impl Deserializable for serde_json::Value {
             fn visit_map(
                 self,
                 ctx: &mut dyn DeserializationContext,
-                members: &mut dyn ExactSizeIterator<
-                    Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>,
-                >,
+                members: &mut MapMembers<'_>,
                 _range: biome_rowan::TextRange,
                 _name: &str,
             ) -> Option<Self::Output> {

--- a/crates/biome_deserialize/src/lib.rs
+++ b/crates/biome_deserialize/src/lib.rs
@@ -188,6 +188,11 @@ impl DeserializableValue for Box<dyn DeserializableValue> {
     }
 }
 
+/// Iterator over the key-value pairs of a map, as passed to
+/// [DeserializationVisitor::visit_map].
+pub type MapMembers<'a> = dyn ExactSizeIterator<Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>>
+    + 'a;
+
 /// Object-safe counterpart of [DeserializationVisitor], used by
 /// [DeserializableValue::deserialize_erased].
 ///
@@ -238,9 +243,7 @@ pub trait ErasedDeserializationVisitor {
     fn visit_map(
         &mut self,
         ctx: &mut dyn DeserializationContext,
-        members: &mut dyn ExactSizeIterator<
-            Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>,
-        >,
+        members: &mut MapMembers<'_>,
         range: TextRange,
         name: &str,
     );
@@ -311,9 +314,7 @@ impl<V: DeserializationVisitor> ErasedDeserializationVisitor for ErasedVisitor<V
     fn visit_map(
         &mut self,
         ctx: &mut dyn DeserializationContext,
-        members: &mut dyn ExactSizeIterator<
-            Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>,
-        >,
+        members: &mut MapMembers<'_>,
         range: TextRange,
         name: &str,
     ) {
@@ -343,7 +344,7 @@ impl<V: DeserializationVisitor> ErasedDeserializationVisitor for ErasedVisitor<V
 /// ## Examples
 ///
 /// ```
-/// use biome_deserialize::{DeserializationDiagnostic, Deserializable, DeserializationContext, DeserializableValue, DeserializationVisitor, Text, DeserializableTypes};
+/// use biome_deserialize::{DeserializationDiagnostic, Deserializable, DeserializationContext, DeserializableValue, DeserializationVisitor, MapMembers, Text, DeserializableTypes};
 /// use biome_rowan::TextRange;
 ///
 /// #[derive(Debug, Eq, PartialEq)]
@@ -369,9 +370,7 @@ impl<V: DeserializationVisitor> ErasedDeserializationVisitor for ErasedVisitor<V
 ///     fn visit_map(
 ///         self,
 ///         ctx: &mut dyn DeserializationContext,
-///         members: &mut dyn ExactSizeIterator<
-///             Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>,
-///         >,
+///         members: &mut MapMembers<'_>,
 ///         range: TextRange,
 ///         _name: &str,
 ///     ) -> Option<Self::Output> {
@@ -408,7 +407,7 @@ impl<V: DeserializationVisitor> ErasedDeserializationVisitor for ErasedVisitor<V
 /// ```
 ///
 /// ```
-/// use biome_deserialize::{DeserializationDiagnostic, Deserializable, DeserializationContext, DeserializableValue, DeserializationVisitor, Text, DeserializableTypes};
+/// use biome_deserialize::{DeserializationDiagnostic, Deserializable, DeserializationContext, DeserializableValue, DeserializationVisitor, MapMembers, Text, DeserializableTypes};
 /// use biome_rowan::TextRange;
 ///
 /// #[derive(Debug, Eq, PartialEq)]
@@ -600,9 +599,7 @@ pub trait DeserializationVisitor: Sized {
     fn visit_map(
         self,
         ctx: &mut dyn DeserializationContext,
-        _members: &mut dyn ExactSizeIterator<
-            Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>,
-        >,
+        _members: &mut MapMembers<'_>,
         range: TextRange,
         name: &str,
     ) -> Option<Self::Output> {

--- a/crates/biome_deserialize/src/lib.rs
+++ b/crates/biome_deserialize/src/lib.rs
@@ -82,7 +82,7 @@ pub trait Deserializable: Sized {
     /// Any diagnostics emitted during deserialization are reported via `ctx`.
     /// `name` corresponds to the name used in a diagnostic to designate the deserialized value.
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self>;
@@ -129,22 +129,198 @@ impl DeserializationContext for DefaultDeserializationContext<'_> {
 ///
 /// This trait should only be implemented when adding the support for a new data format.
 /// See [biome_deserialize::json] for an example of an implementation.
-pub trait DeserializableValue: Sized {
+pub trait DeserializableValue {
     /// Range in the source content of this value
     fn range(&self) -> TextRange;
 
+    /// Visits this value with a type-erased visitor.
+    ///
+    /// This is the method data formats implement: because it is not generic,
+    /// the traversal of the format's AST is compiled once instead of once per
+    /// deserialized type. Use [Self::deserialize] to deserialize a value.
+    fn deserialize_erased(
+        &self,
+        ctx: &mut dyn DeserializationContext,
+        visitor: &mut dyn ErasedDeserializationVisitor,
+        name: &str,
+    );
+
     /// Returns the deserialized form of this value using `visitor`.
-    /// Any diagnostics emitted during deserialization are appended to `diagnostics`.
+    /// Any diagnostics emitted during deserialization are reported via `ctx`.
     /// `name` corresponds to the name used in a diagnostic to designate the value.
     fn deserialize<V: DeserializationVisitor>(
         &self,
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         visitor: V,
         name: &str,
-    ) -> Option<V::Output>;
+    ) -> Option<V::Output>
+    where
+        Self: Sized,
+    {
+        let mut erased = ErasedVisitor {
+            visitor: Some(visitor),
+            output: None,
+        };
+        self.deserialize_erased(ctx, &mut erased, name);
+        erased.output
+    }
 
     /// Returns the type of this value.
     fn visitable_type(&self) -> Option<DeserializableType>;
+}
+
+impl DeserializableValue for Box<dyn DeserializableValue> {
+    fn range(&self) -> TextRange {
+        (**self).range()
+    }
+
+    fn deserialize_erased(
+        &self,
+        ctx: &mut dyn DeserializationContext,
+        visitor: &mut dyn ErasedDeserializationVisitor,
+        name: &str,
+    ) {
+        (**self).deserialize_erased(ctx, visitor, name)
+    }
+
+    fn visitable_type(&self) -> Option<DeserializableType> {
+        (**self).visitable_type()
+    }
+}
+
+/// Object-safe counterpart of [DeserializationVisitor], used by
+/// [DeserializableValue::deserialize_erased].
+///
+/// You should never need to implement this trait: every
+/// [DeserializationVisitor] is adapted to it automatically by
+/// [DeserializableValue::deserialize].
+pub trait ErasedDeserializationVisitor {
+    /// The visited value is `null`.
+    fn visit_null(&mut self, ctx: &mut dyn DeserializationContext, range: TextRange, name: &str);
+
+    /// The visited value is a `bool`.
+    fn visit_bool(
+        &mut self,
+        ctx: &mut dyn DeserializationContext,
+        value: bool,
+        range: TextRange,
+        name: &str,
+    );
+
+    /// The visited value is a number (integer or float), represented by a string.
+    fn visit_number(
+        &mut self,
+        ctx: &mut dyn DeserializationContext,
+        value: TextNumber,
+        range: TextRange,
+        name: &str,
+    );
+
+    /// The visited value is a `string`.
+    fn visit_str(
+        &mut self,
+        ctx: &mut dyn DeserializationContext,
+        value: Text,
+        range: TextRange,
+        name: &str,
+    );
+
+    /// The visited value is an array-like (array, list, vector) structure.
+    fn visit_array(
+        &mut self,
+        ctx: &mut dyn DeserializationContext,
+        items: &mut dyn ExactSizeIterator<Item = Option<Box<dyn DeserializableValue>>>,
+        range: TextRange,
+        name: &str,
+    );
+
+    /// The visited value is a `map` (key-value pairs).
+    fn visit_map(
+        &mut self,
+        ctx: &mut dyn DeserializationContext,
+        members: &mut dyn ExactSizeIterator<
+            Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>,
+        >,
+        range: TextRange,
+        name: &str,
+    );
+}
+
+/// Adapts a [DeserializationVisitor] to [ErasedDeserializationVisitor],
+/// carrying the visitor in and its output out of the type-erased traversal.
+struct ErasedVisitor<V: DeserializationVisitor> {
+    visitor: Option<V>,
+    output: Option<V::Output>,
+}
+
+impl<V: DeserializationVisitor> ErasedDeserializationVisitor for ErasedVisitor<V> {
+    fn visit_null(&mut self, ctx: &mut dyn DeserializationContext, range: TextRange, name: &str) {
+        if let Some(visitor) = self.visitor.take() {
+            self.output = visitor.visit_null(ctx, range, name);
+        }
+    }
+
+    fn visit_bool(
+        &mut self,
+        ctx: &mut dyn DeserializationContext,
+        value: bool,
+        range: TextRange,
+        name: &str,
+    ) {
+        if let Some(visitor) = self.visitor.take() {
+            self.output = visitor.visit_bool(ctx, value, range, name);
+        }
+    }
+
+    fn visit_number(
+        &mut self,
+        ctx: &mut dyn DeserializationContext,
+        value: TextNumber,
+        range: TextRange,
+        name: &str,
+    ) {
+        if let Some(visitor) = self.visitor.take() {
+            self.output = visitor.visit_number(ctx, value, range, name);
+        }
+    }
+
+    fn visit_str(
+        &mut self,
+        ctx: &mut dyn DeserializationContext,
+        value: Text,
+        range: TextRange,
+        name: &str,
+    ) {
+        if let Some(visitor) = self.visitor.take() {
+            self.output = visitor.visit_str(ctx, value, range, name);
+        }
+    }
+
+    fn visit_array(
+        &mut self,
+        ctx: &mut dyn DeserializationContext,
+        items: &mut dyn ExactSizeIterator<Item = Option<Box<dyn DeserializableValue>>>,
+        range: TextRange,
+        name: &str,
+    ) {
+        if let Some(visitor) = self.visitor.take() {
+            self.output = visitor.visit_array(ctx, items, range, name);
+        }
+    }
+
+    fn visit_map(
+        &mut self,
+        ctx: &mut dyn DeserializationContext,
+        members: &mut dyn ExactSizeIterator<
+            Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>,
+        >,
+        range: TextRange,
+        name: &str,
+    ) {
+        if let Some(visitor) = self.visitor.take() {
+            self.output = visitor.visit_map(ctx, members, range, name);
+        }
+    }
 }
 
 /// This trait represents a visitor that walks through a [DeserializableValue].
@@ -177,7 +353,7 @@ pub trait DeserializableValue: Sized {
 ///
 /// impl Deserializable for Person {
 ///     fn deserialize(
-///         ctx: &mut impl DeserializationContext,
+///         ctx: &mut dyn DeserializationContext,
 ///         value: &impl DeserializableValue,
 ///         name: &str,
 ///     ) -> Option<Self> {
@@ -192,8 +368,10 @@ pub trait DeserializableValue: Sized {
 ///
 ///     fn visit_map(
 ///         self,
-///         ctx: &mut impl DeserializationContext,
-///         members: impl Iterator<Item = Option<(impl DeserializableValue, impl DeserializableValue)>>,
+///         ctx: &mut dyn DeserializationContext,
+///         members: &mut dyn ExactSizeIterator<
+///             Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>,
+///         >,
 ///         range: TextRange,
 ///         _name: &str,
 ///     ) -> Option<Self::Output> {
@@ -241,7 +419,7 @@ pub trait DeserializableValue: Sized {
 ///
 /// impl Deserializable for Union {
 ///     fn deserialize(
-///         ctx: &mut impl DeserializationContext,
+///         ctx: &mut dyn DeserializationContext,
 ///         value: &impl DeserializableValue,
 ///         name: &str,
 ///     ) -> Option<Self> {
@@ -256,7 +434,7 @@ pub trait DeserializableValue: Sized {
 ///
 ///     fn visit_bool(
 ///         self,
-///         ctx: &mut impl DeserializationContext,
+///         ctx: &mut dyn DeserializationContext,
 ///         value: bool,
 ///         range: TextRange,
 ///         _name: &str,
@@ -266,7 +444,7 @@ pub trait DeserializableValue: Sized {
 ///
 ///     fn visit_str(
 ///         self,
-///         ctx: &mut impl DeserializationContext,
+///         ctx: &mut dyn DeserializationContext,
 ///         value: Text,
 ///         range: TextRange,
 ///         _name: &str,
@@ -301,7 +479,7 @@ pub trait DeserializationVisitor: Sized {
     /// The expected type is retrieved from [Self::EXPECTED_TYPE].
     fn visit_null(
         self,
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         range: TextRange,
         name: &str,
     ) -> Option<Self::Output> {
@@ -324,7 +502,7 @@ pub trait DeserializationVisitor: Sized {
     /// The expected type is retrieved from [Self::EXPECTED_TYPE].
     fn visit_bool(
         self,
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         _value: bool,
         range: TextRange,
         name: &str,
@@ -349,7 +527,7 @@ pub trait DeserializationVisitor: Sized {
     /// The expected type is retrieved from [Self::EXPECTED_TYPE].
     fn visit_number(
         self,
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         _value: TextNumber,
         range: TextRange,
         name: &str,
@@ -373,7 +551,7 @@ pub trait DeserializationVisitor: Sized {
     /// The expected type is retrieved from [Self::EXPECTED_TYPE].
     fn visit_str(
         self,
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         _value: Text,
         range: TextRange,
         name: &str,
@@ -397,8 +575,8 @@ pub trait DeserializationVisitor: Sized {
     /// The expected type is retrieved from [Self::EXPECTED_TYPE].
     fn visit_array(
         self,
-        ctx: &mut impl DeserializationContext,
-        _items: impl ExactSizeIterator<Item = Option<impl DeserializableValue>>,
+        ctx: &mut dyn DeserializationContext,
+        _items: &mut dyn ExactSizeIterator<Item = Option<Box<dyn DeserializableValue>>>,
         range: TextRange,
         name: &str,
     ) -> Option<Self::Output> {
@@ -421,9 +599,9 @@ pub trait DeserializationVisitor: Sized {
     /// The expected type is retrieved from [Self::EXPECTED_TYPE].
     fn visit_map(
         self,
-        ctx: &mut impl DeserializationContext,
-        _members: impl ExactSizeIterator<
-            Item = Option<(impl DeserializableValue, impl DeserializableValue)>,
+        ctx: &mut dyn DeserializationContext,
+        _members: &mut dyn ExactSizeIterator<
+            Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>,
         >,
         range: TextRange,
         name: &str,

--- a/crates/biome_deserialize/src/validator.rs
+++ b/crates/biome_deserialize/src/validator.rs
@@ -14,7 +14,7 @@ pub trait DeserializableValidator {
     /// should be rejected.
     fn validate(
         &mut self,
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         name: &str,
         range: TextRange,
     ) -> bool;
@@ -22,7 +22,7 @@ pub trait DeserializableValidator {
 
 /// Validates whether the given value is non-empty.
 pub fn non_empty<T: IsEmpty>(
-    ctx: &mut impl DeserializationContext,
+    ctx: &mut dyn DeserializationContext,
     value: &T,
     name: &str,
     range: TextRange,

--- a/crates/biome_deserialize_macros/src/deserializable_derive.rs
+++ b/crates/biome_deserialize_macros/src/deserializable_derive.rs
@@ -267,7 +267,7 @@ fn generate_deserializable_enum(
     quote! {
         impl #generics biome_deserialize::Deserializable for #ident #generics #trait_bounds{
             fn deserialize(
-                ctx: &mut impl biome_deserialize::DeserializationContext,
+                ctx: &mut dyn biome_deserialize::DeserializationContext,
                 value: &impl biome_deserialize::DeserializableValue,
                 name: &str,
             ) -> Option<Self> {
@@ -311,7 +311,7 @@ fn generate_deserializable_newtype(
     quote! {
         impl #generics biome_deserialize::Deserializable for #ident #generics #trait_bounds {
             fn deserialize(
-                ctx: &mut impl biome_deserialize::DeserializationContext,
+                ctx: &mut dyn biome_deserialize::DeserializationContext,
                 value: &impl biome_deserialize::DeserializableValue,
                 name: &str,
             ) -> Option<Self> {
@@ -483,7 +483,7 @@ fn generate_deserializable_struct(
     quote! {
         impl #generics biome_deserialize::Deserializable for #ident #generics #trait_bounds {
             fn deserialize(
-                ctx: &mut impl biome_deserialize::DeserializationContext,
+                ctx: &mut dyn biome_deserialize::DeserializationContext,
                 value: &impl biome_deserialize::DeserializableValue,
                 name: &str,
             ) -> Option<Self> {
@@ -496,8 +496,8 @@ fn generate_deserializable_struct(
 
                     fn visit_map(
                         self,
-                        ctx: &mut impl biome_deserialize::DeserializationContext,
-                        members: impl Iterator<Item = Option<(impl biome_deserialize::DeserializableValue, impl biome_deserialize::DeserializableValue)>>,
+                        ctx: &mut dyn biome_deserialize::DeserializationContext,
+                        members: &mut dyn ExactSizeIterator<Item = Option<(Box<dyn biome_deserialize::DeserializableValue>, Box<dyn biome_deserialize::DeserializableValue>)>>,
                         range: biome_deserialize::TextRange,
                         name: &str,
                     ) -> Option<Self::Output> {
@@ -544,7 +544,7 @@ fn generate_deserializable_from(
     quote! {
         impl #generics biome_deserialize::Deserializable for #ident #generics #trait_bounds {
             fn deserialize(
-                ctx: &mut impl biome_deserialize::DeserializationContext,
+                ctx: &mut dyn biome_deserialize::DeserializationContext,
                 value: &impl biome_deserialize::DeserializableValue,
                 name: &str,
             ) -> Option<Self> {
@@ -577,7 +577,7 @@ fn generate_deserializable_try_from(
     quote! {
         impl #generics biome_deserialize::Deserializable for #ident #generics #trait_bounds {
             fn deserialize(
-                ctx: &mut impl biome_deserialize::DeserializationContext,
+                ctx: &mut dyn biome_deserialize::DeserializationContext,
                 value: &impl biome_deserialize::DeserializableValue,
                 name: &str,
             ) -> Option<Self> {

--- a/crates/biome_deserialize_macros/src/deserializable_derive.rs
+++ b/crates/biome_deserialize_macros/src/deserializable_derive.rs
@@ -497,7 +497,7 @@ fn generate_deserializable_struct(
                     fn visit_map(
                         self,
                         ctx: &mut dyn biome_deserialize::DeserializationContext,
-                        members: &mut dyn ExactSizeIterator<Item = Option<(Box<dyn biome_deserialize::DeserializableValue>, Box<dyn biome_deserialize::DeserializableValue>)>>,
+                        members: &mut biome_deserialize::MapMembers<'_>,
                         range: biome_deserialize::TextRange,
                         name: &str,
                     ) -> Option<Self::Output> {

--- a/crates/biome_formatter/src/lib.rs
+++ b/crates/biome_formatter/src/lib.rs
@@ -320,7 +320,7 @@ impl Default for IndentWidth {
 
 impl Deserializable for IndentWidth {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -422,7 +422,7 @@ impl Default for LineWidth {
 
 impl Deserializable for LineWidth {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {

--- a/crates/biome_glob/src/editorconfig.rs
+++ b/crates/biome_glob/src/editorconfig.rs
@@ -128,7 +128,7 @@ impl TryFrom<String> for EditorconfigGlob {
 #[cfg(feature = "biome_deserialize")]
 impl biome_deserialize::Deserializable for EditorconfigGlob {
     fn deserialize(
-        ctx: &mut impl biome_deserialize::DeserializationContext,
+        ctx: &mut dyn biome_deserialize::DeserializationContext,
         value: &impl biome_deserialize::DeserializableValue,
         name: &str,
     ) -> Option<Self> {

--- a/crates/biome_glob/src/lib.rs
+++ b/crates/biome_glob/src/lib.rs
@@ -358,7 +358,7 @@ impl TryFrom<String> for Glob {
 #[cfg(feature = "biome_deserialize")]
 impl biome_deserialize::Deserializable for Glob {
     fn deserialize(
-        ctx: &mut impl biome_deserialize::DeserializationContext,
+        ctx: &mut dyn biome_deserialize::DeserializationContext,
         value: &impl biome_deserialize::DeserializableValue,
         name: &str,
     ) -> Option<Self> {

--- a/crates/biome_json_value/src/json_value.rs
+++ b/crates/biome_json_value/src/json_value.rs
@@ -91,7 +91,7 @@ impl JsonValue {
 
 impl biome_deserialize::Deserializable for JsonValue {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {

--- a/crates/biome_package/src/node_js_package/package_json.rs
+++ b/crates/biome_package/src/node_js_package/package_json.rs
@@ -447,7 +447,7 @@ pub struct Dependencies(pub Box<[(Box<str>, Box<str>)]>);
 
 impl Deserializable for Dependencies {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -458,10 +458,8 @@ impl Deserializable for Dependencies {
 
             fn visit_map(
                 self,
-                ctx: &mut impl DeserializationContext,
-                members: impl Iterator<
-                    Item = Option<(impl DeserializableValue, impl DeserializableValue)>,
-                >,
+                ctx: &mut dyn DeserializationContext,
+                members: &mut dyn ExactSizeIterator<Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>>,
                 _range: TextRange,
                 name: &str,
             ) -> Option<Self::Output> {
@@ -527,7 +525,7 @@ pub struct BundleDependencies(pub Box<[Box<str>]>);
 /// It can also be a boolean (`true` to mean “bundle everything”).
 impl Deserializable for BundleDependencies {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -541,8 +539,8 @@ impl Deserializable for BundleDependencies {
 
             fn visit_array(
                 self,
-                ctx: &mut impl DeserializationContext,
-                items: impl ExactSizeIterator<Item = Option<impl DeserializableValue>>,
+                ctx: &mut dyn DeserializationContext,
+                items: &mut dyn ExactSizeIterator<Item = Option<Box<dyn DeserializableValue>>>,
                 _range: TextRange,
                 name: &str,
             ) -> Option<Self::Output> {
@@ -558,7 +556,7 @@ impl Deserializable for BundleDependencies {
 
             fn visit_bool(
                 self,
-                _ctx: &mut impl DeserializationContext,
+                _ctx: &mut dyn DeserializationContext,
                 _value: bool,
                 _range: TextRange,
                 _name: &str,
@@ -616,7 +614,7 @@ impl From<String> for Version {
 
 impl Deserializable for PackageJson {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -632,8 +630,8 @@ impl DeserializationVisitor for PackageJsonVisitor {
 
     fn visit_map(
         self,
-        ctx: &mut impl DeserializationContext,
-        members: impl Iterator<Item = Option<(impl DeserializableValue, impl DeserializableValue)>>,
+        ctx: &mut dyn DeserializationContext,
+        members: &mut dyn ExactSizeIterator<Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>>,
         _range: TextRange,
         _name: &str,
     ) -> Option<Self::Output> {
@@ -733,7 +731,7 @@ impl DeserializationVisitor for PackageJsonVisitor {
 
 impl Deserializable for Version {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {

--- a/crates/biome_package/src/node_js_package/package_json.rs
+++ b/crates/biome_package/src/node_js_package/package_json.rs
@@ -459,7 +459,9 @@ impl Deserializable for Dependencies {
             fn visit_map(
                 self,
                 ctx: &mut dyn DeserializationContext,
-                members: &mut dyn ExactSizeIterator<Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>>,
+                members: &mut dyn ExactSizeIterator<
+                    Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>,
+                >,
                 _range: TextRange,
                 name: &str,
             ) -> Option<Self::Output> {
@@ -631,7 +633,9 @@ impl DeserializationVisitor for PackageJsonVisitor {
     fn visit_map(
         self,
         ctx: &mut dyn DeserializationContext,
-        members: &mut dyn ExactSizeIterator<Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>>,
+        members: &mut dyn ExactSizeIterator<
+            Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>,
+        >,
         _range: TextRange,
         _name: &str,
     ) -> Option<Self::Output> {

--- a/crates/biome_package/src/node_js_package/package_json.rs
+++ b/crates/biome_package/src/node_js_package/package_json.rs
@@ -3,7 +3,7 @@ use crate::{LanguageRoot, Manifest};
 use biome_deserialize::json::deserialize_from_json_str;
 use biome_deserialize::{
     Deserializable, DeserializableTypes, DeserializableValue, DeserializationContext,
-    DeserializationVisitor, Deserialized, Text, json::deserialize_from_json_ast,
+    DeserializationVisitor, Deserialized, MapMembers, Text, json::deserialize_from_json_ast,
 };
 use biome_diagnostics::Error;
 use biome_json_parser::JsonParserOptions;
@@ -459,9 +459,7 @@ impl Deserializable for Dependencies {
             fn visit_map(
                 self,
                 ctx: &mut dyn DeserializationContext,
-                members: &mut dyn ExactSizeIterator<
-                    Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>,
-                >,
+                members: &mut MapMembers<'_>,
                 _range: TextRange,
                 name: &str,
             ) -> Option<Self::Output> {
@@ -633,9 +631,7 @@ impl DeserializationVisitor for PackageJsonVisitor {
     fn visit_map(
         self,
         ctx: &mut dyn DeserializationContext,
-        members: &mut dyn ExactSizeIterator<
-            Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>,
-        >,
+        members: &mut MapMembers<'_>,
         _range: TextRange,
         _name: &str,
     ) -> Option<Self::Output> {

--- a/crates/biome_package/src/node_js_package/tsconfig_json.rs
+++ b/crates/biome_package/src/node_js_package/tsconfig_json.rs
@@ -173,7 +173,7 @@ pub enum ExtendsField {
 
 impl Deserializable for ExtendsField {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -215,7 +215,7 @@ impl std::ops::Deref for JsxFactoryIdentifier {
 
 impl Deserializable for JsxFactoryIdentifier {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {

--- a/crates/biome_plugin_loader/src/configuration.rs
+++ b/crates/biome_plugin_loader/src/configuration.rs
@@ -106,7 +106,7 @@ impl PluginConfiguration {
 
 impl Deserializable for PluginConfiguration {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         rule_name: &str,
     ) -> Option<Self> {

--- a/crates/biome_plugin_loader/src/plugin_manifest.rs
+++ b/crates/biome_plugin_loader/src/plugin_manifest.rs
@@ -15,7 +15,7 @@ pub struct PluginManifest {
 
 // There's only one manifest version now.
 pub fn supported_version(
-    ctx: &mut impl DeserializationContext,
+    ctx: &mut dyn DeserializationContext,
     value: &u8,
     name: &str,
     range: TextRange,

--- a/crates/biome_rule_options/src/no_duplicate_classes.rs
+++ b/crates/biome_rule_options/src/no_duplicate_classes.rs
@@ -61,7 +61,7 @@ impl schemars::JsonSchema for NoDuplicateClassesOptions {
 
 impl Deserializable for NoDuplicateClassesOptions {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {

--- a/crates/biome_rule_options/src/no_for_each.rs
+++ b/crates/biome_rule_options/src/no_for_each.rs
@@ -26,7 +26,7 @@ impl biome_deserialize::Merge for NoForEachOptions {
 impl DeserializableValidator for NoForEachOptions {
     fn validate(
         &mut self,
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         _name: &str,
         range: TextRange,
     ) -> bool {

--- a/crates/biome_rule_options/src/no_js_restricted_properties.rs
+++ b/crates/biome_rule_options/src/no_js_restricted_properties.rs
@@ -71,7 +71,7 @@ pub struct RestrictedPropertyEntry {
 impl DeserializableValidator for RestrictedPropertyEntry {
     fn validate(
         &mut self,
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         _name: &str,
         range: TextRange,
     ) -> bool {

--- a/crates/biome_rule_options/src/no_restricted_imports.rs
+++ b/crates/biome_rule_options/src/no_restricted_imports.rs
@@ -70,7 +70,7 @@ impl From<Paths> for PathOptions {
 
 impl Deserializable for Paths {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -180,7 +180,7 @@ impl From<Patterns> for PatternOptions {
 
 impl Deserializable for Patterns {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {

--- a/crates/biome_rule_options/src/no_restricted_types.rs
+++ b/crates/biome_rule_options/src/no_restricted_types.rs
@@ -43,7 +43,7 @@ impl From<CustomRestrictedType> for CustomRestrictedTypeOptions {
 
 impl Deserializable for CustomRestrictedType {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {

--- a/crates/biome_rule_options/src/no_undeclared_dependencies.rs
+++ b/crates/biome_rule_options/src/no_undeclared_dependencies.rs
@@ -50,7 +50,7 @@ impl Default for DependencyAvailability {
 
 impl Deserializable for DependencyAvailability {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {

--- a/crates/biome_rule_options/src/organize_imports.rs
+++ b/crates/biome_rule_options/src/organize_imports.rs
@@ -30,7 +30,7 @@ pub struct OrganizeImportsOptions {
 impl DeserializableValidator for OrganizeImportsOptions {
     fn validate(
         &mut self,
-        ctx: &mut impl biome_deserialize::DeserializationContext,
+        ctx: &mut dyn biome_deserialize::DeserializationContext,
         _name: &str,
         range: biome_rowan::TextRange,
     ) -> bool {

--- a/crates/biome_rule_options/src/organize_imports/import_groups.rs
+++ b/crates/biome_rule_options/src/organize_imports/import_groups.rs
@@ -104,7 +104,7 @@ impl ImportGroup {
 }
 impl Deserializable for ImportGroup {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl biome_deserialize::DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -177,7 +177,7 @@ impl GroupMatcher {
 }
 impl Deserializable for GroupMatcher {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl biome_deserialize::DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -234,7 +234,7 @@ impl NegatableImportKindMatcher {
 }
 impl biome_deserialize::Deserializable for NegatableImportKindMatcher {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl biome_deserialize::DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -356,7 +356,7 @@ pub enum SourcesMatcher {
 }
 impl Deserializable for SourcesMatcher {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl biome_deserialize::DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -410,7 +410,7 @@ impl SourceMatcher {
 }
 impl biome_deserialize::Deserializable for SourceMatcher {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl biome_deserialize::DeserializableValue,
         name: &str,
     ) -> Option<Self> {

--- a/crates/biome_rule_options/src/shared/restricted_regex.rs
+++ b/crates/biome_rule_options/src/shared/restricted_regex.rs
@@ -77,7 +77,7 @@ impl TryFrom<String> for RestrictedRegex {
 // We use a custom impl to precisely report the location of the error.
 impl biome_deserialize::Deserializable for RestrictedRegex {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {

--- a/crates/biome_rule_options/src/use_baseline.rs
+++ b/crates/biome_rule_options/src/use_baseline.rs
@@ -35,7 +35,7 @@ impl biome_deserialize::Merge for AvailabilityTarget {
 
 impl Deserializable for AvailabilityTarget {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {

--- a/crates/biome_rule_options/src/use_consistent_arrow_return.rs
+++ b/crates/biome_rule_options/src/use_consistent_arrow_return.rs
@@ -23,7 +23,7 @@ pub struct UseConsistentArrowReturnOptions {
 impl DeserializableValidator for UseConsistentArrowReturnOptions {
     fn validate(
         &mut self,
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         _name: &str,
         range: biome_rowan::TextRange,
     ) -> bool {

--- a/crates/biome_rule_options/src/use_exhaustive_dependencies.rs
+++ b/crates/biome_rule_options/src/use_exhaustive_dependencies.rs
@@ -27,7 +27,7 @@ pub struct UseExhaustiveDependenciesOptions {
 }
 
 fn non_empty_optional<T: IsEmpty>(
-    ctx: &mut impl DeserializationContext,
+    ctx: &mut dyn DeserializationContext,
     value: &Option<T>,
     name: &str,
     range: TextRange,
@@ -103,7 +103,7 @@ pub struct Hook {
 impl DeserializableValidator for Hook {
     fn validate(
         &mut self,
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         _name: &str,
         range: TextRange,
     ) -> bool {
@@ -192,7 +192,7 @@ impl schemars::JsonSchema for StableHookResult {
 
 impl biome_deserialize::Deserializable for StableHookResult {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -210,8 +210,8 @@ impl DeserializationVisitor for StableResultVisitor {
 
     fn visit_array(
         self,
-        ctx: &mut impl DeserializationContext,
-        items: impl Iterator<Item = Option<impl DeserializableValue>>,
+        ctx: &mut dyn DeserializationContext,
+        items: &mut dyn ExactSizeIterator<Item = Option<Box<dyn DeserializableValue>>>,
         range: TextRange,
         _name: &str,
     ) -> Option<Self::Output> {
@@ -250,7 +250,7 @@ impl DeserializationVisitor for StableResultVisitor {
 
     fn visit_bool(
         self,
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: bool,
         range: TextRange,
         _name: &str,
@@ -272,7 +272,7 @@ impl DeserializationVisitor for StableResultVisitor {
 
     fn visit_number(
         self,
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: biome_deserialize::TextNumber,
         range: TextRange,
         name: &str,
@@ -295,7 +295,7 @@ impl DeserializationVisitor for StableResultArrayVisitor {
 
     fn visit_str(
         self,
-        _ctx: &mut impl DeserializationContext,
+        _ctx: &mut dyn DeserializationContext,
         value: Text,
         _range: TextRange,
         _name: &str,
@@ -305,7 +305,7 @@ impl DeserializationVisitor for StableResultArrayVisitor {
 
     fn visit_number(
         self,
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: biome_deserialize::TextNumber,
         range: TextRange,
         name: &str,
@@ -323,7 +323,7 @@ impl DeserializationVisitor for StableResultIndexVisitor {
 
     fn visit_number(
         self,
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: biome_deserialize::TextNumber,
         range: TextRange,
         _name: &str,

--- a/crates/biome_rule_options/src/use_filenaming_convention.rs
+++ b/crates/biome_rule_options/src/use_filenaming_convention.rs
@@ -116,7 +116,7 @@ impl Default for FilenameCases {
 impl biome_deserialize::DeserializableValidator for FilenameCases {
     fn validate(
         &mut self,
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         name: &str,
         range: TextRange,
     ) -> bool {

--- a/crates/biome_rule_options/src/use_hook_at_top_level.rs
+++ b/crates/biome_rule_options/src/use_hook_at_top_level.rs
@@ -20,7 +20,7 @@ pub struct UseHookAtTopLevelOptions {
 
 impl Deserializable for UseHookAtTopLevelOptions {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -37,8 +37,8 @@ impl DeserializationVisitor for DeprecatedHooksOptionsVisitor {
 
     fn visit_map(
         self,
-        ctx: &mut impl DeserializationContext,
-        members: impl Iterator<Item = Option<(impl DeserializableValue, impl DeserializableValue)>>,
+        ctx: &mut dyn DeserializationContext,
+        members: &mut dyn ExactSizeIterator<Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>>,
         _range: TextRange,
         _name: &str,
     ) -> Option<Self::Output> {

--- a/crates/biome_rule_options/src/use_hook_at_top_level.rs
+++ b/crates/biome_rule_options/src/use_hook_at_top_level.rs
@@ -1,7 +1,7 @@
 use biome_console::markup;
 use biome_deserialize::{
     Deserializable, DeserializableTypes, DeserializableValue, DeserializationContext,
-    DeserializationDiagnostic, DeserializationVisitor, TextRange,
+    DeserializationDiagnostic, DeserializationVisitor, MapMembers, TextRange,
 };
 use biome_deserialize_macros::Merge;
 use biome_rowan::Text;
@@ -38,9 +38,7 @@ impl DeserializationVisitor for DeprecatedHooksOptionsVisitor {
     fn visit_map(
         self,
         ctx: &mut dyn DeserializationContext,
-        members: &mut dyn ExactSizeIterator<
-            Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>,
-        >,
+        members: &mut MapMembers<'_>,
         _range: TextRange,
         _name: &str,
     ) -> Option<Self::Output> {

--- a/crates/biome_rule_options/src/use_hook_at_top_level.rs
+++ b/crates/biome_rule_options/src/use_hook_at_top_level.rs
@@ -38,7 +38,9 @@ impl DeserializationVisitor for DeprecatedHooksOptionsVisitor {
     fn visit_map(
         self,
         ctx: &mut dyn DeserializationContext,
-        members: &mut dyn ExactSizeIterator<Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>>,
+        members: &mut dyn ExactSizeIterator<
+            Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>,
+        >,
         _range: TextRange,
         _name: &str,
     ) -> Option<Self::Output> {

--- a/crates/biome_rule_options/src/use_naming_convention.rs
+++ b/crates/biome_rule_options/src/use_naming_convention.rs
@@ -85,7 +85,7 @@ pub struct Convention {
 impl DeserializableValidator for Convention {
     fn validate(
         &mut self,
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         _name: &str,
         range: biome_rowan::TextRange,
     ) -> bool {
@@ -247,7 +247,7 @@ impl Selector {
 impl DeserializableValidator for Selector {
     fn validate(
         &mut self,
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         _name: &str,
         range: biome_rowan::TextRange,
     ) -> bool {

--- a/crates/biome_rule_options/src/use_nullish_coalescing.rs
+++ b/crates/biome_rule_options/src/use_nullish_coalescing.rs
@@ -141,7 +141,7 @@ impl biome_deserialize::Merge for IgnorePrimitives {
 
 impl Deserializable for IgnorePrimitives {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {

--- a/crates/biome_rule_options/src/use_sorted_classes.rs
+++ b/crates/biome_rule_options/src/use_sorted_classes.rs
@@ -65,7 +65,7 @@ const ALLOWED_OPTIONS: &[&str] = &["attributes", "functions"];
 
 impl Deserializable for UseSortedClassesOptions {
     fn deserialize(
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         value: &impl DeserializableValue,
         name: &str,
     ) -> Option<Self> {
@@ -81,8 +81,8 @@ impl DeserializationVisitor for UtilityClassSortingOptionsVisitor {
 
     fn visit_map(
         self,
-        ctx: &mut impl DeserializationContext,
-        members: impl Iterator<Item = Option<(impl DeserializableValue, impl DeserializableValue)>>,
+        ctx: &mut dyn DeserializationContext,
+        members: &mut dyn ExactSizeIterator<Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>>,
         _range: TextRange,
         _name: &str,
     ) -> Option<Self::Output> {

--- a/crates/biome_rule_options/src/use_sorted_classes.rs
+++ b/crates/biome_rule_options/src/use_sorted_classes.rs
@@ -82,7 +82,9 @@ impl DeserializationVisitor for UtilityClassSortingOptionsVisitor {
     fn visit_map(
         self,
         ctx: &mut dyn DeserializationContext,
-        members: &mut dyn ExactSizeIterator<Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>>,
+        members: &mut dyn ExactSizeIterator<
+            Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>,
+        >,
         _range: TextRange,
         _name: &str,
     ) -> Option<Self::Output> {

--- a/crates/biome_rule_options/src/use_sorted_classes.rs
+++ b/crates/biome_rule_options/src/use_sorted_classes.rs
@@ -1,6 +1,6 @@
 use biome_deserialize::{
     Deserializable, DeserializableTypes, DeserializableValue, DeserializationContext,
-    DeserializationDiagnostic, DeserializationVisitor, TextRange,
+    DeserializationDiagnostic, DeserializationVisitor, MapMembers, TextRange,
 };
 use biome_rowan::Text;
 use serde::{Deserialize, Serialize};
@@ -82,9 +82,7 @@ impl DeserializationVisitor for UtilityClassSortingOptionsVisitor {
     fn visit_map(
         self,
         ctx: &mut dyn DeserializationContext,
-        members: &mut dyn ExactSizeIterator<
-            Item = Option<(Box<dyn DeserializableValue>, Box<dyn DeserializableValue>)>,
-        >,
+        members: &mut MapMembers<'_>,
         _range: TextRange,
         _name: &str,
     ) -> Option<Self::Output> {

--- a/crates/biome_rule_options/src/use_unique_element_ids.rs
+++ b/crates/biome_rule_options/src/use_unique_element_ids.rs
@@ -28,7 +28,7 @@ impl biome_deserialize::Merge for UseUniqueElementIdsOptions {
 impl DeserializableValidator for UseUniqueElementIdsOptions {
     fn validate(
         &mut self,
-        ctx: &mut impl DeserializationContext,
+        ctx: &mut dyn DeserializationContext,
         _name: &str,
         range: TextRange,
     ) -> bool {


### PR DESCRIPTION
## Summary

> [!NOTE]
> **AI Assistance Disclosure**: I used Claude Agent to investigate the binary size and make the changes. I have reviewed the diff before submitting.

After investigating using [cargo-bsize](https://github.com/Boshen/cargo-bsize), I noticed that the `DeserializableValue::deserialize<V: DeserializationVisitor>` function grows the binary size much because it is generic over the visitor and every `Deserialize` type which brings its visitor.

This pull request introduces a type-erased visitor and use it in every `Deserialize` type. Now the `deserialize` function is only implemented once per type for the erased visitor.

Measured with the release profile on linux-x64:

| Before | After | Δ |
|---|---|---|
| 65,160,432 bytes | 61,264,496 bytes | -3.9 MB (-6.0%) |

## Test Plan

Existing tests should pass.

## Docs

N/A
