### PR TITLE
perf(lint/js): optimize some rule queries and unit test call shared logic

### DIFF
--- a/.changeset/twelve-pears-type.md
+++ b/.changeset/twelve-pears-type.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Improved performance of [`useNamedCaptureGroup`](https://biomejs.dev/linter/rules/use-named-capture-group/), [`noMisplacedAssertion`](https://biomejs.dev/linter/rules/no-misplaced-assertion/), [`noSkippedTests`](https://biomejs.dev/linter/rules/no-skipped-tests/), [`noExportsInTest`](https://biomejs.dev/linter/rules/no-exports-in-test/), [`noDuplicateTestHooks`](https://biomejs.dev/linter/rules/no-duplicate-test-hooks/), [`noIdenticalTestTitle`](https://biomejs.dev/linter/rules/no-identical-test-title/), [`useTestHooksInOrder`](https://biomejs.dev/linter/rules/use-test-hooks-in-order/), and [`useTestHooksOnTop`](https://biomejs.dev/linter/rules/use-test-hooks-on-top/).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1188,6 +1188,7 @@ dependencies = [
  "enumflags2",
  "schemars",
  "serde",
+ "smallvec",
 ]
 
 [[package]]

--- a/crates/biome_js_analyze/src/lint/nursery/use_named_capture_group.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_named_capture_group.rs
@@ -2,10 +2,10 @@ use biome_analyze::{Rule, RuleDiagnostic, RuleSource, context::RuleContext, decl
 use biome_console::markup;
 use biome_js_semantic::SemanticModel;
 use biome_js_syntax::{
-    AnyJsCallArgument, AnyJsExpression, JsCallArguments, JsNewOrCallExpression,
-    JsRegexLiteralExpression, global_identifier,
+    AnyJsCallArgument, AnyJsExpression, JsCallArguments, JsCallExpression, JsNewExpression,
+    JsNewOrCallExpression, JsRegexLiteralExpression, global_identifier,
 };
-use biome_rowan::{AstNode, AstSeparatedList, TextRange, TextSize};
+use biome_rowan::{AstNode, AstSeparatedList, TextRange, TextSize, declare_node_union};
 use biome_rule_options::use_named_capture_group::UseNamedCaptureGroupOptions;
 
 use crate::services::semantic::Semantic;
@@ -63,8 +63,15 @@ declare_lint_rule! {
     }
 }
 
