### PR TITLE
feat(analyzer): add automatic refactor for magic constants

### DIFF
--- a/.changeset/module-level-constant-extraction.md
+++ b/.changeset/module-level-constant-extraction.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": minor
 ---
 
-Added unsafe fixes for [`noMagicNumbers`](https://biomejs.dev/linter/rules/no-magic-numbers/) and [`useTopLevelRegex`](https://biomejs.dev/linter/rules/use-top-level-regex/) that extract literals into uniquely named module-level constants. The regex fix intentionally hoists evaluation and can change regex object identity or mutable state visibility; apply it only when that runtime change is acceptable.
+Added unsafe fixes for [`noMagicNumbers`](https://biomejs.dev/linter/rules/no-magic-numbers/) and [`useTopLevelRegex`](https://biomejs.dev/linter/rules/use-top-level-regex/) that extract literals into uniquely named module-level constants, reusing one declaration for repeated literal values in a file. The regex fix intentionally hoists evaluation and can change regex object identity or mutable state visibility; apply it only when that runtime change is acceptable.

--- a/.changeset/module-level-constant-extraction.md
+++ b/.changeset/module-level-constant-extraction.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": minor
+---
+
+Added unsafe fixes for [`noMagicNumbers`](https://biomejs.dev/linter/rules/no-magic-numbers/) and [`useTopLevelRegex`](https://biomejs.dev/linter/rules/use-top-level-regex/) that extract literals into uniquely named module-level constants. The regex fix intentionally hoists evaluation and can change regex object identity or mutable state visibility; apply it only when that runtime change is acceptable.

--- a/crates/biome_js_analyze/src/lint/performance/use_top_level_regex.rs
+++ b/crates/biome_js_analyze/src/lint/performance/use_top_level_regex.rs
@@ -18,9 +18,9 @@ use crate::{
     JsRuleAction,
     services::{control_flow::AnyJsControlFlowRoot, semantic::Semantic},
     utils::module_constant::{
-        collision_free_module_constant_name, extract_module_constant,
-        extract_module_constant_with_reserved_names, is_module_constant_extractable,
-        module_constant_insertion_slot,
+        collision_free_module_constant_name_with_facts, extract_module_constant,
+        extract_module_constant_with_reserved_names, is_module_constant_extractable_with_facts,
+        module_constant_facts, module_constant_insertion_slot,
     },
 };
 
@@ -30,6 +30,9 @@ declare_lint_rule! {
     /// This rule is useful to avoid performance issues when using regex literals inside functions called many times (hot paths). Regex literals create a new RegExp object when they are evaluated. (See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) By declaring them at the top level, this overhead can be avoided.
     ///
     /// It's important to note that this rule is not recommended for all cases. Placing regex literals at the top level can hurt startup times. In browser contexts, this can result in longer page loads.
+    ///
+    /// The unsafe fix intentionally changes evaluation timing and may change object identity or the
+    /// visibility of mutable properties. Apply it only when those runtime semantics are acceptable.
     ///
     /// Additionally, this rule ignores regular expressions with the `g` and/or `y` flags, as they maintain internal state and can cause
     /// [side effects](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex#avoiding_side_effects) when calling `test` and `exec` with them.
@@ -179,6 +182,7 @@ fn coordinated_extraction(
 ) -> Option<(String, FxHashSet<String>, bool)> {
     // Actions are merged in source order, so reserve names from earlier
     // extractable literals to keep repeated candidates unique in a fix-all.
+    let facts = module_constant_facts(root, model);
     let mut reserved_names = FxHashSet::default();
 
     for descendant in root.syntax().descendants() {
@@ -186,17 +190,18 @@ fn coordinated_extraction(
             continue;
         };
         if !is_actionable_regex(&regex)
-            || !is_module_constant_extractable(root, model, regex.syntax())
+            || !is_module_constant_extractable_with_facts(root, regex.syntax(), &facts)
         {
             continue;
         }
 
         let candidate_name = regex_constant_name(&regex);
-        let name = collision_free_module_constant_name(
+        let name = collision_free_module_constant_name_with_facts(
             model,
             regex.syntax(),
             &candidate_name,
             &reserved_names,
+            &facts,
         );
         let transfer_header = module_constant_insertion_slot(root, regex.syntax()) == Some(0);
 
@@ -218,30 +223,28 @@ fn regex_constant_name(regex: &JsRegexLiteralExpression) -> String {
                 .ok()
                 .and_then(|pattern| pattern.as_any_js_binding().cloned())
                 .and_then(|binding| binding_name(&binding))
+            && let Some(name) = normalize_name_component(&name, true)
         {
-            if let Some(name) = normalize_name_component(&name, true) {
-                return format!("{name}_REGEX");
-            }
+            return format!("{name}_REGEX");
         }
 
         if let Some(function) = AnyJsFunction::cast(ancestor.clone())
             && let Some(name) = function_name(&function)
+            && let Some(name) = normalize_name_component(&name, true)
         {
-            if let Some(name) = normalize_name_component(&name, true) {
-                return format!("{name}_REGEX");
-            }
+            return format!("{name}_REGEX");
         }
 
-        if let Some(name) = method_name(&ancestor) {
-            if let Some(name) = normalize_name_component(&name, true) {
-                return format!("{name}_REGEX");
-            }
+        if let Some(name) = method_name(&ancestor)
+            && let Some(name) = normalize_name_component(&name, true)
+        {
+            return format!("{name}_REGEX");
         }
 
-        if let Some(name) = property_name(&ancestor) {
-            if let Some(name) = normalize_name_component(&name, true) {
-                return format!("{name}_REGEX");
-            }
+        if let Some(name) = property_name(&ancestor)
+            && let Some(name) = normalize_name_component(&name, true)
+        {
+            return format!("{name}_REGEX");
         }
     }
 

--- a/crates/biome_js_analyze/src/lint/performance/use_top_level_regex.rs
+++ b/crates/biome_js_analyze/src/lint/performance/use_top_level_regex.rs
@@ -1,15 +1,11 @@
-use biome_analyze::{
-    FixKind, Rule, RuleDiagnostic, context::RuleContext, declare_lint_rule,
-};
+use biome_analyze::{FixKind, Rule, RuleDiagnostic, context::RuleContext, declare_lint_rule};
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_js_syntax::{
-    AnyJsBinding, AnyJsExpression, AnyJsFunction, AnyJsLiteralExpression, AnyJsPropertyModifier,
-    JsGetterClassMember, JsGetterObjectMember, JsMethodClassMember, JsMethodObjectMember,
-    JsPropertyClassMember, JsPropertyObjectMember, JsRegexLiteralExpression,
-    JsSetterClassMember, JsSetterObjectMember, JsSyntaxNode, JsVariableDeclarator,
-};
 use biome_js_semantic::SemanticModel;
+use biome_js_syntax::{
+    AnyJsExpression, AnyJsLiteralExpression, AnyJsPropertyModifier, JsPropertyClassMember,
+    JsRegexLiteralExpression,
+};
 use biome_rowan::{AstNode, AstNodeList};
 use biome_rule_options::use_top_level_regex::UseTopLevelRegexOptions;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -20,7 +16,7 @@ use crate::{
     utils::module_constant::{
         collision_free_module_constant_name_with_facts, extract_module_constant,
         extract_module_constant_with_reserved_names, is_module_constant_extractable_with_facts,
-        module_constant_facts, module_constant_insertion_slot,
+        module_constant_facts, module_constant_insertion_slot, module_constant_regex_name,
     },
 };
 
@@ -100,6 +96,7 @@ impl Rule for UseTopLevelRegex {
         )
     }
 
+    /// Builds an extraction action, or returns `None` when coordinated extraction cannot proceed.
     fn action(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<JsRuleAction> {
         let regex = ctx.query().clone();
         let root = ctx.root();
@@ -109,13 +106,7 @@ impl Rule for UseTopLevelRegex {
             AnyJsLiteralExpression::JsRegexLiteralExpression(regex.clone()),
         );
         let (mutation, name) = if reserved_names.is_empty() && transfer_header {
-            extract_module_constant(
-                &root,
-                ctx.model(),
-                regex.syntax(),
-                value,
-                &candidate_name,
-            )?
+            extract_module_constant(&root, ctx.model(), regex.syntax(), value, &candidate_name)?
         } else {
             extract_module_constant_with_reserved_names(
                 &root,
@@ -147,8 +138,11 @@ fn is_actionable_regex(regex: &JsRegexLiteralExpression) -> bool {
         return false;
     }
 
-    !regex.syntax().ancestors().skip(1).all(|node| {
-        match AnyJsControlFlowRoot::try_cast(node) {
+    !regex
+        .syntax()
+        .ancestors()
+        .skip(1)
+        .all(|node| match AnyJsControlFlowRoot::try_cast(node) {
             Ok(node) => {
                 matches!(
                     node,
@@ -167,10 +161,12 @@ fn is_actionable_regex(regex: &JsRegexLiteralExpression) -> bool {
                     true
                 }
             }
-        }
-    })
+        })
 }
 
+/// Finds the current regex's name and extraction details while scanning regexes in source order.
+/// Identical literals reuse a name; earlier distinct literals reserve the names they select.
+/// Returns `None` when the current regex is not eligible for module-constant extraction.
 fn coordinated_extraction(
     root: &biome_js_syntax::AnyJsRoot,
     model: &SemanticModel,
@@ -205,7 +201,12 @@ fn coordinated_extraction(
             continue;
         }
 
-        let candidate_name = regex_constant_name(&regex);
+        let pattern = regex
+            .decompose()
+            .ok()
+            .map(|(pattern, _)| pattern.text().to_string())
+            .unwrap_or_default();
+        let candidate_name = module_constant_regex_name(regex.syntax(), &pattern);
         let name = collision_free_module_constant_name_with_facts(
             model,
             regex.syntax(),
@@ -224,135 +225,4 @@ fn coordinated_extraction(
     }
 
     None
-}
-
-fn regex_constant_name(regex: &JsRegexLiteralExpression) -> String {
-    for ancestor in regex.syntax().ancestors().skip(1) {
-        if let Some(declarator) = JsVariableDeclarator::cast(ancestor.clone())
-            && let Some(name) = declarator
-                .id()
-                .ok()
-                .and_then(|pattern| pattern.as_any_js_binding().cloned())
-                .and_then(|binding| binding_name(&binding))
-            && let Some(name) = normalize_name_component(&name, true)
-        {
-            return format!("{name}_REGEX");
-        }
-
-        if let Some(function) = AnyJsFunction::cast(ancestor.clone())
-            && let Some(name) = function_name(&function)
-            && let Some(name) = normalize_name_component(&name, true)
-        {
-            return format!("{name}_REGEX");
-        }
-
-        if let Some(name) = method_name(&ancestor)
-            && let Some(name) = normalize_name_component(&name, true)
-        {
-            return format!("{name}_REGEX");
-        }
-
-        if let Some(name) = property_name(&ancestor)
-            && let Some(name) = normalize_name_component(&name, true)
-        {
-            return format!("{name}_REGEX");
-        }
-    }
-
-    // A context-free literal uses its pattern as a stable fallback name.
-    let pattern = regex
-        .decompose()
-        .ok()
-        .map(|(pattern, _)| pattern.text().to_string())
-        .and_then(|pattern| normalize_name_component(&pattern, false));
-    pattern.map_or_else(
-        || "REGEX".to_string(),
-        |pattern| format!("REGEX_{pattern}"),
-    )
-}
-
-fn binding_name(binding: &AnyJsBinding) -> Option<String> {
-    binding
-        .as_js_identifier_binding()?
-        .name_token()
-        .ok()
-        .map(|token| token.text_trimmed().to_string())
-}
-
-fn function_name(function: &AnyJsFunction) -> Option<String> {
-    let binding = match function {
-        AnyJsFunction::JsFunctionDeclaration(function) => function.id().ok(),
-        AnyJsFunction::JsFunctionExportDefaultDeclaration(function) => function.id(),
-        AnyJsFunction::JsFunctionExpression(function) => function.id(),
-        AnyJsFunction::JsArrowFunctionExpression(_) => None,
-    }?;
-    binding_name(&binding)
-}
-
-fn method_name(node: &JsSyntaxNode) -> Option<String> {
-    if let Some(method) = JsMethodObjectMember::cast(node.clone()) {
-        return method.name().ok()?.name().map(|name| name.to_string());
-    }
-    if let Some(method) = JsGetterObjectMember::cast(node.clone()) {
-        return method.name().ok()?.name().map(|name| name.to_string());
-    }
-    if let Some(method) = JsSetterObjectMember::cast(node.clone()) {
-        return method.name().ok()?.name().map(|name| name.to_string());
-    }
-    if let Some(method) = JsMethodClassMember::cast(node.clone()) {
-        return method.name().ok()?.name().map(|name| name.text().to_string());
-    }
-    if let Some(method) = JsGetterClassMember::cast(node.clone()) {
-        return method.name().ok()?.name().map(|name| name.text().to_string());
-    }
-    if let Some(method) = JsSetterClassMember::cast(node.clone()) {
-        return method.name().ok()?.name().map(|name| name.text().to_string());
-    }
-    None
-}
-
-fn property_name(node: &JsSyntaxNode) -> Option<String> {
-    if let Some(property) = JsPropertyObjectMember::cast(node.clone()) {
-        return property.name().ok()?.name().map(|name| name.to_string());
-    }
-    if let Some(property) = JsPropertyClassMember::cast(node.clone()) {
-        return property.name().ok()?.name().map(|name| name.text().to_string());
-    }
-    None
-}
-
-fn normalize_name_component(text: &str, ensure_identifier_start: bool) -> Option<String> {
-    let mut normalized = String::new();
-    let mut previous_is_lowercase = false;
-
-    for character in text.chars() {
-        if character.is_ascii_alphanumeric() {
-            if character.is_ascii_uppercase() && previous_is_lowercase {
-                normalized.push('_');
-            }
-            normalized.push(character.to_ascii_uppercase());
-            previous_is_lowercase = character.is_ascii_lowercase();
-        } else {
-            if !normalized.ends_with('_') {
-                normalized.push('_');
-            }
-            previous_is_lowercase = false;
-        }
-    }
-
-    let normalized = normalized.trim_matches('_');
-    if normalized.is_empty() {
-        return None;
-    }
-
-    if ensure_identifier_start
-        && normalized
-            .as_bytes()
-            .first()
-            .is_some_and(|character| character.is_ascii_digit())
-    {
-        Some(format!("NUMBER_{normalized}"))
-    } else {
-        Some(normalized.to_string())
-    }
 }

--- a/crates/biome_js_analyze/src/lint/performance/use_top_level_regex.rs
+++ b/crates/biome_js_analyze/src/lint/performance/use_top_level_regex.rs
@@ -102,10 +102,6 @@ impl Rule for UseTopLevelRegex {
 
     fn action(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<JsRuleAction> {
         let regex = ctx.query().clone();
-        if !is_actionable_regex(&regex) {
-            return None;
-        }
-
         let root = ctx.root();
         let (candidate_name, reserved_names, transfer_header) =
             coordinated_extraction(&root, ctx.model(), &regex)?;
@@ -180,8 +176,8 @@ fn coordinated_extraction(
     model: &SemanticModel,
     current: &JsRegexLiteralExpression,
 ) -> Option<(String, FxHashSet<String>, bool)> {
-    // Actions are merged in source order, so reuse names for repeated literal values and reserve
-    // names from earlier distinct literals in a fix-all.
+    // Scan regex literals in source order. Reuse a name for identical literals and reserve names
+    // chosen for earlier different literals when fixing multiple diagnostics together.
     let facts = module_constant_facts(root, model);
     let mut reserved_names = FxHashSet::default();
     let mut names_by_value = FxHashMap::default();

--- a/crates/biome_js_analyze/src/lint/performance/use_top_level_regex.rs
+++ b/crates/biome_js_analyze/src/lint/performance/use_top_level_regex.rs
@@ -1,11 +1,28 @@
-use biome_analyze::{Ast, Rule, RuleDiagnostic, context::RuleContext, declare_lint_rule};
+use biome_analyze::{
+    FixKind, Rule, RuleDiagnostic, context::RuleContext, declare_lint_rule,
+};
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_js_syntax::{AnyJsPropertyModifier, JsPropertyClassMember, JsRegexLiteralExpression};
+use biome_js_syntax::{
+    AnyJsBinding, AnyJsExpression, AnyJsFunction, AnyJsLiteralExpression, AnyJsPropertyModifier,
+    JsGetterClassMember, JsGetterObjectMember, JsMethodClassMember, JsMethodObjectMember,
+    JsPropertyClassMember, JsPropertyObjectMember, JsRegexLiteralExpression,
+    JsSetterClassMember, JsSetterObjectMember, JsSyntaxNode, JsVariableDeclarator,
+};
+use biome_js_semantic::SemanticModel;
 use biome_rowan::{AstNode, AstNodeList};
 use biome_rule_options::use_top_level_regex::UseTopLevelRegexOptions;
+use rustc_hash::FxHashSet;
 
-use crate::services::control_flow::AnyJsControlFlowRoot;
+use crate::{
+    JsRuleAction,
+    services::{control_flow::AnyJsControlFlowRoot, semantic::Semantic},
+    utils::module_constant::{
+        collision_free_module_constant_name, extract_module_constant,
+        extract_module_constant_with_reserved_names, is_module_constant_extractable,
+        module_constant_insertion_slot,
+    },
+};
 
 declare_lint_rule! {
     /// Require regex literals to be declared at the top level.
@@ -49,47 +66,19 @@ declare_lint_rule! {
         language: "js",
         recommended: false,
         severity: Severity::Warning,
+        fix_kind: FixKind::Unsafe,
     }
 }
 
 impl Rule for UseTopLevelRegex {
-    type Query = Ast<JsRegexLiteralExpression>;
+    type Query = Semantic<JsRegexLiteralExpression>;
     type State = ();
     type Signals = Option<Self::State>;
     type Options = UseTopLevelRegexOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let regex = ctx.query();
-        // Ignore regular expressions with the g and/or y flags, as calling test/exec has side effects.
-        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex#avoiding_side_effects
-        let (_, flags) = regex.decompose().ok()?;
-        let flags = flags.text();
-        if flags.contains('g') || flags.contains('y') {
-            return None;
-        }
-        let found_all_allowed = regex.syntax().ancestors().skip(1).all(|node| {
-            match AnyJsControlFlowRoot::try_cast(node) {
-                Ok(node) => {
-                    matches!(
-                        node,
-                        AnyJsControlFlowRoot::JsStaticInitializationBlockClassMember(_)
-                            | AnyJsControlFlowRoot::TsModuleDeclaration(_)
-                            | AnyJsControlFlowRoot::JsModule(_)
-                            | AnyJsControlFlowRoot::JsScript(_)
-                    )
-                }
-                Err(node) => {
-                    if let Some(node) = JsPropertyClassMember::cast(node) {
-                        node.modifiers().iter().any(|modifier| {
-                            matches!(modifier, AnyJsPropertyModifier::JsStaticModifier(_))
-                        })
-                    } else {
-                        true
-                    }
-                }
-            }
-        });
-        if found_all_allowed { None } else { Some(()) }
+        is_actionable_regex(regex).then_some(())
     }
 
     fn diagnostic(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<RuleDiagnostic> {
@@ -106,5 +95,250 @@ impl Rule for UseTopLevelRegex {
                 "Move the regex literal outside of this scope, and place it at the top level of this module, as a constant."
             }),
         )
+    }
+
+    fn action(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<JsRuleAction> {
+        let regex = ctx.query().clone();
+        if !is_actionable_regex(&regex) {
+            return None;
+        }
+
+        let root = ctx.root();
+        let (candidate_name, reserved_names, transfer_header) =
+            coordinated_extraction(&root, ctx.model(), &regex)?;
+        let value = AnyJsExpression::AnyJsLiteralExpression(
+            AnyJsLiteralExpression::JsRegexLiteralExpression(regex.clone()),
+        );
+        let (mutation, name) = if reserved_names.is_empty() && transfer_header {
+            extract_module_constant(
+                &root,
+                ctx.model(),
+                regex.syntax(),
+                value,
+                &candidate_name,
+            )?
+        } else {
+            extract_module_constant_with_reserved_names(
+                &root,
+                ctx.model(),
+                regex.syntax(),
+                value,
+                &candidate_name,
+                &reserved_names,
+                transfer_header,
+            )?
+        };
+
+        Some(JsRuleAction::new(
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
+            ctx.metadata().applicability(),
+            markup! { "Extract the regex literal into "<Emphasis>{name}</Emphasis>"." }.to_owned(),
+            mutation,
+        ))
+    }
+}
+
+fn is_actionable_regex(regex: &JsRegexLiteralExpression) -> bool {
+    // Ignore regular expressions with the g and/or y flags, as calling test/exec has side effects.
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex#avoiding_side_effects
+    let Ok((_, flags)) = regex.decompose() else {
+        return false;
+    };
+    if flags.text().contains('g') || flags.text().contains('y') {
+        return false;
+    }
+
+    !regex.syntax().ancestors().skip(1).all(|node| {
+        match AnyJsControlFlowRoot::try_cast(node) {
+            Ok(node) => {
+                matches!(
+                    node,
+                    AnyJsControlFlowRoot::JsStaticInitializationBlockClassMember(_)
+                        | AnyJsControlFlowRoot::TsModuleDeclaration(_)
+                        | AnyJsControlFlowRoot::JsModule(_)
+                        | AnyJsControlFlowRoot::JsScript(_)
+                )
+            }
+            Err(node) => {
+                if let Some(node) = JsPropertyClassMember::cast(node) {
+                    node.modifiers().iter().any(|modifier| {
+                        matches!(modifier, AnyJsPropertyModifier::JsStaticModifier(_))
+                    })
+                } else {
+                    true
+                }
+            }
+        }
+    })
+}
+
+fn coordinated_extraction(
+    root: &biome_js_syntax::AnyJsRoot,
+    model: &SemanticModel,
+    current: &JsRegexLiteralExpression,
+) -> Option<(String, FxHashSet<String>, bool)> {
+    // Actions are merged in source order, so reserve names from earlier
+    // extractable literals to keep repeated candidates unique in a fix-all.
+    let mut reserved_names = FxHashSet::default();
+
+    for descendant in root.syntax().descendants() {
+        let Some(regex) = JsRegexLiteralExpression::cast(descendant) else {
+            continue;
+        };
+        if !is_actionable_regex(&regex)
+            || !is_module_constant_extractable(root, model, regex.syntax())
+        {
+            continue;
+        }
+
+        let candidate_name = regex_constant_name(&regex);
+        let name = collision_free_module_constant_name(
+            model,
+            regex.syntax(),
+            &candidate_name,
+            &reserved_names,
+        );
+        let transfer_header = module_constant_insertion_slot(root, regex.syntax()) == Some(0);
+
+        if regex.syntax() == current.syntax() {
+            return Some((name, reserved_names, transfer_header));
+        }
+
+        reserved_names.insert(name);
+    }
+
+    None
+}
+
+fn regex_constant_name(regex: &JsRegexLiteralExpression) -> String {
+    for ancestor in regex.syntax().ancestors().skip(1) {
+        if let Some(declarator) = JsVariableDeclarator::cast(ancestor.clone())
+            && let Some(name) = declarator
+                .id()
+                .ok()
+                .and_then(|pattern| pattern.as_any_js_binding().cloned())
+                .and_then(|binding| binding_name(&binding))
+        {
+            if let Some(name) = normalize_name_component(&name, true) {
+                return format!("{name}_REGEX");
+            }
+        }
+
+        if let Some(function) = AnyJsFunction::cast(ancestor.clone())
+            && let Some(name) = function_name(&function)
+        {
+            if let Some(name) = normalize_name_component(&name, true) {
+                return format!("{name}_REGEX");
+            }
+        }
+
+        if let Some(name) = method_name(&ancestor) {
+            if let Some(name) = normalize_name_component(&name, true) {
+                return format!("{name}_REGEX");
+            }
+        }
+
+        if let Some(name) = property_name(&ancestor) {
+            if let Some(name) = normalize_name_component(&name, true) {
+                return format!("{name}_REGEX");
+            }
+        }
+    }
+
+    // A context-free literal uses its pattern as a stable fallback name.
+    let pattern = regex
+        .decompose()
+        .ok()
+        .map(|(pattern, _)| pattern.text().to_string())
+        .and_then(|pattern| normalize_name_component(&pattern, false));
+    pattern.map_or_else(
+        || "REGEX".to_string(),
+        |pattern| format!("REGEX_{pattern}"),
+    )
+}
+
+fn binding_name(binding: &AnyJsBinding) -> Option<String> {
+    binding
+        .as_js_identifier_binding()?
+        .name_token()
+        .ok()
+        .map(|token| token.text_trimmed().to_string())
+}
+
+fn function_name(function: &AnyJsFunction) -> Option<String> {
+    let binding = match function {
+        AnyJsFunction::JsFunctionDeclaration(function) => function.id().ok(),
+        AnyJsFunction::JsFunctionExportDefaultDeclaration(function) => function.id(),
+        AnyJsFunction::JsFunctionExpression(function) => function.id(),
+        AnyJsFunction::JsArrowFunctionExpression(_) => None,
+    }?;
+    binding_name(&binding)
+}
+
+fn method_name(node: &JsSyntaxNode) -> Option<String> {
+    if let Some(method) = JsMethodObjectMember::cast(node.clone()) {
+        return method.name().ok()?.name().map(|name| name.to_string());
+    }
+    if let Some(method) = JsGetterObjectMember::cast(node.clone()) {
+        return method.name().ok()?.name().map(|name| name.to_string());
+    }
+    if let Some(method) = JsSetterObjectMember::cast(node.clone()) {
+        return method.name().ok()?.name().map(|name| name.to_string());
+    }
+    if let Some(method) = JsMethodClassMember::cast(node.clone()) {
+        return method.name().ok()?.name().map(|name| name.text().to_string());
+    }
+    if let Some(method) = JsGetterClassMember::cast(node.clone()) {
+        return method.name().ok()?.name().map(|name| name.text().to_string());
+    }
+    if let Some(method) = JsSetterClassMember::cast(node.clone()) {
+        return method.name().ok()?.name().map(|name| name.text().to_string());
+    }
+    None
+}
+
+fn property_name(node: &JsSyntaxNode) -> Option<String> {
+    if let Some(property) = JsPropertyObjectMember::cast(node.clone()) {
+        return property.name().ok()?.name().map(|name| name.to_string());
+    }
+    if let Some(property) = JsPropertyClassMember::cast(node.clone()) {
+        return property.name().ok()?.name().map(|name| name.text().to_string());
+    }
+    None
+}
+
+fn normalize_name_component(text: &str, ensure_identifier_start: bool) -> Option<String> {
+    let mut normalized = String::new();
+    let mut previous_is_lowercase = false;
+
+    for character in text.chars() {
+        if character.is_ascii_alphanumeric() {
+            if character.is_ascii_uppercase() && previous_is_lowercase {
+                normalized.push('_');
+            }
+            normalized.push(character.to_ascii_uppercase());
+            previous_is_lowercase = character.is_ascii_lowercase();
+        } else {
+            if !normalized.ends_with('_') {
+                normalized.push('_');
+            }
+            previous_is_lowercase = false;
+        }
+    }
+
+    let normalized = normalized.trim_matches('_');
+    if normalized.is_empty() {
+        return None;
+    }
+
+    if ensure_identifier_start
+        && normalized
+            .as_bytes()
+            .first()
+            .is_some_and(|character| character.is_ascii_digit())
+    {
+        Some(format!("NUMBER_{normalized}"))
+    } else {
+        Some(normalized.to_string())
     }
 }

--- a/crates/biome_js_analyze/src/lint/performance/use_top_level_regex.rs
+++ b/crates/biome_js_analyze/src/lint/performance/use_top_level_regex.rs
@@ -1,20 +1,23 @@
-use biome_analyze::{FixKind, Rule, RuleDiagnostic, context::RuleContext, declare_lint_rule};
+use biome_analyze::{
+    FixKind, QueryMatch, Rule, RuleDiagnostic, context::RuleContext, declare_lint_rule,
+};
 use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_semantic::SemanticModel;
 use biome_js_syntax::{
-    AnyJsExpression, AnyJsLiteralExpression, AnyJsPropertyModifier, JsPropertyClassMember,
-    JsRegexLiteralExpression,
+    AnyJsExpression, AnyJsLiteralExpression, AnyJsPropertyModifier, AnyJsRoot,
+    JsPropertyClassMember, JsRegexLiteralExpression, JsSyntaxNode,
 };
-use biome_rowan::{AstNode, AstNodeList};
+use biome_rowan::{AstNode, AstNodeList, TextRange};
 use biome_rule_options::use_top_level_regex::UseTopLevelRegexOptions;
 use rustc_hash::{FxHashMap, FxHashSet};
+use std::cell::RefCell;
 
 use crate::{
     JsRuleAction,
     services::{control_flow::AnyJsControlFlowRoot, semantic::Semantic},
     utils::module_constant::{
-        collision_free_module_constant_name_with_facts, extract_module_constant,
+        collision_free_module_constant_name_with_facts,
         extract_module_constant_with_reserved_names, is_module_constant_extractable_with_facts,
         module_constant_facts, module_constant_insertion_slot, module_constant_regex_name,
     },
@@ -105,19 +108,15 @@ impl Rule for UseTopLevelRegex {
         let value = AnyJsExpression::AnyJsLiteralExpression(
             AnyJsLiteralExpression::JsRegexLiteralExpression(regex.clone()),
         );
-        let (mutation, name) = if reserved_names.is_empty() && transfer_header {
-            extract_module_constant(&root, ctx.model(), regex.syntax(), value, &candidate_name)?
-        } else {
-            extract_module_constant_with_reserved_names(
-                &root,
-                ctx.model(),
-                regex.syntax(),
-                value,
-                &candidate_name,
-                &reserved_names,
-                transfer_header,
-            )?
-        };
+        let (mutation, name) = extract_module_constant_with_reserved_names(
+            &root,
+            ctx.model(),
+            regex.syntax(),
+            value,
+            &candidate_name,
+            &reserved_names,
+            transfer_header,
+        )?;
 
         Some(JsRuleAction::new(
             ctx.metadata().action_category(ctx.category(), ctx.group()),
@@ -168,15 +167,59 @@ fn is_actionable_regex(regex: &JsRegexLiteralExpression) -> bool {
 /// Identical literals reuse a name; earlier distinct literals reserve the names they select.
 /// Returns `None` when the current regex is not eligible for module-constant extraction.
 fn coordinated_extraction(
-    root: &biome_js_syntax::AnyJsRoot,
+    root: &AnyJsRoot,
     model: &SemanticModel,
     current: &JsRegexLiteralExpression,
 ) -> Option<(String, FxHashSet<String>, bool)> {
+    let current_range = current.syntax().text_range();
+
+    REGEX_COORDINATION.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        if cache
+            .as_ref()
+            .is_none_or(|cached| !cached.root.eq(root.syntax()))
+        {
+            *cache = Some(CachedRegexCoordination {
+                root: root.syntax().clone(),
+                extractions: build_coordinated_extractions(root, model),
+            });
+        }
+
+        let extraction = cache.as_ref()?.extractions.get(&current_range)?.clone();
+        Some((
+            extraction.name,
+            extraction.reserved_names,
+            extraction.transfer_header,
+        ))
+    })
+}
+
+#[derive(Clone)]
+struct CoordinatedExtraction {
+    name: String,
+    reserved_names: FxHashSet<String>,
+    transfer_header: bool,
+}
+
+struct CachedRegexCoordination {
+    root: JsSyntaxNode,
+    extractions: FxHashMap<TextRange, CoordinatedExtraction>,
+}
+
+thread_local! {
+    static REGEX_COORDINATION: RefCell<Option<CachedRegexCoordination>> = const { RefCell::new(None) };
+}
+
+fn build_coordinated_extractions(
+    root: &AnyJsRoot,
+    model: &SemanticModel,
+) -> FxHashMap<TextRange, CoordinatedExtraction> {
     // Scan regex literals in source order. Reuse a name for identical literals and reserve names
     // chosen for earlier different literals when fixing multiple diagnostics together.
     let facts = module_constant_facts(root, model);
+    let mut extractions = FxHashMap::default();
     let mut reserved_names = FxHashSet::default();
-    let mut names_by_value = FxHashMap::default();
+    let mut names_by_value: FxHashMap<String, Vec<String>> = FxHashMap::default();
 
     for descendant in root.syntax().descendants() {
         let Some(regex) = JsRegexLiteralExpression::cast(descendant) else {
@@ -189,40 +232,106 @@ fn coordinated_extraction(
         }
 
         let value_key = regex.syntax().text_trimmed().to_string();
-        if let Some(name) = names_by_value.get(&value_key).cloned() {
-            if regex.syntax() == current.syntax() {
-                reserved_names.remove(&name);
-                return Some((
-                    name,
-                    reserved_names,
-                    module_constant_insertion_slot(root, regex.syntax()) == Some(0),
-                ));
-            }
-            continue;
-        }
-
         let pattern = regex
             .decompose()
             .ok()
             .map(|(pattern, _)| pattern.text().to_string())
             .unwrap_or_default();
         let candidate_name = module_constant_regex_name(regex.syntax(), &pattern);
-        let name = collision_free_module_constant_name_with_facts(
-            model,
-            regex.syntax(),
-            &candidate_name,
-            &reserved_names,
-            &facts,
+        let (name, reused_name) = if let Some(names) = names_by_value.get(&value_key) {
+            let reusable_name = names.iter().find(|name| {
+                let name = name.as_str();
+                let mut names_available_for_target = reserved_names.clone();
+                names_available_for_target.remove(name);
+                collision_free_module_constant_name_with_facts(
+                    model,
+                    regex.syntax(),
+                    name,
+                    &names_available_for_target,
+                    &facts,
+                ) == name
+            });
+
+            if let Some(name) = reusable_name {
+                (name.clone(), true)
+            } else {
+                (
+                    collision_free_module_constant_name_with_facts(
+                        model,
+                        regex.syntax(),
+                        &candidate_name,
+                        &reserved_names,
+                        &facts,
+                    ),
+                    false,
+                )
+            }
+        } else {
+            (
+                collision_free_module_constant_name_with_facts(
+                    model,
+                    regex.syntax(),
+                    &candidate_name,
+                    &reserved_names,
+                    &facts,
+                ),
+                false,
+            )
+        };
+
+        let mut names_for_current = reserved_names.clone();
+        names_for_current.remove(&name);
+        extractions.insert(
+            regex.syntax().text_range(),
+            CoordinatedExtraction {
+                name: name.clone(),
+                reserved_names: names_for_current,
+                transfer_header: module_constant_insertion_slot(root, regex.syntax()) == Some(0),
+            },
         );
-        let transfer_header = module_constant_insertion_slot(root, regex.syntax()) == Some(0);
-        names_by_value.insert(value_key, name.clone());
 
-        if regex.syntax() == current.syntax() {
-            return Some((name, reserved_names, transfer_header));
+        if !reused_name {
+            names_by_value
+                .entry(value_key)
+                .or_default()
+                .push(name.clone());
+            reserved_names.insert(name);
         }
-
-        reserved_names.insert(name);
     }
 
-    None
+    extractions
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{coordinated_extraction, JsRegexLiteralExpression};
+    use biome_js_parser::{JsParserOptions, parse};
+    use biome_js_semantic::{SemanticModelOptions, semantic_model};
+    use biome_languages::JsFileSource;
+    use biome_rowan::AstNode;
+
+    #[test]
+    fn does_not_reuse_regex_name_when_shadowed() {
+        let parsed = parse(
+            r#"function read(value) {
+    /x/.test(value);
+    ((READ_REGEX) => /x/.test(value))(value);
+}
+"#,
+            JsFileSource::js_module(),
+            JsParserOptions::default(),
+        );
+        let model = semantic_model(&parsed.tree(), SemanticModelOptions::default());
+        let regexes = parsed
+            .syntax()
+            .descendants()
+            .filter_map(JsRegexLiteralExpression::cast)
+            .collect::<Vec<_>>();
+        let second = regexes.get(1).expect("expected a second regex literal");
+
+        let (name, _, _) = coordinated_extraction(&parsed.tree(), &model, second)
+            .expect("expected a coordinated extraction");
+
+        assert_eq!(name, "READ_REGEX_2");
+    }
 }

--- a/crates/biome_js_analyze/src/lint/performance/use_top_level_regex.rs
+++ b/crates/biome_js_analyze/src/lint/performance/use_top_level_regex.rs
@@ -12,7 +12,7 @@ use biome_js_syntax::{
 use biome_js_semantic::SemanticModel;
 use biome_rowan::{AstNode, AstNodeList};
 use biome_rule_options::use_top_level_regex::UseTopLevelRegexOptions;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
     JsRuleAction,
@@ -180,10 +180,11 @@ fn coordinated_extraction(
     model: &SemanticModel,
     current: &JsRegexLiteralExpression,
 ) -> Option<(String, FxHashSet<String>, bool)> {
-    // Actions are merged in source order, so reserve names from earlier
-    // extractable literals to keep repeated candidates unique in a fix-all.
+    // Actions are merged in source order, so reuse names for repeated literal values and reserve
+    // names from earlier distinct literals in a fix-all.
     let facts = module_constant_facts(root, model);
     let mut reserved_names = FxHashSet::default();
+    let mut names_by_value = FxHashMap::default();
 
     for descendant in root.syntax().descendants() {
         let Some(regex) = JsRegexLiteralExpression::cast(descendant) else {
@@ -192,6 +193,19 @@ fn coordinated_extraction(
         if !is_actionable_regex(&regex)
             || !is_module_constant_extractable_with_facts(root, regex.syntax(), &facts)
         {
+            continue;
+        }
+
+        let value_key = regex.syntax().text_trimmed().to_string();
+        if let Some(name) = names_by_value.get(&value_key).cloned() {
+            if regex.syntax() == current.syntax() {
+                reserved_names.remove(&name);
+                return Some((
+                    name,
+                    reserved_names,
+                    module_constant_insertion_slot(root, regex.syntax()) == Some(0),
+                ));
+            }
             continue;
         }
 
@@ -204,6 +218,7 @@ fn coordinated_extraction(
             &facts,
         );
         let transfer_header = module_constant_insertion_slot(root, regex.syntax()) == Some(0);
+        names_by_value.insert(value_key, name.clone());
 
         if regex.syntax() == current.syntax() {
             return Some((name, reserved_names, transfer_header));

--- a/crates/biome_js_analyze/src/lint/style/no_magic_numbers.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_magic_numbers.rs
@@ -19,7 +19,7 @@ use biome_js_syntax::{
 use biome_js_semantic::SemanticModel;
 use biome_rowan::{AstNode, declare_node_union};
 use biome_rule_options::no_magic_numbers::NoMagicNumbersOptions;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
     JsRuleAction,
@@ -164,6 +164,7 @@ fn coordinated_extraction(
 ) -> Option<(String, FxHashSet<String>, bool)> {
     let facts = module_constant_facts(root, model);
     let mut reserved_names = FxHashSet::default();
+    let mut names_by_value = FxHashMap::default();
 
     for descendant in root.syntax().descendants() {
         let Some(numeric_literal) = AnyJsNumericLiteral::cast(descendant) else {
@@ -177,6 +178,19 @@ fn coordinated_extraction(
             continue;
         }
 
+        let value_key = numeric_literal.syntax().text_trimmed().to_string();
+        if let Some(name) = names_by_value.get(&value_key).cloned() {
+            if numeric_literal.syntax() == current.syntax() {
+                reserved_names.remove(&name);
+                return Some((
+                    name,
+                    reserved_names,
+                    module_constant_insertion_slot(root, numeric_literal.syntax()) == Some(0),
+                ));
+            }
+            continue;
+        }
+
         let candidate_name = numeric_constant_name(&numeric_literal);
         let name = collision_free_module_constant_name_with_facts(
             model,
@@ -187,6 +201,7 @@ fn coordinated_extraction(
         );
         let insertion_slot = module_constant_insertion_slot(root, numeric_literal.syntax());
         let owns_header = insertion_slot == Some(0);
+        names_by_value.insert(value_key, name.clone());
 
         if numeric_literal.syntax() == current.syntax() {
             return Some((name, reserved_names, owns_header));

--- a/crates/biome_js_analyze/src/lint/style/no_magic_numbers.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_magic_numbers.rs
@@ -1,20 +1,35 @@
 use biome_analyze::{
-    Ast, Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule,
+    FixKind, Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule,
 };
 use biome_console::markup;
 use biome_js_syntax::{
-    JsArrayAssignmentPatternElement, JsAssignmentExpression, JsAssignmentOperator,
+    AnyJsBinding, AnyJsExpression, AnyJsFunction, AnyJsLiteralExpression, AnyJsMemberExpression,
+    AnyJsRoot, AnyTsType, JsArrayAssignmentPatternElement, JsAssignmentExpression,
+    JsAssignmentOperator,
     JsBigintLiteralExpression, JsBinaryExpression, JsBinaryOperator, JsCallExpression,
     JsComputedMemberAssignment, JsComputedMemberExpression, JsFormalParameter, JsInitializerClause,
     JsNumberLiteralExpression, JsObjectBindingPatternShorthandProperty, JsParenthesizedExpression,
-    JsPropertyClassMember, JsPropertyObjectMember, JsSyntaxNode, JsUnaryExpression,
-    JsUnaryOperator, JsxExpressionAttributeValue, JsxExpressionChild, TsAsExpression,
-    TsEnumMemberList, TsIndexedAccessType, TsNonNullAssertionExpression, TsNumberLiteralType,
-    TsPredicateReturnType, TsReturnTypeAnnotation, TsSatisfiesExpression, TsTypeAnnotation,
-    TsTypeAssertionExpression, TsUnionTypeVariantList,
+    JsPropertyClassMember, JsPropertyObjectMember, JsStaticMemberAssignment, JsSyntaxNode,
+    JsUnaryExpression, JsUnaryOperator, JsVariableDeclarator,
+    JsxExpressionAttributeValue, JsxExpressionChild, TsAsExpression, TsEnumMemberList,
+    TsIndexedAccessType, TsNonNullAssertionExpression, TsNumberLiteralType, TsPredicateReturnType,
+    TsReturnTypeAnnotation, TsSatisfiesExpression, TsTypeAnnotation, TsTypeAssertionExpression,
+    TsUnionTypeVariantList,
 };
+use biome_js_semantic::SemanticModel;
 use biome_rowan::{AstNode, declare_node_union};
 use biome_rule_options::no_magic_numbers::NoMagicNumbersOptions;
+use rustc_hash::FxHashSet;
+
+use crate::{
+    JsRuleAction,
+    services::semantic::Semantic,
+    utils::module_constant::{
+    collision_free_module_constant_name, extract_module_constant,
+    extract_module_constant_with_reserved_names, is_module_constant_extractable,
+    module_constant_insertion_slot,
+    },
+};
 
 declare_lint_rule! {
     /// Reports usage of "magic numbers" — numbers used directly instead of being assigned to named constants.
@@ -57,11 +72,12 @@ declare_lint_rule! {
         language: "ts",
         sources: &[RuleSource::Eslint("no-magic-numbers").inspired(), RuleSource::EslintTypeScript("no-magic-numbers").same()],
         recommended: false,
+        fix_kind: FixKind::Unsafe,
     }
 }
 
 impl Rule for NoMagicNumbers {
-    type Query = Ast<JsOrTsNumericLiteral>;
+    type Query = Semantic<JsOrTsNumericLiteral>;
     type State = ();
     type Signals = Option<Self::State>;
     type Options = NoMagicNumbersOptions;
@@ -91,6 +107,93 @@ impl Rule for NoMagicNumbers {
             }),
         )
     }
+
+    fn action(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<JsRuleAction> {
+        let numeric_literal = AnyJsNumericLiteral::cast(ctx.query().syntax().clone())?;
+        if !is_actionable_numeric_literal(&numeric_literal) {
+            return None;
+        }
+        let value = match numeric_literal.clone() {
+            AnyJsNumericLiteral::JsNumberLiteralExpression(literal) => {
+                AnyJsExpression::AnyJsLiteralExpression(
+                    AnyJsLiteralExpression::JsNumberLiteralExpression(literal),
+                )
+            }
+            AnyJsNumericLiteral::JsBigintLiteralExpression(literal) => {
+                AnyJsExpression::AnyJsLiteralExpression(
+                    AnyJsLiteralExpression::JsBigintLiteralExpression(literal),
+                )
+            }
+        };
+        let root = ctx.root();
+        let (candidate_name, reserved_names, transfer_header) =
+            coordinated_extraction(&root, ctx.model(), &numeric_literal)?;
+        let (mutation, name) = if reserved_names.is_empty() && transfer_header {
+            extract_module_constant(
+                &root,
+                ctx.model(),
+                numeric_literal.syntax(),
+                value,
+                &candidate_name,
+            )?
+        } else {
+            extract_module_constant_with_reserved_names(
+                &root,
+                ctx.model(),
+                numeric_literal.syntax(),
+                value,
+                &candidate_name,
+                &reserved_names,
+                transfer_header,
+            )?
+        };
+
+        Some(JsRuleAction::new(
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
+            ctx.metadata().applicability(),
+            markup! { "Extract the magic number into "<Emphasis>{name}</Emphasis>"." }.to_owned(),
+            mutation,
+        ))
+    }
+}
+
+fn coordinated_extraction(
+    root: &AnyJsRoot,
+    model: &SemanticModel,
+    current: &AnyJsNumericLiteral,
+) -> Option<(String, FxHashSet<String>, bool)> {
+    let mut reserved_names = FxHashSet::default();
+
+    for descendant in root.syntax().descendants() {
+        let Some(numeric_literal) = AnyJsNumericLiteral::cast(descendant) else {
+            continue;
+        };
+        let query = JsOrTsNumericLiteral::AnyJsNumericLiteral(numeric_literal.clone());
+        if is_valid_number_in_relevant_context(&query)
+            || !is_actionable_numeric_literal(&numeric_literal)
+            || !is_module_constant_extractable(root, model, numeric_literal.syntax())
+        {
+            continue;
+        }
+
+        let candidate_name = numeric_constant_name(&numeric_literal);
+        let name = collision_free_module_constant_name(
+            model,
+            numeric_literal.syntax(),
+            &candidate_name,
+            &reserved_names,
+        );
+        let insertion_slot = module_constant_insertion_slot(root, numeric_literal.syntax());
+        let owns_header = insertion_slot == Some(0);
+
+        if numeric_literal.syntax() == current.syntax() {
+            return Some((name, reserved_names, owns_header));
+        }
+
+        reserved_names.insert(name);
+    }
+
+    None
 }
 
 declare_node_union! {
@@ -99,6 +202,171 @@ declare_node_union! {
 
 declare_node_union! {
     pub JsOrTsNumericLiteral = AnyJsNumericLiteral | TsNumberLiteralType
+}
+
+/// Builds a stable uppercase name from the syntax surrounding a runtime number.
+fn numeric_constant_name(numeric_literal: &AnyJsNumericLiteral) -> String {
+    let literal_text = match numeric_literal {
+        AnyJsNumericLiteral::JsNumberLiteralExpression(literal) => literal
+            .value_token()
+            .ok()
+            .map(|token| token.text_trimmed().to_string()),
+        AnyJsNumericLiteral::JsBigintLiteralExpression(literal) => literal
+            .value_token()
+            .ok()
+            .map(|token| token.text_trimmed().to_string()),
+    }
+    .unwrap_or_else(|| "NUMBER".to_string());
+
+    let mut variable = None;
+    let mut property = None;
+    let mut function = None;
+    let mut call = None;
+
+    for ancestor in numeric_literal.syntax().ancestors().skip(1) {
+        if variable.is_none()
+            && let Some(declarator) = JsVariableDeclarator::cast(ancestor.clone())
+        {
+            variable = declarator
+                .id()
+                .ok()
+                .and_then(|pattern| pattern.as_any_js_binding().cloned())
+                .and_then(|binding| binding_name(&binding));
+        }
+
+        if property.is_none() {
+            property = property_name(&ancestor);
+        }
+
+        if function.is_none()
+            && let Some(enclosing_function) = AnyJsFunction::cast(ancestor.clone())
+        {
+            function = function_name(&enclosing_function);
+        }
+
+        if call.is_none()
+            && let Some(call_expression) = JsCallExpression::cast(ancestor.clone())
+        {
+            call = call_expression
+                .callee()
+                .ok()
+                .and_then(|callee| callee.get_callee_member_name())
+                .map(|token| token.text_trimmed().to_string());
+        }
+
+        if variable.is_some() && property.is_some() && function.is_some() && call.is_some() {
+            break;
+        }
+    }
+
+    let mut parts = Vec::new();
+    for context in [variable, property, function, call].into_iter().flatten() {
+        if let Some(normalized) = normalize_name_component(&context, true)
+            && !parts.contains(&normalized)
+        {
+            parts.push(normalized);
+        }
+    }
+
+    let value =
+        normalize_name_component(&literal_text, false).unwrap_or_else(|| "NUMBER".to_string());
+    if parts.is_empty() {
+        format!("NUMBER_{value}")
+    } else {
+        parts.push(value);
+        parts.join("_")
+    }
+}
+
+fn binding_name(binding: &AnyJsBinding) -> Option<String> {
+    binding
+        .as_js_identifier_binding()?
+        .name_token()
+        .ok()
+        .map(|token| token.text_trimmed().to_string())
+}
+
+fn function_name(function: &AnyJsFunction) -> Option<String> {
+    let binding = match function {
+        AnyJsFunction::JsFunctionDeclaration(function) => function.id().ok(),
+        AnyJsFunction::JsFunctionExportDefaultDeclaration(function) => function.id(),
+        AnyJsFunction::JsFunctionExpression(function) => function.id(),
+        AnyJsFunction::JsArrowFunctionExpression(_) => None,
+    }?;
+    binding_name(&binding)
+}
+
+fn property_name(node: &JsSyntaxNode) -> Option<String> {
+    if let Some(assignment) = JsAssignmentExpression::cast(node.clone()) {
+        return property_name(&assignment.left().ok()?.into_syntax());
+    }
+    if let Some(property) = JsPropertyObjectMember::cast(node.clone()) {
+        return property
+            .name()
+            .ok()?
+            .name()
+            .map(|name| name.to_string());
+    }
+    if let Some(property) = JsPropertyClassMember::cast(node.clone()) {
+        return property.name().ok()?.name().map(|name| name.text().to_string());
+    }
+    if let Some(member) = AnyJsMemberExpression::cast(node.clone()) {
+        return member.member_name().map(|name| name.text().to_string());
+    }
+    if let Some(member) = JsStaticMemberAssignment::cast(node.clone()) {
+        return member
+            .member()
+            .ok()?
+            .as_js_name()?
+            .value_token()
+            .ok()
+            .map(|token| token.text_trimmed().to_string());
+    }
+    if let Some(member) = JsComputedMemberAssignment::cast(node.clone()) {
+        return member
+            .member()
+            .ok()?
+            .as_static_value()
+            .map(|value| value.text().to_string());
+    }
+    None
+}
+
+fn normalize_name_component(text: &str, ensure_identifier_start: bool) -> Option<String> {
+    let mut normalized = String::new();
+    let mut previous_is_lowercase = false;
+
+    for character in text.chars() {
+        if character.is_ascii_alphanumeric() {
+            if character.is_ascii_uppercase() && previous_is_lowercase {
+                normalized.push('_');
+            }
+            normalized.push(character.to_ascii_uppercase());
+            previous_is_lowercase = character.is_ascii_lowercase();
+        } else {
+            if !normalized.ends_with('_') {
+                normalized.push('_');
+            }
+            previous_is_lowercase = false;
+        }
+    }
+
+    let normalized = normalized.trim_matches('_');
+    if normalized.is_empty() {
+        return None;
+    }
+
+    // Numeric context names need a prefix before they can participate in a binding name.
+    if ensure_identifier_start
+        && normalized
+        .as_bytes()
+        .first()
+        .is_some_and(|character| character.is_ascii_digit())
+    {
+        Some(format!("NUMBER_{normalized}"))
+    } else {
+        Some(normalized.to_string())
+    }
 }
 
 /// Checks if the given `numeric_literal` is not a magic number.
@@ -128,6 +396,37 @@ fn is_valid_number_in_relevant_context(numeric_literal: &JsOrTsNumericLiteral) -
     }
 
     false
+}
+
+fn is_ts_const_assertion(numeric_literal: &AnyJsNumericLiteral) -> bool {
+    numeric_literal.syntax().ancestors().any(|ancestor| {
+        let ty = if let Some(expression) = TsAsExpression::cast(ancestor.clone()) {
+            expression.ty().ok()
+        } else {
+            TsTypeAssertionExpression::cast(ancestor).and_then(|expression| expression.ty().ok())
+        };
+        ty.is_some_and(|ty| is_ts_const_type(&ty))
+    })
+}
+
+fn is_actionable_numeric_literal(numeric_literal: &AnyJsNumericLiteral) -> bool {
+    !is_ts_const_assertion(numeric_literal)
+}
+
+fn is_ts_const_type(ty: &AnyTsType) -> bool {
+    let Some(reference) = ty.as_ts_reference_type() else {
+        return false;
+    };
+    let Ok(name) = reference.name() else {
+        return false;
+    };
+    let Some(identifier) = name.as_js_reference_identifier() else {
+        return false;
+    };
+    let Ok(token) = identifier.value_token() else {
+        return false;
+    };
+    token.text_trimmed() == "const"
 }
 
 const BITWISE_BINARY_OPERATORS: &[JsBinaryOperator] = &[

--- a/crates/biome_js_analyze/src/lint/style/no_magic_numbers.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_magic_numbers.rs
@@ -2,21 +2,19 @@ use biome_analyze::{
     FixKind, Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule,
 };
 use biome_console::markup;
+use biome_js_semantic::SemanticModel;
 use biome_js_syntax::{
-    AnyJsBinding, AnyJsExpression, AnyJsFunction, AnyJsLiteralExpression, AnyJsMemberExpression,
-    AnyJsRoot, AnyTsType, JsArrayAssignmentPatternElement, JsAssignmentExpression,
-    JsAssignmentOperator,
-    JsBigintLiteralExpression, JsBinaryExpression, JsBinaryOperator, JsCallExpression,
-    JsComputedMemberAssignment, JsComputedMemberExpression, JsFormalParameter, JsInitializerClause,
-    JsNumberLiteralExpression, JsObjectBindingPatternShorthandProperty, JsParenthesizedExpression,
-    JsPropertyClassMember, JsPropertyObjectMember, JsStaticMemberAssignment, JsSyntaxNode,
-    JsUnaryExpression, JsUnaryOperator, JsVariableDeclarator,
+    AnyJsExpression, AnyJsLiteralExpression, AnyJsRoot, AnyTsType, JsArrayAssignmentPatternElement,
+    JsAssignmentExpression, JsAssignmentOperator, JsBigintLiteralExpression, JsBinaryExpression,
+    JsBinaryOperator, JsCallExpression, JsComputedMemberAssignment, JsComputedMemberExpression,
+    JsFormalParameter, JsInitializerClause, JsNumberLiteralExpression,
+    JsObjectBindingPatternShorthandProperty, JsParenthesizedExpression, JsPropertyClassMember,
+    JsPropertyObjectMember, JsSyntaxNode, JsUnaryExpression, JsUnaryOperator,
     JsxExpressionAttributeValue, JsxExpressionChild, TsAsExpression, TsEnumMemberList,
     TsIndexedAccessType, TsNonNullAssertionExpression, TsNumberLiteralType, TsPredicateReturnType,
     TsReturnTypeAnnotation, TsSatisfiesExpression, TsTypeAnnotation, TsTypeAssertionExpression,
     TsUnionTypeVariantList,
 };
-use biome_js_semantic::SemanticModel;
 use biome_rowan::{AstNode, declare_node_union};
 use biome_rule_options::no_magic_numbers::NoMagicNumbersOptions;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -27,7 +25,7 @@ use crate::{
     utils::module_constant::{
         collision_free_module_constant_name_with_facts, extract_module_constant,
         extract_module_constant_with_reserved_names, is_module_constant_extractable_with_facts,
-        module_constant_facts, module_constant_insertion_slot,
+        module_constant_facts, module_constant_insertion_slot, module_constant_numeric_name,
     },
 };
 
@@ -108,6 +106,7 @@ impl Rule for NoMagicNumbers {
         )
     }
 
+    /// Builds an unsafe action that extracts the actionable literal into a collision-free constant.
     fn action(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<JsRuleAction> {
         let numeric_literal = AnyJsNumericLiteral::cast(ctx.query().syntax().clone())?;
         if !is_actionable_numeric_literal(&numeric_literal) {
@@ -157,6 +156,8 @@ impl Rule for NoMagicNumbers {
     }
 }
 
+/// Coordinates constant names and insertion metadata for the current literal with other extractable
+/// literals in the file.
 fn coordinated_extraction(
     root: &AnyJsRoot,
     model: &SemanticModel,
@@ -191,7 +192,8 @@ fn coordinated_extraction(
             continue;
         }
 
-        let candidate_name = numeric_constant_name(&numeric_literal);
+        let literal_text = numeric_literal.syntax().text_trimmed().to_string();
+        let candidate_name = module_constant_numeric_name(numeric_literal.syntax(), &literal_text);
         let name = collision_free_module_constant_name_with_facts(
             model,
             numeric_literal.syntax(),
@@ -219,171 +221,6 @@ declare_node_union! {
 
 declare_node_union! {
     pub JsOrTsNumericLiteral = AnyJsNumericLiteral | TsNumberLiteralType
-}
-
-/// Builds a stable uppercase name from the syntax surrounding a runtime number.
-fn numeric_constant_name(numeric_literal: &AnyJsNumericLiteral) -> String {
-    let literal_text = match numeric_literal {
-        AnyJsNumericLiteral::JsNumberLiteralExpression(literal) => literal
-            .value_token()
-            .ok()
-            .map(|token| token.text_trimmed().to_string()),
-        AnyJsNumericLiteral::JsBigintLiteralExpression(literal) => literal
-            .value_token()
-            .ok()
-            .map(|token| token.text_trimmed().to_string()),
-    }
-    .unwrap_or_else(|| "NUMBER".to_string());
-
-    let mut variable = None;
-    let mut property = None;
-    let mut function = None;
-    let mut call = None;
-
-    for ancestor in numeric_literal.syntax().ancestors().skip(1) {
-        if variable.is_none()
-            && let Some(declarator) = JsVariableDeclarator::cast(ancestor.clone())
-        {
-            variable = declarator
-                .id()
-                .ok()
-                .and_then(|pattern| pattern.as_any_js_binding().cloned())
-                .and_then(|binding| binding_name(&binding));
-        }
-
-        if property.is_none() {
-            property = property_name(&ancestor);
-        }
-
-        if function.is_none()
-            && let Some(enclosing_function) = AnyJsFunction::cast(ancestor.clone())
-        {
-            function = function_name(&enclosing_function);
-        }
-
-        if call.is_none()
-            && let Some(call_expression) = JsCallExpression::cast(ancestor.clone())
-        {
-            call = call_expression
-                .callee()
-                .ok()
-                .and_then(|callee| callee.get_callee_member_name())
-                .map(|token| token.text_trimmed().to_string());
-        }
-
-        if variable.is_some() && property.is_some() && function.is_some() && call.is_some() {
-            break;
-        }
-    }
-
-    let mut parts = Vec::new();
-    for context in [variable, property, function, call].into_iter().flatten() {
-        if let Some(normalized) = normalize_name_component(&context, true)
-            && !parts.contains(&normalized)
-        {
-            parts.push(normalized);
-        }
-    }
-
-    let value =
-        normalize_name_component(&literal_text, false).unwrap_or_else(|| "NUMBER".to_string());
-    if parts.is_empty() {
-        format!("NUMBER_{value}")
-    } else {
-        parts.push(value);
-        parts.join("_")
-    }
-}
-
-fn binding_name(binding: &AnyJsBinding) -> Option<String> {
-    binding
-        .as_js_identifier_binding()?
-        .name_token()
-        .ok()
-        .map(|token| token.text_trimmed().to_string())
-}
-
-fn function_name(function: &AnyJsFunction) -> Option<String> {
-    let binding = match function {
-        AnyJsFunction::JsFunctionDeclaration(function) => function.id().ok(),
-        AnyJsFunction::JsFunctionExportDefaultDeclaration(function) => function.id(),
-        AnyJsFunction::JsFunctionExpression(function) => function.id(),
-        AnyJsFunction::JsArrowFunctionExpression(_) => None,
-    }?;
-    binding_name(&binding)
-}
-
-fn property_name(node: &JsSyntaxNode) -> Option<String> {
-    if let Some(assignment) = JsAssignmentExpression::cast(node.clone()) {
-        return property_name(&assignment.left().ok()?.into_syntax());
-    }
-    if let Some(property) = JsPropertyObjectMember::cast(node.clone()) {
-        return property
-            .name()
-            .ok()?
-            .name()
-            .map(|name| name.to_string());
-    }
-    if let Some(property) = JsPropertyClassMember::cast(node.clone()) {
-        return property.name().ok()?.name().map(|name| name.text().to_string());
-    }
-    if let Some(member) = AnyJsMemberExpression::cast(node.clone()) {
-        return member.member_name().map(|name| name.text().to_string());
-    }
-    if let Some(member) = JsStaticMemberAssignment::cast(node.clone()) {
-        return member
-            .member()
-            .ok()?
-            .as_js_name()?
-            .value_token()
-            .ok()
-            .map(|token| token.text_trimmed().to_string());
-    }
-    if let Some(member) = JsComputedMemberAssignment::cast(node.clone()) {
-        return member
-            .member()
-            .ok()?
-            .as_static_value()
-            .map(|value| value.text().to_string());
-    }
-    None
-}
-
-fn normalize_name_component(text: &str, ensure_identifier_start: bool) -> Option<String> {
-    let mut normalized = String::new();
-    let mut previous_is_lowercase = false;
-
-    for character in text.chars() {
-        if character.is_ascii_alphanumeric() {
-            if character.is_ascii_uppercase() && previous_is_lowercase {
-                normalized.push('_');
-            }
-            normalized.push(character.to_ascii_uppercase());
-            previous_is_lowercase = character.is_ascii_lowercase();
-        } else {
-            if !normalized.ends_with('_') {
-                normalized.push('_');
-            }
-            previous_is_lowercase = false;
-        }
-    }
-
-    let normalized = normalized.trim_matches('_');
-    if normalized.is_empty() {
-        return None;
-    }
-
-    // Numeric context names need a prefix before they can participate in a binding name.
-    if ensure_identifier_start
-        && normalized
-        .as_bytes()
-        .first()
-        .is_some_and(|character| character.is_ascii_digit())
-    {
-        Some(format!("NUMBER_{normalized}"))
-    } else {
-        Some(normalized.to_string())
-    }
 }
 
 /// Checks if the given `numeric_literal` is not a magic number.

--- a/crates/biome_js_analyze/src/lint/style/no_magic_numbers.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_magic_numbers.rs
@@ -1,5 +1,5 @@
 use biome_analyze::{
-    FixKind, Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule,
+    FixKind, QueryMatch, Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule,
 };
 use biome_console::markup;
 use biome_js_semantic::SemanticModel;
@@ -15,15 +15,16 @@ use biome_js_syntax::{
     TsReturnTypeAnnotation, TsSatisfiesExpression, TsTypeAnnotation, TsTypeAssertionExpression,
     TsUnionTypeVariantList,
 };
-use biome_rowan::{AstNode, declare_node_union};
+use biome_rowan::{AstNode, TextRange, declare_node_union};
 use biome_rule_options::no_magic_numbers::NoMagicNumbersOptions;
 use rustc_hash::{FxHashMap, FxHashSet};
+use std::cell::RefCell;
 
 use crate::{
     JsRuleAction,
     services::semantic::Semantic,
     utils::module_constant::{
-        collision_free_module_constant_name_with_facts, extract_module_constant,
+        collision_free_module_constant_name_with_facts,
         extract_module_constant_with_reserved_names, is_module_constant_extractable_with_facts,
         module_constant_facts, module_constant_insertion_slot, module_constant_numeric_name,
     },
@@ -64,6 +65,9 @@ declare_lint_rule! {
     /// const TAX_RATE = 1.23 as const;
     /// let total = price * TAX_RATE;
     /// ```
+    ///
+    /// The unsafe fix creates a module-level constant. Review the generated declaration and its
+    /// placement before applying it.
     pub NoMagicNumbers {
         version: "2.1.0",
         name: "noMagicNumbers",
@@ -127,25 +131,15 @@ impl Rule for NoMagicNumbers {
         let root = ctx.root();
         let (candidate_name, reserved_names, transfer_header) =
             coordinated_extraction(&root, ctx.model(), &numeric_literal)?;
-        let (mutation, name) = if reserved_names.is_empty() && transfer_header {
-            extract_module_constant(
-                &root,
-                ctx.model(),
-                numeric_literal.syntax(),
-                value,
-                &candidate_name,
-            )?
-        } else {
-            extract_module_constant_with_reserved_names(
-                &root,
-                ctx.model(),
-                numeric_literal.syntax(),
-                value,
-                &candidate_name,
-                &reserved_names,
-                transfer_header,
-            )?
-        };
+        let (mutation, name) = extract_module_constant_with_reserved_names(
+            &root,
+            ctx.model(),
+            numeric_literal.syntax(),
+            value,
+            &candidate_name,
+            &reserved_names,
+            transfer_header,
+        )?;
 
         Some(JsRuleAction::new(
             ctx.metadata().action_category(ctx.category(), ctx.group()),
@@ -163,9 +157,37 @@ fn coordinated_extraction(
     model: &SemanticModel,
     current: &AnyJsNumericLiteral,
 ) -> Option<(String, FxHashSet<String>, bool)> {
+    let current_range = current.syntax().text_range();
+
+    NUMERIC_COORDINATION.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        if cache
+            .as_ref()
+            .is_none_or(|cached| !cached.root.eq(root.syntax()))
+        {
+            *cache = Some(CachedNumericCoordination {
+                root: root.syntax().clone(),
+                extractions: build_coordinated_extractions(root, model),
+            });
+        }
+
+        let extraction = cache.as_ref()?.extractions.get(&current_range)?.clone();
+        Some((
+            extraction.name,
+            extraction.reserved_names,
+            extraction.transfer_header,
+        ))
+    })
+}
+
+fn build_coordinated_extractions(
+    root: &AnyJsRoot,
+    model: &SemanticModel,
+) -> FxHashMap<TextRange, CoordinatedExtraction> {
     let facts = module_constant_facts(root, model);
+    let mut extractions = FxHashMap::default();
     let mut reserved_names = FxHashSet::default();
-    let mut names_by_value = FxHashMap::default();
+    let mut names_by_value: FxHashMap<String, Vec<String>> = FxHashMap::default();
 
     for descendant in root.syntax().descendants() {
         let Some(numeric_literal) = AnyJsNumericLiteral::cast(descendant) else {
@@ -180,39 +202,70 @@ fn coordinated_extraction(
         }
 
         let value_key = numeric_literal.syntax().text_trimmed().to_string();
-        if let Some(name) = names_by_value.get(&value_key).cloned() {
-            if numeric_literal.syntax() == current.syntax() {
-                reserved_names.remove(&name);
-                return Some((
+        let candidate_name = module_constant_numeric_name(numeric_literal.syntax(), &value_key);
+        let (name, reused_name) = if let Some(names) = names_by_value.get(&value_key) {
+            let reusable_name = names.iter().find(|name| {
+                let name = name.as_str();
+                let mut names_available_for_target = reserved_names.clone();
+                names_available_for_target.remove(name);
+                collision_free_module_constant_name_with_facts(
+                    model,
+                    numeric_literal.syntax(),
                     name,
-                    reserved_names,
-                    module_constant_insertion_slot(root, numeric_literal.syntax()) == Some(0),
-                ));
+                    &names_available_for_target,
+                    &facts,
+                ) == name
+            });
+
+            if let Some(name) = reusable_name {
+                (name.clone(), true)
+            } else {
+                (
+                    collision_free_module_constant_name_with_facts(
+                        model,
+                        numeric_literal.syntax(),
+                        &candidate_name,
+                        &reserved_names,
+                        &facts,
+                    ),
+                    false,
+                )
             }
-            continue;
-        }
+        } else {
+            (
+                collision_free_module_constant_name_with_facts(
+                    model,
+                    numeric_literal.syntax(),
+                    &candidate_name,
+                    &reserved_names,
+                    &facts,
+                ),
+                false,
+            )
+        };
 
-        let literal_text = numeric_literal.syntax().text_trimmed().to_string();
-        let candidate_name = module_constant_numeric_name(numeric_literal.syntax(), &literal_text);
-        let name = collision_free_module_constant_name_with_facts(
-            model,
-            numeric_literal.syntax(),
-            &candidate_name,
-            &reserved_names,
-            &facts,
+        let mut names_for_current = reserved_names.clone();
+        names_for_current.remove(&name);
+        extractions.insert(
+            numeric_literal.syntax().text_range(),
+            CoordinatedExtraction {
+                name: name.clone(),
+                reserved_names: names_for_current,
+                transfer_header: module_constant_insertion_slot(root, numeric_literal.syntax())
+                    == Some(0),
+            },
         );
-        let insertion_slot = module_constant_insertion_slot(root, numeric_literal.syntax());
-        let owns_header = insertion_slot == Some(0);
-        names_by_value.insert(value_key, name.clone());
 
-        if numeric_literal.syntax() == current.syntax() {
-            return Some((name, reserved_names, owns_header));
+        if !reused_name {
+            names_by_value
+                .entry(value_key)
+                .or_default()
+                .push(name.clone());
+            reserved_names.insert(name);
         }
-
-        reserved_names.insert(name);
     }
 
-    None
+    extractions
 }
 
 declare_node_union! {
@@ -221,6 +274,22 @@ declare_node_union! {
 
 declare_node_union! {
     pub JsOrTsNumericLiteral = AnyJsNumericLiteral | TsNumberLiteralType
+}
+
+#[derive(Clone)]
+struct CoordinatedExtraction {
+    name: String,
+    reserved_names: FxHashSet<String>,
+    transfer_header: bool,
+}
+
+struct CachedNumericCoordination {
+    root: JsSyntaxNode,
+    extractions: FxHashMap<TextRange, CoordinatedExtraction>,
+}
+
+thread_local! {
+    static NUMERIC_COORDINATION: RefCell<Option<CachedNumericCoordination>> = const { RefCell::new(None) };
 }
 
 /// Checks if the given `numeric_literal` is not a magic number.
@@ -565,4 +634,38 @@ fn is_allowed_number(numeric_literal: &AnyJsNumericLiteral) -> bool {
         AnyJsNumericLiteral::JsBigintLiteralExpression(expr) => expr.value_token(),
     }
     .is_ok_and(|token| ALWAYS_IGNORED_IN_ARITHMETIC_OPERATIONS.contains(&token.text_trimmed()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AnyJsNumericLiteral, coordinated_extraction};
+    use biome_js_parser::{JsParserOptions, parse};
+    use biome_js_semantic::{SemanticModelOptions, semantic_model};
+    use biome_languages::JsFileSource;
+    use biome_rowan::AstNode;
+
+    #[test]
+    fn does_not_reuse_numeric_name_when_shadowed() {
+        let parsed = parse(
+            r#"function read(value) {
+    value + 123;
+    ((READ_123) => value + 123)(value);
+}
+"#,
+            JsFileSource::js_module(),
+            JsParserOptions::default(),
+        );
+        let model = semantic_model(&parsed.tree(), SemanticModelOptions::default());
+        let literals = parsed
+            .syntax()
+            .descendants()
+            .filter_map(AnyJsNumericLiteral::cast)
+            .collect::<Vec<_>>();
+        let second = literals.get(1).expect("expected a second numeric literal");
+
+        let (name, _, _) = coordinated_extraction(&parsed.tree(), &model, second)
+            .expect("expected a coordinated extraction");
+
+        assert_eq!(name, "READ_123_2");
+    }
 }

--- a/crates/biome_js_analyze/src/lint/style/no_magic_numbers.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_magic_numbers.rs
@@ -25,9 +25,9 @@ use crate::{
     JsRuleAction,
     services::semantic::Semantic,
     utils::module_constant::{
-    collision_free_module_constant_name, extract_module_constant,
-    extract_module_constant_with_reserved_names, is_module_constant_extractable,
-    module_constant_insertion_slot,
+        collision_free_module_constant_name_with_facts, extract_module_constant,
+        extract_module_constant_with_reserved_names, is_module_constant_extractable_with_facts,
+        module_constant_facts, module_constant_insertion_slot,
     },
 };
 
@@ -162,6 +162,7 @@ fn coordinated_extraction(
     model: &SemanticModel,
     current: &AnyJsNumericLiteral,
 ) -> Option<(String, FxHashSet<String>, bool)> {
+    let facts = module_constant_facts(root, model);
     let mut reserved_names = FxHashSet::default();
 
     for descendant in root.syntax().descendants() {
@@ -171,17 +172,18 @@ fn coordinated_extraction(
         let query = JsOrTsNumericLiteral::AnyJsNumericLiteral(numeric_literal.clone());
         if is_valid_number_in_relevant_context(&query)
             || !is_actionable_numeric_literal(&numeric_literal)
-            || !is_module_constant_extractable(root, model, numeric_literal.syntax())
+            || !is_module_constant_extractable_with_facts(root, numeric_literal.syntax(), &facts)
         {
             continue;
         }
 
         let candidate_name = numeric_constant_name(&numeric_literal);
-        let name = collision_free_module_constant_name(
+        let name = collision_free_module_constant_name_with_facts(
             model,
             numeric_literal.syntax(),
             &candidate_name,
             &reserved_names,
+            &facts,
         );
         let insertion_slot = module_constant_insertion_slot(root, numeric_literal.syntax());
         let owns_header = insertion_slot == Some(0);

--- a/crates/biome_js_analyze/src/utils.rs
+++ b/crates/biome_js_analyze/src/utils.rs
@@ -3,6 +3,7 @@ use biome_rowan::{AstNode, Direction, WalkEvent};
 use std::iter;
 
 pub mod batch;
+pub mod module_constant;
 pub mod rename;
 #[cfg(test)]
 pub mod tests;

--- a/crates/biome_js_analyze/src/utils/module_constant.rs
+++ b/crates/biome_js_analyze/src/utils/module_constant.rs
@@ -1,0 +1,994 @@
+use biome_js_factory::make;
+use biome_js_semantic::SemanticModel;
+use biome_js_syntax::{
+    AnyJsBinding, AnyJsBindingPattern, AnyJsExpression, AnyJsFunction, AnyJsRoot, JsCallExpression,
+    JsExpressionStatement, JsLanguage, JsModuleItemList, JsStatementList, JsSyntaxKind,
+    JsSyntaxNode, T,
+};
+use biome_rowan::TriviaPieceKind;
+use biome_rowan::{
+    AstNode, BatchMutation, BatchMutationExt, Direction, SyntaxElement, SyntaxTriviaPiece,
+};
+use rustc_hash::FxHashSet;
+
+struct HeaderTrivia {
+    declaration: Vec<(TriviaPieceKind, String)>,
+    first_item: Vec<SyntaxTriviaPiece<JsLanguage>>,
+}
+
+pub(crate) fn extract_module_constant(
+    root: &AnyJsRoot,
+    model: &SemanticModel,
+    target: &JsSyntaxNode,
+    value: AnyJsExpression,
+    candidate_name: &str,
+) -> Option<(BatchMutation<JsLanguage>, String)> {
+    let list = root_list(root)?;
+    let top_level_item = target
+        .ancestors()
+        .find(|ancestor| ancestor.parent().is_some_and(|parent| parent == list))?;
+    if target
+        .ancestors()
+        .any(|ancestor| ancestor.kind() == JsSyntaxKind::JS_WITH_STATEMENT)
+    {
+        // A `with` scope can dynamically shadow any generated identifier.
+        return None;
+    }
+    if direct_eval_affects_target(root, model, target) {
+        // Direct eval in a sloppy script can introduce a binding into an enclosing function.
+        return None;
+    }
+
+    let occupied_reference_names = occupied_reference_names(model);
+    let name = collision_free_name(model, target, candidate_name, &occupied_reference_names);
+    let replacement =
+        make::js_identifier_expression(make::js_reference_identifier(make::ident(&name)))
+            .into_syntax();
+    let replacement = preserve_target_trivia(target, replacement)?;
+    let transformed_item = replace_target(&top_level_item, target, replacement)?;
+    let insertion_slot = insertion_slot(&list, top_level_item.index())?;
+    let line_ending = source_line_ending(&list);
+    let value = trim_expression_trivia(value)?;
+    let header_trivia = if insertion_slot == 0 {
+        Some(split_header_trivia(&list)?)
+    } else {
+        None
+    };
+    let declaration = make_declaration(
+        &name,
+        value,
+        header_trivia
+            .as_ref()
+            .map_or(&[][..], |trivia| trivia.declaration.as_slice()),
+        header_trivia
+            .as_ref()
+            .map_or(&[][..], |trivia| trivia.first_item.as_slice()),
+        insertion_slot == 0,
+        &line_ending,
+    );
+
+    let replaced_list = list.clone().splice_slots(
+        top_level_item.index()..=top_level_item.index(),
+        [Some(SyntaxElement::Node(transformed_item))],
+    );
+    let new_list = if insertion_slot == 0 {
+        // Detach the original first item's remaining whitespace before inserting at slot zero.
+        // Leading trivia on the first list item is rendered before every list child by the CST.
+        let first_item = replaced_list.first_child()?;
+        let first_item = first_item.with_leading_trivia_pieces([])?;
+        let list_without_first_trivia =
+            replaced_list.splice_slots(0..=0, [Some(SyntaxElement::Node(first_item))]);
+        let list_with_declaration =
+            list_without_first_trivia.splice_slots(0..0, [Some(SyntaxElement::Node(declaration))]);
+        list_with_declaration
+    } else {
+        replaced_list.splice_slots(
+            insertion_slot..insertion_slot,
+            [Some(SyntaxElement::Node(declaration))],
+        )
+    };
+
+    let mut mutation = root.clone().begin();
+    // The replacement list already contains the deliberate header/item trivia split. The
+    // default replacement would copy the old list's leading trivia and duplicate the header.
+    mutation.replace_element_discard_trivia(list.into(), new_list.into());
+
+    Some((mutation, name))
+}
+
+fn root_list(root: &AnyJsRoot) -> Option<JsSyntaxNode> {
+    // Expression snippets and declaration-only roots cannot receive a runtime binding.
+    let list = match root {
+        AnyJsRoot::JsModule(module) => module.items().into_syntax(),
+        AnyJsRoot::JsScript(script) => script.statements().into_syntax(),
+        _ => return None,
+    };
+
+    (JsModuleItemList::can_cast(list.kind()) || JsStatementList::can_cast(list.kind()))
+        .then_some(list)
+}
+
+fn collision_free_name(
+    model: &SemanticModel,
+    target: &JsSyntaxNode,
+    candidate_name: &str,
+    occupied_reference_names: &FxHashSet<String>,
+) -> String {
+    if name_is_free_in_target_scopes(model, target, candidate_name, occupied_reference_names) {
+        return candidate_name.to_string();
+    }
+
+    let mut suffix = 2;
+    loop {
+        let name = format!("{candidate_name}_{suffix}");
+        if name_is_free_in_target_scopes(model, target, &name, occupied_reference_names) {
+            return name;
+        }
+        suffix += 1;
+    }
+}
+
+fn name_is_free_in_target_scopes(
+    model: &SemanticModel,
+    target: &JsSyntaxNode,
+    name: &str,
+    occupied_reference_names: &FxHashSet<String>,
+) -> bool {
+    model
+        .scope(target)
+        .ancestors()
+        .all(|scope| scope.get_binding(name).is_none())
+        && !occupied_reference_names.contains(name)
+}
+
+fn occupied_reference_names(model: &SemanticModel) -> FxHashSet<String> {
+    let mut names = FxHashSet::default();
+    for reference in model.all_unresolved_references() {
+        if let Some(token) = reference.syntax().first_token() {
+            names.insert(token.text_trimmed().to_string());
+        }
+    }
+    for reference in model.all_global_references() {
+        if let Some(token) = reference.syntax().first_token() {
+            names.insert(token.text_trimmed().to_string());
+        }
+    }
+    names
+}
+
+fn direct_eval_affects_target(
+    root: &AnyJsRoot,
+    model: &SemanticModel,
+    target: &JsSyntaxNode,
+) -> bool {
+    if !matches!(root, AnyJsRoot::JsScript(_)) {
+        return false;
+    }
+
+    let target_functions = target
+        .ancestors()
+        .filter(|ancestor| AnyJsFunction::can_cast(ancestor.kind()))
+        .collect::<Vec<_>>();
+
+    root.syntax()
+        .descendants()
+        .filter_map(JsCallExpression::cast)
+        .any(|call| {
+            if !is_direct_eval(model, &call) {
+                return false;
+            }
+
+            let eval_function = call
+                .syntax()
+                .ancestors()
+                .find(|ancestor| AnyJsFunction::can_cast(ancestor.kind()));
+            eval_function.is_none_or(|eval_function| {
+                target_functions
+                    .iter()
+                    .any(|target_function| target_function == &eval_function)
+            })
+        })
+}
+
+fn is_direct_eval(model: &SemanticModel, call: &JsCallExpression) -> bool {
+    let Some(reference) = call
+        .callee()
+        .ok()
+        .map(|callee| callee.omit_parentheses())
+        .and_then(|callee| callee.as_js_reference_identifier())
+    else {
+        return false;
+    };
+
+    reference
+        .value_token()
+        .is_ok_and(|token| token.text_trimmed() == "eval")
+        && model.binding(&reference).is_none()
+}
+
+fn preserve_target_trivia(
+    target: &JsSyntaxNode,
+    replacement: JsSyntaxNode,
+) -> Option<JsSyntaxNode> {
+    let replacement = if let Some(trivia) = target.first_leading_trivia() {
+        replacement.with_leading_trivia_pieces(trivia.pieces())?
+    } else {
+        replacement
+    };
+
+    if let Some(trivia) = target.last_trailing_trivia() {
+        replacement.with_trailing_trivia_pieces(trivia.pieces())
+    } else {
+        Some(replacement)
+    }
+}
+
+fn trim_expression_trivia(value: AnyJsExpression) -> Option<AnyJsExpression> {
+    let value = value
+        .into_syntax()
+        .with_leading_trivia_pieces([])?
+        .with_trailing_trivia_pieces([])?;
+
+    AnyJsExpression::cast(value)
+}
+
+fn split_header_trivia(list: &JsSyntaxNode) -> Option<HeaderTrivia> {
+    let first_item = list.first_child()?;
+    let pieces = first_item
+        .first_leading_trivia()
+        .map(|trivia| trivia.pieces().collect::<Vec<_>>())
+        .unwrap_or_default();
+    let split_index = if pieces.iter().any(|piece| piece.kind().is_comment()) {
+        find_first_blank_line_index(&pieces)?
+    } else {
+        pieces.len()
+    };
+    let first_item = pieces[split_index..].to_vec();
+    if first_item.iter().any(|piece| piece.kind().is_comment()) {
+        // Comments after the header separator belong to the original item and cannot safely be
+        // relocated through a slot-zero insertion.
+        return None;
+    }
+
+    Some(HeaderTrivia {
+        declaration: pieces[..split_index]
+            .iter()
+            .map(|piece| (piece.kind(), piece.text().to_string()))
+            .collect(),
+        first_item,
+    })
+}
+
+fn find_first_blank_line_index(pieces: &[SyntaxTriviaPiece<JsLanguage>]) -> Option<usize> {
+    for (index, piece) in pieces.iter().enumerate() {
+        if !piece.is_newline() {
+            continue;
+        }
+
+        let mut next_index = index + 1;
+        while pieces
+            .get(next_index)
+            .is_some_and(SyntaxTriviaPiece::is_whitespace)
+        {
+            next_index += 1;
+        }
+        if pieces
+            .get(next_index)
+            .is_some_and(SyntaxTriviaPiece::is_newline)
+        {
+            return Some(next_index);
+        }
+    }
+    None
+}
+
+fn replace_target(
+    top_level_item: &JsSyntaxNode,
+    target: &JsSyntaxNode,
+    replacement: JsSyntaxNode,
+) -> Option<JsSyntaxNode> {
+    let mut child = target.clone();
+    let mut replacement = replacement;
+
+    loop {
+        let parent = child.parent()?;
+        let is_top_level_item = &parent == top_level_item;
+        // Keep the original parent for the next ancestor step; replacement returns a new tree.
+        let updated_parent = parent
+            .clone()
+            .replace_child(child.into(), replacement.into())?;
+        if is_top_level_item {
+            return Some(updated_parent);
+        }
+        child = parent;
+        replacement = updated_parent;
+    }
+}
+
+fn insertion_slot(list: &JsSyntaxNode, target_index: usize) -> Option<usize> {
+    let mut slot = 0;
+    let mut in_directive_prologue = true;
+
+    for child in list.children() {
+        if is_import_like(&child) {
+            slot = child.index() + 1;
+        } else if in_directive_prologue && is_directive_statement(&child) {
+            slot = child.index() + 1;
+        } else {
+            // A non-leading statement ends the prologue, so later string expressions are ordinary code.
+            in_directive_prologue = false;
+        }
+    }
+
+    // Inserting after the target could move initialization below code that uses it.
+    (slot <= target_index).then_some(slot)
+}
+
+fn is_import_like(node: &JsSyntaxNode) -> bool {
+    matches!(
+        node.kind(),
+        JsSyntaxKind::JS_IMPORT | JsSyntaxKind::TS_IMPORT_EQUALS_DECLARATION
+    ) || (node.kind() == JsSyntaxKind::JS_EXPORT
+        && node
+            .descendants()
+            .any(|descendant| descendant.kind() == JsSyntaxKind::TS_IMPORT_EQUALS_DECLARATION))
+}
+
+fn is_directive_statement(node: &JsSyntaxNode) -> bool {
+    let Some(statement) = JsExpressionStatement::cast_ref(node) else {
+        return false;
+    };
+
+    statement.expression().ok().is_some_and(|expression| {
+        expression
+            .as_any_js_literal_expression()
+            .is_some_and(|literal| literal.as_js_string_literal_expression().is_some())
+    })
+}
+
+fn make_declaration(
+    name: &str,
+    value: AnyJsExpression,
+    declaration_leading_trivia: &[(TriviaPieceKind, String)],
+    declaration_trailing_trivia: &[SyntaxTriviaPiece<JsLanguage>],
+    add_trailing_line_ending: bool,
+    line_ending: &str,
+) -> JsSyntaxNode {
+    let mut leading_trivia = declaration_leading_trivia.to_vec();
+    if !matches!(leading_trivia.last(), Some((TriviaPieceKind::Newline, _))) {
+        leading_trivia.push((TriviaPieceKind::Newline, line_ending.to_string()));
+    }
+
+    let whitespace = [(TriviaPieceKind::Whitespace, " ")];
+    let const_token = make::token(T![const])
+        .with_leading_trivia(
+            leading_trivia
+                .iter()
+                .map(|(kind, text)| (*kind, text.as_str())),
+        )
+        .with_trailing_trivia(whitespace);
+    let name_token = make::ident(name).with_trailing_trivia(whitespace);
+    let initializer =
+        make::js_initializer_clause(make::token(T![=]).with_trailing_trivia(whitespace), value);
+    // Identifier bindings are nested in the binding-pattern union in the CST schema.
+    let binding = AnyJsBinding::JsIdentifierBinding(make::js_identifier_binding(name_token));
+    let binding_pattern = AnyJsBindingPattern::AnyJsBinding(binding);
+    let declarator = make::js_variable_declarator(binding_pattern)
+        .with_initializer(initializer)
+        .build();
+    let declaration = make::js_variable_declaration(
+        const_token,
+        make::js_variable_declarator_list([declarator], []),
+    )
+    .build();
+
+    let mut statement = make::js_variable_statement(declaration);
+    let mut semicolon = make::token(T![;]);
+    if add_trailing_line_ending {
+        let mut trailing_trivia = vec![(TriviaPieceKind::Newline, line_ending.to_string())];
+        trailing_trivia.extend(
+            declaration_trailing_trivia
+                .iter()
+                .map(|piece| (piece.kind(), piece.text().to_string())),
+        );
+        semicolon = semicolon.with_trailing_trivia(
+            trailing_trivia
+                .iter()
+                .map(|(kind, text)| (*kind, text.as_str())),
+        );
+    }
+    statement = statement.with_semicolon_token(semicolon);
+    statement.build().into_syntax()
+}
+
+fn source_line_ending(list: &JsSyntaxNode) -> &'static str {
+    // Detached factory tokens do not inherit the source file's line-separator convention.
+    for token in list.descendants_tokens(Direction::Next) {
+        for text in [
+            token.leading_trivia().text(),
+            token.text(),
+            token.trailing_trivia().text(),
+        ] {
+            if let Some(line_ending) = find_line_ending(text) {
+                return line_ending;
+            }
+        }
+    }
+
+    "\n"
+}
+
+fn find_line_ending(text: &str) -> Option<&'static str> {
+    let mut characters = text.chars().peekable();
+    while let Some(character) = characters.next() {
+        let line_ending = match character {
+            '\r' if characters.peek() == Some(&'\n') => "\r\n",
+            '\r' => "\r",
+            '\n' => "\n",
+            '\u{2028}' => "\u{2028}",
+            '\u{2029}' => "\u{2029}",
+            _ => continue,
+        };
+        return Some(line_ending);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_module_constant;
+    use biome_js_parser::{JsParserOptions, parse};
+    use biome_js_semantic::{SemanticModelOptions, semantic_model};
+    use biome_js_syntax::{
+        AnyJsExpression, JsFunctionDeclaration, JsModuleItemList, JsReferenceIdentifier,
+        JsRegexLiteralExpression,
+    };
+    use biome_languages::JsFileSource;
+    use biome_rowan::{AstNode, AstNodeList, AstSeparatedList};
+
+    #[test]
+    fn extracts_expression_after_imports_and_directives() {
+        let parsed = parse(
+            r#"import value from "module";
+"use strict";
+function read(input) {
+    return /x/.test(input);
+}
+"#,
+            JsFileSource::js_module(),
+            JsParserOptions::default(),
+        );
+        let model = semantic_model(&parsed.tree(), SemanticModelOptions::default());
+        let target = parsed
+            .syntax()
+            .descendants()
+            .find_map(JsRegexLiteralExpression::cast)
+            .expect("expected a regex literal");
+        let value = AnyJsExpression::cast(target.syntax().clone()).expect("regex expression");
+
+        let (mutation, name) =
+            extract_module_constant(&parsed.tree(), &model, target.syntax(), value, "REGEX")
+                .expect("expected a module-level extraction");
+        let output = mutation.commit().to_string();
+        let transformed = parse(
+            &output,
+            JsFileSource::js_module(),
+            JsParserOptions::default(),
+        );
+
+        assert_eq!(name, "REGEX");
+        assert!(output.contains("const REGEX = /x/;"));
+        assert!(output.contains("return REGEX.test(input);"));
+        assert!(
+            output.find("import value from \"module\";").unwrap()
+                < output.find("const REGEX").unwrap()
+        );
+        assert!(output.find("\"use strict\";").unwrap() < output.find("const REGEX").unwrap());
+
+        let module_items = transformed
+            .syntax()
+            .descendants()
+            .find_map(JsModuleItemList::cast)
+            .expect("expected a module item list");
+        let generated_declaration = module_items
+            .iter()
+            .find_map(|item| {
+                let statement = item
+                    .as_any_js_statement()?
+                    .as_js_variable_statement()?
+                    .clone();
+                let declarator = statement
+                    .declaration()
+                    .ok()?
+                    .declarators()
+                    .iter()
+                    .next()?
+                    .ok()?;
+                let id = declarator.id().ok()?;
+                let binding = id.as_any_js_binding()?.as_js_identifier_binding()?;
+                (binding
+                    .name_token()
+                    .ok()
+                    .is_some_and(|token| token.text_trimmed() == "REGEX"))
+                .then_some(statement)
+            })
+            .expect("expected REGEX at module scope");
+        assert!(
+            generated_declaration
+                .syntax()
+                .parent()
+                .is_some_and(|parent| JsModuleItemList::can_cast(parent.kind()))
+        );
+        assert!(
+            generated_declaration
+                .syntax()
+                .descendants()
+                .any(|node| JsRegexLiteralExpression::can_cast(node.kind()))
+        );
+
+        let function = transformed
+            .syntax()
+            .descendants()
+            .find_map(JsFunctionDeclaration::cast)
+            .expect("expected read function");
+        assert!(
+            function
+                .syntax()
+                .descendants()
+                .filter_map(JsReferenceIdentifier::cast)
+                .any(|reference| {
+                    reference
+                        .value_token()
+                        .ok()
+                        .is_some_and(|token| token.text_trimmed() == "REGEX")
+                })
+        );
+        assert!(
+            !function
+                .syntax()
+                .descendants()
+                .any(|node| JsRegexLiteralExpression::can_cast(node.kind()))
+        );
+    }
+
+    #[test]
+    fn extracts_script_expression_with_collision_suffix() {
+        let parsed = parse(
+            r#"const REGEX = 0;
+function read(input) {
+    return /x/.test(input);
+}
+"#,
+            JsFileSource::js_script(),
+            JsParserOptions::default(),
+        );
+        let model = semantic_model(&parsed.tree(), SemanticModelOptions::default());
+        let target = parsed
+            .syntax()
+            .descendants()
+            .find_map(JsRegexLiteralExpression::cast)
+            .expect("expected a regex literal");
+        let value = AnyJsExpression::cast(target.syntax().clone()).expect("regex expression");
+
+        let (mutation, name) =
+            extract_module_constant(&parsed.tree(), &model, target.syntax(), value, "REGEX")
+                .expect("expected a script-level extraction");
+        let output = mutation.commit().to_string();
+
+        assert_eq!(name, "REGEX_2");
+        assert!(output.contains("const REGEX_2 = /x/;"));
+        assert!(output.contains("return REGEX_2.test(input);"));
+    }
+
+    #[test]
+    fn transfers_header_trivia_when_target_is_not_first_item() {
+        let source = "// header\n \t\nconst before = 0;\nfunction read(input) {\n    return /x/.test(input);\n}\n";
+        let parsed = parse(
+            source,
+            JsFileSource::js_module(),
+            JsParserOptions::default(),
+        );
+        let model = semantic_model(&parsed.tree(), SemanticModelOptions::default());
+        let target = parsed
+            .syntax()
+            .descendants()
+            .find_map(JsRegexLiteralExpression::cast)
+            .expect("expected a regex literal");
+        let value = AnyJsExpression::cast(target.syntax().clone()).expect("regex expression");
+
+        let (mutation, _) =
+            extract_module_constant(&parsed.tree(), &model, target.syntax(), value, "REGEX")
+                .expect("expected a module-level extraction");
+        let output = mutation.commit().to_string();
+
+        assert_eq!(output.matches("// header").count(), 1);
+        assert!(output.starts_with("// header\n \t\nconst REGEX = /x/;\n\nconst before = 0;"));
+    }
+
+    #[test]
+    fn rejects_attached_first_item_documentation() {
+        let parsed = parse(
+            r#"/** Documentation for before. */
+const before = 0;
+function read(input) {
+    return /x/.test(input);
+}
+"#,
+            JsFileSource::js_module(),
+            JsParserOptions::default(),
+        );
+        let model = semantic_model(&parsed.tree(), SemanticModelOptions::default());
+        let target = parsed
+            .syntax()
+            .descendants()
+            .find_map(JsRegexLiteralExpression::cast)
+            .expect("expected a regex literal");
+        let value = AnyJsExpression::cast(target.syntax().clone()).expect("regex expression");
+
+        assert!(
+            extract_module_constant(&parsed.tree(), &model, target.syntax(), value, "REGEX")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn rejects_later_comment_blocks_after_header_separator() {
+        let parsed = parse(
+            r#"/** File header. */
+
+/** Documentation for before. */
+const before = 0;
+function read(input) {
+    return /x/.test(input);
+}
+"#,
+            JsFileSource::js_module(),
+            JsParserOptions::default(),
+        );
+        let model = semantic_model(&parsed.tree(), SemanticModelOptions::default());
+        let target = parsed
+            .syntax()
+            .descendants()
+            .find_map(JsRegexLiteralExpression::cast)
+            .expect("expected a regex literal");
+        let value = AnyJsExpression::cast(target.syntax().clone()).expect("regex expression");
+
+        assert!(
+            extract_module_constant(&parsed.tree(), &model, target.syntax(), value, "REGEX")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn avoids_shadowing_target_scope_bindings() {
+        let parsed = parse(
+            r#"function read(REGEX) {
+    return /x/.test(REGEX);
+}
+"#,
+            JsFileSource::js_module(),
+            JsParserOptions::default(),
+        );
+        let model = semantic_model(&parsed.tree(), SemanticModelOptions::default());
+        let target = parsed
+            .syntax()
+            .descendants()
+            .find_map(JsRegexLiteralExpression::cast)
+            .expect("expected a regex literal");
+        let value = AnyJsExpression::cast(target.syntax().clone()).expect("regex expression");
+
+        let (mutation, name) =
+            extract_module_constant(&parsed.tree(), &model, target.syntax(), value, "REGEX")
+                .expect("expected a module-level extraction");
+        let output = mutation.commit().to_string();
+
+        assert_eq!(name, "REGEX_2");
+        assert!(output.contains("const REGEX_2 = /x/;"));
+        assert!(output.contains("return REGEX_2.test(REGEX);"));
+    }
+
+    #[test]
+    fn avoids_capturing_unresolved_reference_elsewhere() {
+        let parsed = parse(
+            r#"function read(input) {
+    return /x/.test(input);
+}
+console.log(REGEX);
+"#,
+            JsFileSource::js_module(),
+            JsParserOptions::default(),
+        );
+        let model = semantic_model(&parsed.tree(), SemanticModelOptions::default());
+        let target = parsed
+            .syntax()
+            .descendants()
+            .find_map(JsRegexLiteralExpression::cast)
+            .expect("expected a regex literal");
+        let value = AnyJsExpression::cast(target.syntax().clone()).expect("regex expression");
+
+        let (mutation, name) =
+            extract_module_constant(&parsed.tree(), &model, target.syntax(), value, "REGEX")
+                .expect("expected a module-level extraction");
+        let output = mutation.commit().to_string();
+
+        assert_eq!(name, "REGEX_2");
+        assert!(output.contains("const REGEX_2 = /x/;"));
+        assert!(output.contains("console.log(REGEX);"));
+    }
+
+    #[test]
+    fn avoids_capturing_configured_global_reference_elsewhere() {
+        let parsed = parse(
+            r#"function read(input) {
+    return /x/.test(input);
+}
+console.log(REGEX);
+"#,
+            JsFileSource::js_module(),
+            JsParserOptions::default(),
+        );
+        let mut options = SemanticModelOptions::default();
+        options.globals.insert("REGEX".to_string());
+        let model = semantic_model(&parsed.tree(), options);
+        let target = parsed
+            .syntax()
+            .descendants()
+            .find_map(JsRegexLiteralExpression::cast)
+            .expect("expected a regex literal");
+        let value = AnyJsExpression::cast(target.syntax().clone()).expect("regex expression");
+
+        let (mutation, name) =
+            extract_module_constant(&parsed.tree(), &model, target.syntax(), value, "REGEX")
+                .expect("expected a module-level extraction");
+        let output = mutation.commit().to_string();
+
+        assert_eq!(name, "REGEX_2");
+        assert!(output.contains("const REGEX_2 = /x/;"));
+        assert!(output.contains("console.log(REGEX);"));
+    }
+
+    #[test]
+    fn rejects_target_under_dynamic_with() {
+        let parsed = parse(
+            r#"function read(input) {
+    with (scope) {
+        return /x/.test(input);
+    }
+}
+"#,
+            JsFileSource::js_script(),
+            JsParserOptions::default(),
+        );
+        let model = semantic_model(&parsed.tree(), SemanticModelOptions::default());
+        let target = parsed
+            .syntax()
+            .descendants()
+            .find_map(JsRegexLiteralExpression::cast)
+            .expect("expected a regex literal");
+        let value = AnyJsExpression::cast(target.syntax().clone()).expect("regex expression");
+
+        assert!(
+            extract_module_constant(&parsed.tree(), &model, target.syntax(), value, "REGEX")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn rejects_target_affected_by_direct_eval_in_sloppy_script() {
+        let parsed = parse(
+            r#"function read(input) {
+    eval("var REGEX = /other/;");
+    return /x/.test(input);
+}
+"#,
+            JsFileSource::js_script(),
+            JsParserOptions::default(),
+        );
+        let model = semantic_model(&parsed.tree(), SemanticModelOptions::default());
+        let target = parsed
+            .syntax()
+            .descendants()
+            .find_map(JsRegexLiteralExpression::cast)
+            .expect("expected a regex literal");
+        let value = AnyJsExpression::cast(target.syntax().clone()).expect("regex expression");
+
+        assert!(
+            extract_module_constant(&parsed.tree(), &model, target.syntax(), value, "REGEX")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn rejects_target_before_later_import() {
+        let parsed = parse(
+            r#"function read(input) {
+    return /x/.test(input);
+}
+import value from "module";
+"#,
+            JsFileSource::js_module(),
+            JsParserOptions::default(),
+        );
+        let model = semantic_model(&parsed.tree(), SemanticModelOptions::default());
+        let target = parsed
+            .syntax()
+            .descendants()
+            .find_map(JsRegexLiteralExpression::cast)
+            .expect("expected a regex literal");
+        let value = AnyJsExpression::cast(target.syntax().clone()).expect("regex expression");
+
+        assert!(
+            extract_module_constant(&parsed.tree(), &model, target.syntax(), value, "REGEX")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn places_constant_after_typescript_import_equals() {
+        let parsed = parse(
+            r#"import value = require("module");
+function read(input) {
+    return /x/.test(input);
+}
+"#,
+            JsFileSource::ts(),
+            JsParserOptions::default(),
+        );
+        let model = semantic_model(&parsed.tree(), SemanticModelOptions::default());
+        let target = parsed
+            .syntax()
+            .descendants()
+            .find_map(JsRegexLiteralExpression::cast)
+            .expect("expected a regex literal");
+        let value = AnyJsExpression::cast(target.syntax().clone()).expect("regex expression");
+
+        let (mutation, _) =
+            extract_module_constant(&parsed.tree(), &model, target.syntax(), value, "REGEX")
+                .expect("expected a TypeScript module-level extraction");
+        let output = mutation.commit().to_string();
+
+        assert!(
+            output.find("import value = require(\"module\");").unwrap()
+                < output.find("const REGEX").unwrap()
+        );
+        assert!(output.find("const REGEX").unwrap() < output.find("function read").unwrap());
+    }
+
+    #[test]
+    fn places_constant_after_exported_typescript_import_equals() {
+        let parsed = parse(
+            r#"export import value = require("module");
+function read(input) {
+    return /x/.test(input);
+}
+"#,
+            JsFileSource::ts(),
+            JsParserOptions::default(),
+        );
+        let model = semantic_model(&parsed.tree(), SemanticModelOptions::default());
+        let target = parsed
+            .syntax()
+            .descendants()
+            .find_map(JsRegexLiteralExpression::cast)
+            .expect("expected a regex literal");
+        let value = AnyJsExpression::cast(target.syntax().clone()).expect("regex expression");
+
+        let (mutation, _) =
+            extract_module_constant(&parsed.tree(), &model, target.syntax(), value, "REGEX")
+                .expect("expected a TypeScript module-level extraction");
+        let output = mutation.commit().to_string();
+
+        assert!(
+            output
+                .find("export import value = require(\"module\");")
+                .unwrap()
+                < output.find("const REGEX").unwrap()
+        );
+        assert!(output.find("const REGEX").unwrap() < output.find("function read").unwrap());
+    }
+
+    #[test]
+    fn preserves_target_comments_without_duplicating_them() {
+        let parsed = parse(
+            r#"function read(input) {
+    return /* before */ /x/ /* after */.test(input);
+}
+"#,
+            JsFileSource::js_module(),
+            JsParserOptions::default(),
+        );
+        let model = semantic_model(&parsed.tree(), SemanticModelOptions::default());
+        let target = parsed
+            .syntax()
+            .descendants()
+            .find_map(JsRegexLiteralExpression::cast)
+            .expect("expected a regex literal");
+        let value = AnyJsExpression::cast(target.syntax().clone()).expect("regex expression");
+
+        let (mutation, _) =
+            extract_module_constant(&parsed.tree(), &model, target.syntax(), value, "REGEX")
+                .expect("expected a module-level extraction");
+        let output = mutation.commit().to_string();
+
+        assert_eq!(output.matches("/* before */").count(), 1);
+        assert_eq!(output.matches("/* after */").count(), 1);
+        assert!(output.contains("const REGEX = /x/;"));
+        assert!(output.contains("return /* before */ REGEX /* after */.test(input);"));
+    }
+
+    #[test]
+    fn places_script_constant_after_directives_with_crlf() {
+        let parsed = parse(
+            "\"use strict\";\r\nfunction read(input) {\r\n    return /x/.test(input);\r\n}\r\n",
+            JsFileSource::js_script(),
+            JsParserOptions::default(),
+        );
+        let model = semantic_model(&parsed.tree(), SemanticModelOptions::default());
+        let target = parsed
+            .syntax()
+            .descendants()
+            .find_map(JsRegexLiteralExpression::cast)
+            .expect("expected a regex literal");
+        let value = AnyJsExpression::cast(target.syntax().clone()).expect("regex expression");
+
+        let (mutation, _) =
+            extract_module_constant(&parsed.tree(), &model, target.syntax(), value, "REGEX")
+                .expect("expected a script-level extraction");
+        let output = mutation.commit().to_string();
+
+        assert!(output.contains("\"use strict\";\r\nconst REGEX = /x/;\r\nfunction"));
+        assert!(output.contains("return REGEX.test(input);"));
+    }
+
+    #[test]
+    fn preserves_unicode_line_separators() {
+        for separator in ["\u{2028}", "\u{2029}"] {
+            let source = format!(
+                "function read(input) {{{separator}    return /x/.test(input);{separator}}}{separator}"
+            );
+            let parsed = parse(
+                &source,
+                JsFileSource::js_script(),
+                JsParserOptions::default(),
+            );
+            let model = semantic_model(&parsed.tree(), SemanticModelOptions::default());
+            let target = parsed
+                .syntax()
+                .descendants()
+                .find_map(JsRegexLiteralExpression::cast)
+                .expect("expected a regex literal");
+            let value = AnyJsExpression::cast(target.syntax().clone()).expect("regex expression");
+
+            let (mutation, _) =
+                extract_module_constant(&parsed.tree(), &model, target.syntax(), value, "REGEX")
+                    .expect("expected a script-level extraction");
+            let output = mutation.commit().to_string();
+
+            assert!(output.contains(&format!("const REGEX = /x/;{separator}function")));
+        }
+    }
+
+    #[test]
+    fn preserves_crlf_inside_multiline_comment_tokens() {
+        let source = "const before = /* first line\r\nsecond line */ 0;\nfunction read(input) {\n    return /x/.test(input);\n}\n";
+        let parsed = parse(
+            source,
+            JsFileSource::js_script(),
+            JsParserOptions::default(),
+        );
+        let model = semantic_model(&parsed.tree(), SemanticModelOptions::default());
+        let target = parsed
+            .syntax()
+            .descendants()
+            .find_map(JsRegexLiteralExpression::cast)
+            .expect("expected a regex literal");
+        let value = AnyJsExpression::cast(target.syntax().clone()).expect("regex expression");
+
+        let (mutation, _) =
+            extract_module_constant(&parsed.tree(), &model, target.syntax(), value, "REGEX")
+                .expect("expected a script-level extraction");
+        let output = mutation.commit().to_string();
+
+        assert!(output.contains("const REGEX = /x/;\r\nconst before"));
+    }
+}

--- a/crates/biome_js_analyze/src/utils/module_constant.rs
+++ b/crates/biome_js_analyze/src/utils/module_constant.rs
@@ -1,17 +1,61 @@
 use biome_js_factory::make;
 use biome_js_semantic::SemanticModel;
 use biome_js_syntax::{
-    AnyJsBinding, AnyJsBindingPattern, AnyJsExpression, AnyJsFunction, AnyJsRoot, JsCallExpression,
+    AnyJsBinding, AnyJsBindingPattern, AnyJsExpression, AnyJsRoot, JsCallExpression,
     JsExpressionStatement, JsLanguage, JsModuleItemList, JsStatementList, JsSyntaxKind,
     JsSyntaxNode, T,
 };
 use biome_rowan::TriviaPieceKind;
 use biome_rowan::{AstNode, BatchMutation, BatchMutationExt, Direction, SyntaxTriviaPiece};
 use rustc_hash::FxHashSet;
+use std::{cell::RefCell, sync::Arc};
 
 struct HeaderTrivia {
     declaration: Vec<(TriviaPieceKind, String)>,
     first_item: Vec<SyntaxTriviaPiece<JsLanguage>>,
+}
+
+#[derive(Clone)]
+pub(crate) struct ModuleConstantFacts {
+    occupied_reference_names: Arc<FxHashSet<String>>,
+    has_unbound_direct_eval: bool,
+}
+
+struct CachedModuleConstantFacts {
+    root: JsSyntaxNode,
+    facts: ModuleConstantFacts,
+}
+
+thread_local! {
+    // Rule actions for one file share this bounded cache; replacing the entry keeps memory use
+    // independent of the number of files analyzed on a worker thread.
+    static MODULE_CONSTANT_FACTS: RefCell<Option<CachedModuleConstantFacts>> = const { RefCell::new(None) };
+}
+
+pub(crate) fn module_constant_facts(
+    root: &AnyJsRoot,
+    model: &SemanticModel,
+) -> ModuleConstantFacts {
+    let root_syntax = root.syntax();
+    MODULE_CONSTANT_FACTS.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        if let Some(cached) = cache
+            .as_ref()
+            .filter(|cached| cached.root == root_syntax.clone())
+        {
+            return cached.facts.clone();
+        }
+
+        let facts = ModuleConstantFacts {
+            occupied_reference_names: Arc::new(occupied_reference_names(model)),
+            has_unbound_direct_eval: has_unbound_direct_eval(root, model),
+        };
+        *cache = Some(CachedModuleConstantFacts {
+            root: root_syntax.clone(),
+            facts: facts.clone(),
+        });
+        facts
+    })
 }
 
 pub(crate) fn extract_module_constant(
@@ -41,7 +85,8 @@ pub(crate) fn extract_module_constant_with_reserved_names(
     reserved_names: &FxHashSet<String>,
     transfer_header: bool,
 ) -> Option<(BatchMutation<JsLanguage>, String)> {
-    if !is_module_constant_extractable(root, model, target) {
+    let facts = module_constant_facts(root, model);
+    if !is_module_constant_extractable_with_facts(root, target, &facts) {
         return None;
     }
 
@@ -50,12 +95,11 @@ pub(crate) fn extract_module_constant_with_reserved_names(
         .ancestors()
         .find(|ancestor| ancestor.parent().is_some_and(|parent| parent == list))?;
 
-    let occupied_reference_names = occupied_reference_names(model);
     let name = collision_free_name(
         model,
         target,
         candidate_name,
-        &occupied_reference_names,
+        &facts.occupied_reference_names,
         reserved_names,
     );
     let insertion_slot = insertion_slot(&list, top_level_item.index())?;
@@ -91,7 +135,7 @@ pub(crate) fn extract_module_constant_with_reserved_names(
             .map_or(&[][..], |trivia| trivia.first_item.as_slice()),
         insertion_slot > 0,
         insertion_slot == 0,
-        &line_ending,
+        line_ending,
     );
 
     let mut mutation = root.clone().begin();
@@ -110,18 +154,18 @@ pub(crate) fn extract_module_constant_with_reserved_names(
     Some((mutation, name))
 }
 
-pub(crate) fn collision_free_module_constant_name(
+pub(crate) fn collision_free_module_constant_name_with_facts(
     model: &SemanticModel,
     target: &JsSyntaxNode,
     candidate_name: &str,
     reserved_names: &FxHashSet<String>,
+    facts: &ModuleConstantFacts,
 ) -> String {
-    let occupied_reference_names = occupied_reference_names(model);
     collision_free_name(
         model,
         target,
         candidate_name,
-        &occupied_reference_names,
+        &facts.occupied_reference_names,
         reserved_names,
     )
 }
@@ -201,11 +245,7 @@ fn occupied_reference_names(model: &SemanticModel) -> FxHashSet<String> {
     names
 }
 
-fn direct_eval_affects_target(
-    root: &AnyJsRoot,
-    model: &SemanticModel,
-    _target: &JsSyntaxNode,
-) -> bool {
+fn has_unbound_direct_eval(root: &AnyJsRoot, model: &SemanticModel) -> bool {
     root.syntax()
         .descendants()
         .filter_map(JsCallExpression::cast)
@@ -318,9 +358,7 @@ fn insertion_slot(list: &JsSyntaxNode, target_index: usize) -> Option<usize> {
     let mut in_directive_prologue = true;
 
     for child in list.children() {
-        if is_import_like(&child) {
-            slot = child.index() + 1;
-        } else if in_directive_prologue && is_directive_statement(&child) {
+        if is_import_like(&child) || in_directive_prologue && is_directive_statement(&child) {
             slot = child.index() + 1;
         } else {
             // A non-leading statement ends the prologue, so later string expressions are ordinary code.
@@ -343,10 +381,10 @@ pub(crate) fn module_constant_insertion_slot(
     insertion_slot(&list, top_level_item.index())
 }
 
-pub(crate) fn is_module_constant_extractable(
+pub(crate) fn is_module_constant_extractable_with_facts(
     root: &AnyJsRoot,
-    model: &SemanticModel,
     target: &JsSyntaxNode,
+    facts: &ModuleConstantFacts,
 ) -> bool {
     if target
         .ancestors()
@@ -355,7 +393,7 @@ pub(crate) fn is_module_constant_extractable(
         // A `with` scope can dynamically shadow any generated identifier.
         return false;
     }
-    if direct_eval_affects_target(root, model, target) {
+    if facts.has_unbound_direct_eval {
         // Direct eval in a sloppy script can introduce a binding into an enclosing function.
         return false;
     }

--- a/crates/biome_js_analyze/src/utils/module_constant.rs
+++ b/crates/biome_js_analyze/src/utils/module_constant.rs
@@ -89,6 +89,7 @@ pub(crate) fn extract_module_constant_with_reserved_names(
         header_trivia
             .as_ref()
             .map_or(&[][..], |trivia| trivia.first_item.as_slice()),
+        insertion_slot > 0,
         insertion_slot == 0,
         &line_ending,
     );
@@ -389,11 +390,14 @@ fn make_declaration(
     value: AnyJsExpression,
     declaration_leading_trivia: &[(TriviaPieceKind, String)],
     declaration_trailing_trivia: &[SyntaxTriviaPiece<JsLanguage>],
+    add_leading_line_ending: bool,
     add_trailing_line_ending: bool,
     line_ending: &str,
 ) -> JsSyntaxNode {
     let mut leading_trivia = declaration_leading_trivia.to_vec();
-    if !leading_trivia.is_empty()
+    // Inserted list items take the following item's leading trivia with them, so a nonzero-slot
+    // declaration needs its own separator even when the preceding statement used ASI.
+    if (add_leading_line_ending || !leading_trivia.is_empty())
         && !matches!(leading_trivia.last(), Some((TriviaPieceKind::Newline, _)))
     {
         leading_trivia.push((TriviaPieceKind::Newline, line_ending.to_string()));
@@ -593,6 +597,52 @@ function read(input) {
                 .descendants()
                 .any(|node| JsRegexLiteralExpression::can_cast(node.kind()))
         );
+    }
+
+    #[test]
+    fn merges_expressions_after_semicolonless_import_and_directive() {
+        let parsed = parse(
+            r#""use strict"
+import value from "module"
+
+function read(input) {
+    return /x/.test(input) && /y/.test(input);
+}
+"#,
+            JsFileSource::js_module(),
+            JsParserOptions::default(),
+        );
+        let model = semantic_model(&parsed.tree(), SemanticModelOptions::default());
+        let targets = parsed
+            .syntax()
+            .descendants()
+            .filter_map(JsRegexLiteralExpression::cast)
+            .collect::<Vec<_>>();
+        assert_eq!(targets.len(), 2);
+
+        let mut mutations = targets.into_iter().enumerate().map(|(index, target)| {
+            let value = AnyJsExpression::cast(target.syntax().clone()).expect("regex expression");
+            extract_module_constant(
+                &parsed.tree(),
+                &model,
+                target.syntax(),
+                value,
+                &format!("REGEX_{}", index + 1),
+            )
+            .expect("expected a module-level extraction")
+        });
+        let (mut mutation, first_name) = mutations.next().expect("first extraction");
+        let (second_mutation, second_name) = mutations.next().expect("second extraction");
+        mutation.merge(second_mutation);
+
+        let output = mutation.commit().to_string();
+        assert_eq!(first_name, "REGEX_1");
+        assert_eq!(second_name, "REGEX_2");
+        assert!(output.contains(
+            "\"use strict\"\nimport value from \"module\"\nconst REGEX_1 = /x/;\nconst REGEX_2 = /y/;\n\nfunction"
+        ));
+        assert!(!output.contains("module\"const"));
+        assert!(output.contains("return REGEX_1.test(input) && REGEX_2.test(input);"));
     }
 
     #[test]

--- a/crates/biome_js_analyze/src/utils/module_constant.rs
+++ b/crates/biome_js_analyze/src/utils/module_constant.rs
@@ -795,6 +795,38 @@ function read(input) {
     }
 
     #[test]
+    fn deduplicates_identical_extractions_for_fix_all() {
+        let parsed = parse(
+            r#"function read(input) {
+    return input + 5 + 5;
+}
+"#,
+            JsFileSource::js_module(),
+            JsParserOptions::default(),
+        );
+        let model = semantic_model(&parsed.tree(), SemanticModelOptions::default());
+        let targets = parsed
+            .syntax()
+            .descendants()
+            .filter_map(JsNumberLiteralExpression::cast)
+            .collect::<Vec<_>>();
+        assert_eq!(targets.len(), 2);
+
+        let mut mutations = targets.into_iter().map(|target| {
+            let value = AnyJsExpression::cast(target.syntax().clone()).expect("number expression");
+            extract_module_constant(&parsed.tree(), &model, target.syntax(), value, "NUMBER")
+                .expect("expected a module-level extraction")
+                .0
+        });
+        let mut mutation = mutations.next().expect("first extraction");
+        mutation.merge(mutations.next().expect("second extraction"));
+
+        let output = mutation.commit().to_string();
+        assert_eq!(output.matches("const NUMBER = 5;").count(), 1);
+        assert!(output.contains("return input + NUMBER + NUMBER;"));
+    }
+
+    #[test]
     fn coordinates_repeated_names_and_header_for_fix_all() {
         let source = "// header\n\nfunction read(input) {\n    return 5 + 5 + 5;\n}\n";
         let parsed = parse(

--- a/crates/biome_js_analyze/src/utils/module_constant.rs
+++ b/crates/biome_js_analyze/src/utils/module_constant.rs
@@ -6,9 +6,7 @@ use biome_js_syntax::{
     JsSyntaxNode, T,
 };
 use biome_rowan::TriviaPieceKind;
-use biome_rowan::{
-    AstNode, BatchMutation, BatchMutationExt, Direction, SyntaxElement, SyntaxTriviaPiece,
-};
+use biome_rowan::{AstNode, BatchMutation, BatchMutationExt, Direction, SyntaxTriviaPiece};
 use rustc_hash::FxHashSet;
 
 struct HeaderTrivia {
@@ -23,33 +21,61 @@ pub(crate) fn extract_module_constant(
     value: AnyJsExpression,
     candidate_name: &str,
 ) -> Option<(BatchMutation<JsLanguage>, String)> {
+    extract_module_constant_with_reserved_names(
+        root,
+        model,
+        target,
+        value,
+        candidate_name,
+        &FxHashSet::default(),
+        true,
+    )
+}
+
+pub(crate) fn extract_module_constant_with_reserved_names(
+    root: &AnyJsRoot,
+    model: &SemanticModel,
+    target: &JsSyntaxNode,
+    value: AnyJsExpression,
+    candidate_name: &str,
+    reserved_names: &FxHashSet<String>,
+    transfer_header: bool,
+) -> Option<(BatchMutation<JsLanguage>, String)> {
+    if !is_module_constant_extractable(root, model, target) {
+        return None;
+    }
+
     let list = root_list(root)?;
     let top_level_item = target
         .ancestors()
         .find(|ancestor| ancestor.parent().is_some_and(|parent| parent == list))?;
-    if target
-        .ancestors()
-        .any(|ancestor| ancestor.kind() == JsSyntaxKind::JS_WITH_STATEMENT)
-    {
-        // A `with` scope can dynamically shadow any generated identifier.
-        return None;
-    }
-    if direct_eval_affects_target(root, model, target) {
-        // Direct eval in a sloppy script can introduce a binding into an enclosing function.
-        return None;
-    }
 
     let occupied_reference_names = occupied_reference_names(model);
-    let name = collision_free_name(model, target, candidate_name, &occupied_reference_names);
+    let name = collision_free_name(
+        model,
+        target,
+        candidate_name,
+        &occupied_reference_names,
+        reserved_names,
+    );
+    let insertion_slot = insertion_slot(&list, top_level_item.index())?;
+    let first_token = if insertion_slot == 0 && transfer_header {
+        Some(list.first_token()?)
+    } else {
+        None
+    };
+    let target_starts_with_first_token = first_token.as_ref().is_some_and(|first_token| {
+        target
+            .first_token()
+            .is_some_and(|target_token| target_token == first_token.clone())
+    });
     let replacement =
         make::js_identifier_expression(make::js_reference_identifier(make::ident(&name)))
             .into_syntax();
-    let replacement = preserve_target_trivia(target, replacement)?;
-    let transformed_item = replace_target(&top_level_item, target, replacement)?;
-    let insertion_slot = insertion_slot(&list, top_level_item.index())?;
+    let replacement = preserve_target_trivia(target, replacement, !target_starts_with_first_token)?;
     let line_ending = source_line_ending(&list);
     let value = trim_expression_trivia(value)?;
-    let header_trivia = if insertion_slot == 0 {
+    let header_trivia = if insertion_slot == 0 && transfer_header {
         Some(split_header_trivia(&list)?)
     } else {
         None
@@ -67,33 +93,36 @@ pub(crate) fn extract_module_constant(
         &line_ending,
     );
 
-    let replaced_list = list.clone().splice_slots(
-        top_level_item.index()..=top_level_item.index(),
-        [Some(SyntaxElement::Node(transformed_item))],
-    );
-    let new_list = if insertion_slot == 0 {
-        // Detach the original first item's remaining whitespace before inserting at slot zero.
-        // Leading trivia on the first list item is rendered before every list child by the CST.
-        let first_item = replaced_list.first_child()?;
-        let first_item = first_item.with_leading_trivia_pieces([])?;
-        let list_without_first_trivia =
-            replaced_list.splice_slots(0..=0, [Some(SyntaxElement::Node(first_item))]);
-        let list_with_declaration =
-            list_without_first_trivia.splice_slots(0..0, [Some(SyntaxElement::Node(declaration))]);
-        list_with_declaration
-    } else {
-        replaced_list.splice_slots(
-            insertion_slot..insertion_slot,
-            [Some(SyntaxElement::Node(declaration))],
-        )
-    };
-
     let mut mutation = root.clone().begin();
-    // The replacement list already contains the deliberate header/item trivia split. The
-    // default replacement would copy the old list's leading trivia and duplicate the header.
-    mutation.replace_element_discard_trivia(list.into(), new_list.into());
+    mutation.replace_element_discard_trivia(target.clone().into(), replacement.into());
+    if let Some(first_token) = first_token.filter(|_| !target_starts_with_first_token) {
+        // Header trivia belongs to the generated declaration; clear it from the actual first
+        // item so attached comments are not moved or duplicated.
+        mutation.clear_leading_trivia(first_token);
+    }
+    if insertion_slot == 0 && transfer_header {
+        mutation.insert_element_with_header(list, insertion_slot, declaration.into());
+    } else {
+        mutation.insert_element(list, insertion_slot, declaration.into());
+    }
 
     Some((mutation, name))
+}
+
+pub(crate) fn collision_free_module_constant_name(
+    model: &SemanticModel,
+    target: &JsSyntaxNode,
+    candidate_name: &str,
+    reserved_names: &FxHashSet<String>,
+) -> String {
+    let occupied_reference_names = occupied_reference_names(model);
+    collision_free_name(
+        model,
+        target,
+        candidate_name,
+        &occupied_reference_names,
+        reserved_names,
+    )
 }
 
 fn root_list(root: &AnyJsRoot) -> Option<JsSyntaxNode> {
@@ -113,15 +142,28 @@ fn collision_free_name(
     target: &JsSyntaxNode,
     candidate_name: &str,
     occupied_reference_names: &FxHashSet<String>,
+    reserved_names: &FxHashSet<String>,
 ) -> String {
-    if name_is_free_in_target_scopes(model, target, candidate_name, occupied_reference_names) {
+    if name_is_free_in_target_scopes(
+        model,
+        target,
+        candidate_name,
+        occupied_reference_names,
+        reserved_names,
+    ) {
         return candidate_name.to_string();
     }
 
     let mut suffix = 2;
     loop {
         let name = format!("{candidate_name}_{suffix}");
-        if name_is_free_in_target_scopes(model, target, &name, occupied_reference_names) {
+        if name_is_free_in_target_scopes(
+            model,
+            target,
+            &name,
+            occupied_reference_names,
+            reserved_names,
+        ) {
             return name;
         }
         suffix += 1;
@@ -133,12 +175,14 @@ fn name_is_free_in_target_scopes(
     target: &JsSyntaxNode,
     name: &str,
     occupied_reference_names: &FxHashSet<String>,
+    reserved_names: &FxHashSet<String>,
 ) -> bool {
     model
         .scope(target)
         .ancestors()
         .all(|scope| scope.get_binding(name).is_none())
         && !occupied_reference_names.contains(name)
+        && !reserved_names.contains(name)
 }
 
 fn occupied_reference_names(model: &SemanticModel) -> FxHashSet<String> {
@@ -159,34 +203,15 @@ fn occupied_reference_names(model: &SemanticModel) -> FxHashSet<String> {
 fn direct_eval_affects_target(
     root: &AnyJsRoot,
     model: &SemanticModel,
-    target: &JsSyntaxNode,
+    _target: &JsSyntaxNode,
 ) -> bool {
-    if !matches!(root, AnyJsRoot::JsScript(_)) {
-        return false;
-    }
-
-    let target_functions = target
-        .ancestors()
-        .filter(|ancestor| AnyJsFunction::can_cast(ancestor.kind()))
-        .collect::<Vec<_>>();
-
     root.syntax()
         .descendants()
         .filter_map(JsCallExpression::cast)
         .any(|call| {
-            if !is_direct_eval(model, &call) {
-                return false;
-            }
-
-            let eval_function = call
-                .syntax()
-                .ancestors()
-                .find(|ancestor| AnyJsFunction::can_cast(ancestor.kind()));
-            eval_function.is_none_or(|eval_function| {
-                target_functions
-                    .iter()
-                    .any(|target_function| target_function == &eval_function)
-            })
+            // A direct eval anywhere in the accepted root can observe a newly inserted
+            // top-level binding, including from a sibling or nested function.
+            is_direct_eval(model, &call)
         })
 }
 
@@ -209,9 +234,14 @@ fn is_direct_eval(model: &SemanticModel, call: &JsCallExpression) -> bool {
 fn preserve_target_trivia(
     target: &JsSyntaxNode,
     replacement: JsSyntaxNode,
+    preserve_leading_trivia: bool,
 ) -> Option<JsSyntaxNode> {
-    let replacement = if let Some(trivia) = target.first_leading_trivia() {
-        replacement.with_leading_trivia_pieces(trivia.pieces())?
+    let replacement = if preserve_leading_trivia {
+        if let Some(trivia) = target.first_leading_trivia() {
+            replacement.with_leading_trivia_pieces(trivia.pieces())?
+        } else {
+            replacement
+        }
     } else {
         replacement
     };
@@ -282,29 +312,6 @@ fn find_first_blank_line_index(pieces: &[SyntaxTriviaPiece<JsLanguage>]) -> Opti
     None
 }
 
-fn replace_target(
-    top_level_item: &JsSyntaxNode,
-    target: &JsSyntaxNode,
-    replacement: JsSyntaxNode,
-) -> Option<JsSyntaxNode> {
-    let mut child = target.clone();
-    let mut replacement = replacement;
-
-    loop {
-        let parent = child.parent()?;
-        let is_top_level_item = &parent == top_level_item;
-        // Keep the original parent for the next ancestor step; replacement returns a new tree.
-        let updated_parent = parent
-            .clone()
-            .replace_child(child.into(), replacement.into())?;
-        if is_top_level_item {
-            return Some(updated_parent);
-        }
-        child = parent;
-        replacement = updated_parent;
-    }
-}
-
 fn insertion_slot(list: &JsSyntaxNode, target_index: usize) -> Option<usize> {
     let mut slot = 0;
     let mut in_directive_prologue = true;
@@ -322,6 +329,37 @@ fn insertion_slot(list: &JsSyntaxNode, target_index: usize) -> Option<usize> {
 
     // Inserting after the target could move initialization below code that uses it.
     (slot <= target_index).then_some(slot)
+}
+
+pub(crate) fn module_constant_insertion_slot(
+    root: &AnyJsRoot,
+    target: &JsSyntaxNode,
+) -> Option<usize> {
+    let list = root_list(root)?;
+    let top_level_item = target
+        .ancestors()
+        .find(|ancestor| ancestor.parent().is_some_and(|parent| parent == list))?;
+    insertion_slot(&list, top_level_item.index())
+}
+
+pub(crate) fn is_module_constant_extractable(
+    root: &AnyJsRoot,
+    model: &SemanticModel,
+    target: &JsSyntaxNode,
+) -> bool {
+    if target
+        .ancestors()
+        .any(|ancestor| ancestor.kind() == JsSyntaxKind::JS_WITH_STATEMENT)
+    {
+        // A `with` scope can dynamically shadow any generated identifier.
+        return false;
+    }
+    if direct_eval_affects_target(root, model, target) {
+        // Direct eval in a sloppy script can introduce a binding into an enclosing function.
+        return false;
+    }
+
+    module_constant_insertion_slot(root, target).is_some()
 }
 
 fn is_import_like(node: &JsSyntaxNode) -> bool {
@@ -355,7 +393,9 @@ fn make_declaration(
     line_ending: &str,
 ) -> JsSyntaxNode {
     let mut leading_trivia = declaration_leading_trivia.to_vec();
-    if !matches!(leading_trivia.last(), Some((TriviaPieceKind::Newline, _))) {
+    if !leading_trivia.is_empty()
+        && !matches!(leading_trivia.last(), Some((TriviaPieceKind::Newline, _)))
+    {
         leading_trivia.push((TriviaPieceKind::Newline, line_ending.to_string()));
     }
 
@@ -404,13 +444,16 @@ fn make_declaration(
 fn source_line_ending(list: &JsSyntaxNode) -> &'static str {
     // Detached factory tokens do not inherit the source file's line-separator convention.
     for token in list.descendants_tokens(Direction::Next) {
-        for text in [
-            token.leading_trivia().text(),
-            token.text(),
-            token.trailing_trivia().text(),
-        ] {
-            if let Some(line_ending) = find_line_ending(text) {
-                return line_ending;
+        for trivia in [token.leading_trivia(), token.trailing_trivia()] {
+            // A comment or template token can contain a different separator than the
+            // separators between source tokens. Only newline trivia establishes the file convention.
+            for piece in trivia.pieces() {
+                if !piece.is_newline() {
+                    continue;
+                }
+                if let Some(line_ending) = find_line_ending(piece.text()) {
+                    return line_ending;
+                }
             }
         }
     }
@@ -436,15 +479,16 @@ fn find_line_ending(text: &str) -> Option<&'static str> {
 
 #[cfg(test)]
 mod tests {
-    use super::extract_module_constant;
+    use super::{extract_module_constant, extract_module_constant_with_reserved_names};
     use biome_js_parser::{JsParserOptions, parse};
     use biome_js_semantic::{SemanticModelOptions, semantic_model};
     use biome_js_syntax::{
-        AnyJsExpression, JsFunctionDeclaration, JsModuleItemList, JsReferenceIdentifier,
-        JsRegexLiteralExpression,
+        AnyJsExpression, JsFunctionDeclaration, JsModuleItemList, JsNumberLiteralExpression,
+        JsReferenceIdentifier, JsRegexLiteralExpression,
     };
     use biome_languages::JsFileSource;
     use biome_rowan::{AstNode, AstNodeList, AstSeparatedList};
+    use rustc_hash::FxHashSet;
 
     #[test]
     fn extracts_expression_after_imports_and_directives() {
@@ -549,6 +593,177 @@ function read(input) {
                 .descendants()
                 .any(|node| JsRegexLiteralExpression::can_cast(node.kind()))
         );
+    }
+
+    #[test]
+    fn preserves_first_target_replacement_when_transferring_header() {
+        let source = "// header\n\n31 + value;\n";
+        let parsed = parse(
+            source,
+            JsFileSource::js_module(),
+            JsParserOptions::default(),
+        );
+        let model = semantic_model(&parsed.tree(), SemanticModelOptions::default());
+        let target = parsed
+            .syntax()
+            .descendants()
+            .find_map(JsNumberLiteralExpression::cast)
+            .expect("expected a number literal");
+        let value = AnyJsExpression::cast(target.syntax().clone()).expect("number expression");
+
+        let (mutation, name) =
+            extract_module_constant(&parsed.tree(), &model, target.syntax(), value, "NUMBER")
+                .expect("expected a module-level extraction");
+        let output = mutation.commit().to_string();
+
+        assert_eq!(name, "NUMBER");
+        assert_eq!(output.matches("const NUMBER = 31;").count(), 1);
+        assert!(output.contains("NUMBER + value;"));
+        assert!(!output.contains("31 + value;"));
+    }
+
+    #[test]
+    fn merges_header_cleanup_with_first_target_replacement() {
+        let source = "// header\n\n31 + 32;\n";
+        let parsed = parse(
+            source,
+            JsFileSource::js_module(),
+            JsParserOptions::default(),
+        );
+        let model = semantic_model(&parsed.tree(), SemanticModelOptions::default());
+        let targets = parsed
+            .syntax()
+            .descendants()
+            .filter_map(JsNumberLiteralExpression::cast)
+            .collect::<Vec<_>>();
+        assert_eq!(targets.len(), 2);
+
+        let mut mutations = targets.into_iter().enumerate().map(|(index, target)| {
+            let value = AnyJsExpression::cast(target.syntax().clone()).expect("number expression");
+            extract_module_constant(
+                &parsed.tree(),
+                &model,
+                target.syntax(),
+                value,
+                &format!("NUMBER_{}", index + 31),
+            )
+            .expect("expected a module-level extraction")
+        });
+        let (mut mutation, first_name) = mutations.next().expect("first extraction");
+        let (second_mutation, second_name) = mutations.next().expect("second extraction");
+        mutation.merge(second_mutation);
+
+        let (committed_tree, text_edit) = mutation.clone().commit_with_text_range_and_edit(true);
+        let output = mutation.commit().to_string();
+        let (_, text_edit) = text_edit.expect("merged mutation should produce a text edit");
+
+        assert_eq!(first_name, "NUMBER_31");
+        assert_eq!(second_name, "NUMBER_32");
+        assert!(output.contains("NUMBER_31 + NUMBER_32;"));
+        assert!(!output.contains("31 + 32;"));
+        assert_eq!(committed_tree.to_string(), output);
+        assert_eq!(text_edit.new_string(source), output);
+    }
+
+    #[test]
+    fn merges_two_extractions_for_fix_all() {
+        let parsed = parse(
+            r#"function read(input) {
+    return /first/.test(input) && /second/.test(input);
+}
+"#,
+            JsFileSource::js_module(),
+            JsParserOptions::default(),
+        );
+        let model = semantic_model(&parsed.tree(), SemanticModelOptions::default());
+        let targets = parsed
+            .syntax()
+            .descendants()
+            .filter_map(JsRegexLiteralExpression::cast)
+            .collect::<Vec<_>>();
+        assert_eq!(targets.len(), 2);
+
+        let mut mutations = targets.into_iter().enumerate().map(|(index, target)| {
+            let value = AnyJsExpression::cast(target.syntax().clone()).expect("regex expression");
+            extract_module_constant(
+                &parsed.tree(),
+                &model,
+                target.syntax(),
+                value,
+                &format!("REGEX_{}", index + 1),
+            )
+            .expect("expected a module-level extraction")
+        });
+        let (mut mutation, first_name) = mutations.next().expect("first extraction");
+        let (second_mutation, second_name) = mutations.next().expect("second extraction");
+        mutation.merge(second_mutation);
+
+        let output = mutation.commit().to_string();
+        assert_eq!(first_name, "REGEX_1");
+        assert_eq!(second_name, "REGEX_2");
+        assert!(output.contains("const REGEX_1 = /first/;"));
+        assert!(output.contains("const REGEX_2 = /second/;"));
+        assert!(output.contains("return REGEX_1.test(input) && REGEX_2.test(input);"));
+    }
+
+    #[test]
+    fn coordinates_repeated_names_and_header_for_fix_all() {
+        let source = "// header\n\nfunction read(input) {\n    return 5 + 5 + 5;\n}\n";
+        let parsed = parse(
+            source,
+            JsFileSource::js_module(),
+            JsParserOptions::default(),
+        );
+        let model = semantic_model(&parsed.tree(), SemanticModelOptions::default());
+        let targets = parsed
+            .syntax()
+            .descendants()
+            .filter_map(JsNumberLiteralExpression::cast)
+            .collect::<Vec<_>>();
+        assert_eq!(targets.len(), 3);
+
+        let mut reserved_names = FxHashSet::default();
+        let mut mutations = targets
+            .into_iter()
+            .map(|target| {
+                let value =
+                    AnyJsExpression::cast(target.syntax().clone()).expect("number expression");
+                let (mutation, name) = extract_module_constant_with_reserved_names(
+                    &parsed.tree(),
+                    &model,
+                    target.syntax(),
+                    value,
+                    "NUMBER_5",
+                    &reserved_names,
+                    true,
+                )
+                .expect("expected a module-level extraction");
+                reserved_names.insert(name.clone());
+                (mutation, name)
+            })
+            .collect::<Vec<_>>();
+        let (mut mutation, first_name) = mutations.remove(0);
+        let (second_mutation, second_name) = mutations.remove(0);
+        let (third_mutation, third_name) = mutations.remove(0);
+        let standalone_second = second_mutation.clone().commit().to_string();
+        assert!(standalone_second.starts_with("// header\nconst NUMBER_5_2 = 5;"));
+        mutation.merge(second_mutation);
+        mutation.merge(third_mutation);
+
+        let (committed_tree, text_edit) = mutation.clone().commit_with_text_range_and_edit(true);
+        let output = mutation.commit().to_string();
+        let (_, text_edit) = text_edit.expect("merged mutation should produce a text edit");
+        assert_eq!(first_name, "NUMBER_5");
+        assert_eq!(second_name, "NUMBER_5_2");
+        assert_eq!(third_name, "NUMBER_5_3");
+        assert_eq!(output.matches("// header").count(), 1);
+        assert!(output.contains("const NUMBER_5 = 5;"));
+        assert!(output.contains("const NUMBER_5_2 = 5;"));
+        assert!(output.contains("const NUMBER_5_3 = 5;"));
+        assert!(output.contains("return NUMBER_5 + NUMBER_5_2 + NUMBER_5_3;"));
+        assert!(output.find("// header").unwrap() < output.find("const NUMBER_5 =").unwrap());
+        assert_eq!(committed_tree.to_string(), output);
+        assert_eq!(text_edit.new_string(source), output);
     }
 
     #[test]
@@ -799,6 +1014,61 @@ console.log(REGEX);
     }
 
     #[test]
+    fn rejects_script_target_with_sibling_nested_direct_eval() {
+        let parsed = parse(
+            r#"function other() {
+    function nested() {
+        eval("var REGEX = /other/;");
+    }
+    nested();
+}
+function read(input) {
+    return /x/.test(input);
+}
+"#,
+            JsFileSource::js_script(),
+            JsParserOptions::default(),
+        );
+        let model = semantic_model(&parsed.tree(), SemanticModelOptions::default());
+        let target = parsed
+            .syntax()
+            .descendants()
+            .find_map(JsRegexLiteralExpression::cast)
+            .expect("expected a regex literal");
+        let value = AnyJsExpression::cast(target.syntax().clone()).expect("regex expression");
+
+        assert!(
+            extract_module_constant(&parsed.tree(), &model, target.syntax(), value, "REGEX")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn rejects_module_target_observable_to_direct_eval() {
+        let parsed = parse(
+            r#"function read(input) {
+    eval("REGEX");
+    return /x/.test(input);
+}
+"#,
+            JsFileSource::js_module(),
+            JsParserOptions::default(),
+        );
+        let model = semantic_model(&parsed.tree(), SemanticModelOptions::default());
+        let target = parsed
+            .syntax()
+            .descendants()
+            .find_map(JsRegexLiteralExpression::cast)
+            .expect("expected a regex literal");
+        let value = AnyJsExpression::cast(target.syntax().clone()).expect("regex expression");
+
+        assert!(
+            extract_module_constant(&parsed.tree(), &model, target.syntax(), value, "REGEX")
+                .is_none()
+        );
+    }
+
+    #[test]
     fn rejects_target_before_later_import() {
         let parsed = parse(
             r#"function read(input) {
@@ -969,7 +1239,7 @@ function read(input) {
     }
 
     #[test]
-    fn preserves_crlf_inside_multiline_comment_tokens() {
+    fn ignores_crlf_inside_multiline_comment_tokens() {
         let source = "const before = /* first line\r\nsecond line */ 0;\nfunction read(input) {\n    return /x/.test(input);\n}\n";
         let parsed = parse(
             source,
@@ -989,6 +1259,6 @@ function read(input) {
                 .expect("expected a script-level extraction");
         let output = mutation.commit().to_string();
 
-        assert!(output.contains("const REGEX = /x/;\r\nconst before"));
+        assert!(output.contains("const REGEX = /x/;\nconst before"));
     }
 }

--- a/crates/biome_js_analyze/src/utils/module_constant.rs
+++ b/crates/biome_js_analyze/src/utils/module_constant.rs
@@ -1,9 +1,12 @@
 use biome_js_factory::make;
 use biome_js_semantic::SemanticModel;
 use biome_js_syntax::{
-    AnyJsBinding, AnyJsBindingPattern, AnyJsExpression, AnyJsRoot, JsCallExpression,
-    JsExpressionStatement, JsLanguage, JsModuleItemList, JsStatementList, JsSyntaxKind,
-    JsSyntaxNode, T,
+    AnyJsBinding, AnyJsBindingPattern, AnyJsExpression, AnyJsFunction, AnyJsMemberExpression,
+    AnyJsRoot, JsAssignmentExpression, JsCallExpression, JsComputedMemberAssignment,
+    JsExpressionStatement, JsGetterClassMember, JsGetterObjectMember, JsLanguage,
+    JsMethodClassMember, JsMethodObjectMember, JsModuleItemList, JsPropertyClassMember,
+    JsPropertyObjectMember, JsSetterClassMember, JsSetterObjectMember, JsStatementList,
+    JsStaticMemberAssignment, JsSyntaxKind, JsSyntaxNode, JsVariableDeclarator, T,
 };
 use biome_rowan::TriviaPieceKind;
 use biome_rowan::{AstNode, BatchMutation, BatchMutationExt, Direction, SyntaxTriviaPiece};
@@ -26,12 +29,306 @@ struct CachedModuleConstantFacts {
     facts: ModuleConstantFacts,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ModuleConstantNameKind {
+    Binding,
+    Function,
+    Property,
+    Member,
+    Method,
+    CallCallee,
+}
+
+pub(crate) struct ModuleConstantNameCandidate {
+    pub(crate) kind: ModuleConstantNameKind,
+    pub(crate) name: String,
+}
+
+/// Returns readable naming contexts found while walking from `node` toward its root.
+///
+/// Candidates are emitted in ancestor order. Within one ancestor, bindings, functions, methods,
+/// properties, members, and call callees are emitted in that order.
+pub(crate) fn module_constant_name_candidates(
+    node: &JsSyntaxNode,
+) -> Vec<ModuleConstantNameCandidate> {
+    let mut candidates = Vec::new();
+
+    for ancestor in node.ancestors().skip(1) {
+        if let Some(declarator) = JsVariableDeclarator::cast(ancestor.clone())
+            && let Some(binding) = declarator
+                .id()
+                .ok()
+                .and_then(|pattern| pattern.as_any_js_binding().cloned())
+            && let Some(name) = module_constant_binding_name(&binding)
+        {
+            candidates.push(ModuleConstantNameCandidate {
+                kind: ModuleConstantNameKind::Binding,
+                name,
+            });
+        }
+
+        if let Some(function) = AnyJsFunction::cast(ancestor.clone())
+            && let Some(name) = module_constant_function_name(&function)
+        {
+            candidates.push(ModuleConstantNameCandidate {
+                kind: ModuleConstantNameKind::Function,
+                name,
+            });
+        }
+
+        if let Some(name) = module_constant_method_name(&ancestor) {
+            candidates.push(ModuleConstantNameCandidate {
+                kind: ModuleConstantNameKind::Method,
+                name,
+            });
+        }
+
+        if let Some(name) = module_constant_property_name(&ancestor) {
+            candidates.push(ModuleConstantNameCandidate {
+                kind: ModuleConstantNameKind::Property,
+                name,
+            });
+        }
+
+        if let Some(name) = module_constant_member_name(&ancestor) {
+            candidates.push(ModuleConstantNameCandidate {
+                kind: ModuleConstantNameKind::Member,
+                name,
+            });
+        }
+
+        if let Some(call) = JsCallExpression::cast(ancestor)
+            && let Some(name) = call
+                .callee()
+                .ok()
+                .and_then(|callee| callee.get_callee_member_name())
+                .map(|token| token.text_trimmed().to_string())
+        {
+            candidates.push(ModuleConstantNameCandidate {
+                kind: ModuleConstantNameKind::CallCallee,
+                name,
+            });
+        }
+    }
+
+    candidates
+}
+
+/// Returns the identifier text for a simple binding pattern.
+pub(crate) fn module_constant_binding_name(binding: &AnyJsBinding) -> Option<String> {
+    binding
+        .as_js_identifier_binding()?
+        .name_token()
+        .ok()
+        .map(|token| token.text_trimmed().to_string())
+}
+
+/// Returns the declared name of a named function.
+pub(crate) fn module_constant_function_name(function: &AnyJsFunction) -> Option<String> {
+    let binding = match function {
+        AnyJsFunction::JsFunctionDeclaration(function) => function.id().ok(),
+        AnyJsFunction::JsFunctionExportDefaultDeclaration(function) => function.id(),
+        AnyJsFunction::JsFunctionExpression(function) => function.id(),
+        AnyJsFunction::JsArrowFunctionExpression(_) => None,
+    }?;
+    module_constant_binding_name(&binding)
+}
+
+/// Returns a readable object or class method name.
+pub(crate) fn module_constant_method_name(node: &JsSyntaxNode) -> Option<String> {
+    if let Some(method) = JsMethodObjectMember::cast(node.clone()) {
+        return method.name().ok()?.name().map(|name| name.to_string());
+    }
+    if let Some(method) = JsGetterObjectMember::cast(node.clone()) {
+        return method.name().ok()?.name().map(|name| name.to_string());
+    }
+    if let Some(method) = JsSetterObjectMember::cast(node.clone()) {
+        return method.name().ok()?.name().map(|name| name.to_string());
+    }
+    if let Some(method) = JsMethodClassMember::cast(node.clone()) {
+        return method
+            .name()
+            .ok()?
+            .name()
+            .map(|name| name.text().to_string());
+    }
+    if let Some(method) = JsGetterClassMember::cast(node.clone()) {
+        return method
+            .name()
+            .ok()?
+            .name()
+            .map(|name| name.text().to_string());
+    }
+    if let Some(method) = JsSetterClassMember::cast(node.clone()) {
+        return method
+            .name()
+            .ok()?
+            .name()
+            .map(|name| name.text().to_string());
+    }
+    None
+}
+
+/// Returns the readable name of an object or class property.
+pub(crate) fn module_constant_property_name(node: &JsSyntaxNode) -> Option<String> {
+    if let Some(property) = JsPropertyObjectMember::cast(node.clone()) {
+        return property.name().ok()?.name().map(|name| name.to_string());
+    }
+    if let Some(property) = JsPropertyClassMember::cast(node.clone()) {
+        return property
+            .name()
+            .ok()?
+            .name()
+            .map(|name| name.text().to_string());
+    }
+    None
+}
+
+/// Returns the readable name of a member expression or member assignment.
+pub(crate) fn module_constant_member_name(node: &JsSyntaxNode) -> Option<String> {
+    if let Some(assignment) = JsAssignmentExpression::cast(node.clone()) {
+        return module_constant_member_name(&assignment.left().ok()?.into_syntax());
+    }
+    if let Some(member) = AnyJsMemberExpression::cast(node.clone()) {
+        return member.member_name().map(|name| name.text().to_string());
+    }
+    if let Some(member) = JsStaticMemberAssignment::cast(node.clone()) {
+        return member
+            .member()
+            .ok()?
+            .as_js_name()?
+            .value_token()
+            .ok()
+            .map(|token| token.text_trimmed().to_string());
+    }
+    if let Some(member) = JsComputedMemberAssignment::cast(node.clone()) {
+        return member
+            .member()
+            .ok()?
+            .as_static_value()
+            .map(|value| value.text().to_string());
+    }
+    None
+}
+
+/// Converts text into an uppercase identifier component.
+pub(crate) fn normalize_module_constant_name_component(
+    text: &str,
+    ensure_identifier_start: bool,
+) -> Option<String> {
+    let mut normalized = String::new();
+    let mut previous_is_lowercase = false;
+
+    for character in text.chars() {
+        if character.is_ascii_alphanumeric() {
+            if character.is_ascii_uppercase() && previous_is_lowercase {
+                normalized.push('_');
+            }
+            normalized.push(character.to_ascii_uppercase());
+            previous_is_lowercase = character.is_ascii_lowercase();
+        } else {
+            if !normalized.ends_with('_') {
+                normalized.push('_');
+            }
+            previous_is_lowercase = false;
+        }
+    }
+
+    let normalized = normalized.trim_matches('_');
+    if normalized.is_empty() {
+        return None;
+    }
+
+    // Numeric context names need a prefix before they can participate in a binding name.
+    if ensure_identifier_start
+        && normalized
+            .as_bytes()
+            .first()
+            .is_some_and(|character| character.is_ascii_digit())
+    {
+        Some(format!("NUMBER_{normalized}"))
+    } else {
+        Some(normalized.to_string())
+    }
+}
+
+/// Builds a stable uppercase name from the syntax surrounding a runtime number.
+pub(crate) fn module_constant_numeric_name(target: &JsSyntaxNode, literal_text: &str) -> String {
+    let mut variable = None;
+    let mut property = None;
+    let mut function = None;
+    let mut call = None;
+
+    for candidate in module_constant_name_candidates(target) {
+        match candidate.kind {
+            ModuleConstantNameKind::Binding if variable.is_none() => {
+                variable = Some(candidate.name)
+            }
+            ModuleConstantNameKind::Property | ModuleConstantNameKind::Member
+                if property.is_none() =>
+            {
+                property = Some(candidate.name)
+            }
+            ModuleConstantNameKind::Function if function.is_none() => {
+                function = Some(candidate.name)
+            }
+            ModuleConstantNameKind::CallCallee if call.is_none() => call = Some(candidate.name),
+            ModuleConstantNameKind::Binding
+            | ModuleConstantNameKind::Function
+            | ModuleConstantNameKind::Property
+            | ModuleConstantNameKind::Member
+            | ModuleConstantNameKind::Method
+            | ModuleConstantNameKind::CallCallee => {}
+        }
+    }
+
+    let mut parts = Vec::new();
+    for context in [variable, property, function, call].into_iter().flatten() {
+        if let Some(normalized) = normalize_module_constant_name_component(&context, true)
+            && !parts.contains(&normalized)
+        {
+            parts.push(normalized);
+        }
+    }
+
+    let value = normalize_module_constant_name_component(literal_text, false)
+        .unwrap_or_else(|| "NUMBER".to_string());
+    if parts.is_empty() {
+        format!("NUMBER_{value}")
+    } else {
+        parts.push(value);
+        parts.join("_")
+    }
+}
+
+/// Builds a stable uppercase name for a regular-expression constant from its enclosing context.
+pub(crate) fn module_constant_regex_name(target: &JsSyntaxNode, pattern: &str) -> String {
+    for candidate in module_constant_name_candidates(target) {
+        if matches!(
+            candidate.kind,
+            ModuleConstantNameKind::Binding
+                | ModuleConstantNameKind::Function
+                | ModuleConstantNameKind::Method
+                | ModuleConstantNameKind::Property
+        ) && let Some(name) = normalize_module_constant_name_component(&candidate.name, true)
+        {
+            return format!("{name}_REGEX");
+        }
+    }
+
+    let pattern = normalize_module_constant_name_component(pattern, false);
+    pattern.map_or_else(|| "REGEX".to_string(), |pattern| format!("REGEX_{pattern}"))
+}
+
 thread_local! {
     // Rule actions for one file share this bounded cache; replacing the entry keeps memory use
     // independent of the number of files analyzed on a worker thread.
     static MODULE_CONSTANT_FACTS: RefCell<Option<CachedModuleConstantFacts>> = const { RefCell::new(None) };
 }
 
+/// Returns the facts shared by module-constant extraction checks for `root`.
+///
+/// The facts are cached per thread and replaced when the syntax root changes.
 pub(crate) fn module_constant_facts(
     root: &AnyJsRoot,
     model: &SemanticModel,
@@ -58,6 +355,10 @@ pub(crate) fn module_constant_facts(
     })
 }
 
+/// Builds a mutation that replaces `target` with a module-level constant reference.
+///
+/// Returns `None` when the target cannot be safely extracted or the generated declaration cannot be
+/// placed in the root. The candidate name is checked against bindings and references in scope.
 pub(crate) fn extract_module_constant(
     root: &AnyJsRoot,
     model: &SemanticModel,
@@ -76,6 +377,11 @@ pub(crate) fn extract_module_constant(
     )
 }
 
+/// Builds a constant-extraction mutation while excluding names already reserved by sibling fixes.
+///
+/// The mutation replaces the target, inserts a `const` declaration at the earliest safe slot, and
+/// optionally transfers file-header trivia to that declaration. It returns `None` for unsupported
+/// roots, unsafe dynamic scopes, ambiguous header trivia, or unavailable insertion points.
 pub(crate) fn extract_module_constant_with_reserved_names(
     root: &AnyJsRoot,
     model: &SemanticModel,
@@ -154,6 +460,10 @@ pub(crate) fn extract_module_constant_with_reserved_names(
     Some((mutation, name))
 }
 
+/// Chooses a name that is free in the target scopes and absent from known references and reservations.
+///
+/// If `candidate_name` is occupied, numeric suffixes starting at `_2` are tried until a free name is
+/// found.
 pub(crate) fn collision_free_module_constant_name_with_facts(
     model: &SemanticModel,
     target: &JsSyntaxNode,
@@ -170,6 +480,10 @@ pub(crate) fn collision_free_module_constant_name_with_facts(
     )
 }
 
+/// Returns the top-level item list that can receive a generated runtime binding.
+///
+/// Expression and declaration-only roots return `None` because they have no mutable module or
+/// script statement list.
 fn root_list(root: &AnyJsRoot) -> Option<JsSyntaxNode> {
     // Expression snippets and declaration-only roots cannot receive a runtime binding.
     let list = match root {
@@ -182,6 +496,7 @@ fn root_list(root: &AnyJsRoot) -> Option<JsSyntaxNode> {
         .then_some(list)
 }
 
+/// Returns `candidate_name` or the first suffixed name free from scope and reference collisions.
 fn collision_free_name(
     model: &SemanticModel,
     target: &JsSyntaxNode,
@@ -215,6 +530,7 @@ fn collision_free_name(
     }
 }
 
+/// Checks whether `name` is free in every scope enclosing `target` and absent from known references.
 fn name_is_free_in_target_scopes(
     model: &SemanticModel,
     target: &JsSyntaxNode,
@@ -230,6 +546,9 @@ fn name_is_free_in_target_scopes(
         && !reserved_names.contains(name)
 }
 
+/// Collects names used by unresolved and configured-global references in the semantic model.
+///
+/// These names must not be captured by a generated top-level binding.
 fn occupied_reference_names(model: &SemanticModel) -> FxHashSet<String> {
     let mut names = FxHashSet::default();
     for reference in model.all_unresolved_references() {
@@ -245,6 +564,10 @@ fn occupied_reference_names(model: &SemanticModel) -> FxHashSet<String> {
     names
 }
 
+/// Reports whether an unbound direct `eval` can observe or introduce a generated binding.
+///
+/// Any such call makes extraction unsafe because its runtime scope effects cannot be determined
+/// statically.
 fn has_unbound_direct_eval(root: &AnyJsRoot, model: &SemanticModel) -> bool {
     root.syntax()
         .descendants()
@@ -256,6 +579,9 @@ fn has_unbound_direct_eval(root: &AnyJsRoot, model: &SemanticModel) -> bool {
         })
 }
 
+/// Checks whether `call` invokes the unbound identifier named `eval` directly.
+///
+/// Parenthesized callees still count as direct calls; property calls and bound identifiers do not.
 fn is_direct_eval(model: &SemanticModel, call: &JsCallExpression) -> bool {
     let Some(reference) = call
         .callee()
@@ -272,6 +598,9 @@ fn is_direct_eval(model: &SemanticModel, call: &JsCallExpression) -> bool {
         && model.binding(&reference).is_none()
 }
 
+/// Copies the target's selected leading and trailing trivia onto a replacement node.
+///
+/// Leading trivia is copied only when requested; any invalid trivia attachment returns `None`.
 fn preserve_target_trivia(
     target: &JsSyntaxNode,
     replacement: JsSyntaxNode,
@@ -294,6 +623,9 @@ fn preserve_target_trivia(
     }
 }
 
+/// Removes leading and trailing trivia from an expression before embedding it in a declaration.
+///
+/// Returns `None` if the trivia edits no longer produce a valid expression node.
 fn trim_expression_trivia(value: AnyJsExpression) -> Option<AnyJsExpression> {
     let value = value
         .into_syntax()
@@ -303,6 +635,10 @@ fn trim_expression_trivia(value: AnyJsExpression) -> Option<AnyJsExpression> {
     AnyJsExpression::cast(value)
 }
 
+/// Separates file-header trivia from trivia attached to the first top-level item.
+///
+/// Returns `None` when comments occur after the first blank-line separator, because moving those
+/// comments with a new declaration could change their attachment.
 fn split_header_trivia(list: &JsSyntaxNode) -> Option<HeaderTrivia> {
     let first_item = list.first_child()?;
     let pieces = first_item
@@ -330,6 +666,10 @@ fn split_header_trivia(list: &JsSyntaxNode) -> Option<HeaderTrivia> {
     })
 }
 
+/// Finds the newline that ends the first blank line in a trivia sequence.
+///
+/// Whitespace between two newline pieces is treated as part of the blank line; missing separators
+/// return `None`.
 fn find_first_blank_line_index(pieces: &[SyntaxTriviaPiece<JsLanguage>]) -> Option<usize> {
     for (index, piece) in pieces.iter().enumerate() {
         if !piece.is_newline() {
@@ -353,6 +693,9 @@ fn find_first_blank_line_index(pieces: &[SyntaxTriviaPiece<JsLanguage>]) -> Opti
     None
 }
 
+/// Computes the earliest declaration slot after imports and leading directives but before `target`.
+///
+/// Returns `None` when inserting there would place initialization after the target's top-level item.
 fn insertion_slot(list: &JsSyntaxNode, target_index: usize) -> Option<usize> {
     let mut slot = 0;
     let mut in_directive_prologue = true;
@@ -370,6 +713,9 @@ fn insertion_slot(list: &JsSyntaxNode, target_index: usize) -> Option<usize> {
     (slot <= target_index).then_some(slot)
 }
 
+/// Returns the safe top-level insertion slot for extracting `target` from `root`.
+///
+/// Unsupported roots or targets outside the root's item list return `None`.
 pub(crate) fn module_constant_insertion_slot(
     root: &AnyJsRoot,
     target: &JsSyntaxNode,
@@ -381,6 +727,10 @@ pub(crate) fn module_constant_insertion_slot(
     insertion_slot(&list, top_level_item.index())
 }
 
+/// Reports whether `target` can be replaced by a generated module-level constant reference.
+///
+/// Targets under `with`, roots affected by unbound direct `eval`, and roots without a safe
+/// insertion slot are rejected.
 pub(crate) fn is_module_constant_extractable_with_facts(
     root: &AnyJsRoot,
     target: &JsSyntaxNode,
@@ -401,6 +751,7 @@ pub(crate) fn is_module_constant_extractable_with_facts(
     module_constant_insertion_slot(root, target).is_some()
 }
 
+/// Reports whether a top-level node is an import or a TypeScript import-equals declaration.
 fn is_import_like(node: &JsSyntaxNode) -> bool {
     matches!(
         node.kind(),
@@ -411,6 +762,7 @@ fn is_import_like(node: &JsSyntaxNode) -> bool {
             .any(|descendant| descendant.kind() == JsSyntaxKind::TS_IMPORT_EQUALS_DECLARATION))
 }
 
+/// Reports whether a node is an expression statement containing a string literal directive.
 fn is_directive_statement(node: &JsSyntaxNode) -> bool {
     let Some(statement) = JsExpressionStatement::cast_ref(node) else {
         return false;
@@ -423,6 +775,10 @@ fn is_directive_statement(node: &JsSyntaxNode) -> bool {
     })
 }
 
+/// Constructs a `const` statement with the supplied value, trivia, separators, and line ending.
+///
+/// The returned statement owns the provided declaration trivia and adds line separators when the
+/// insertion context requires them.
 fn make_declaration(
     name: &str,
     value: AnyJsExpression,
@@ -483,6 +839,10 @@ fn make_declaration(
     statement.build().into_syntax()
 }
 
+/// Returns the first newline convention found in source trivia, defaulting to LF.
+///
+/// Newlines inside comments and templates are ignored unless they are represented as newline
+/// trivia pieces.
 fn source_line_ending(list: &JsSyntaxNode) -> &'static str {
     // Detached factory tokens do not inherit the source file's line-separator convention.
     for token in list.descendants_tokens(Direction::Next) {
@@ -503,6 +863,9 @@ fn source_line_ending(list: &JsSyntaxNode) -> &'static str {
     "\n"
 }
 
+/// Returns the first recognized line-ending sequence in `text`.
+///
+/// CRLF is matched before CR, and CR, LF, and Unicode line separators are returned distinctly.
 fn find_line_ending(text: &str) -> Option<&'static str> {
     let mut characters = text.chars().peekable();
     while let Some(character) = characters.next() {
@@ -671,7 +1034,7 @@ function read(input) {
         });
         let (mut mutation, first_name) = mutations.next().expect("first extraction");
         let (second_mutation, second_name) = mutations.next().expect("second extraction");
-        mutation.merge(second_mutation);
+        mutation.merge_actions(second_mutation);
 
         let output = mutation.commit().to_string();
         assert_eq!(first_name, "REGEX_1");
@@ -739,7 +1102,7 @@ function read(input) {
         });
         let (mut mutation, first_name) = mutations.next().expect("first extraction");
         let (second_mutation, second_name) = mutations.next().expect("second extraction");
-        mutation.merge(second_mutation);
+        mutation.merge_actions(second_mutation);
 
         let (committed_tree, text_edit) = mutation.clone().commit_with_text_range_and_edit(true);
         let output = mutation.commit().to_string();
@@ -784,7 +1147,7 @@ function read(input) {
         });
         let (mut mutation, first_name) = mutations.next().expect("first extraction");
         let (second_mutation, second_name) = mutations.next().expect("second extraction");
-        mutation.merge(second_mutation);
+        mutation.merge_actions(second_mutation);
 
         let output = mutation.commit().to_string();
         assert_eq!(first_name, "REGEX_1");
@@ -819,7 +1182,7 @@ function read(input) {
                 .0
         });
         let mut mutation = mutations.next().expect("first extraction");
-        mutation.merge(mutations.next().expect("second extraction"));
+        mutation.merge_actions(mutations.next().expect("second extraction"));
 
         let output = mutation.commit().to_string();
         assert_eq!(output.matches("const NUMBER = 5;").count(), 1);
@@ -867,8 +1230,8 @@ function read(input) {
         let (third_mutation, third_name) = mutations.remove(0);
         let standalone_second = second_mutation.clone().commit().to_string();
         assert!(standalone_second.starts_with("// header\nconst NUMBER_5_2 = 5;"));
-        mutation.merge(second_mutation);
-        mutation.merge(third_mutation);
+        mutation.merge_actions(second_mutation);
+        mutation.merge_actions(third_mutation);
 
         let (committed_tree, text_edit) = mutation.clone().commit_with_text_range_and_edit(true);
         let output = mutation.commit().to_string();

--- a/crates/biome_js_analyze/src/utils/module_constant.rs
+++ b/crates/biome_js_analyze/src/utils/module_constant.rs
@@ -439,7 +439,6 @@ pub(crate) fn extract_module_constant_with_reserved_names(
         header_trivia
             .as_ref()
             .map_or(&[][..], |trivia| trivia.first_item.as_slice()),
-        insertion_slot > 0,
         insertion_slot == 0,
         line_ending,
     );
@@ -783,15 +782,14 @@ fn make_declaration(
     name: &str,
     value: AnyJsExpression,
     declaration_leading_trivia: &[(TriviaPieceKind, String)],
-    declaration_trailing_trivia: &[SyntaxTriviaPiece<JsLanguage>],
-    add_leading_line_ending: bool,
-    add_trailing_line_ending: bool,
+    first_item_leading_trivia: &[SyntaxTriviaPiece<JsLanguage>],
+    insert_at_start: bool,
     line_ending: &str,
 ) -> JsSyntaxNode {
     let mut leading_trivia = declaration_leading_trivia.to_vec();
     // Inserted list items take the following item's leading trivia with them, so a nonzero-slot
     // declaration needs its own separator even when the preceding statement used ASI.
-    if (add_leading_line_ending || !leading_trivia.is_empty())
+    if (!insert_at_start || !leading_trivia.is_empty())
         && !matches!(leading_trivia.last(), Some((TriviaPieceKind::Newline, _)))
     {
         leading_trivia.push((TriviaPieceKind::Newline, line_ending.to_string()));
@@ -822,10 +820,10 @@ fn make_declaration(
 
     let mut statement = make::js_variable_statement(declaration);
     let mut semicolon = make::token(T![;]);
-    if add_trailing_line_ending {
+    if insert_at_start {
         let mut trailing_trivia = vec![(TriviaPieceKind::Newline, line_ending.to_string())];
         trailing_trivia.extend(
-            declaration_trailing_trivia
+            first_item_leading_trivia
                 .iter()
                 .map(|piece| (piece.kind(), piece.text().to_string())),
         );
@@ -853,7 +851,7 @@ fn source_line_ending(list: &JsSyntaxNode) -> &'static str {
                 if !piece.is_newline() {
                     continue;
                 }
-                if let Some(line_ending) = find_line_ending(piece.text()) {
+                if let Some(line_ending) = line_ending_from_newline(piece.text()) {
                     return line_ending;
                 }
             }
@@ -863,23 +861,16 @@ fn source_line_ending(list: &JsSyntaxNode) -> &'static str {
     "\n"
 }
 
-/// Returns the first recognized line-ending sequence in `text`.
-///
-/// CRLF is matched before CR, and CR, LF, and Unicode line separators are returned distinctly.
-fn find_line_ending(text: &str) -> Option<&'static str> {
-    let mut characters = text.chars().peekable();
-    while let Some(character) = characters.next() {
-        let line_ending = match character {
-            '\r' if characters.peek() == Some(&'\n') => "\r\n",
-            '\r' => "\r",
-            '\n' => "\n",
-            '\u{2028}' => "\u{2028}",
-            '\u{2029}' => "\u{2029}",
-            _ => continue,
-        };
-        return Some(line_ending);
+/// Returns the line-ending represented by a newline trivia piece.
+fn line_ending_from_newline(text: &str) -> Option<&'static str> {
+    match text {
+        "\r\n" => Some("\r\n"),
+        "\r" => Some("\r"),
+        "\n" => Some("\n"),
+        "\u{2028}" => Some("\u{2028}"),
+        "\u{2029}" => Some("\u{2029}"),
+        _ => None,
     }
-    None
 }
 
 #[cfg(test)]

--- a/crates/biome_js_analyze/src/utils/module_constant.rs
+++ b/crates/biome_js_analyze/src/utils/module_constant.rs
@@ -214,7 +214,7 @@ pub(crate) fn module_constant_member_name(node: &JsSyntaxNode) -> Option<String>
 /// Converts text into an uppercase identifier component.
 pub(crate) fn normalize_module_constant_name_component(
     text: &str,
-    ensure_identifier_start: bool,
+    digit_prefix: Option<&str>,
 ) -> Option<String> {
     let mut normalized = String::new();
     let mut previous_is_lowercase = false;
@@ -239,14 +239,13 @@ pub(crate) fn normalize_module_constant_name_component(
         return None;
     }
 
-    // Numeric context names need a prefix before they can participate in a binding name.
-    if ensure_identifier_start
+    if let Some(prefix) = digit_prefix
         && normalized
             .as_bytes()
             .first()
             .is_some_and(|character| character.is_ascii_digit())
     {
-        Some(format!("NUMBER_{normalized}"))
+        Some(format!("{prefix}{normalized}"))
     } else {
         Some(normalized.to_string())
     }
@@ -284,14 +283,15 @@ pub(crate) fn module_constant_numeric_name(target: &JsSyntaxNode, literal_text: 
 
     let mut parts = Vec::new();
     for context in [variable, property, function, call].into_iter().flatten() {
-        if let Some(normalized) = normalize_module_constant_name_component(&context, true)
+        if let Some(normalized) =
+            normalize_module_constant_name_component(&context, Some("NUMBER_"))
             && !parts.contains(&normalized)
         {
             parts.push(normalized);
         }
     }
 
-    let value = normalize_module_constant_name_component(literal_text, false)
+    let value = normalize_module_constant_name_component(literal_text, None)
         .unwrap_or_else(|| "NUMBER".to_string());
     if parts.is_empty() {
         format!("NUMBER_{value}")
@@ -310,19 +310,20 @@ pub(crate) fn module_constant_regex_name(target: &JsSyntaxNode, pattern: &str) -
                 | ModuleConstantNameKind::Function
                 | ModuleConstantNameKind::Method
                 | ModuleConstantNameKind::Property
-        ) && let Some(name) = normalize_module_constant_name_component(&candidate.name, true)
+        ) && let Some(name) =
+            normalize_module_constant_name_component(&candidate.name, Some("_"))
         {
             return format!("{name}_REGEX");
         }
     }
 
-    let pattern = normalize_module_constant_name_component(pattern, false);
+    let pattern = normalize_module_constant_name_component(pattern, None);
     pattern.map_or_else(|| "REGEX".to_string(), |pattern| format!("REGEX_{pattern}"))
 }
 
 thread_local! {
-    // Rule actions for one file share this bounded cache; replacing the entry keeps memory use
-    // independent of the number of files analyzed on a worker thread.
+    // This bounded cache retains the last analyzed root and its facts for the worker thread's
+    // lifetime; replacing the entry keeps memory use independent of the number of files analyzed.
     static MODULE_CONSTANT_FACTS: RefCell<Option<CachedModuleConstantFacts>> = const { RefCell::new(None) };
 }
 
@@ -336,10 +337,7 @@ pub(crate) fn module_constant_facts(
     let root_syntax = root.syntax();
     MODULE_CONSTANT_FACTS.with(|cache| {
         let mut cache = cache.borrow_mut();
-        if let Some(cached) = cache
-            .as_ref()
-            .filter(|cached| cached.root == root_syntax.clone())
-        {
+        if let Some(cached) = cache.as_ref().filter(|cached| cached.root.eq(root_syntax)) {
             return cached.facts.clone();
         }
 
@@ -366,7 +364,7 @@ pub(crate) fn extract_module_constant(
     value: AnyJsExpression,
     candidate_name: &str,
 ) -> Option<(BatchMutation<JsLanguage>, String)> {
-    extract_module_constant_with_reserved_names(
+    extract_module_constant_impl(
         root,
         model,
         target,
@@ -380,9 +378,34 @@ pub(crate) fn extract_module_constant(
 /// Builds a constant-extraction mutation while excluding names already reserved by sibling fixes.
 ///
 /// The mutation replaces the target, inserts a `const` declaration at the earliest safe slot, and
-/// optionally transfers file-header trivia to that declaration. It returns `None` for unsupported
-/// roots, unsafe dynamic scopes, ambiguous header trivia, or unavailable insertion points.
+/// optionally transfers file-header trivia to that declaration. If header trivia is ambiguous, it
+/// remains attached to the original first item and the declaration is inserted without transfer.
+/// It returns `None` for unsupported roots, unsafe dynamic scopes, or unavailable insertion points.
 pub(crate) fn extract_module_constant_with_reserved_names(
+    root: &AnyJsRoot,
+    model: &SemanticModel,
+    target: &JsSyntaxNode,
+    value: AnyJsExpression,
+    candidate_name: &str,
+    reserved_names: &FxHashSet<String>,
+    transfer_header: bool,
+) -> Option<(BatchMutation<JsLanguage>, String)> {
+    if reserved_names.is_empty() && transfer_header {
+        return extract_module_constant(root, model, target, value, candidate_name);
+    }
+
+    extract_module_constant_impl(
+        root,
+        model,
+        target,
+        value,
+        candidate_name,
+        reserved_names,
+        transfer_header,
+    )
+}
+
+fn extract_module_constant_impl(
     root: &AnyJsRoot,
     model: &SemanticModel,
     target: &JsSyntaxNode,
@@ -409,7 +432,13 @@ pub(crate) fn extract_module_constant_with_reserved_names(
         reserved_names,
     );
     let insertion_slot = insertion_slot(&list, top_level_item.index())?;
-    let first_token = if insertion_slot == 0 && transfer_header {
+    let header_trivia = if insertion_slot == 0 && transfer_header {
+        split_header_trivia(&list)
+    } else {
+        None
+    };
+    let transfer_header = header_trivia.is_some();
+    let first_token = if transfer_header {
         Some(list.first_token()?)
     } else {
         None
@@ -425,11 +454,6 @@ pub(crate) fn extract_module_constant_with_reserved_names(
     let replacement = preserve_target_trivia(target, replacement, !target_starts_with_first_token)?;
     let line_ending = source_line_ending(&list);
     let value = trim_expression_trivia(value)?;
-    let header_trivia = if insertion_slot == 0 && transfer_header {
-        Some(split_header_trivia(&list)?)
-    } else {
-        None
-    };
     let declaration = make_declaration(
         &name,
         value,
@@ -863,14 +887,9 @@ fn source_line_ending(list: &JsSyntaxNode) -> &'static str {
 
 /// Returns the line-ending represented by a newline trivia piece.
 fn line_ending_from_newline(text: &str) -> Option<&'static str> {
-    match text {
-        "\r\n" => Some("\r\n"),
-        "\r" => Some("\r"),
-        "\n" => Some("\n"),
-        "\u{2028}" => Some("\u{2028}"),
-        "\u{2029}" => Some("\u{2029}"),
-        _ => None,
-    }
+    ["\r\n", "\r", "\n", "\u{2028}", "\u{2029}"]
+        .into_iter()
+        .find(|line_ending| *line_ending == text)
 }
 
 #[cfg(test)]
@@ -1295,7 +1314,7 @@ function read(input) {
     }
 
     #[test]
-    fn rejects_attached_first_item_documentation() {
+    fn preserves_attached_first_item_documentation() {
         let parsed = parse(
             r#"/** Documentation for before. */
 const before = 0;
@@ -1314,14 +1333,16 @@ function read(input) {
             .expect("expected a regex literal");
         let value = AnyJsExpression::cast(target.syntax().clone()).expect("regex expression");
 
-        assert!(
+        let (mutation, _) =
             extract_module_constant(&parsed.tree(), &model, target.syntax(), value, "REGEX")
-                .is_none()
-        );
+                .expect("expected a module-level extraction");
+        let output = mutation.commit().to_string();
+
+        assert!(output.starts_with("const REGEX = /x/;\n/** Documentation for before. */"));
     }
 
     #[test]
-    fn rejects_later_comment_blocks_after_header_separator() {
+    fn preserves_later_comment_blocks_after_header_separator() {
         let parsed = parse(
             r#"/** File header. */
 
@@ -1342,10 +1363,12 @@ function read(input) {
             .expect("expected a regex literal");
         let value = AnyJsExpression::cast(target.syntax().clone()).expect("regex expression");
 
-        assert!(
+        let (mutation, _) =
             extract_module_constant(&parsed.tree(), &model, target.syntax(), value, "REGEX")
-                .is_none()
-        );
+                .expect("expected a module-level extraction");
+        let output = mutation.commit().to_string();
+
+        assert!(output.starts_with("const REGEX = /x/;\n/** File header. */\n\n/** Documentation"));
     }
 
     #[test]

--- a/crates/biome_js_analyze/tests/specs/performance/useTopLevelRegex/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/performance/useTopLevelRegex/invalid.js
@@ -1,3 +1,26 @@
+"use strict"
+import dependency from "dependency"
+
+function parseInput(input) {
+	return /[a-z]+/.test(input);
+}
+
+const parser = {
+	parseValue(input) {
+		return /[0-9]+/.test(input);
+	}
+};
+
+class Parser {
+	parseToken(input) {
+		return /[A-Z]+/.test(input);
+	}
+}
+
+const matches = [1].map(() => /[!]/);
+
+[1].map(() => /[?]/);
+
 function foo(someString) {
 	return /[a-Z]*/.test(someString)
 }

--- a/crates/biome_js_analyze/tests/specs/performance/useTopLevelRegex/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/performance/useTopLevelRegex/invalid.js.snap
@@ -4,6 +4,29 @@ expression: invalid.js
 ---
 # Input
 ```js
+"use strict"
+import dependency from "dependency"
+
+function parseInput(input) {
+	return /[a-z]+/.test(input);
+}
+
+const parser = {
+	parseValue(input) {
+		return /[0-9]+/.test(input);
+	}
+};
+
+class Parser {
+	parseToken(input) {
+		return /[A-Z]+/.test(input);
+	}
+}
+
+const matches = [1].map(() => /[!]/);
+
+[1].map(() => /[?]/);
+
 function foo(someString) {
 	return /[a-Z]*/.test(someString)
 }
@@ -61,167 +84,488 @@ const foo = {
 
 # Diagnostics
 ```
-invalid.js:2:9 lint/performance/useTopLevelRegex ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:5:9 lint/performance/useTopLevelRegex  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This regex literal is not defined in the top level scope. This can lead to performance issues if this function is called frequently.
   
-    1 │ function foo(someString) {
-  > 2 │ 	return /[a-Z]*/.test(someString)
+    4 │ function parseInput(input) {
+  > 5 │ 	return /[a-z]+/.test(input);
       │ 	       ^^^^^^^^
-    3 │ }
-    4 │ 
+    6 │ }
+    7 │ 
   
   i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
   
+  i Unsafe fix: Extract the regex literal into PARSE_INPUT_REGEX.
+  
+     1  1 │   "use strict"
+     2    │ - import·dependency·from·"dependency"
+        2 │ + import·dependency·from·"dependency"
+        3 │ + const·PARSE_INPUT_REGEX·=·/[a-z]+/;
+     3  4 │   
+     4  5 │   function parseInput(input) {
+     5    │ - → return·/[a-z]+/.test(input);
+        6 │ + → return·PARSE_INPUT_REGEX.test(input);
+     6  7 │   }
+     7  8 │   
+  
 
 ```
 
 ```
-invalid.js:6:12 lint/performance/useTopLevelRegex ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:10:10 lint/performance/useTopLevelRegex  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This regex literal is not defined in the top level scope. This can lead to performance issues if this function is called frequently.
   
-    5 │ function foo(someString) {
-  > 6 │ 	const r = /[a-Z]*/;
-      │ 	          ^^^^^^^^
-    7 │ 	return r.test(someString)
-    8 │ }
+     8 │ const parser = {
+     9 │ 	parseValue(input) {
+  > 10 │ 		return /[0-9]+/.test(input);
+       │ 		       ^^^^^^^^
+    11 │ 	}
+    12 │ };
   
   i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
   
+  i Unsafe fix: Extract the regex literal into PARSE_VALUE_REGEX.
+  
+     1  1 │   "use strict"
+     2    │ - import·dependency·from·"dependency"
+        2 │ + import·dependency·from·"dependency"
+        3 │ + const·PARSE_VALUE_REGEX·=·/[0-9]+/;
+     3  4 │   
+     4  5 │   function parseInput(input) {
+    ····· │ 
+     8  9 │   const parser = {
+     9 10 │     parseValue(input) {
+    10    │ - → → return·/[0-9]+/.test(input);
+       11 │ + → → return·PARSE_VALUE_REGEX.test(input);
+    11 12 │     }
+    12 13 │   };
+  
 
 ```
 
 ```
-invalid.js:11:9 lint/performance/useTopLevelRegex ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:16:10 lint/performance/useTopLevelRegex  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This regex literal is not defined in the top level scope. This can lead to performance issues if this function is called frequently.
   
-    10 │ const foo = (someString) => {
-  > 11 │ 	return /[a-Z]*/.test(someString)
-       │ 	       ^^^^^^^^
-    12 │ }
-    13 │ 
-  
-  i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
-  
-
-```
-
-```
-invalid.js:16:16 lint/performance/useTopLevelRegex ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This regex literal is not defined in the top level scope. This can lead to performance issues if this function is called frequently.
-  
-    14 │ class Foo {
-    15 │ 	constructor() {
-  > 16 │ 		this.regex = /[a-Z]*/;
-       │ 		             ^^^^^^^^
+    14 │ class Parser {
+    15 │ 	parseToken(input) {
+  > 16 │ 		return /[A-Z]+/.test(input);
+       │ 		       ^^^^^^^^
     17 │ 	}
     18 │ }
   
   i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
   
+  i Unsafe fix: Extract the regex literal into PARSE_TOKEN_REGEX.
+  
+     1  1 │   "use strict"
+     2    │ - import·dependency·from·"dependency"
+        2 │ + import·dependency·from·"dependency"
+        3 │ + const·PARSE_TOKEN_REGEX·=·/[A-Z]+/;
+     3  4 │   
+     4  5 │   function parseInput(input) {
+    ····· │ 
+    14 15 │   class Parser {
+    15 16 │     parseToken(input) {
+    16    │ - → → return·/[A-Z]+/.test(input);
+       17 │ + → → return·PARSE_TOKEN_REGEX.test(input);
+    17 18 │     }
+    18 19 │   }
+  
 
 ```
 
 ```
-invalid.js:21:10 lint/performance/useTopLevelRegex ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:20:31 lint/performance/useTopLevelRegex  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This regex literal is not defined in the top level scope. This can lead to performance issues if this function is called frequently.
   
-    20 │ class Foo {
-  > 21 │ 	regex = /[a-Z]*/;
-       │ 	        ^^^^^^^^
-    22 │ }
+    18 │ }
+    19 │ 
+  > 20 │ const matches = [1].map(() => /[!]/);
+       │                               ^^^^^
+    21 │ 
+    22 │ [1].map(() => /[?]/);
+  
+  i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
+  
+  i Unsafe fix: Extract the regex literal into MATCHES_REGEX.
+  
+     1  1 │   "use strict"
+     2    │ - import·dependency·from·"dependency"
+        2 │ + import·dependency·from·"dependency"
+        3 │ + const·MATCHES_REGEX·=·/[!]/;
+     3  4 │   
+     4  5 │   function parseInput(input) {
+    ····· │ 
+    18 19 │   }
+    19 20 │   
+    20    │ - const·matches·=·[1].map(()·=>·/[!]/);
+       21 │ + const·matches·=·[1].map(()·=>·MATCHES_REGEX);
+    21 22 │   
+    22 23 │   [1].map(() => /[?]/);
+  
+
+```
+
+```
+invalid.js:22:15 lint/performance/useTopLevelRegex  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This regex literal is not defined in the top level scope. This can lead to performance issues if this function is called frequently.
+  
+    20 │ const matches = [1].map(() => /[!]/);
+    21 │ 
+  > 22 │ [1].map(() => /[?]/);
+       │               ^^^^^
     23 │ 
+    24 │ function foo(someString) {
   
   i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
   
+  i Unsafe fix: Extract the regex literal into REGEX.
+  
+     1  1 │   "use strict"
+     2    │ - import·dependency·from·"dependency"
+        2 │ + import·dependency·from·"dependency"
+        3 │ + const·REGEX·=·/[?]/;
+     3  4 │   
+     4  5 │   function parseInput(input) {
+    ····· │ 
+    20 21 │   const matches = [1].map(() => /[!]/);
+    21 22 │   
+    22    │ - [1].map(()·=>·/[?]/);
+       23 │ + [1].map(()·=>·REGEX);
+    23 24 │   
+    24 25 │   function foo(someString) {
+  
 
 ```
 
 ```
-invalid.js:26:10 lint/performance/useTopLevelRegex ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:25:9 lint/performance/useTopLevelRegex  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This regex literal is not defined in the top level scope. This can lead to performance issues if this function is called frequently.
   
-    24 │ class Foo {
-    25 │ 	get regex() {
-  > 26 │ 		return /[a-Z]*/;
-       │ 		       ^^^^^^^^
-    27 │ 	}
-    28 │ }
+    24 │ function foo(someString) {
+  > 25 │ 	return /[a-Z]*/.test(someString)
+       │ 	       ^^^^^^^^
+    26 │ }
+    27 │ 
   
   i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
   
+  i Unsafe fix: Extract the regex literal into FOO_REGEX.
+  
+     1  1 │   "use strict"
+     2    │ - import·dependency·from·"dependency"
+        2 │ + import·dependency·from·"dependency"
+        3 │ + const·FOO_REGEX·=·/[a-Z]*/;
+     3  4 │   
+     4  5 │   function parseInput(input) {
+    ····· │ 
+    23 24 │   
+    24 25 │   function foo(someString) {
+    25    │ - → return·/[a-Z]*/.test(someString)
+       26 │ + → return·FOO_REGEX.test(someString)
+    26 27 │   }
+    27 28 │   
+  
 
 ```
 
 ```
-invalid.js:32:16 lint/performance/useTopLevelRegex ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:29:12 lint/performance/useTopLevelRegex  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This regex literal is not defined in the top level scope. This can lead to performance issues if this function is called frequently.
   
-    30 │ class Foo {
-    31 │ 	set apply(s) {
-  > 32 │ 		this.value = /[a-Z]*/.test(s);
+    28 │ function foo(someString) {
+  > 29 │ 	const r = /[a-Z]*/;
+       │ 	          ^^^^^^^^
+    30 │ 	return r.test(someString)
+    31 │ }
+  
+  i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
+  
+  i Unsafe fix: Extract the regex literal into R_REGEX.
+  
+     1  1 │   "use strict"
+     2    │ - import·dependency·from·"dependency"
+        2 │ + import·dependency·from·"dependency"
+        3 │ + const·R_REGEX·=·/[a-Z]*/;
+     3  4 │   
+     4  5 │   function parseInput(input) {
+    ····· │ 
+    27 28 │   
+    28 29 │   function foo(someString) {
+    29    │ - → const·r·=·/[a-Z]*/;
+       30 │ + → const·r·=·R_REGEX;
+    30 31 │     return r.test(someString)
+    31 32 │   }
+  
+
+```
+
+```
+invalid.js:34:9 lint/performance/useTopLevelRegex  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This regex literal is not defined in the top level scope. This can lead to performance issues if this function is called frequently.
+  
+    33 │ const foo = (someString) => {
+  > 34 │ 	return /[a-Z]*/.test(someString)
+       │ 	       ^^^^^^^^
+    35 │ }
+    36 │ 
+  
+  i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
+  
+  i Unsafe fix: Extract the regex literal into FOO_REGEX_2.
+  
+     1  1 │   "use strict"
+     2    │ - import·dependency·from·"dependency"
+        2 │ + import·dependency·from·"dependency"
+        3 │ + const·FOO_REGEX_2·=·/[a-Z]*/;
+     3  4 │   
+     4  5 │   function parseInput(input) {
+    ····· │ 
+    32 33 │   
+    33 34 │   const foo = (someString) => {
+    34    │ - → return·/[a-Z]*/.test(someString)
+       35 │ + → return·FOO_REGEX_2.test(someString)
+    35 36 │   }
+    36 37 │   
+  
+
+```
+
+```
+invalid.js:39:16 lint/performance/useTopLevelRegex  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This regex literal is not defined in the top level scope. This can lead to performance issues if this function is called frequently.
+  
+    37 │ class Foo {
+    38 │ 	constructor() {
+  > 39 │ 		this.regex = /[a-Z]*/;
        │ 		             ^^^^^^^^
-    33 │ 	}
-    34 │ }
+    40 │ 	}
+    41 │ }
   
   i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
   
+  i Unsafe fix: Extract the regex literal into REGEX_A_Z.
+  
+     1  1 │   "use strict"
+     2    │ - import·dependency·from·"dependency"
+        2 │ + import·dependency·from·"dependency"
+        3 │ + const·REGEX_A_Z·=·/[a-Z]*/;
+     3  4 │   
+     4  5 │   function parseInput(input) {
+    ····· │ 
+    37 38 │   class Foo {
+    38 39 │     constructor() {
+    39    │ - → → this.regex·=·/[a-Z]*/;
+       40 │ + → → this.regex·=·REGEX_A_Z;
+    40 41 │     }
+    41 42 │   }
+  
 
 ```
 
 ```
-invalid.js:38:10 lint/performance/useTopLevelRegex ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:44:10 lint/performance/useTopLevelRegex  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This regex literal is not defined in the top level scope. This can lead to performance issues if this function is called frequently.
   
-    36 │ const foo = {
-    37 │ 	regex() {
-  > 38 │ 		return /[a-Z]*/;
+    43 │ class Foo {
+  > 44 │ 	regex = /[a-Z]*/;
+       │ 	        ^^^^^^^^
+    45 │ }
+    46 │ 
+  
+  i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
+  
+  i Unsafe fix: Extract the regex literal into REGEX_REGEX.
+  
+     1  1 │   "use strict"
+     2    │ - import·dependency·from·"dependency"
+        2 │ + import·dependency·from·"dependency"
+        3 │ + const·REGEX_REGEX·=·/[a-Z]*/;
+     3  4 │   
+     4  5 │   function parseInput(input) {
+    ····· │ 
+    42 43 │   
+    43 44 │   class Foo {
+    44    │ - → regex·=·/[a-Z]*/;
+       45 │ + → regex·=·REGEX_REGEX;
+    45 46 │   }
+    46 47 │   
+  
+
+```
+
+```
+invalid.js:49:10 lint/performance/useTopLevelRegex  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This regex literal is not defined in the top level scope. This can lead to performance issues if this function is called frequently.
+  
+    47 │ class Foo {
+    48 │ 	get regex() {
+  > 49 │ 		return /[a-Z]*/;
        │ 		       ^^^^^^^^
-    39 │ 	}
-    40 │ }
+    50 │ 	}
+    51 │ }
   
   i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
   
+  i Unsafe fix: Extract the regex literal into REGEX_REGEX_2.
+  
+     1  1 │   "use strict"
+     2    │ - import·dependency·from·"dependency"
+        2 │ + import·dependency·from·"dependency"
+        3 │ + const·REGEX_REGEX_2·=·/[a-Z]*/;
+     3  4 │   
+     4  5 │   function parseInput(input) {
+    ····· │ 
+    47 48 │   class Foo {
+    48 49 │     get regex() {
+    49    │ - → → return·/[a-Z]*/;
+       50 │ + → → return·REGEX_REGEX_2;
+    50 51 │     }
+    51 52 │   }
+  
 
 ```
 
 ```
-invalid.js:44:10 lint/performance/useTopLevelRegex ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:55:16 lint/performance/useTopLevelRegex  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This regex literal is not defined in the top level scope. This can lead to performance issues if this function is called frequently.
   
-    42 │ const foo = {
-    43 │ 	get regex() {
-  > 44 │ 		return /[a-Z]*/;
-       │ 		       ^^^^^^^^
-    45 │ 	}
-    46 │ }
-  
-  i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
-  
-
-```
-
-```
-invalid.js:50:16 lint/performance/useTopLevelRegex ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This regex literal is not defined in the top level scope. This can lead to performance issues if this function is called frequently.
-  
-    48 │ const foo = {
-    49 │ 	set apply(s) {
-  > 50 │ 		this.value = /[a-Z]*/.test(s);
+    53 │ class Foo {
+    54 │ 	set apply(s) {
+  > 55 │ 		this.value = /[a-Z]*/.test(s);
        │ 		             ^^^^^^^^
-    51 │ 	}
-    52 │ }
+    56 │ 	}
+    57 │ }
   
   i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
+  
+  i Unsafe fix: Extract the regex literal into APPLY_REGEX.
+  
+     1  1 │   "use strict"
+     2    │ - import·dependency·from·"dependency"
+        2 │ + import·dependency·from·"dependency"
+        3 │ + const·APPLY_REGEX·=·/[a-Z]*/;
+     3  4 │   
+     4  5 │   function parseInput(input) {
+    ····· │ 
+    53 54 │   class Foo {
+    54 55 │     set apply(s) {
+    55    │ - → → this.value·=·/[a-Z]*/.test(s);
+       56 │ + → → this.value·=·APPLY_REGEX.test(s);
+    56 57 │     }
+    57 58 │   }
+  
+
+```
+
+```
+invalid.js:61:10 lint/performance/useTopLevelRegex  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This regex literal is not defined in the top level scope. This can lead to performance issues if this function is called frequently.
+  
+    59 │ const foo = {
+    60 │ 	regex() {
+  > 61 │ 		return /[a-Z]*/;
+       │ 		       ^^^^^^^^
+    62 │ 	}
+    63 │ }
+  
+  i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
+  
+  i Unsafe fix: Extract the regex literal into REGEX_REGEX_3.
+  
+     1  1 │   "use strict"
+     2    │ - import·dependency·from·"dependency"
+        2 │ + import·dependency·from·"dependency"
+        3 │ + const·REGEX_REGEX_3·=·/[a-Z]*/;
+     3  4 │   
+     4  5 │   function parseInput(input) {
+    ····· │ 
+    59 60 │   const foo = {
+    60 61 │     regex() {
+    61    │ - → → return·/[a-Z]*/;
+       62 │ + → → return·REGEX_REGEX_3;
+    62 63 │     }
+    63 64 │   }
+  
+
+```
+
+```
+invalid.js:67:10 lint/performance/useTopLevelRegex  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This regex literal is not defined in the top level scope. This can lead to performance issues if this function is called frequently.
+  
+    65 │ const foo = {
+    66 │ 	get regex() {
+  > 67 │ 		return /[a-Z]*/;
+       │ 		       ^^^^^^^^
+    68 │ 	}
+    69 │ }
+  
+  i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
+  
+  i Unsafe fix: Extract the regex literal into REGEX_REGEX_4.
+  
+     1  1 │   "use strict"
+     2    │ - import·dependency·from·"dependency"
+        2 │ + import·dependency·from·"dependency"
+        3 │ + const·REGEX_REGEX_4·=·/[a-Z]*/;
+     3  4 │   
+     4  5 │   function parseInput(input) {
+    ····· │ 
+    65 66 │   const foo = {
+    66 67 │     get regex() {
+    67    │ - → → return·/[a-Z]*/;
+       68 │ + → → return·REGEX_REGEX_4;
+    68 69 │     }
+    69 70 │   }
+  
+
+```
+
+```
+invalid.js:73:16 lint/performance/useTopLevelRegex  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This regex literal is not defined in the top level scope. This can lead to performance issues if this function is called frequently.
+  
+    71 │ const foo = {
+    72 │ 	set apply(s) {
+  > 73 │ 		this.value = /[a-Z]*/.test(s);
+       │ 		             ^^^^^^^^
+    74 │ 	}
+    75 │ }
+  
+  i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
+  
+  i Unsafe fix: Extract the regex literal into APPLY_REGEX_2.
+  
+     1  1 │   "use strict"
+     2    │ - import·dependency·from·"dependency"
+        2 │ + import·dependency·from·"dependency"
+        3 │ + const·APPLY_REGEX_2·=·/[a-Z]*/;
+     3  4 │   
+     4  5 │   function parseInput(input) {
+    ····· │ 
+    71 72 │   const foo = {
+    72 73 │     set apply(s) {
+    73    │ - → → this.value·=·/[a-Z]*/.test(s);
+       74 │ + → → this.value·=·APPLY_REGEX_2.test(s);
+    74 75 │     }
+    75 76 │   }
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/performance/useTopLevelRegex/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/performance/useTopLevelRegex/invalid.js.snap
@@ -289,19 +289,19 @@ invalid.js:29:12 lint/performance/useTopLevelRegex  FIXABLE  ━━━━━━�
   
   i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
   
-  i Unsafe fix: Extract the regex literal into R_REGEX.
+  i Unsafe fix: Extract the regex literal into FOO_REGEX.
   
      1  1 │   "use strict"
      2    │ - import·dependency·from·"dependency"
         2 │ + import·dependency·from·"dependency"
-        3 │ + const·R_REGEX·=·/[a-Z]*/;
+        3 │ + const·FOO_REGEX·=·/[a-Z]*/;
      3  4 │   
      4  5 │   function parseInput(input) {
     ····· │ 
     27 28 │   
     28 29 │   function foo(someString) {
     29    │ - → const·r·=·/[a-Z]*/;
-       30 │ + → const·r·=·R_REGEX;
+       30 │ + → const·r·=·FOO_REGEX;
     30 31 │     return r.test(someString)
     31 32 │   }
   
@@ -321,19 +321,19 @@ invalid.js:34:9 lint/performance/useTopLevelRegex  FIXABLE  ━━━━━━�
   
   i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
   
-  i Unsafe fix: Extract the regex literal into FOO_REGEX_2.
+  i Unsafe fix: Extract the regex literal into FOO_REGEX.
   
      1  1 │   "use strict"
      2    │ - import·dependency·from·"dependency"
         2 │ + import·dependency·from·"dependency"
-        3 │ + const·FOO_REGEX_2·=·/[a-Z]*/;
+        3 │ + const·FOO_REGEX·=·/[a-Z]*/;
      3  4 │   
      4  5 │   function parseInput(input) {
     ····· │ 
     32 33 │   
     33 34 │   const foo = (someString) => {
     34    │ - → return·/[a-Z]*/.test(someString)
-       35 │ + → return·FOO_REGEX_2.test(someString)
+       35 │ + → return·FOO_REGEX.test(someString)
     35 36 │   }
     36 37 │   
   
@@ -354,19 +354,19 @@ invalid.js:39:16 lint/performance/useTopLevelRegex  FIXABLE  ━━━━━━�
   
   i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
   
-  i Unsafe fix: Extract the regex literal into REGEX_A_Z.
+  i Unsafe fix: Extract the regex literal into FOO_REGEX.
   
      1  1 │   "use strict"
      2    │ - import·dependency·from·"dependency"
         2 │ + import·dependency·from·"dependency"
-        3 │ + const·REGEX_A_Z·=·/[a-Z]*/;
+        3 │ + const·FOO_REGEX·=·/[a-Z]*/;
      3  4 │   
      4  5 │   function parseInput(input) {
     ····· │ 
     37 38 │   class Foo {
     38 39 │     constructor() {
     39    │ - → → this.regex·=·/[a-Z]*/;
-       40 │ + → → this.regex·=·REGEX_A_Z;
+       40 │ + → → this.regex·=·FOO_REGEX;
     40 41 │     }
     41 42 │   }
   
@@ -386,19 +386,19 @@ invalid.js:44:10 lint/performance/useTopLevelRegex  FIXABLE  ━━━━━━�
   
   i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
   
-  i Unsafe fix: Extract the regex literal into REGEX_REGEX.
+  i Unsafe fix: Extract the regex literal into FOO_REGEX.
   
      1  1 │   "use strict"
      2    │ - import·dependency·from·"dependency"
         2 │ + import·dependency·from·"dependency"
-        3 │ + const·REGEX_REGEX·=·/[a-Z]*/;
+        3 │ + const·FOO_REGEX·=·/[a-Z]*/;
      3  4 │   
      4  5 │   function parseInput(input) {
     ····· │ 
     42 43 │   
     43 44 │   class Foo {
     44    │ - → regex·=·/[a-Z]*/;
-       45 │ + → regex·=·REGEX_REGEX;
+       45 │ + → regex·=·FOO_REGEX;
     45 46 │   }
     46 47 │   
   
@@ -419,19 +419,19 @@ invalid.js:49:10 lint/performance/useTopLevelRegex  FIXABLE  ━━━━━━�
   
   i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
   
-  i Unsafe fix: Extract the regex literal into REGEX_REGEX_2.
+  i Unsafe fix: Extract the regex literal into FOO_REGEX.
   
      1  1 │   "use strict"
      2    │ - import·dependency·from·"dependency"
         2 │ + import·dependency·from·"dependency"
-        3 │ + const·REGEX_REGEX_2·=·/[a-Z]*/;
+        3 │ + const·FOO_REGEX·=·/[a-Z]*/;
      3  4 │   
      4  5 │   function parseInput(input) {
     ····· │ 
     47 48 │   class Foo {
     48 49 │     get regex() {
     49    │ - → → return·/[a-Z]*/;
-       50 │ + → → return·REGEX_REGEX_2;
+       50 │ + → → return·FOO_REGEX;
     50 51 │     }
     51 52 │   }
   
@@ -452,19 +452,19 @@ invalid.js:55:16 lint/performance/useTopLevelRegex  FIXABLE  ━━━━━━�
   
   i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
   
-  i Unsafe fix: Extract the regex literal into APPLY_REGEX.
+  i Unsafe fix: Extract the regex literal into FOO_REGEX.
   
      1  1 │   "use strict"
      2    │ - import·dependency·from·"dependency"
         2 │ + import·dependency·from·"dependency"
-        3 │ + const·APPLY_REGEX·=·/[a-Z]*/;
+        3 │ + const·FOO_REGEX·=·/[a-Z]*/;
      3  4 │   
      4  5 │   function parseInput(input) {
     ····· │ 
     53 54 │   class Foo {
     54 55 │     set apply(s) {
     55    │ - → → this.value·=·/[a-Z]*/.test(s);
-       56 │ + → → this.value·=·APPLY_REGEX.test(s);
+       56 │ + → → this.value·=·FOO_REGEX.test(s);
     56 57 │     }
     57 58 │   }
   
@@ -485,19 +485,19 @@ invalid.js:61:10 lint/performance/useTopLevelRegex  FIXABLE  ━━━━━━�
   
   i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
   
-  i Unsafe fix: Extract the regex literal into REGEX_REGEX_3.
+  i Unsafe fix: Extract the regex literal into FOO_REGEX.
   
      1  1 │   "use strict"
      2    │ - import·dependency·from·"dependency"
         2 │ + import·dependency·from·"dependency"
-        3 │ + const·REGEX_REGEX_3·=·/[a-Z]*/;
+        3 │ + const·FOO_REGEX·=·/[a-Z]*/;
      3  4 │   
      4  5 │   function parseInput(input) {
     ····· │ 
     59 60 │   const foo = {
     60 61 │     regex() {
     61    │ - → → return·/[a-Z]*/;
-       62 │ + → → return·REGEX_REGEX_3;
+       62 │ + → → return·FOO_REGEX;
     62 63 │     }
     63 64 │   }
   
@@ -518,19 +518,19 @@ invalid.js:67:10 lint/performance/useTopLevelRegex  FIXABLE  ━━━━━━�
   
   i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
   
-  i Unsafe fix: Extract the regex literal into REGEX_REGEX_4.
+  i Unsafe fix: Extract the regex literal into FOO_REGEX.
   
      1  1 │   "use strict"
      2    │ - import·dependency·from·"dependency"
         2 │ + import·dependency·from·"dependency"
-        3 │ + const·REGEX_REGEX_4·=·/[a-Z]*/;
+        3 │ + const·FOO_REGEX·=·/[a-Z]*/;
      3  4 │   
      4  5 │   function parseInput(input) {
     ····· │ 
     65 66 │   const foo = {
     66 67 │     get regex() {
     67    │ - → → return·/[a-Z]*/;
-       68 │ + → → return·REGEX_REGEX_4;
+       68 │ + → → return·FOO_REGEX;
     68 69 │     }
     69 70 │   }
   
@@ -551,19 +551,19 @@ invalid.js:73:16 lint/performance/useTopLevelRegex  FIXABLE  ━━━━━━�
   
   i Move the regex literal outside of this scope, and place it at the top level of this module, as a constant.
   
-  i Unsafe fix: Extract the regex literal into APPLY_REGEX_2.
+  i Unsafe fix: Extract the regex literal into FOO_REGEX.
   
      1  1 │   "use strict"
      2    │ - import·dependency·from·"dependency"
         2 │ + import·dependency·from·"dependency"
-        3 │ + const·APPLY_REGEX_2·=·/[a-Z]*/;
+        3 │ + const·FOO_REGEX·=·/[a-Z]*/;
      3  4 │   
      4  5 │   function parseInput(input) {
     ····· │ 
     71 72 │   const foo = {
     72 73 │     set apply(s) {
     73    │ - → → this.value·=·/[a-Z]*/.test(s);
-       74 │ + → → this.value·=·APPLY_REGEX_2.test(s);
+       74 │ + → → this.value·=·FOO_REGEX.test(s);
     74 75 │     }
     75 76 │   }
   

--- a/crates/biome_js_analyze/tests/specs/style/noMagicNumbers/angle-const.ts
+++ b/crates/biome_js_analyze/tests/specs/style/noMagicNumbers/angle-const.ts
@@ -1,0 +1,1 @@
+const asserted = value + <const>31;

--- a/crates/biome_js_analyze/tests/specs/style/noMagicNumbers/angle-const.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/noMagicNumbers/angle-const.ts.snap
@@ -1,0 +1,24 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: angle-const.ts
+---
+# Input
+```ts
+const asserted = value + <const>31;
+
+```
+
+# Diagnostics
+```
+angle-const.ts:1:33 lint/style/noMagicNumbers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Magic number detected. Extract it to a constant with a meaningful name.
+  
+  > 1 │ const asserted = value + <const>31;
+      │                                 ^^
+    2 │ 
+  
+  i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/style/noMagicNumbers/invalid.tsx
+++ b/crates/biome_js_analyze/tests/specs/style/noMagicNumbers/invalid.tsx
@@ -5,7 +5,7 @@ var foo = 0 + 1 + -4 + 4;
 var foo = 0 + 1 + 5;
 
 console.log(0x1A + 0x02);
-console.log(071);
+console.log(0o71); // Equivalent to the legacy-octal 071 case; kept parseable for action validation.
 
 var colors = {}; colors.RED = 3; colors.YELLOW = 4; colors.BLUE = 4 + 5;
 function getSecondsInMinute() {return 60;}
@@ -25,4 +25,27 @@ function callLater(func) {
 
 var a = <div arrayProp={[1,2,3]}></div>;
 
+function getMillisecondsSinceStart() {
+	return getSecondsInDay() * 1000;
+}
 
+function schedule(work) {
+	setTimeout(work, 100);
+}
+
+const existing = 1;
+function usesFallback(value) {
+	return value + 31;
+}
+
+const numericKeys = {};
+numericKeys[7] = 31;
+
+const bigintTotal = bigintValue + 123n;
+const commented = value + /* keep */ 37;
+
+const assertedNumber = (31 as const) + value;
+const mixedAssertions = [31 as const, 31];
+const nestedAssertion = ((31 as const) as number) + value;
+
+type NumericLiteral = 31;

--- a/crates/biome_js_analyze/tests/specs/style/noMagicNumbers/invalid.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/style/noMagicNumbers/invalid.tsx.snap
@@ -11,7 +11,7 @@ var foo = 0 + 1 + -4 + 4;
 var foo = 0 + 1 + 5;
 
 console.log(0x1A + 0x02);
-console.log(071);
+console.log(0o71); // Equivalent to the legacy-octal 071 case; kept parseable for action validation.
 
 var colors = {}; colors.RED = 3; colors.YELLOW = 4; colors.BLUE = 4 + 5;
 function getSecondsInMinute() {return 60;}
@@ -31,15 +31,36 @@ function callLater(func) {
 
 var a = <div arrayProp={[1,2,3]}></div>;
 
+function getMillisecondsSinceStart() {
+	return getSecondsInDay() * 1000;
+}
 
+function schedule(work) {
+	setTimeout(work, 100);
+}
+
+const existing = 1;
+function usesFallback(value) {
+	return value + 31;
+}
+
+const numericKeys = {};
+numericKeys[7] = 31;
+
+const bigintTotal = bigintValue + 123n;
+const commented = value + /* keep */ 37;
+
+const assertedNumber = (31 as const) + value;
+const mixedAssertions = [31 as const, 31];
+const nestedAssertion = ((31 as const) as number) + value;
+
+type NumericLiteral = 31;
 
 ```
-
-_Note: The parser emitted 1 diagnostics which are not shown here._
 
 # Diagnostics
 ```
-invalid.tsx:1:15 lint/style/noMagicNumbers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.tsx:1:15 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Magic number detected. Extract it to a constant with a meaningful name.
   
@@ -50,11 +71,19 @@ invalid.tsx:1:15 lint/style/noMagicNumbers ━━━━━━━━━━━━�
   
   i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
   
+  i Unsafe fix: Extract the magic number into FOO_31.
+  
+     1    │ - var·foo·=·0·+·31;
+        1 │ + const·FOO_31·=·31;
+        2 │ + var·foo·=·0·+·FOO_31;
+     2  3 │   a = a + 5;
+     3  4 │   a += 5;
+  
 
 ```
 
 ```
-invalid.tsx:2:9 lint/style/noMagicNumbers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.tsx:2:9 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Magic number detected. Extract it to a constant with a meaningful name.
   
@@ -66,11 +95,20 @@ invalid.tsx:2:9 lint/style/noMagicNumbers ━━━━━━━━━━━━�
   
   i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
   
+  i Unsafe fix: Extract the magic number into NUMBER_5.
+  
+        1 │ + const·NUMBER_5·=·5;
+     1  2 │   var foo = 0 + 31;
+     2    │ - a·=·a·+·5;
+        3 │ + a·=·a·+·NUMBER_5;
+     3  4 │   a += 5;
+     4  5 │   var foo = 0 + 1 + -4 + 4;
+  
 
 ```
 
 ```
-invalid.tsx:3:6 lint/style/noMagicNumbers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.tsx:3:6 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Magic number detected. Extract it to a constant with a meaningful name.
   
@@ -83,11 +121,21 @@ invalid.tsx:3:6 lint/style/noMagicNumbers ━━━━━━━━━━━━�
   
   i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
   
+  i Unsafe fix: Extract the magic number into NUMBER_5_2.
+  
+        1 │ + const·NUMBER_5_2·=·5;
+     1  2 │   var foo = 0 + 31;
+     2  3 │   a = a + 5;
+     3    │ - a·+=·5;
+        4 │ + a·+=·NUMBER_5_2;
+     4  5 │   var foo = 0 + 1 + -4 + 4;
+     5  6 │   var foo = 0 + 1 + 5;
+  
 
 ```
 
 ```
-invalid.tsx:4:20 lint/style/noMagicNumbers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.tsx:4:20 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Magic number detected. Extract it to a constant with a meaningful name.
   
@@ -100,11 +148,22 @@ invalid.tsx:4:20 lint/style/noMagicNumbers ━━━━━━━━━━━━�
   
   i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
   
+  i Unsafe fix: Extract the magic number into FOO_4.
+  
+        1 │ + const·FOO_4·=·4;
+     1  2 │   var foo = 0 + 31;
+     2  3 │   a = a + 5;
+     3  4 │   a += 5;
+     4    │ - var·foo·=·0·+·1·+·-4·+·4;
+        5 │ + var·foo·=·0·+·1·+·-FOO_4·+·4;
+     5  6 │   var foo = 0 + 1 + 5;
+     6  7 │   
+  
 
 ```
 
 ```
-invalid.tsx:4:24 lint/style/noMagicNumbers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.tsx:4:24 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Magic number detected. Extract it to a constant with a meaningful name.
   
@@ -117,11 +176,22 @@ invalid.tsx:4:24 lint/style/noMagicNumbers ━━━━━━━━━━━━�
   
   i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
   
+  i Unsafe fix: Extract the magic number into FOO_4_2.
+  
+        1 │ + const·FOO_4_2·=·4;
+     1  2 │   var foo = 0 + 31;
+     2  3 │   a = a + 5;
+     3  4 │   a += 5;
+     4    │ - var·foo·=·0·+·1·+·-4·+·4;
+        5 │ + var·foo·=·0·+·1·+·-4·+·FOO_4_2;
+     5  6 │   var foo = 0 + 1 + 5;
+     6  7 │   
+  
 
 ```
 
 ```
-invalid.tsx:5:19 lint/style/noMagicNumbers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.tsx:5:19 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Magic number detected. Extract it to a constant with a meaningful name.
   
@@ -134,11 +204,23 @@ invalid.tsx:5:19 lint/style/noMagicNumbers ━━━━━━━━━━━━�
   
   i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
   
+  i Unsafe fix: Extract the magic number into FOO_5.
+  
+        1 │ + const·FOO_5·=·5;
+     1  2 │   var foo = 0 + 31;
+     2  3 │   a = a + 5;
+     3  4 │   a += 5;
+     4  5 │   var foo = 0 + 1 + -4 + 4;
+     5    │ - var·foo·=·0·+·1·+·5;
+        6 │ + var·foo·=·0·+·1·+·FOO_5;
+     6  7 │   
+     7  8 │   console.log(0x1A + 0x02);
+  
 
 ```
 
 ```
-invalid.tsx:7:13 lint/style/noMagicNumbers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.tsx:7:13 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Magic number detected. Extract it to a constant with a meaningful name.
   
@@ -146,16 +228,29 @@ invalid.tsx:7:13 lint/style/noMagicNumbers ━━━━━━━━━━━━�
     6 │ 
   > 7 │ console.log(0x1A + 0x02);
       │             ^^^^
-    8 │ console.log(071);
+    8 │ console.log(0o71); // Equivalent to the legacy-octal 071 case; kept parseable for action validation.
     9 │ 
   
   i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
   
+  i Unsafe fix: Extract the magic number into LOG_0X1A.
+  
+        1 │ + const·LOG_0X1A·=·0x1A;
+     1  2 │   var foo = 0 + 31;
+     2  3 │   a = a + 5;
+    ····· │ 
+     5  6 │   var foo = 0 + 1 + 5;
+     6  7 │   
+     7    │ - console.log(0x1A·+·0x02);
+        8 │ + console.log(LOG_0X1A·+·0x02);
+     8  9 │   console.log(0o71); // Equivalent to the legacy-octal 071 case; kept parseable for action validation.
+     9 10 │   
+  
 
 ```
 
 ```
-invalid.tsx:7:20 lint/style/noMagicNumbers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.tsx:7:20 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Magic number detected. Extract it to a constant with a meaningful name.
   
@@ -163,36 +258,62 @@ invalid.tsx:7:20 lint/style/noMagicNumbers ━━━━━━━━━━━━�
     6 │ 
   > 7 │ console.log(0x1A + 0x02);
       │                    ^^^^
-    8 │ console.log(071);
+    8 │ console.log(0o71); // Equivalent to the legacy-octal 071 case; kept parseable for action validation.
     9 │ 
   
   i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
   
+  i Unsafe fix: Extract the magic number into LOG_0X02.
+  
+        1 │ + const·LOG_0X02·=·0x02;
+     1  2 │   var foo = 0 + 31;
+     2  3 │   a = a + 5;
+    ····· │ 
+     5  6 │   var foo = 0 + 1 + 5;
+     6  7 │   
+     7    │ - console.log(0x1A·+·0x02);
+        8 │ + console.log(0x1A·+·LOG_0X02);
+     8  9 │   console.log(0o71); // Equivalent to the legacy-octal 071 case; kept parseable for action validation.
+     9 10 │   
+  
 
 ```
 
 ```
-invalid.tsx:8:13 lint/style/noMagicNumbers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.tsx:8:13 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Magic number detected. Extract it to a constant with a meaningful name.
   
      7 │ console.log(0x1A + 0x02);
-   > 8 │ console.log(071);
-       │             ^^^
+   > 8 │ console.log(0o71); // Equivalent to the legacy-octal 071 case; kept parseable for action validation.
+       │             ^^^^
      9 │ 
     10 │ var colors = {}; colors.RED = 3; colors.YELLOW = 4; colors.BLUE = 4 + 5;
   
   i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
   
+  i Unsafe fix: Extract the magic number into LOG_0O71.
+  
+        1 │ + const·LOG_0O71·=·0o71;
+     1  2 │   var foo = 0 + 31;
+     2  3 │   a = a + 5;
+    ····· │ 
+     6  7 │   
+     7  8 │   console.log(0x1A + 0x02);
+     8    │ - console.log(0o71);·//·Equivalent·to·the·legacy-octal·071·case;·kept·parseable·for·action·validation.
+        9 │ + console.log(LOG_0O71);·//·Equivalent·to·the·legacy-octal·071·case;·kept·parseable·for·action·validation.
+     9 10 │   
+    10 11 │   var colors = {}; colors.RED = 3; colors.YELLOW = 4; colors.BLUE = 4 + 5;
+  
 
 ```
 
 ```
-invalid.tsx:10:31 lint/style/noMagicNumbers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.tsx:10:31 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Magic number detected. Extract it to a constant with a meaningful name.
   
-     8 │ console.log(071);
+     8 │ console.log(0o71); // Equivalent to the legacy-octal 071 case; kept parseable for action validation.
      9 │ 
   > 10 │ var colors = {}; colors.RED = 3; colors.YELLOW = 4; colors.BLUE = 4 + 5;
        │                               ^
@@ -201,15 +322,28 @@ invalid.tsx:10:31 lint/style/noMagicNumbers ━━━━━━━━━━━━
   
   i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
   
+  i Unsafe fix: Extract the magic number into RED_3.
+  
+        1 │ + const·RED_3·=·3;
+     1  2 │   var foo = 0 + 31;
+     2  3 │   a = a + 5;
+    ····· │ 
+     8  9 │   console.log(0o71); // Equivalent to the legacy-octal 071 case; kept parseable for action validation.
+     9 10 │   
+    10    │ - var·colors·=·{};·colors.RED·=·3;·colors.YELLOW·=·4;·colors.BLUE·=·4·+·5;
+       11 │ + var·colors·=·{};·colors.RED·=·RED_3;·colors.YELLOW·=·4;·colors.BLUE·=·4·+·5;
+    11 12 │   function getSecondsInMinute() {return 60;}
+    12 13 │   function getNegativeSecondsInMinute() {return -60;}
+  
 
 ```
 
 ```
-invalid.tsx:10:50 lint/style/noMagicNumbers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.tsx:10:50 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Magic number detected. Extract it to a constant with a meaningful name.
   
-     8 │ console.log(071);
+     8 │ console.log(0o71); // Equivalent to the legacy-octal 071 case; kept parseable for action validation.
      9 │ 
   > 10 │ var colors = {}; colors.RED = 3; colors.YELLOW = 4; colors.BLUE = 4 + 5;
        │                                                  ^
@@ -218,15 +352,28 @@ invalid.tsx:10:50 lint/style/noMagicNumbers ━━━━━━━━━━━━
   
   i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
   
+  i Unsafe fix: Extract the magic number into YELLOW_4.
+  
+        1 │ + const·YELLOW_4·=·4;
+     1  2 │   var foo = 0 + 31;
+     2  3 │   a = a + 5;
+    ····· │ 
+     8  9 │   console.log(0o71); // Equivalent to the legacy-octal 071 case; kept parseable for action validation.
+     9 10 │   
+    10    │ - var·colors·=·{};·colors.RED·=·3;·colors.YELLOW·=·4;·colors.BLUE·=·4·+·5;
+       11 │ + var·colors·=·{};·colors.RED·=·3;·colors.YELLOW·=·YELLOW_4;·colors.BLUE·=·4·+·5;
+    11 12 │   function getSecondsInMinute() {return 60;}
+    12 13 │   function getNegativeSecondsInMinute() {return -60;}
+  
 
 ```
 
 ```
-invalid.tsx:10:67 lint/style/noMagicNumbers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.tsx:10:67 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Magic number detected. Extract it to a constant with a meaningful name.
   
-     8 │ console.log(071);
+     8 │ console.log(0o71); // Equivalent to the legacy-octal 071 case; kept parseable for action validation.
      9 │ 
   > 10 │ var colors = {}; colors.RED = 3; colors.YELLOW = 4; colors.BLUE = 4 + 5;
        │                                                                   ^
@@ -235,15 +382,28 @@ invalid.tsx:10:67 lint/style/noMagicNumbers ━━━━━━━━━━━━
   
   i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
   
+  i Unsafe fix: Extract the magic number into BLUE_4.
+  
+        1 │ + const·BLUE_4·=·4;
+     1  2 │   var foo = 0 + 31;
+     2  3 │   a = a + 5;
+    ····· │ 
+     8  9 │   console.log(0o71); // Equivalent to the legacy-octal 071 case; kept parseable for action validation.
+     9 10 │   
+    10    │ - var·colors·=·{};·colors.RED·=·3;·colors.YELLOW·=·4;·colors.BLUE·=·4·+·5;
+       11 │ + var·colors·=·{};·colors.RED·=·3;·colors.YELLOW·=·4;·colors.BLUE·=·BLUE_4·+·5;
+    11 12 │   function getSecondsInMinute() {return 60;}
+    12 13 │   function getNegativeSecondsInMinute() {return -60;}
+  
 
 ```
 
 ```
-invalid.tsx:10:71 lint/style/noMagicNumbers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.tsx:10:71 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Magic number detected. Extract it to a constant with a meaningful name.
   
-     8 │ console.log(071);
+     8 │ console.log(0o71); // Equivalent to the legacy-octal 071 case; kept parseable for action validation.
      9 │ 
   > 10 │ var colors = {}; colors.RED = 3; colors.YELLOW = 4; colors.BLUE = 4 + 5;
        │                                                                       ^
@@ -252,11 +412,24 @@ invalid.tsx:10:71 lint/style/noMagicNumbers ━━━━━━━━━━━━
   
   i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
   
+  i Unsafe fix: Extract the magic number into BLUE_5.
+  
+        1 │ + const·BLUE_5·=·5;
+     1  2 │   var foo = 0 + 31;
+     2  3 │   a = a + 5;
+    ····· │ 
+     8  9 │   console.log(0o71); // Equivalent to the legacy-octal 071 case; kept parseable for action validation.
+     9 10 │   
+    10    │ - var·colors·=·{};·colors.RED·=·3;·colors.YELLOW·=·4;·colors.BLUE·=·4·+·5;
+       11 │ + var·colors·=·{};·colors.RED·=·3;·colors.YELLOW·=·4;·colors.BLUE·=·4·+·BLUE_5;
+    11 12 │   function getSecondsInMinute() {return 60;}
+    12 13 │   function getNegativeSecondsInMinute() {return -60;}
+  
 
 ```
 
 ```
-invalid.tsx:19:4 lint/style/noMagicNumbers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.tsx:19:4 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Magic number detected. Extract it to a constant with a meaningful name.
   
@@ -269,11 +442,24 @@ invalid.tsx:19:4 lint/style/noMagicNumbers ━━━━━━━━━━━━�
   
   i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
   
+  i Unsafe fix: Extract the magic number into GET_MILLISECONDS_IN_DAY_1000.
+  
+        1 │ + const·GET_MILLISECONDS_IN_DAY_1000·=·1000;
+     1  2 │   var foo = 0 + 31;
+     2  3 │   a = a + 5;
+    ····· │ 
+    17 18 │   function getMillisecondsInDay() {
+    18 19 │     return (getSecondsInDay() *
+    19    │ - → → (1000)
+       20 │ + → → (GET_MILLISECONDS_IN_DAY_1000)
+    20 21 │     );
+    21 22 │   }
+  
 
 ```
 
 ```
-invalid.tsx:23:19 lint/style/noMagicNumbers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.tsx:23:19 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Magic number detected. Extract it to a constant with a meaningful name.
   
@@ -286,11 +472,24 @@ invalid.tsx:23:19 lint/style/noMagicNumbers ━━━━━━━━━━━━
   
   i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
   
+  i Unsafe fix: Extract the magic number into CALL_LATER_SET_TIMEOUT_100.
+  
+        1 │ + const·CALL_LATER_SET_TIMEOUT_100·=·100;
+     1  2 │   var foo = 0 + 31;
+     2  3 │   a = a + 5;
+    ····· │ 
+    21 22 │   }
+    22 23 │   function callLater(func) {
+    23    │ - → setTimeout(func,·100);
+       24 │ + → setTimeout(func,·CALL_LATER_SET_TIMEOUT_100);
+    24 25 │   }
+    25 26 │   
+  
 
 ```
 
 ```
-invalid.tsx:26:30 lint/style/noMagicNumbers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.tsx:26:30 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Magic number detected. Extract it to a constant with a meaningful name.
   
@@ -299,6 +498,291 @@ invalid.tsx:26:30 lint/style/noMagicNumbers ━━━━━━━━━━━━
   > 26 │ var a = <div arrayProp={[1,2,3]}></div>;
        │                              ^
     27 │ 
+    28 │ function getMillisecondsSinceStart() {
+  
+  i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
+  
+  i Unsafe fix: Extract the magic number into A_3.
+  
+        1 │ + const·A_3·=·3;
+     1  2 │   var foo = 0 + 31;
+     2  3 │   a = a + 5;
+    ····· │ 
+    24 25 │   }
+    25 26 │   
+    26    │ - var·a·=·<div·arrayProp={[1,2,3]}></div>;
+       27 │ + var·a·=·<div·arrayProp={[1,2,A_3]}></div>;
+    27 28 │   
+    28 29 │   function getMillisecondsSinceStart() {
+  
+
+```
+
+```
+invalid.tsx:29:29 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Magic number detected. Extract it to a constant with a meaningful name.
+  
+    28 │ function getMillisecondsSinceStart() {
+  > 29 │ 	return getSecondsInDay() * 1000;
+       │ 	                           ^^^^
+    30 │ }
+    31 │ 
+  
+  i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
+  
+  i Unsafe fix: Extract the magic number into GET_MILLISECONDS_SINCE_START_1000.
+  
+        1 │ + const·GET_MILLISECONDS_SINCE_START_1000·=·1000;
+     1  2 │   var foo = 0 + 31;
+     2  3 │   a = a + 5;
+    ····· │ 
+    27 28 │   
+    28 29 │   function getMillisecondsSinceStart() {
+    29    │ - → return·getSecondsInDay()·*·1000;
+       30 │ + → return·getSecondsInDay()·*·GET_MILLISECONDS_SINCE_START_1000;
+    30 31 │   }
+    31 32 │   
+  
+
+```
+
+```
+invalid.tsx:33:19 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Magic number detected. Extract it to a constant with a meaningful name.
+  
+    32 │ function schedule(work) {
+  > 33 │ 	setTimeout(work, 100);
+       │ 	                 ^^^
+    34 │ }
+    35 │ 
+  
+  i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
+  
+  i Unsafe fix: Extract the magic number into SCHEDULE_SET_TIMEOUT_100.
+  
+        1 │ + const·SCHEDULE_SET_TIMEOUT_100·=·100;
+     1  2 │   var foo = 0 + 31;
+     2  3 │   a = a + 5;
+    ····· │ 
+    31 32 │   
+    32 33 │   function schedule(work) {
+    33    │ - → setTimeout(work,·100);
+       34 │ + → setTimeout(work,·SCHEDULE_SET_TIMEOUT_100);
+    34 35 │   }
+    35 36 │   
+  
+
+```
+
+```
+invalid.tsx:38:17 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Magic number detected. Extract it to a constant with a meaningful name.
+  
+    36 │ const existing = 1;
+    37 │ function usesFallback(value) {
+  > 38 │ 	return value + 31;
+       │ 	               ^^
+    39 │ }
+    40 │ 
+  
+  i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
+  
+  i Unsafe fix: Extract the magic number into USES_FALLBACK_31.
+  
+        1 │ + const·USES_FALLBACK_31·=·31;
+     1  2 │   var foo = 0 + 31;
+     2  3 │   a = a + 5;
+    ····· │ 
+    36 37 │   const existing = 1;
+    37 38 │   function usesFallback(value) {
+    38    │ - → return·value·+·31;
+       39 │ + → return·value·+·USES_FALLBACK_31;
+    39 40 │   }
+    40 41 │   
+  
+
+```
+
+```
+invalid.tsx:42:18 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Magic number detected. Extract it to a constant with a meaningful name.
+  
+    41 │ const numericKeys = {};
+  > 42 │ numericKeys[7] = 31;
+       │                  ^^
+    43 │ 
+    44 │ const bigintTotal = bigintValue + 123n;
+  
+  i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
+  
+  i Unsafe fix: Extract the magic number into NUMBER_7_31.
+  
+        1 │ + const·NUMBER_7_31·=·31;
+     1  2 │   var foo = 0 + 31;
+     2  3 │   a = a + 5;
+    ····· │ 
+    40 41 │   
+    41 42 │   const numericKeys = {};
+    42    │ - numericKeys[7]·=·31;
+       43 │ + numericKeys[7]·=·NUMBER_7_31;
+    43 44 │   
+    44 45 │   const bigintTotal = bigintValue + 123n;
+  
+
+```
+
+```
+invalid.tsx:44:35 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Magic number detected. Extract it to a constant with a meaningful name.
+  
+    42 │ numericKeys[7] = 31;
+    43 │ 
+  > 44 │ const bigintTotal = bigintValue + 123n;
+       │                                   ^^^^
+    45 │ const commented = value + /* keep */ 37;
+    46 │ 
+  
+  i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
+  
+  i Unsafe fix: Extract the magic number into BIGINT_TOTAL_123N.
+  
+        1 │ + const·BIGINT_TOTAL_123N·=·123n;
+     1  2 │   var foo = 0 + 31;
+     2  3 │   a = a + 5;
+    ····· │ 
+    42 43 │   numericKeys[7] = 31;
+    43 44 │   
+    44    │ - const·bigintTotal·=·bigintValue·+·123n;
+       45 │ + const·bigintTotal·=·bigintValue·+·BIGINT_TOTAL_123N;
+    45 46 │   const commented = value + /* keep */ 37;
+    46 47 │   
+  
+
+```
+
+```
+invalid.tsx:45:38 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Magic number detected. Extract it to a constant with a meaningful name.
+  
+    44 │ const bigintTotal = bigintValue + 123n;
+  > 45 │ const commented = value + /* keep */ 37;
+       │                                      ^^
+    46 │ 
+    47 │ const assertedNumber = (31 as const) + value;
+  
+  i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
+  
+  i Unsafe fix: Extract the magic number into COMMENTED_37.
+  
+        1 │ + const·COMMENTED_37·=·37;
+     1  2 │   var foo = 0 + 31;
+     2  3 │   a = a + 5;
+    ····· │ 
+    43 44 │   
+    44 45 │   const bigintTotal = bigintValue + 123n;
+    45    │ - const·commented·=·value·+·/*·keep·*/·37;
+       46 │ + const·commented·=·value·+·/*·keep·*/·COMMENTED_37;
+    46 47 │   
+    47 48 │   const assertedNumber = (31 as const) + value;
+  
+
+```
+
+```
+invalid.tsx:47:25 lint/style/noMagicNumbers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Magic number detected. Extract it to a constant with a meaningful name.
+  
+    45 │ const commented = value + /* keep */ 37;
+    46 │ 
+  > 47 │ const assertedNumber = (31 as const) + value;
+       │                         ^^
+    48 │ const mixedAssertions = [31 as const, 31];
+    49 │ const nestedAssertion = ((31 as const) as number) + value;
+  
+  i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
+  
+
+```
+
+```
+invalid.tsx:48:26 lint/style/noMagicNumbers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Magic number detected. Extract it to a constant with a meaningful name.
+  
+    47 │ const assertedNumber = (31 as const) + value;
+  > 48 │ const mixedAssertions = [31 as const, 31];
+       │                          ^^
+    49 │ const nestedAssertion = ((31 as const) as number) + value;
+    50 │ 
+  
+  i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
+  
+
+```
+
+```
+invalid.tsx:48:39 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Magic number detected. Extract it to a constant with a meaningful name.
+  
+    47 │ const assertedNumber = (31 as const) + value;
+  > 48 │ const mixedAssertions = [31 as const, 31];
+       │                                       ^^
+    49 │ const nestedAssertion = ((31 as const) as number) + value;
+    50 │ 
+  
+  i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
+  
+  i Unsafe fix: Extract the magic number into MIXED_ASSERTIONS_31.
+  
+        1 │ + const·MIXED_ASSERTIONS_31·=·31;
+     1  2 │   var foo = 0 + 31;
+     2  3 │   a = a + 5;
+    ····· │ 
+    46 47 │   
+    47 48 │   const assertedNumber = (31 as const) + value;
+    48    │ - const·mixedAssertions·=·[31·as·const,·31];
+       49 │ + const·mixedAssertions·=·[31·as·const,·MIXED_ASSERTIONS_31];
+    49 50 │   const nestedAssertion = ((31 as const) as number) + value;
+    50 51 │   
+  
+
+```
+
+```
+invalid.tsx:49:27 lint/style/noMagicNumbers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Magic number detected. Extract it to a constant with a meaningful name.
+  
+    47 │ const assertedNumber = (31 as const) + value;
+    48 │ const mixedAssertions = [31 as const, 31];
+  > 49 │ const nestedAssertion = ((31 as const) as number) + value;
+       │                           ^^
+    50 │ 
+    51 │ type NumericLiteral = 31;
+  
+  i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
+  
+
+```
+
+```
+invalid.tsx:51:23 lint/style/noMagicNumbers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Magic number detected. Extract it to a constant with a meaningful name.
+  
+    49 │ const nestedAssertion = ((31 as const) as number) + value;
+    50 │ 
+  > 51 │ type NumericLiteral = 31;
+       │                       ^^
+    52 │ 
   
   i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
   

--- a/crates/biome_js_analyze/tests/specs/style/noMagicNumbers/invalid.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/style/noMagicNumbers/invalid.tsx.snap
@@ -121,13 +121,13 @@ invalid.tsx:3:6 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━━�
   
   i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
   
-  i Unsafe fix: Extract the magic number into NUMBER_5_2.
+  i Unsafe fix: Extract the magic number into NUMBER_5.
   
-        1 │ + const·NUMBER_5_2·=·5;
+        1 │ + const·NUMBER_5·=·5;
      1  2 │   var foo = 0 + 31;
      2  3 │   a = a + 5;
      3    │ - a·+=·5;
-        4 │ + a·+=·NUMBER_5_2;
+        4 │ + a·+=·NUMBER_5;
      4  5 │   var foo = 0 + 1 + -4 + 4;
      5  6 │   var foo = 0 + 1 + 5;
   
@@ -176,14 +176,14 @@ invalid.tsx:4:24 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━━
   
   i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
   
-  i Unsafe fix: Extract the magic number into FOO_4_2.
+  i Unsafe fix: Extract the magic number into FOO_4.
   
-        1 │ + const·FOO_4_2·=·4;
+        1 │ + const·FOO_4·=·4;
      1  2 │   var foo = 0 + 31;
      2  3 │   a = a + 5;
      3  4 │   a += 5;
      4    │ - var·foo·=·0·+·1·+·-4·+·4;
-        5 │ + var·foo·=·0·+·1·+·-4·+·FOO_4_2;
+        5 │ + var·foo·=·0·+·1·+·-4·+·FOO_4;
      5  6 │   var foo = 0 + 1 + 5;
      6  7 │   
   
@@ -204,15 +204,15 @@ invalid.tsx:5:19 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━━
   
   i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
   
-  i Unsafe fix: Extract the magic number into FOO_5.
+  i Unsafe fix: Extract the magic number into NUMBER_5.
   
-        1 │ + const·FOO_5·=·5;
+        1 │ + const·NUMBER_5·=·5;
      1  2 │   var foo = 0 + 31;
      2  3 │   a = a + 5;
      3  4 │   a += 5;
      4  5 │   var foo = 0 + 1 + -4 + 4;
      5    │ - var·foo·=·0·+·1·+·5;
-        6 │ + var·foo·=·0·+·1·+·FOO_5;
+        6 │ + var·foo·=·0·+·1·+·NUMBER_5;
      6  7 │   
      7  8 │   console.log(0x1A + 0x02);
   
@@ -352,16 +352,16 @@ invalid.tsx:10:50 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━�
   
   i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
   
-  i Unsafe fix: Extract the magic number into YELLOW_4.
+  i Unsafe fix: Extract the magic number into FOO_4.
   
-        1 │ + const·YELLOW_4·=·4;
+        1 │ + const·FOO_4·=·4;
      1  2 │   var foo = 0 + 31;
      2  3 │   a = a + 5;
     ····· │ 
      8  9 │   console.log(0o71); // Equivalent to the legacy-octal 071 case; kept parseable for action validation.
      9 10 │   
     10    │ - var·colors·=·{};·colors.RED·=·3;·colors.YELLOW·=·4;·colors.BLUE·=·4·+·5;
-       11 │ + var·colors·=·{};·colors.RED·=·3;·colors.YELLOW·=·YELLOW_4;·colors.BLUE·=·4·+·5;
+       11 │ + var·colors·=·{};·colors.RED·=·3;·colors.YELLOW·=·FOO_4;·colors.BLUE·=·4·+·5;
     11 12 │   function getSecondsInMinute() {return 60;}
     12 13 │   function getNegativeSecondsInMinute() {return -60;}
   
@@ -382,16 +382,16 @@ invalid.tsx:10:67 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━�
   
   i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
   
-  i Unsafe fix: Extract the magic number into BLUE_4.
+  i Unsafe fix: Extract the magic number into FOO_4.
   
-        1 │ + const·BLUE_4·=·4;
+        1 │ + const·FOO_4·=·4;
      1  2 │   var foo = 0 + 31;
      2  3 │   a = a + 5;
     ····· │ 
      8  9 │   console.log(0o71); // Equivalent to the legacy-octal 071 case; kept parseable for action validation.
      9 10 │   
     10    │ - var·colors·=·{};·colors.RED·=·3;·colors.YELLOW·=·4;·colors.BLUE·=·4·+·5;
-       11 │ + var·colors·=·{};·colors.RED·=·3;·colors.YELLOW·=·4;·colors.BLUE·=·BLUE_4·+·5;
+       11 │ + var·colors·=·{};·colors.RED·=·3;·colors.YELLOW·=·4;·colors.BLUE·=·FOO_4·+·5;
     11 12 │   function getSecondsInMinute() {return 60;}
     12 13 │   function getNegativeSecondsInMinute() {return -60;}
   
@@ -412,16 +412,16 @@ invalid.tsx:10:71 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━�
   
   i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
   
-  i Unsafe fix: Extract the magic number into BLUE_5.
+  i Unsafe fix: Extract the magic number into NUMBER_5.
   
-        1 │ + const·BLUE_5·=·5;
+        1 │ + const·NUMBER_5·=·5;
      1  2 │   var foo = 0 + 31;
      2  3 │   a = a + 5;
     ····· │ 
      8  9 │   console.log(0o71); // Equivalent to the legacy-octal 071 case; kept parseable for action validation.
      9 10 │   
     10    │ - var·colors·=·{};·colors.RED·=·3;·colors.YELLOW·=·4;·colors.BLUE·=·4·+·5;
-       11 │ + var·colors·=·{};·colors.RED·=·3;·colors.YELLOW·=·4;·colors.BLUE·=·4·+·BLUE_5;
+       11 │ + var·colors·=·{};·colors.RED·=·3;·colors.YELLOW·=·4;·colors.BLUE·=·4·+·NUMBER_5;
     11 12 │   function getSecondsInMinute() {return 60;}
     12 13 │   function getNegativeSecondsInMinute() {return -60;}
   
@@ -502,16 +502,16 @@ invalid.tsx:26:30 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━�
   
   i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
   
-  i Unsafe fix: Extract the magic number into A_3.
+  i Unsafe fix: Extract the magic number into RED_3.
   
-        1 │ + const·A_3·=·3;
+        1 │ + const·RED_3·=·3;
      1  2 │   var foo = 0 + 31;
      2  3 │   a = a + 5;
     ····· │ 
     24 25 │   }
     25 26 │   
     26    │ - var·a·=·<div·arrayProp={[1,2,3]}></div>;
-       27 │ + var·a·=·<div·arrayProp={[1,2,A_3]}></div>;
+       27 │ + var·a·=·<div·arrayProp={[1,2,RED_3]}></div>;
     27 28 │   
     28 29 │   function getMillisecondsSinceStart() {
   
@@ -531,16 +531,16 @@ invalid.tsx:29:29 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━�
   
   i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
   
-  i Unsafe fix: Extract the magic number into GET_MILLISECONDS_SINCE_START_1000.
+  i Unsafe fix: Extract the magic number into GET_MILLISECONDS_IN_DAY_1000.
   
-        1 │ + const·GET_MILLISECONDS_SINCE_START_1000·=·1000;
+        1 │ + const·GET_MILLISECONDS_IN_DAY_1000·=·1000;
      1  2 │   var foo = 0 + 31;
      2  3 │   a = a + 5;
     ····· │ 
     27 28 │   
     28 29 │   function getMillisecondsSinceStart() {
     29    │ - → return·getSecondsInDay()·*·1000;
-       30 │ + → return·getSecondsInDay()·*·GET_MILLISECONDS_SINCE_START_1000;
+       30 │ + → return·getSecondsInDay()·*·GET_MILLISECONDS_IN_DAY_1000;
     30 31 │   }
     31 32 │   
   
@@ -560,16 +560,16 @@ invalid.tsx:33:19 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━�
   
   i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
   
-  i Unsafe fix: Extract the magic number into SCHEDULE_SET_TIMEOUT_100.
+  i Unsafe fix: Extract the magic number into CALL_LATER_SET_TIMEOUT_100.
   
-        1 │ + const·SCHEDULE_SET_TIMEOUT_100·=·100;
+        1 │ + const·CALL_LATER_SET_TIMEOUT_100·=·100;
      1  2 │   var foo = 0 + 31;
      2  3 │   a = a + 5;
     ····· │ 
     31 32 │   
     32 33 │   function schedule(work) {
     33    │ - → setTimeout(work,·100);
-       34 │ + → setTimeout(work,·SCHEDULE_SET_TIMEOUT_100);
+       34 │ + → setTimeout(work,·CALL_LATER_SET_TIMEOUT_100);
     34 35 │   }
     35 36 │   
   
@@ -590,16 +590,16 @@ invalid.tsx:38:17 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━�
   
   i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
   
-  i Unsafe fix: Extract the magic number into USES_FALLBACK_31.
+  i Unsafe fix: Extract the magic number into FOO_31.
   
-        1 │ + const·USES_FALLBACK_31·=·31;
+        1 │ + const·FOO_31·=·31;
      1  2 │   var foo = 0 + 31;
      2  3 │   a = a + 5;
     ····· │ 
     36 37 │   const existing = 1;
     37 38 │   function usesFallback(value) {
     38    │ - → return·value·+·31;
-       39 │ + → return·value·+·USES_FALLBACK_31;
+       39 │ + → return·value·+·FOO_31;
     39 40 │   }
     40 41 │   
   
@@ -619,16 +619,16 @@ invalid.tsx:42:18 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━�
   
   i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
   
-  i Unsafe fix: Extract the magic number into NUMBER_7_31.
+  i Unsafe fix: Extract the magic number into FOO_31.
   
-        1 │ + const·NUMBER_7_31·=·31;
+        1 │ + const·FOO_31·=·31;
      1  2 │   var foo = 0 + 31;
      2  3 │   a = a + 5;
     ····· │ 
     40 41 │   
     41 42 │   const numericKeys = {};
     42    │ - numericKeys[7]·=·31;
-       43 │ + numericKeys[7]·=·NUMBER_7_31;
+       43 │ + numericKeys[7]·=·FOO_31;
     43 44 │   
     44 45 │   const bigintTotal = bigintValue + 123n;
   
@@ -740,16 +740,16 @@ invalid.tsx:48:39 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━�
   
   i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
   
-  i Unsafe fix: Extract the magic number into MIXED_ASSERTIONS_31.
+  i Unsafe fix: Extract the magic number into FOO_31.
   
-        1 │ + const·MIXED_ASSERTIONS_31·=·31;
+        1 │ + const·FOO_31·=·31;
      1  2 │   var foo = 0 + 31;
      2  3 │   a = a + 5;
     ····· │ 
     46 47 │   
     47 48 │   const assertedNumber = (31 as const) + value;
     48    │ - const·mixedAssertions·=·[31·as·const,·31];
-       49 │ + const·mixedAssertions·=·[31·as·const,·MIXED_ASSERTIONS_31];
+       49 │ + const·mixedAssertions·=·[31·as·const,·FOO_31];
     49 50 │   const nestedAssertion = ((31 as const) as number) + value;
     50 51 │   
   

--- a/crates/biome_js_analyze/tests/specs/style/noMagicNumbers/legacy-octal.cjs
+++ b/crates/biome_js_analyze/tests/specs/style/noMagicNumbers/legacy-octal.cjs
@@ -1,0 +1,6 @@
+console.log(071);
+
+with (scope) {
+	console.log(31);
+}
+console.log(31);

--- a/crates/biome_js_analyze/tests/specs/style/noMagicNumbers/legacy-octal.cjs.snap
+++ b/crates/biome_js_analyze/tests/specs/style/noMagicNumbers/legacy-octal.cjs.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: legacy-octal.cjs
+---
+# Input
+```cjs
+console.log(071);
+
+with (scope) {
+	console.log(31);
+}
+console.log(31);
+
+```
+
+# Diagnostics
+```
+legacy-octal.cjs:1:13 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Magic number detected. Extract it to a constant with a meaningful name.
+  
+  > 1 │ console.log(071);
+      │             ^^^
+    2 │ 
+    3 │ with (scope) {
+  
+  i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
+  
+  i Unsafe fix: Extract the magic number into LOG_071.
+  
+    1   │ - console.log(071);
+      1 │ + const·LOG_071·=·071;
+      2 │ + console.log(LOG_071);
+    2 3 │   
+    3 4 │   with (scope) {
+  
+
+```
+
+```
+legacy-octal.cjs:4:14 lint/style/noMagicNumbers ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Magic number detected. Extract it to a constant with a meaningful name.
+  
+    3 │ with (scope) {
+  > 4 │ 	console.log(31);
+      │ 	            ^^
+    5 │ }
+    6 │ console.log(31);
+  
+  i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
+  
+
+```
+
+```
+legacy-octal.cjs:6:13 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Magic number detected. Extract it to a constant with a meaningful name.
+  
+    4 │ 	console.log(31);
+    5 │ }
+  > 6 │ console.log(31);
+      │             ^^
+    7 │ 
+  
+  i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
+  
+  i Unsafe fix: Extract the magic number into LOG_31.
+  
+      1 │ + const·LOG_31·=·31;
+    1 2 │   console.log(071);
+    2 3 │   
+    ··· │ 
+    4 5 │   	console.log(31);
+    5 6 │   }
+    6   │ - console.log(31);
+      7 │ + console.log(LOG_31);
+    7 8 │   
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/style/noMagicNumbers/repeated.tsx
+++ b/crates/biome_js_analyze/tests/specs/style/noMagicNumbers/repeated.tsx
@@ -1,0 +1,5 @@
+// File header
+
+function repeatedNumbers(value) {
+	return value + 5 + 5;
+}

--- a/crates/biome_js_analyze/tests/specs/style/noMagicNumbers/repeated.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/style/noMagicNumbers/repeated.tsx.snap
@@ -55,16 +55,16 @@ repeated.tsx:4:21 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━�
   
   i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
   
-  i Unsafe fix: Extract the magic number into REPEATED_NUMBERS_5_2.
+  i Unsafe fix: Extract the magic number into REPEATED_NUMBERS_5.
   
     1   │ - //·File·header
     2   │ - 
       1 │ + //·File·header
-      2 │ + const·REPEATED_NUMBERS_5_2·=·5;
+      2 │ + const·REPEATED_NUMBERS_5·=·5;
       3 │ + 
     3 4 │   function repeatedNumbers(value) {
     4   │ - → return·value·+·5·+·5;
-      5 │ + → return·value·+·5·+·REPEATED_NUMBERS_5_2;
+      5 │ + → return·value·+·5·+·REPEATED_NUMBERS_5;
     5 6 │   }
     6 7 │   
   

--- a/crates/biome_js_analyze/tests/specs/style/noMagicNumbers/repeated.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/style/noMagicNumbers/repeated.tsx.snap
@@ -1,0 +1,72 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: repeated.tsx
+---
+# Input
+```tsx
+// File header
+
+function repeatedNumbers(value) {
+	return value + 5 + 5;
+}
+
+```
+
+# Diagnostics
+```
+repeated.tsx:4:17 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Magic number detected. Extract it to a constant with a meaningful name.
+  
+    3 │ function repeatedNumbers(value) {
+  > 4 │ 	return value + 5 + 5;
+      │ 	               ^
+    5 │ }
+    6 │ 
+  
+  i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
+  
+  i Unsafe fix: Extract the magic number into REPEATED_NUMBERS_5.
+  
+    1   │ - //·File·header
+    2   │ - 
+      1 │ + //·File·header
+      2 │ + const·REPEATED_NUMBERS_5·=·5;
+      3 │ + 
+    3 4 │   function repeatedNumbers(value) {
+    4   │ - → return·value·+·5·+·5;
+      5 │ + → return·value·+·REPEATED_NUMBERS_5·+·5;
+    5 6 │   }
+    6 7 │   
+  
+
+```
+
+```
+repeated.tsx:4:21 lint/style/noMagicNumbers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Magic number detected. Extract it to a constant with a meaningful name.
+  
+    3 │ function repeatedNumbers(value) {
+  > 4 │ 	return value + 5 + 5;
+      │ 	                   ^
+    5 │ }
+    6 │ 
+  
+  i Code is more readable and refactoring easier when special numbers are declared as constants as it makes their meaning explicit.
+  
+  i Unsafe fix: Extract the magic number into REPEATED_NUMBERS_5_2.
+  
+    1   │ - //·File·header
+    2   │ - 
+      1 │ + //·File·header
+      2 │ + const·REPEATED_NUMBERS_5_2·=·5;
+      3 │ + 
+    3 4 │   function repeatedNumbers(value) {
+    4   │ - → return·value·+·5·+·5;
+      5 │ + → return·value·+·5·+·REPEATED_NUMBERS_5_2;
+    5 6 │   }
+    6 7 │   
+  
+
+```

--- a/crates/biome_rowan/src/ast/batch.rs
+++ b/crates/biome_rowan/src/ast/batch.rs
@@ -78,6 +78,7 @@ impl<L: Language> CommitChange<L> {
         )
     }
 
+    /// Reports whether both changes insert identical elements into the same parent slot.
     fn is_duplicate_insertion(&self, other: &Self) -> bool {
         self.is_insertion
             && other.is_insertion
@@ -214,8 +215,23 @@ where
     /// changes are applied together in a single [`Self::commit`] call.
     /// Non-overlapping changes combine naturally. If two changes target the
     /// same slot of the same parent, the existing last-write-wins semantics
-    /// apply. Identical insertions at the same slot are kept only once.
+    /// apply.
     pub fn merge(&mut self, other: Self) {
+        debug_assert!(
+            self.root == other.root,
+            "Cannot merge mutations from different trees"
+        );
+        self.changes.extend(other.changes);
+    }
+
+    /// Merge mutations produced by separate analyzer actions.
+    ///
+    /// Action mutations need additional ordering and trivia handling because
+    /// they are collected independently and applied together during fix-all.
+    /// This keeps identical list insertions from being repeated, coalesces
+    /// header cleanup with replacements, and preserves the order in which
+    /// actions were collected.
+    pub fn merge_actions(&mut self, other: Self) {
         debug_assert!(
             self.root == other.root,
             "Cannot merge mutations from different trees"
@@ -292,6 +308,7 @@ where
             }));
     }
 
+    /// Removes leading trivia from the first token of a node or from a token element.
     fn remove_leading_trivia(element: SyntaxElement<L>) -> SyntaxElement<L> {
         match element {
             SyntaxElement::Node(node) => node
@@ -421,6 +438,7 @@ where
         self.insert_element_internal(parent, slot_index, new_element, true);
     }
 
+    /// Records a list insertion together with its slot, merge order, and header-transfer state.
     fn insert_element_internal(
         &mut self,
         parent: SyntaxNode<L>,
@@ -612,6 +630,7 @@ where
         self.push_change_internal(prev_element, next_element, false);
     }
 
+    /// Records a leading-trivia removal that can be coalesced with a later replacement.
     fn push_header_cleanup_change(
         &mut self,
         prev_element: SyntaxElement<L>,
@@ -620,6 +639,7 @@ where
         self.push_change_internal(prev_element, next_element, true);
     }
 
+    /// Records a replacement or removal and preserves the metadata needed to merge it safely.
     fn push_change_internal(
         &mut self,
         prev_element: SyntaxElement<L>,
@@ -1146,7 +1166,7 @@ pub mod test {
         let source = before.syntax().text_with_trivia().to_string();
         let mut second = before.begin();
         second.replace_node(a, c);
-        first.merge(second);
+        first.merge_actions(second);
 
         let (after, text_edit) = first.commit_with_text_range_and_edit(true);
         assert_eq!(expected_debug, format!("{after:#?}"));
@@ -1191,7 +1211,7 @@ pub mod test {
             0,
             literal_with_header("B", "// second\n").into_syntax().into(),
         );
-        first.merge(second);
+        first.merge_actions(second);
 
         let output = first.commit().to_string();
         assert_eq!(output.matches("// first\n").count(), 1);

--- a/crates/biome_rowan/src/ast/batch.rs
+++ b/crates/biome_rowan/src/ast/batch.rs
@@ -828,11 +828,12 @@ where
                 if with_text_range_and_edit {
                     let mut text_modifications = modifications.clone();
                     text_modifications.sort_by(|left, right| {
-                        if left.0 == right.0 && left.3 && right.3 {
-                            left.4.cmp(&right.4)
-                        } else {
-                            cmp::Ordering::Equal
-                        }
+                        right.0.cmp(&left.0).then_with(|| match (left.3, right.3) {
+                            (false, true) => cmp::Ordering::Less,
+                            (true, false) => cmp::Ordering::Greater,
+                            (true, true) => left.4.cmp(&right.4),
+                            (false, false) => right.4.cmp(&left.4),
+                        })
                     });
                     for (new_node_slot, new_node, is_from_action, is_insertion, _) in
                         &text_modifications

--- a/crates/biome_rowan/src/ast/batch.rs
+++ b/crates/biome_rowan/src/ast/batch.rs
@@ -31,7 +31,8 @@ where
 
 /// Stores the changes internally used by the [BatchMutation::commit] algorithm.
 /// It needs to be sorted by depth in decreasing order, then by range start and
-/// by slot in increasing order.
+/// by slot in increasing order. The mutation order breaks ties between
+/// independent insertions at the same list slot.
 ///
 /// This is necessary so we can aggregate all changes to the same node using "peek".
 #[derive(Debug, Clone)]
@@ -42,6 +43,11 @@ struct CommitChange<L: Language> {
     new_node_slot: usize,
     new_node: Option<SyntaxElement<L>>,
     is_from_action: bool,
+    is_insertion: bool,
+    is_header_transfer: bool,
+    is_header_cleanup: bool,
+    previous_range: Option<TextRange>,
+    order: usize,
 }
 
 impl<L: Language> CommitChange<L> {
@@ -51,7 +57,7 @@ impl<L: Language> CommitChange<L> {
     /// index of the corresponding change.
     ///
     /// So, we order first by depth. Then by the range of the node. Then by the
-    /// slot index of the node.
+    /// slot index of the node and the mutation order.
     ///
     /// The first is important to guarantee that all nodes that will be changed
     /// in the future are still valid with using SyntaxNode that we have.
@@ -62,11 +68,13 @@ impl<L: Language> CommitChange<L> {
     ///
     /// All of them will be prioritized in the descending order in a binary heap
     /// to ensure one change won't invalidate its following changes.
-    fn key(&self) -> (usize, u32, usize) {
+    fn key(&self) -> (usize, u32, usize, u8, usize) {
         (
             self.parent_depth,
             self.parent_range.map(|(start, _)| start).unwrap_or(0),
             self.new_node_slot,
+            u8::from(!self.is_insertion),
+            self.order,
         )
     }
 }
@@ -96,6 +104,7 @@ where
 {
     root: SyntaxNode<L>,
     changes: BinaryHeap<CommitChange<L>>,
+    next_order: usize,
 }
 
 impl<L> BatchMutation<L>
@@ -181,6 +190,7 @@ where
         Self {
             root,
             changes: BinaryHeap::new(),
+            next_order: 0,
         }
     }
 
@@ -196,7 +206,80 @@ where
             self.root == other.root,
             "Cannot merge mutations from different trees"
         );
-        self.changes.extend(other.changes);
+        let order_offset = self.next_order;
+        self.next_order += other.next_order;
+        let mut existing_changes = std::mem::take(&mut self.changes).into_vec();
+        let incoming_changes = other.changes.into_vec();
+        let incoming_replacement_ranges = incoming_changes
+            .iter()
+            .filter(|change| {
+                !change.is_insertion && !change.is_header_cleanup && change.new_node.is_some()
+            })
+            .filter_map(|change| change.previous_range)
+            .collect::<Vec<_>>();
+        let existing_replacement_ranges = existing_changes
+            .iter()
+            .filter(|change| {
+                !change.is_insertion && !change.is_header_cleanup && change.new_node.is_some()
+            })
+            .filter_map(|change| change.previous_range)
+            .collect::<Vec<_>>();
+        existing_changes.retain(|change| {
+            !change.is_header_cleanup
+                || !change
+                    .previous_range
+                    .is_some_and(|range| incoming_replacement_ranges.contains(&range))
+        });
+        let existing_header_transfers = existing_changes
+            .iter()
+            .filter(|change| change.is_header_transfer)
+            .filter_map(|change| {
+                change
+                    .parent
+                    .clone()
+                    .map(|parent| (parent, change.new_node_slot))
+            })
+            .collect::<Vec<_>>();
+        self.changes.extend(existing_changes);
+        self.changes
+            .extend(incoming_changes.into_iter().filter_map(|mut change| {
+                change.order += order_offset;
+                if change.is_header_cleanup
+                    && change
+                        .previous_range
+                        .is_some_and(|range| existing_replacement_ranges.contains(&range))
+                {
+                    return None;
+                }
+                let has_matching_header_transfer = change.is_header_transfer
+                    && existing_header_transfers.iter().any(|(parent, slot)| {
+                        *slot == change.new_node_slot
+                            && change
+                                .parent
+                                .as_ref()
+                                .is_some_and(|change_parent| change_parent == parent)
+                    });
+                if has_matching_header_transfer {
+                    change.new_node = change.new_node.map(Self::remove_leading_trivia);
+                    change.is_header_transfer = false;
+                }
+                Some(change)
+            }));
+    }
+
+    fn remove_leading_trivia(element: SyntaxElement<L>) -> SyntaxElement<L> {
+        match element {
+            SyntaxElement::Node(node) => node
+                .first_token()
+                .and_then(|token| {
+                    let replacement = token.with_leading_trivia_pieces([]);
+                    node.clone().replace_child(token.into(), replacement.into())
+                })
+                .map_or_else(|| node.into(), SyntaxElement::Node),
+            SyntaxElement::Token(token) => {
+                SyntaxElement::Token(token.with_leading_trivia_pieces([]))
+            }
+        }
     }
 
     /// Push a change to replace the "prev_node" with "next_node".
@@ -287,6 +370,59 @@ where
         self.push_change(prev_element, Some(next_element))
     }
 
+    /// Push a change that inserts an element into a list at `slot_index`.
+    ///
+    /// List insertions are kept separate from replacements so independent
+    /// mutations can be merged without one list replacement overwriting the other.
+    pub fn insert_element(
+        &mut self,
+        parent: SyntaxNode<L>,
+        slot_index: usize,
+        new_element: SyntaxElement<L>,
+    ) {
+        self.insert_element_internal(parent, slot_index, new_element, false);
+    }
+
+    /// Push a list insertion whose leading trivia came from the original first item.
+    ///
+    /// When two such mutations are merged, the first insertion retains the header and later
+    /// insertions have only their copied leading trivia removed.
+    pub fn insert_element_with_header(
+        &mut self,
+        parent: SyntaxNode<L>,
+        slot_index: usize,
+        new_element: SyntaxElement<L>,
+    ) {
+        self.insert_element_internal(parent, slot_index, new_element, true);
+    }
+
+    fn insert_element_internal(
+        &mut self,
+        parent: SyntaxNode<L>,
+        slot_index: usize,
+        new_element: SyntaxElement<L>,
+        is_header_transfer: bool,
+    ) {
+        debug_assert!(parent.kind().is_list());
+        debug_assert!(slot_index <= parent.slots().count());
+
+        let parent_range = parent.text_range_with_trivia();
+        self.changes.push(CommitChange {
+            parent_depth: parent.ancestors().count(),
+            parent: Some(parent),
+            parent_range: Some((parent_range.start().into(), parent_range.end().into())),
+            new_node_slot: slot_index,
+            new_node: Some(new_element),
+            is_from_action: true,
+            is_insertion: true,
+            is_header_transfer,
+            is_header_cleanup: false,
+            previous_range: None,
+            order: self.next_order,
+        });
+        self.next_order += 1;
+    }
+
     /// Push a change to replace the "prev_node" with "next_node".
     ///
     /// Changes to take effect must be committed.
@@ -309,6 +445,13 @@ where
         next_token: SyntaxToken<L>,
     ) {
         self.replace_element_discard_trivia(prev_token.into(), next_token.into())
+    }
+
+    /// Pushes a leading-trivia cleanup that can be coalesced with a merged
+    /// replacement of the same syntax element.
+    pub fn clear_leading_trivia(&mut self, token: SyntaxToken<L>) {
+        let next_token = token.with_leading_trivia_pieces([]);
+        self.push_header_cleanup_change(token.into(), Some(next_token.into()));
     }
 
     /// Push a change to replace the "prev_node" with "next_node".
@@ -441,6 +584,23 @@ where
         prev_element: SyntaxElement<L>,
         next_element: Option<SyntaxElement<L>>,
     ) {
+        self.push_change_internal(prev_element, next_element, false);
+    }
+
+    fn push_header_cleanup_change(
+        &mut self,
+        prev_element: SyntaxElement<L>,
+        next_element: Option<SyntaxElement<L>>,
+    ) {
+        self.push_change_internal(prev_element, next_element, true);
+    }
+
+    fn push_change_internal(
+        &mut self,
+        prev_element: SyntaxElement<L>,
+        next_element: Option<SyntaxElement<L>>,
+        is_header_cleanup: bool,
+    ) {
         let new_node_slot = prev_element.index();
         let parent = prev_element.parent();
         #[cfg(debug_assertions)]
@@ -456,6 +616,10 @@ where
         });
         let parent_depth = parent.as_ref().map(|p| p.ancestors().count()).unwrap_or(0);
 
+        let previous_range = match &prev_element {
+            SyntaxElement::Node(node) => node.text_range_with_trivia(),
+            SyntaxElement::Token(token) => token.text_range(),
+        };
         self.changes.push(CommitChange {
             parent_depth,
             parent,
@@ -463,7 +627,13 @@ where
             new_node_slot,
             new_node: next_element,
             is_from_action: true,
+            is_insertion: false,
+            is_header_transfer: false,
+            is_header_cleanup,
+            previous_range: Some(previous_range),
+            order: self.next_order,
         });
+        self.next_order += 1;
     }
 
     /// Returns the range of the document modified by this mutation along with
@@ -516,7 +686,9 @@ where
         self,
         with_text_range_and_edit: bool,
     ) -> (SyntaxNode<L>, Option<(TextRange, TextEdit)>) {
-        let Self { root, mut changes } = self;
+        let Self {
+            root, mut changes, ..
+        } = self;
 
         // Ordered text mutation list sorted by text range
         let mut text_mutation_list: Vec<(TextRange, Option<SyntaxElement<L>>)> =
@@ -532,6 +704,8 @@ where
             parent: curr_parent,
             parent_depth: curr_parent_depth,
             is_from_action: curr_is_from_action,
+            is_insertion: curr_is_insertion,
+            order: curr_order,
             ..
         }) = changes.pop()
         {
@@ -547,8 +721,13 @@ where
 
                 // Aggregate all modifications to the current parent
                 // This works because of the Ord we defined in the [CommitChange] struct
-                let mut modifications =
-                    vec![(curr_new_node_slot, curr_new_node, curr_is_from_action)];
+                let mut modifications = vec![(
+                    curr_new_node_slot,
+                    curr_new_node,
+                    curr_is_from_action,
+                    curr_is_insertion,
+                    curr_order,
+                )];
 
                 while changes
                     .peek()
@@ -560,47 +739,110 @@ where
                         new_node: next_new_node,
                         new_node_slot: next_new_node_slot,
                         is_from_action: next_is_from_action,
+                        is_insertion: next_is_insertion,
+                        order: next_order,
                         ..
                     } = changes.pop().expect("changes.pop");
 
                     // If we have two modifications to the same slot,
                     // last write wins
-                    if let Some(&(prev_new_node_slot, ..)) = modifications.last()
+                    if let Some(&(prev_new_node_slot, _, _, prev_is_insertion, _)) =
+                        modifications.last()
                         && prev_new_node_slot == next_new_node_slot
+                        && !prev_is_insertion
+                        && !next_is_insertion
                     {
-                        modifications.pop();
+                        // Heap priority visits the later replacement first, so keep it and
+                        // discard the earlier write to preserve last-write-wins semantics.
+                        continue;
                     }
 
                     // Add to the modifications
-                    modifications.push((next_new_node_slot, next_new_node, next_is_from_action));
+                    modifications.push((
+                        next_new_node_slot,
+                        next_new_node,
+                        next_is_from_action,
+                        next_is_insertion,
+                        next_order,
+                    ));
                 }
 
+                // Each same-slot splice is placed before the prior insertion. Apply those
+                // changes in reverse mutation order so the committed CST follows merge order,
+                // while keeping higher slots ahead of lower slots.
+                modifications.sort_by(|left, right| {
+                    right.0.cmp(&left.0).then_with(|| match (left.3, right.3) {
+                        (false, true) => cmp::Ordering::Less,
+                        (true, false) => cmp::Ordering::Greater,
+                        (true, true) => right.4.cmp(&left.4),
+                        (false, false) => right.4.cmp(&left.4),
+                    })
+                });
                 // Collect text mutations, this has to be done before the detach below,
                 // or we'll lose the "deleted_text_range" info
                 if with_text_range_and_edit {
-                    for (new_node_slot, new_node, is_from_action) in &modifications {
+                    let mut text_modifications = modifications.clone();
+                    text_modifications.sort_by(|left, right| {
+                        if left.0 == right.0 && left.3 && right.3 {
+                            left.4.cmp(&right.4)
+                        } else {
+                            cmp::Ordering::Equal
+                        }
+                    });
+                    for (new_node_slot, new_node, is_from_action, is_insertion, _) in
+                        &text_modifications
+                    {
                         if !is_from_action {
                             continue;
                         }
-                        let deleted_text_range = match curr_parent.slots().nth(*new_node_slot) {
-                            Some(SyntaxSlot::Node(node)) => node.text_range_with_trivia(),
-                            Some(SyntaxSlot::Token(token)) => token.text_range(),
-                            Some(SyntaxSlot::Empty { index }) => {
-                                TextRange::new(index.into(), index.into())
+                        let deleted_text_range = if *is_insertion {
+                            let position = match curr_parent.slots().nth(*new_node_slot) {
+                                Some(SyntaxSlot::Node(node)) => {
+                                    node.text_range_with_trivia().start()
+                                }
+                                Some(SyntaxSlot::Token(token)) => token.text_range().start(),
+                                Some(SyntaxSlot::Empty { index }) => index.into(),
+                                None => curr_parent.text_range_with_trivia().end(),
+                            };
+                            TextRange::new(position, position)
+                        } else {
+                            match curr_parent.slots().nth(*new_node_slot) {
+                                Some(SyntaxSlot::Node(node)) => node.text_range_with_trivia(),
+                                Some(SyntaxSlot::Token(token)) => token.text_range(),
+                                Some(SyntaxSlot::Empty { index }) => {
+                                    TextRange::new(index.into(), index.into())
+                                }
+                                None => continue,
                             }
-                            None => continue,
                         };
-                        // We use binary search to keep the text mutations in order
-                        match text_mutation_list
-                            .binary_search_by(|(range, _)| range.ordering(deleted_text_range))
-                        {
-                            // Overwrite the text mutation with an overlapping text range
-                            Ok(pos) => {
-                                text_mutation_list[pos] = (deleted_text_range, new_node.clone())
+                        // Keep the text mutations ordered by source range. Equal insertion
+                        // ranges use an explicit upper-bound scan because binary search may
+                        // return any one of several equal entries.
+                        if deleted_text_range.is_empty() && new_node.is_some() {
+                            let mut pos = match text_mutation_list
+                                .binary_search_by(|(range, _)| range.ordering(deleted_text_range))
+                            {
+                                Ok(pos) | Err(pos) => pos,
+                            };
+                            while text_mutation_list
+                                .get(pos)
+                                .is_some_and(|(range, _)| *range == deleted_text_range)
+                            {
+                                pos += 1;
                             }
-                            // Insert the text mutation at the correct position
-                            Err(pos) => text_mutation_list
-                                .insert(pos, (deleted_text_range, new_node.clone())),
+                            text_mutation_list.insert(pos, (deleted_text_range, new_node.clone()));
+                        } else {
+                            match text_mutation_list
+                                .binary_search_by(|(range, _)| range.ordering(deleted_text_range))
+                            {
+                                // Overwrite an overlapping non-insertion text mutation.
+                                Ok(pos) => {
+                                    text_mutation_list[pos] = (deleted_text_range, new_node.clone())
+                                }
+                                // Insert the text mutation at the correct position.
+                                Err(pos) => text_mutation_list
+                                    .insert(pos, (deleted_text_range, new_node.clone())),
+                            }
                         }
                     }
                 }
@@ -609,8 +851,10 @@ where
                 // and push a pending change to its parent
                 let mut current_parent = curr_parent.detach();
                 let is_list = current_parent.kind().is_list();
-                for (new_node_slot, new_node, ..) in modifications.clone() {
-                    current_parent = if is_list && new_node.is_none() {
+                for (new_node_slot, new_node, _, is_insertion, _) in modifications.clone() {
+                    current_parent = if is_insertion {
+                        current_parent.splice_slots(new_node_slot..new_node_slot, once(new_node))
+                    } else if is_list && new_node.is_none() {
                         current_parent.splice_slots(new_node_slot..=new_node_slot, empty())
                     } else {
                         current_parent.splice_slots(new_node_slot..=new_node_slot, once(new_node))
@@ -624,6 +868,11 @@ where
                     new_node_slot: curr_parent_slot,
                     new_node: Some(SyntaxElement::Node(current_parent)),
                     is_from_action: false,
+                    is_insertion: false,
+                    is_header_transfer: false,
+                    is_header_cleanup: false,
+                    previous_range: None,
+                    order: curr_order,
                 });
             }
             // If parent is None, we reached the document root
@@ -799,6 +1048,22 @@ pub mod test {
             .unwrap()
     }
 
+    fn literal_with_header(value: &str, header: &str) -> LiteralExpression {
+        let mut builder = RawSyntaxTreeBuilder::new();
+        builder.start_node(RawLanguageKind::LITERAL_EXPRESSION);
+        builder.token_with_trivia(
+            RawLanguageKind::STRING_TOKEN,
+            &format!("{header}{value}"),
+            &[TriviaPiece::single_line_comment(header.len() as u32)],
+            &[],
+        );
+        builder.finish_node();
+        builder
+            .finish()
+            .cast::<LiteralExpression>()
+            .expect("literal expression")
+    }
+
     #[test]
     pub fn ok_batch_mutation_no_changes() {
         let (before, before_debug) = tree_one("a");
@@ -840,6 +1105,74 @@ pub mod test {
         let after = batch.commit();
 
         assert_eq!(expected_debug, format!("{after:#?}"));
+    }
+
+    #[test]
+    pub fn ok_batch_mutation_merge_same_slot_last_write_wins() {
+        let (before, _) = tree_one("a");
+        let (expected, expected_debug) = tree_one("c");
+
+        let a = find(&before, "a");
+        let b = clone_detach(&tree_one("b").0, "b");
+        let c = clone_detach(&expected, "c");
+
+        let mut first = before.clone().begin();
+        first.replace_node(a.clone(), b);
+        let source = before.syntax().text_with_trivia().to_string();
+        let mut second = before.begin();
+        second.replace_node(a, c);
+        first.merge(second);
+
+        let (after, text_edit) = first.commit_with_text_range_and_edit(true);
+        assert_eq!(expected_debug, format!("{after:#?}"));
+        let (_, text_edit) = text_edit.expect("replacement should produce a text edit");
+        assert_eq!(text_edit.new_string(&source), after.to_string());
+    }
+
+    #[test]
+    pub fn ok_batch_mutation_merge_header_transfer_is_scoped_to_parent() {
+        let mut builder = RawSyntaxTreeBuilder::new();
+        builder.start_node(RawLanguageKind::ROOT);
+        builder.start_node(RawLanguageKind::EXPRESSION_LIST);
+        builder
+            .start_node(RawLanguageKind::LITERAL_EXPRESSION)
+            .token(RawLanguageKind::STRING_TOKEN, "first")
+            .finish_node()
+            .finish_node();
+        builder.start_node(RawLanguageKind::EXPRESSION_LIST);
+        builder
+            .start_node(RawLanguageKind::LITERAL_EXPRESSION)
+            .token(RawLanguageKind::STRING_TOKEN, "second")
+            .finish_node()
+            .finish_node();
+        builder.finish_node();
+        let root = builder.finish().cast::<RawLanguageRoot>().unwrap();
+        let lists = root
+            .syntax()
+            .descendants()
+            .filter(|node| node.kind() == RawLanguageKind::EXPRESSION_LIST)
+            .collect::<Vec<_>>();
+        assert_eq!(lists.len(), 2);
+
+        let mut first = root.clone().begin();
+        first.insert_element_with_header(
+            lists[0].clone(),
+            0,
+            literal_with_header("A", "// first\n").into_syntax().into(),
+        );
+        let mut second = root.begin();
+        second.insert_element_with_header(
+            lists[1].clone(),
+            0,
+            literal_with_header("B", "// second\n").into_syntax().into(),
+        );
+        first.merge(second);
+
+        let output = first.commit().to_string();
+        assert_eq!(output.matches("// first\n").count(), 1);
+        assert_eq!(output.matches("// second\n").count(), 1);
+        assert!(output.contains("// first\nAfirst"));
+        assert!(output.contains("// second\nBsecond"));
     }
 
     /// Builds a tree with two LITERAL_EXPRESSION nodes where the first node's

--- a/crates/biome_rowan/src/ast/batch.rs
+++ b/crates/biome_rowan/src/ast/batch.rs
@@ -77,6 +77,20 @@ impl<L: Language> CommitChange<L> {
             self.order,
         )
     }
+
+    fn is_duplicate_insertion(&self, other: &Self) -> bool {
+        self.is_insertion
+            && other.is_insertion
+            && self.parent == other.parent
+            && self.new_node_slot == other.new_node_slot
+            && match (&self.new_node, &other.new_node) {
+                (Some(left), Some(right)) => {
+                    left.kind() == right.kind() && left.to_string() == right.to_string()
+                }
+                (None, None) => true,
+                _ => false,
+            }
+    }
 }
 
 impl<L: Language> PartialEq for CommitChange<L> {
@@ -200,7 +214,7 @@ where
     /// changes are applied together in a single [`Self::commit`] call.
     /// Non-overlapping changes combine naturally. If two changes target the
     /// same slot of the same parent, the existing last-write-wins semantics
-    /// apply.
+    /// apply. Identical insertions at the same slot are kept only once.
     pub fn merge(&mut self, other: Self) {
         debug_assert!(
             self.root == other.root,
@@ -230,6 +244,11 @@ where
                     .previous_range
                     .is_some_and(|range| incoming_replacement_ranges.contains(&range))
         });
+        let existing_insertions = existing_changes
+            .iter()
+            .filter(|change| change.is_insertion)
+            .cloned()
+            .collect::<Vec<_>>();
         let existing_header_transfers = existing_changes
             .iter()
             .filter(|change| change.is_header_transfer)
@@ -243,6 +262,12 @@ where
         self.changes.extend(existing_changes);
         self.changes
             .extend(incoming_changes.into_iter().filter_map(|mut change| {
+                if existing_insertions
+                    .iter()
+                    .any(|existing| existing.is_duplicate_insertion(&change))
+                {
+                    return None;
+                }
                 change.order += order_offset;
                 if change.is_header_cleanup
                     && change

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -817,7 +817,7 @@ impl<'a> ProcessFixAll<'a> {
                 continue;
             }
             match &mut master {
-                Some(m) => m.merge(action.mutation),
+                Some(m) => m.merge_actions(action.mutation),
                 None => master = Some(action.mutation),
             }
             count += 1;

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -7058,6 +7058,7 @@ export interface RuleWithUseSolidForComponentOptions {
 	options?: UseSolidForComponentOptions;
 }
 export interface RuleWithUseTopLevelRegexOptions {
+	fix?: FixKind;
 	level: RulePlainConfiguration;
 	options?: UseTopLevelRegexOptions;
 }
@@ -7154,6 +7155,7 @@ export interface RuleWithNoJsxLiteralsOptions {
 	options?: NoJsxLiteralsOptions;
 }
 export interface RuleWithNoMagicNumbersOptions {
+	fix?: FixKind;
 	level: RulePlainConfiguration;
 	options?: NoMagicNumbersOptions;
 }

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -9570,6 +9570,7 @@
 		"RuleWithNoMagicNumbersOptions": {
 			"type": "object",
 			"properties": {
+				"fix": { "anyOf": [{ "$ref": "#/$defs/FixKind" }, { "type": "null" }] },
 				"level": { "$ref": "#/$defs/RulePlainConfiguration" },
 				"options": { "$ref": "#/$defs/NoMagicNumbersOptions" }
 			},
@@ -12704,6 +12705,7 @@
 		"RuleWithUseTopLevelRegexOptions": {
 			"type": "object",
 			"properties": {
+				"fix": { "anyOf": [{ "$ref": "#/$defs/FixKind" }, { "type": "null" }] },
 				"level": { "$ref": "#/$defs/RulePlainConfiguration" },
 				"options": { "$ref": "#/$defs/UseTopLevelRegexOptions" }
 			},


### PR DESCRIPTION


## Summary

This adds automatic fixes for magic constants and inline regex issues. The constants are extracted to the top-level module and automatically named based on the context; heuristics and collisions are avoided. They are de-duplicated as well to avoid repetition.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
Related to https://github.com/biomejs/biome/issues/4333, https://github.com/biomejs/biome/pull/6562

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Changes

The two rules share a new extraction module (`module_constants`) that:

- Suggests readable names from the surrounding code.
- Reuses one declaration when the same literal appears multiple times in a fix-all.
- Avoids name collisions and unsafe shadowing.
- Preserves comments, headers, and line-ending conventions.
- Places declarations after imports and directive prologues.
- Rejects cases involving dynamic scope behaviour such as with and direct eval.

`BatchMutation` has been updated to safely merge these extractions via `merge_actions`, including multiple declarations inserted at the same module slot and deduplication of identical declarations.

Marked as unsafe simply due to changing the value scope and evaluation time; otherwise, the name collisions are handled automatically.

## Test Plan

I've added extensive tests for unit, snapshot, and integration. 

I also tested it on a big real-world project with several of these issues auto-fixed. Addressing it in the big repo was too time-consuming, so I created the auto-fix.

```sh
cd crates/biome_js_analyze/ && cargo test module_constant
cd crates/biome_js_analyze/ && cargo test use_top_level_regex
cd crates/biome_js_analyze/ && cargo test no_magic_numbers
```

## Docs

Added release notes about the new fix. An LLM was used to find the key files and write unit test examples.

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->