+declare_node_union! {
+    pub AnyUseNamedCaptureGroupQuery =
+        JsCallExpression
+        | JsNewExpression
+        | JsRegexLiteralExpression
+}
+
 impl Rule for UseNamedCaptureGroup {
-    type Query = Semantic<AnyJsExpression>;
+    type Query = Semantic<AnyUseNamedCaptureGroupQuery>;
     type State = TextRange;
     type Signals = Box<[Self::State]>;
     type Options = UseNamedCaptureGroupOptions;
@@ -72,13 +79,17 @@ impl Rule for UseNamedCaptureGroup {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
         match node {
-            AnyJsExpression::AnyJsLiteralExpression(
-                biome_js_syntax::AnyJsLiteralExpression::JsRegexLiteralExpression(regex),
-            ) => run_regex_literal(regex),
-            AnyJsExpression::JsNewExpression(_) | AnyJsExpression::JsCallExpression(_) => {
-                run_regexp_constructor(node, ctx.model())
+            AnyUseNamedCaptureGroupQuery::JsRegexLiteralExpression(regex) => {
+                run_regex_literal(regex)
             }
-            _ => Default::default(),
+            AnyUseNamedCaptureGroupQuery::JsNewExpression(node) => run_regexp_constructor(
+                &JsNewOrCallExpression::from(node.clone()),
+                ctx.model(),
+            ),
+            AnyUseNamedCaptureGroupQuery::JsCallExpression(node) => run_regexp_constructor(
+                &JsNewOrCallExpression::from(node.clone()),
+                ctx.model(),
+            ),
         }
     }
 
@@ -227,13 +238,11 @@ fn run_regex_literal(node: &JsRegexLiteralExpression) -> Box<[TextRange]> {
         .collect()
 }
 
-fn run_regexp_constructor(node: &AnyJsExpression, model: &SemanticModel) -> Box<[TextRange]> {
-    let new_or_call = match node {
-        AnyJsExpression::JsNewExpression(n) => JsNewOrCallExpression::from(n.clone()),
-        AnyJsExpression::JsCallExpression(n) => JsNewOrCallExpression::from(n.clone()),
-        _ => return Default::default(),
-    };
-    let Some((callee, arguments)) = parse_regexp_node(&new_or_call) else {
+fn run_regexp_constructor(
+    node: &JsNewOrCallExpression,
+    model: &SemanticModel,
+) -> Box<[TextRange]> {
+    let Some((callee, arguments)) = parse_regexp_node(node) else {
         return Default::default();
     };
     if !is_regexp_object(&callee, model) {

--- a/crates/biome_js_analyze/src/lint/suspicious/no_misplaced_assertion.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_misplaced_assertion.rs
@@ -138,49 +138,35 @@ const EXCEPTION_MEMBERS_FOR_EXPECT: [&str; 10] = [
 ];
 
 impl Rule for NoMisplacedAssertion {
-    type Query = Semantic<AnyJsExpression>;
+    type Query = Semantic<JsCallExpression>;
     type State = TextRange;
     type Signals = Option<Self::State>;
     type Options = NoMisplacedAssertionOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
-        let node = ctx.query();
+        let call = ctx.query();
+        let node = call.callee().ok()?;
         let model = ctx.model();
 
         if let Some(call_text) = node.to_assertion_call() {
-            let ancestor_is_test_call = {
-                node.syntax()
-                    .ancestors()
-                    .filter_map(JsCallExpression::cast)
-                    .find_map(|call_expression| {
-                        let callee = call_expression.callee().ok()?;
-                        let callee = may_extract_nested_expr(callee)?;
-                        callee.contains_it_call().then_some(true)
-                    })
-                    .unwrap_or_default()
-            };
-
-            let ancestor_is_describe_call = {
-                node.syntax()
-                    .ancestors()
-                    .filter_map(JsCallExpression::cast)
-                    .find_map(|call_expression| {
-                        let callee = call_expression.callee().ok()?;
-                        let callee = may_extract_nested_expr(callee)?;
-                        callee.contains_describe_call().then_some(true)
-                    })
-            };
             let assertion_call = node.get_callee_object_identifier()?;
 
-            if let Some(ancestor_is_describe_call) = ancestor_is_describe_call {
-                if ancestor_is_describe_call && ancestor_is_test_call {
-                    return None;
-                }
-            } else if ancestor_is_test_call {
+            if call
+                .syntax()
+                .ancestors()
+                .filter_map(JsCallExpression::cast)
+                .any(|call_expression| {
+                    call_expression
+                        .callee()
+                        .ok()
+                        .and_then(may_extract_nested_expr)
+                        .is_some_and(|callee| callee.contains_it_call())
+                })
+            {
                 return None;
             }
 
-            let is_exception = is_exception_for_expect(node)?;
+            let is_exception = is_exception_for_expect(&node)?;
             let binding = model.binding(&assertion_call);
             if let Some(binding) = binding {
                 let ident = JsIdentifierBinding::cast_ref(&binding.syntax())?;

--- a/crates/biome_js_syntax/Cargo.toml
+++ b/crates/biome_js_syntax/Cargo.toml
@@ -21,6 +21,7 @@ camino              = { workspace = true }
 enumflags2          = { workspace = true }
 schemars            = { workspace = true, optional = true }
 serde               = { workspace = true, features = ["derive"] }
+smallvec            = { workspace = true }
 
 [dev-dependencies]
 biome_js_factory = { path = "../biome_js_factory" }

--- a/crates/biome_js_syntax/src/expr_ext.rs
+++ b/crates/biome_js_syntax/src/expr_ext.rs
@@ -20,7 +20,7 @@ use biome_rowan::{
     TextSize, TokenText, declare_node_union,
 };
 use core::iter;
-use std::collections::HashSet;
+use smallvec::SmallVec;
 
 const GLOBAL_THIS: &str = "globalThis";
 const UNDEFINED: &str = "undefined";
@@ -957,22 +957,21 @@ impl AnyJsExpression {
     ///
     /// [article]: https://craftinginterpreters.com/scanning-on-demand.html#tries-and-state-machines
     pub fn contains_a_test_pattern(&self) -> bool {
-        let members = CalleeNamesIterator::new(self.clone()).collect::<Vec<_>>();
-
-        let mut set = HashSet::new();
-        let has_duplicates = members.iter().any(|x| !set.insert(x));
-
-        if has_duplicates {
+        let members = CalleeNamesIterator::new(self.clone()).collect::<SmallVec<[TokenText; 5]>>();
+        if members
+            .iter()
+            .enumerate()
+            .any(|(index, current)| members.iter().skip(index + 1).any(|other| current == other))
+        {
             return false;
         }
 
-        let mut rev = members.iter().rev();
-
-        let first = rev.next().map(|t| t.text());
-        let second = rev.next().map(|t| t.text());
-        let third = rev.next().map(|t| t.text());
-        let fourth = rev.next().map(|t| t.text());
-        let fifth = rev.next().map(|t| t.text());
+        let mut members = members.iter().rev();
+        let first = members.next().map(TokenText::text);
+        let second = members.next().map(TokenText::text);
+        let third = members.next().map(TokenText::text);
+        let fourth = members.next().map(TokenText::text);
+        let fifth = members.next().map(TokenText::text);
 
         match first {
             Some("describe") => match second {
@@ -1103,12 +1102,10 @@ impl AnyJsExpression {
     /// [`contains_a_test_pattern`]: crate::AnyJsExpression::contains_a_test_pattern
     /// [`contains_a_test_each_pattern`]: crate::AnyJsExpression::contains_a_test_each_pattern
     pub fn contains_it_call(&self) -> bool {
-        let members = CalleeNamesIterator::new(self.clone()).collect::<Vec<_>>();
-
-        let mut rev = members.iter().rev();
-
-        let first = rev.next().map(|t| t.text());
-        let second = rev.next().map(|t| t.text());
+        let members = CalleeNamesIterator::new(self.clone()).collect::<SmallVec<[TokenText; 5]>>();
+        let mut members = members.iter().rev();
+        let first = members.next().map(TokenText::text);
+        let second = members.next().map(TokenText::text);
 
         match first {
             Some("test" | "it") => {
@@ -2416,6 +2413,10 @@ mod test {
     #[test]
     fn doesnt_test_call_expression_with_duplicates() {
         let call_expression = extract_call_expression("test.only.only.only();");
+        assert!(!call_expression.callee().unwrap().contains_a_test_pattern());
+
+        let call_expression =
+            extract_call_expression("test.only.skip.fixme.concurrent.sequential.only();");
         assert!(!call_expression.callee().unwrap().contains_a_test_pattern());
     }
 


### PR DESCRIPTION
## Summary

I had my clanker do a quick performance pass when I was trying a new tool. I had it do some targeted benchmarks:

| Benchmark | Final | Change |
| --- | ---: | ---: |
| `useNamedCaptureGroup` | 14.623 ms | −16.1% |
| `noMisplacedAssertion` | 14.730 ms | −23.6% |
| `contains_a_test_pattern` | 275.19 ns | −30.0% |
| `contains_it_call` | 539.32 ns | −19.0% |

So we'll see if they appear in codspeed.

implemented by gpt 5.6 sol

## Test Plan

no snapshot changes