### PR TITLE
fix(inference): use local inference for constructor dependent members

### DIFF
--- a/.changeset/tricky-meals-judge.md
+++ b/.changeset/tricky-meals-judge.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11390](https://github.com/biomejs/biome/issues/11390): [`noFloatingPromises`](https://biomejs.dev/linter/rules/no-floating-promises/) no longer performs unnecessary type inference on call arguments when checking methods of non-generic class instances created with `new`.

--- a/.claude/skills/type-inference/SKILL.md
+++ b/.claude/skills/type-inference/SKILL.md
@@ -1,408 +1,318 @@
 ---
 name: type-inference
-description: Guide for working with Biome's module graph and type inference system. Use when implementing type-aware lint rules, understanding type resolution, working on the module graph infrastructure, or implementing type inference for new features.
+description: Guide for Biome's Salsa-backed JavaScript and TypeScript type inference. Use when implementing type-aware lint rules, changing raw type collection or inferred type representations, adding analyzer requests or tracked queries, resolving imports or cycles, profiling inference, or testing Salsa invalidation.
 compatibility: Designed for coding agents working on the Biome codebase (github.com/biomejs/biome).
 ---
 
-## Purpose
+# Salsa-Backed Type Inference
 
-Use this skill when working with Biome's type inference system and module graph. Covers type references, resolution phases, and the architecture designed for IDE performance.
+## Scope
 
-## Prerequisites
+Use this skill for JavaScript and TypeScript type inference. It covers the raw
+collector representation, Salsa-backed inferred values, analyzer requests,
+tracked queries, and inference-specific tests.
 
-1. Read `crates/biome_js_type_info/CONTRIBUTING.md` for architecture details
-2. Understand Biome's focus on IDE support and instant updates
-3. Familiarity with TypeScript type system concepts
+For general lint-rule scaffolding, diagnostics, snapshots, or changesets, load
+the corresponding skill instead of duplicating that guidance here. CSS and HTML
+module-graph data is also outside this skill unless it directly participates in
+JavaScript or TypeScript type inference.
 
-## Key Concepts
+## Read First
 
-### Module Graph Constraint
+Read both canonical guides before changing inference architecture:
 
-**Critical rule**: No module may copy or clone data from another module, not even behind `Arc`.
+1. `crates/biome_module_graph/CONTRIBUTING.md` for request and query boundaries,
+   widening, profiling, and Salsa execution tests.
+2. `crates/biome_js_type_info/CONTRIBUTING.md` for raw and inferred type
+   representations, inference layers, handles, normalization, and work limits.
 
-**Why**: Any module can be updated at any time (IDE file changes). Copying data would create stale references that are hard to invalidate.
+Then read the implementation files for the boundary being changed. Do not use
+the following checked-in files as current examples:
 
-**Solution**: Use `TypeReference` instead of direct type references.
+- `crates/biome_js_type_info/src/resolver.rs`
+- `crates/biome_js_type_info/src/flattening.rs`
+- `crates/biome_js_type_info/src/type.rs`
+- `crates/biome_js_type_info/src/conditionals.rs`
+- `crates/biome_js_type_info/src/helpers.rs`
+- `crates/biome_module_graph/src/js_module_info/module_resolver.rs`
 
-### Type Data Structure
+These files are not declared by the active crate module trees. Treat them as
+legacy residue unless the task explicitly concerns removing or migrating them.
 
-Types are stored in `TypeData` enum with many variants:
+## Mental Model
 
-```rust
-// Simplified — see crates/biome_js_type_info/src/type_data.rs for the full enum
-enum TypeData {
-    Unknown,                            // Inference not implemented
-    Global,                             // Global type reference
-    BigInt, Boolean, Null, Number,      // Primitive types
-    String, Symbol, Undefined,
-    Function(Box<Function>),            // Function with parameters
-    Object(Box<Object>),                // Object with properties
-    Class(Box<Class>),                  // Class definition
-    Interface(Box<Interface>),          // Interface definition
-    Union(Box<Union>),                  // Union type (A | B)
-    Intersection(Box<Intersection>),    // Intersection type (A & B)
-    Tuple(Box<Tuple>),                  // Tuple type
-    Literal(Box<Literal>),              // Literal type ("foo", 42)
-    Reference(TypeReference),           // Reference to another type
-    TypeofExpression(Box<TypeofExpression>), // typeof an expression
-    // ... plus Conditional, Generic, TypeOperator, InstanceOf,
-    //     keyword variants (AnyKeyword, NeverKeyword, VoidKeyword, etc.)
-}
+Type inference has five layers:
+
+```text
+syntax and semantic collection
+    -> raw module tables
+    -> analyzer-facing requests
+    -> tracked Salsa queries
+    -> resolver helpers
 ```
 
-### Type References
+Collection walks one module without database access. It records `raw_types`,
+`raw_expressions`, and `raw_binding_types` in `JsModuleInfo`. A request represents
+one analyzer-facing result contract. Tracked queries provide memoization and
+invalidation boundaries. Resolver helpers evaluate raw references, imports,
+expressions, and inferred structures inside those query boundaries.
 
-Instead of direct type references, use `TypeReference`:
+### Two Type Worlds
 
-```rust
-enum TypeReference {
-    Qualifier(Box<TypeReferenceQualifier>),  // Name-based reference
-    Resolved(ResolvedTypeId),                 // Resolved to type ID
-    Import(Box<TypeImportQualifier>),         // Import reference
-}
+Keep the collector and database representations distinct:
+
+| World | Main types | Purpose |
+| --- | --- | --- |
+| Raw collector | `TypeData` / `RawTypeData`, `TypeReference`, `RawTypeId`, `TypeStore` | Records module-local syntax, declarations, imports, and deferred expressions without database access |
+| Database-backed | `InferredTypeData<'db>`, `LocalTypeHandle`, `GlobalTypeId`, Salsa-interned payloads | Carries inferred values and module ownership through tracked computations |
+| Analyzer-facing | `InferredType<'db>` | Provides conservative, bounded inspection methods to lint rules |
+
+Relevant sources:
+
+- Raw types: `crates/biome_js_type_info/src/type_data.rs`
+- Raw collection: `crates/biome_js_type_info/src/local_inference.rs` and
+  `crates/biome_js_type_info/src/type_store.rs`
+- Inferred types: `crates/biome_js_type_info/src/interned_types.rs` and
+  `crates/biome_js_type_info/src/resolved.rs`
+- Analyzer wrapper: `crates/biome_js_type_info/src/inferred_type.rs`
+
+`TypeReference` belongs to the raw world. Database-backed values use module-aware
+handles such as `LocalTypeHandle`; they do not use the legacy resolver context.
+Do not pattern-match raw `TypeData` from a lint rule when `InferredType` already
+provides the required operation.
+
+### Cross-Module Ownership
+
+Inferred data remains owned by the module that declared it. Do not copy or clone
+another module's inferred payload into the current module, including behind
+`Arc`. Preserve ownership through raw import references, `LocalTypeHandle`,
+global IDs, and tracked queries.
+
+## Choose the Narrowest Boundary
+
+The three inference levels are alternatives, not sequential phases:
+
+| Need | Boundary |
+| --- | --- |
+| Inspect what collection recorded in one module | Raw local tables |
+| Resolve one expression, binding, export, member, argument, or classification | Targeted request and tracked query |
+| Resolve every raw type, expression, and binding in a module | Complete module inference |
+
+A wider boundary is not inherently more correct. Choose it only when the
+operation's result contract requires the wider data. An inconclusive targeted
+result does not automatically justify complete-module inference.
+
+When an operation can answer from more than one level, use this escalation
+order:
+
+```text
+inspect raw local information
+    -> return when the local result is conclusive
+    -> resolve the smallest selected reference with a targeted query
+    -> preserve uncertainty or widen only when the contract requires it
+    -> use complete-module inference as the last resort
 ```
 
-**Note:** There is no `Unknown` variant. Unknown types are represented as `TypeReference::Resolved(GLOBAL_UNKNOWN_ID)`. Use `TypeReference::unknown()` to create one.
+This is a decision order, not a pipeline that every request must execute. A
+request whose contract inherently requires database resolution may start with a
+targeted query, but it must still avoid complete-module inference unless the
+complete tables are required.
 
-## Type Resolution Phases
+Targeted lookups are the default. `infer_module_types` is for contracts that
+need complete tables. `infer_module_types_bottom_up` is an untracked external
+scheduler for complete inference and must not be called from a new tracked
+query.
 
-### 1. Local Inference
+## Type-Aware Lint Rules
 
-**What**: Derives types from expressions without surrounding context.
+Type-aware JavaScript rules use the analyzer service rather than database
+queries directly:
 
-**Example**: For `a + b`, creates:
-```rust
-TypeData::TypeofExpression(TypeofExpression::Addition {
-    left: TypeReference::from(TypeReferenceQualifier::from_name("a")),
-    right: TypeReference::from(TypeReferenceQualifier::from_name("b"))
-})
+1. Declare `domains: &[RuleDomain::Types]` in rule metadata.
+2. Use `Typed<N>` as the rule query.
+3. Call an existing inference method on `RuleContext`, backed by `TypedService`.
+4. Inspect returned `InferredType` values with their bounded helper methods.
+5. Handle classifications explicitly as `Match`, `NoMatch`, or `Indeterminate`.
+
+Start with `crates/biome_js_analyze/src/services/typed.rs`. Current consumers
+include `no_floating_promises.rs` and `no_misused_promises.rs` under
+`crates/biome_js_analyze/src/lint/nursery/`.
+
+Prefer a classification request when a rule asks one property, such as whether
+an expression is Promise-like. Do not normalize and traverse a complete type
+when a narrower classifier can answer the rule's question.
+
+## Changing Raw Inference
+
+When adding or changing syntax-derived type information:
+
+1. Define the raw representation in
+   `crates/biome_js_type_info/src/type_data.rs`.
+2. Collect it from syntax in
+   `crates/biome_js_type_info/src/local_inference.rs` or
+   `crates/biome_module_graph/src/js_module_info/collector.rs`. Preserve
+   unresolved operands as `TypeReference` values.
+3. Add or update conversion to the inferred representation in
+   `crates/biome_js_type_info/src/interned_types.rs`.
+4. Add custom database-backed evaluation under
+   `crates/biome_module_graph/src/db/type_inference/` only when the variant needs
+   behavior beyond generic raw-to-inferred conversion.
+5. Audit raw/inferred conversion, semantic variant matches, and formatting in
+   `interned_types.rs`, `inferred_type.rs`, `format_type_info.rs`, and
+   `format_inferred_type_info.rs`.
+
+Collector snapshots must prove the raw structure remains deferred when database
+resolution is required. Query tests must separately prove the inferred result.
+Change `type_traversal.rs` only when the generic traversal engine or its limits
+change; type-specific child scheduling belongs to semantic visitor matches.
+
+## Adding an Analyzer Request
+
+Requests live under `crates/biome_module_graph/src/type_inference/requests/`.
+Add one only for a reusable result contract, not for an individual lint rule.
+
+1. Search existing `TypeInferenceRequestMetadata` implementations for a matching
+   output and uncertainty contract.
+2. Implement `Sealed`, `TypeInferenceRequestMetadata`, and
+   `TypeInferenceRequest` with a stable ID, label, implementation reference, and
+   exact source origin.
+3. Compose operations through `TypeInferenceRequestContext`; do not construct
+   low-level query inputs in analyzer code.
+4. Re-export the request and add a thin method to `TypedService`.
+5. Test the result and tracked query flow. When the contract is targeted, use
+   the complete-inference checks under [Salsa Inputs and
+   Invalidation](#salsa-inputs-and-invalidation).
+
+Use `NormalizedExpressionTypeRequest` and
+`ExpectedCallArgumentTypeRequest` as current examples. Request infrastructure is
+defined in `type_inference/request.rs`, `type_inference/context.rs`, and
+`type_inference/requests/` under `crates/biome_module_graph/src/`.
+
+## Adding a Tracked Query
+
+Queries live under
+`crates/biome_module_graph/src/db/queries/type_inference/`, organized by subject.
+Add a query only when its result needs an independent memoization and
+invalidation boundary.
+
+1. Return the smallest semantic result the consumer needs.
+2. Use a two-parameter signature: the database and one Salsa input or interned
+   key. Add a compound key in `interned.rs` when several logical values are
+   required.
+3. Define uncertainty behavior. Recursive tracked queries need a `cycle_result`:
+   type queries preserve uncertainty as `Unknown`, while classification queries
+   use `Indeterminate`.
+4. Wrap the observable query body with `execute_query` and the matching
+   `TypeInferenceQueryKind` family. Reuse an existing family when its subject
+   matches; add one only for a new subject module with a distinct responsibility.
+5. Read only dependencies that can affect the result, and verify this with Salsa
+   execution tests.
+
+Interning equal query inputs gives them a stable shared identity; it does not
+memoize a query result. Memoization belongs to `#[salsa::tracked]` functions.
+
+The query facade is
+`crates/biome_module_graph/src/db/queries/type_inference.rs`. Shared resolution
+algorithms live under `crates/biome_module_graph/src/db/type_inference/`.
+
+## Resolution, Normalization, and Widening
+
+- On-demand import resolution follows only the selected export and lookup path
+  until the request requires broader work.
+- Normalization resolves reachable local handles and structural wrappers with a
+  bounded traversal. It is not complete-module inference.
+- Namespace imports and re-exports can expand every visible export. Treat them
+  as namespace-wide work.
+- Exhausting the guarded import-depth budget can widen to bottom-up complete
+  inference. This recovery may return a conclusive selected type from the
+  complete tables; keep the widening explicit and observable.
+- Lookup-query cycles preserve uncertainty. Complete-module cycles use the
+  existing strongly-connected-component fallback, which may retain information
+  resolved outside the active component.
+
+Do not derive a definite result from incomplete work alone. Preserve uncertainty
+when bounded traversal or cycle recovery cannot conclude; an explicit recovery
+algorithm may return a conclusive result from the data it successfully resolves.
+
+## Result Semantics
+
+Do not conflate these outcomes:
+
+| Result | Meaning |
+| --- | --- |
+| `None` | The request or query has no result under its documented contract, such as an uncollected range or disabled inference |
+| `InferredTypeData::Unknown` | Inference produced a type value whose structure could not be determined |
+| `InferredTypeData::UnknownKeyword` | Source code explicitly uses TypeScript's `unknown` type |
+| `TypeInferenceClassification::Indeterminate` | Available inference cannot prove either a match or a non-match |
+| `TypeInferenceClassification::NoMatch` | Available inference conclusively disproves the requested condition |
+
+Unknown or indeterminate information is not a negative result. Preserve it to
+avoid false-positive diagnostics.
+
+## Salsa Inputs and Invalidation
+
+`ModuleInfo` is a Salsa input containing a path and module kind. Path-to-module
+associations live outside Salsa, so dynamic path lookup is tracked through
+`ModuleGraphGeneration`. Read existing module database APIs rather than bypassing
+that generation.
+
+When changing dependencies or invalidation:
+
+1. Run the query once and repeat it to prove cache reuse.
+2. Edit an unrelated input and prove the query body is not recomputed.
+3. Edit a consumed input and prove the query body is recomputed.
+4. Use `biome_db::testing` event helpers to inspect `WillExecute` events.
+5. For ordinary targeted flows that should not widen, assert that
+   `infer_module_types` did not execute and that the
+   `prepare_module_types_bottom_up_for_import_depth` execution count is zero. A
+   query-level depth-limit fallback test instead asserts that preparation
+   executed and verifies its semantic result. Changes to profiling attribution
+   additionally verify the displayed whole-module widening reason.
+
+Representative tests are in
+`crates/biome_module_graph/tests/spec_tests/requests.test.rs`, `queries.test.rs`,
+and `database.test.rs`.
+
+## Testing
+
+Test the narrowest affected boundary:
+
+| Boundary | Command |
+| --- | --- |
+| Raw collection | `cargo test -p biome_js_type_info --test local_inference` |
+| Raw type data | `cargo test -p biome_js_type_info --test type_data` |
+| Queries and requests | `cargo test -p biome_module_graph --test spec_tests` |
+| Type-aware lint rule | `just test-lintrule <ruleName>` |
+| Snapshot review | `cargo insta review` |
+
+Collector tests verify deferred raw values. Module-graph tests verify resolved
+types, request contracts, cycles, imports, and Salsa execution. Analyzer fixtures
+verify the final diagnostic behavior.
+
+## Profiling
+
+Use the hidden maintenance profile when a request resolves more data than
+expected:
+
+```shell
+cargo biome-cli-dev lint \
+  --profile-type-inference \
+  --verbose \
+  --only=nursery/noFloatingPromises \
+  path/to/file.ts
 ```
 
-**Where**: Implemented in `local_inference.rs`
-
-**Output**: Types with unresolved `TypeReference::Qualifier` references
-
-### 2. Module-Level ("Thin") Inference
-
-**What**: Resolves references within a single module's scope.
-
-**Process**:
-1. Takes results from local inference
-2. Looks up qualifiers in local scopes
-3. Converts to `TypeReference::Resolved` if found locally
-4. Converts to `TypeReference::Import` if from import statement
-5. Falls back to globals (like `Array`, `Promise`)
-6. Uses `TypeReference::unknown()` if nothing is found
-
-**Where**: Implemented in `js_module_info/collector.rs`
-
-**Output**: Types with resolved local references, import markers, or unknown
-
-### 3. Full Inference
-
-**What**: Resolves import references across module boundaries.
-
-**Process**:
-1. Has access to entire module graph
-2. Resolves `TypeReference::Import` by following imports
-3. Converts to `TypeReference::Resolved` after following imports
-
-**Where**: The Salsa-backed implementation starts at
-`db/queries/type_inference.rs::infer_module_types` and uses helpers under
-`db/type_inference/`. `js_module_info/module_resolver.rs` contains the legacy
-`TypeResolver`-based path.
-
-**Caching**: `infer_module_types` is tracked by Salsa. Imported module results
-are dependencies, so Salsa invalidates affected importers after a change.
-
-## Working with Type Resolvers
-
-### Available Resolvers
-
-```rust
-// 1. For tests
-HardcodedSymbolResolver
-
-// 2. For globals (Array, Promise, etc.)
-GlobalsResolver
-
-// 3. For thin inference (single module)
-JsModuleInfoCollector
-
-// 4. For full inference (across modules)
-ModuleResolver
-```
-
-### Using a Resolver
-
-```rust
-use biome_js_type_info::{TypeResolver, ResolvedTypeData};
-
-fn analyze_type(resolver: &impl TypeResolver, type_ref: TypeReference) {
-    // Resolve the reference
-    let resolved_data: ResolvedTypeData = resolver.resolve_type(type_ref);
-
-    // Get raw data for pattern matching
-    match resolved_data.as_raw_data() {
-        TypeData::String => { /* handle string */ },
-        TypeData::Number => { /* handle number */ },
-        TypeData::Function(func) => { /* handle function */ },
-        _ => { /* handle others */ }
-    }
-
-    // Resolve nested references
-    if let TypeData::Reference(inner_ref) = resolved_data.as_raw_data() {
-        let inner_data = resolver.resolve_type(*inner_ref);
-        // Process inner type
-    }
-}
-```
-
-### Type Flattening
-
-**What**: Converts complex type expressions to concrete types.
-
-**Example**: After resolving `a + b`:
-- If both are `TypeData::Number` → Flatten to `TypeData::Number`
-- Otherwise → Usually flatten to `TypeData::String`
-
-**Where**: Implemented in `flattening.rs`
-
-## Common Workflows
-
-### Implement Type-Aware Lint Rule
-
-```rust
-use biome_analyze::Semantic;
-use biome_js_type_info::{TypeResolver, TypeData};
-
-impl Rule for MyTypeRule {
-    type Query = Semantic<JsCallExpression>;
-
-    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
-        let node = ctx.query();
-        let model = ctx.model();
-
-        // Get type resolver from model
-        let resolver = model.type_resolver();
-
-        // Get type of expression
-        let expr_type = node.callee().ok()?.infer_type(resolver);
-
-        // Check the type
-        match expr_type.as_raw_data() {
-            TypeData::Function(_) => { /* valid */ },
-            TypeData::Unknown => { /* might be valid, can't tell */ },
-            _ => { return Some(()); /* not callable */ }
-        }
-
-        None
-    }
-}
-```
-
-### Navigate Type References
-
-```rust
-fn is_string_type(resolver: &impl TypeResolver, type_ref: TypeReference) -> bool {
-    let resolved = resolver.resolve_type(type_ref);
-
-    // Follow references
-    let data = match resolved.as_raw_data() {
-        TypeData::Reference(ref_to) => resolver.resolve_type(*ref_to),
-        _other => resolved,
-    };
-
-    // Check the resolved type
-    matches!(data.as_raw_data(), TypeData::String)
-}
-```
-
-### Work with Function Types
-
-```rust
-fn analyze_function(resolver: &impl TypeResolver, type_ref: TypeReference) {
-    let resolved = resolver.resolve_type(type_ref);
-
-    if let TypeData::Function(func_type) = resolved.as_raw_data() {
-        // Access parameters
-        for param in func_type.parameters() {
-            let param_type = resolver.resolve_type(param.type_ref());
-            // Analyze parameter type
-        }
-
-        // Access return type
-        let return_type = resolver.resolve_type(func_type.return_type());
-    }
-}
-```
-
-## Architecture Principles
-
-### Why Type References?
-
-**Advantages**:
-1. **No stale data**: Module updates don't leave old types in memory
-2. **Better performance**: Types stored in vectors (data locality)
-3. **Easier debugging**: Can inspect all types in vector
-4. **Simpler algorithms**: Process vectors instead of traversing graphs
-
-**Trade-off**: Must explicitly resolve references (not automatic like `Arc`)
-
-### ResolvedTypeId Structure
-
-```rust
-struct ResolvedTypeId(ResolverId, TypeId)
-```
-
-- `TypeId` (u32): Index into a type vector
-- `ResolverId` (u32): Identifies which vector to use
-- Total: 64 bits (compact representation)
-
-### ResolvedTypeData
-
-Always work with `ResolvedTypeData` from resolver, not raw `&TypeData`:
-
-```rust
-// Good - tracks resolver context
-let resolved_data: ResolvedTypeData = resolver.resolve_type(type_ref);
-
-// Be careful - loses resolver context
-let raw_data: &TypeData = resolved_data.as_raw_data();
-// Can't resolve nested TypeReferences without ResolverId!
-```
-
-## Tips
-
-- **Unknown types**: `TypeData::Unknown` means inference not implemented, treat as "could be anything"
-- **Follow references**: Always follow `TypeData::Reference` to get actual type
-- **Resolver context**: Keep `ResolvedTypeData` when possible, don't extract raw `TypeData` early
-- **Performance**: Type vectors are fast - iterate directly instead of recursive traversal
-- **IDE focus**: All design decisions prioritize instant IDE updates over CLI performance
-- **Caching**: Salsa memoizes full-inference query results and invalidates them through tracked module dependencies
-- **Globals**: Currently hardcoded, eventually should use TypeScript's `.d.ts` files
-
-## Common Patterns
-
-```rust
-// Pattern 1: Resolve and flatten
-let type_ref = expr.infer_type(resolver);
-let flattened = type_ref.flatten(resolver);
-
-// Pattern 2: Check if type matches
-fn is_string_type(resolver: &impl TypeResolver, type_ref: TypeReference) -> bool {
-    let resolved = resolver.resolve_type(type_ref);
-    matches!(resolved.as_raw_data(), TypeData::String)
-}
-
-// Pattern 3: Handle unknown gracefully
-match resolved.as_raw_data() {
-    TypeData::Unknown | TypeData::UnknownKeyword => {
-        // Can't verify, assume valid
-        return None;
-    }
-    TypeData::String => { /* handle */ }
-    _ => { /* handle */ }
-}
-```
-
-## CSS and HTML Module Graph
-
-The module graph tracks not only JS imports/exports but also CSS class names and HTML class references, used by cross-file lint rules like `noUnusedStyles` and `noUndeclaredStyles`.
-
-### Key Types
-
-```
-CssModuleInfo   — classes: IndexSet<CssClass>
-HtmlModuleInfo  — style_classes: IndexSet<CssClass>   (from <style> blocks)
-                — referenced_classes: IndexSet<CssClass> (from class="..." attrs)
-                — imported_stylesheets: Vec<ResolvedPath>
-JsModuleInfo    — referenced_classes: IndexSet<CssClass> (from className="...")
-```
-
-### `CssClass` Design
-
-`CssClass` stores a class name **without allocating a `String` per word**:
-
-```rust
-pub struct CssClass {
-    pub(crate) token: TokenText,  // the full token (or its inner text) — refcount only
-    pub range: TextRange,         // byte range relative to token.text()
-}
-
-impl CssClass {
-    pub fn text(&self) -> &str {
-        let start = usize::from(self.range.start());
-        let end = usize::from(self.range.end());
-        &self.token.text()[start..end]
-    }
-}
-```
-
-- `Borrow<str>`, `Hash`, and `Eq` all delegate to `self.text()`, so `IndexSet::contains("foo")` works with a plain `&str`.
-- For CSS selectors (`.foo`), the token is the whole selector token and the range covers it entirely.
-- For HTML/JSX string attributes (`class="foo bar"`), the token is the **inner** (quote-stripped) `TokenText` from `inner_string_text()`, and each word has its own offset range within that inner text.
-
-### Populating `CssClass` from a CSS selector
-
-```rust
-let token_text = token.token_text_trimmed();
-let len = u32::from(token_text.len());
-classes.insert(CssClass {
-    token: token_text,
-    range: TextRange::new(TextSize::from(0), TextSize::from(len)),
-});
-```
-
-### Populating `CssClass` from a `class="foo bar"` attribute
-
-```rust
-// Use inner_string_text() — strips quotes, no allocation.
-let inner: TokenText = html_string.inner_string_text()?;
-let content = inner.text();
-let mut offset: u32 = 0;
-for word in content.split_ascii_whitespace() {
-    let word_offset = content[offset as usize..]
-        .find(word)
-        .map_or(offset, |pos| offset + pos as u32);
-    let start = TextSize::from(word_offset);
-    let end = start + TextSize::from(word.len() as u32);
-    classes.insert(CssClass {
-        token: inner.clone(), // refcount bump only
-        range: TextRange::new(start, end),
-    });
-    offset = word_offset + word.len() as u32;
-}
-```
-
-### Cross-file class lookup
-
-```rust
-// In a CSS lint rule:
-module_graph.is_class_referenced_by_importers(css_file_path, class_name_str)
-
-// In an HTML lint rule:
-let html_info = module_graph.html_module_info_for_path(file_path)?;
-let css_info  = module_graph.css_module_info_for_path(stylesheet_path)?;
-
-// Zero-alloc lookup (Borrow<str> impl):
-html_info.style_classes.contains("foo")
-css_info.classes.contains("bar")
-```
-
-### Public Function Audit Rules
-
-When adding or removing functions from the module graph, always verify each **public** function has a real production call site (not just test code).
-
-**Rules:**
-- A function used only in tests is not justified — remove it
-- Tests calling a function do not count as "production use"
-- Check with `grep` across all crates before removing anything
-- `data()` is used from `biome_service/workspace/server.rs` — do not remove it even if it looks test-only
-
-## References
-
-- Architecture guide: `crates/biome_js_type_info/CONTRIBUTING.md`
-- Module graph: `crates/biome_module_graph/`
-- Type resolver trait: `crates/biome_js_type_info/src/resolver.rs`
-- Flattening: `crates/biome_js_type_info/src/flattening.rs`
+Profiles attribute tracked query executions and whole-module widening to an
+analyzer request. A missing query record can mean the query was not invoked or
+Salsa reused its cached result. Request and query timings are inclusive and must
+not be added together.
+
+## Review Checklist
+
+- The implementation uses the correct raw, inferred, or analyzer-facing type
+  world.
+- The request or query is the narrowest boundary that satisfies its contract.
+- Missing data, ambiguity, cycles, and work-limit exhaustion preserve
+  uncertainty.
+- Cross-module inferred data remains owned by its source module.
+- Correctness tests and Salsa execution tests cover the changed boundary.

--- a/crates/biome_js_syntax/src/class_ext.rs
+++ b/crates/biome_js_syntax/src/class_ext.rs
@@ -1,0 +1,63 @@
+use crate::AnyJsClassMemberName;
+
+impl AnyJsClassMemberName {
+    /// Returns whether this class member name matches `expected`.
+    ///
+    /// Private names require their leading `#`. Computed names and
+    /// metavariables do not match. Malformed literal and private names return
+    /// `None`.
+    pub fn class_member_name_matches(&self, expected: &str) -> Option<bool> {
+        match self {
+            Self::JsLiteralMemberName(name) => Some(name.value().ok()?.text_trimmed() == expected),
+            Self::JsPrivateClassMemberName(name) => {
+                let identifier = name.id_token().ok()?.token_text_trimmed();
+                Some(
+                    expected
+                        .strip_prefix('#')
+                        .is_some_and(|expected| identifier == expected),
+                )
+            }
+            Self::JsComputedMemberName(_) | Self::JsMetavariable(_) => Some(false),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use biome_js_factory::syntax::AnyJsClass;
+    use biome_js_parser::{JsParserOptions, parse_module};
+    use biome_rowan::AstNode;
+
+    #[test]
+    fn matches_public_and_private_class_member_names() {
+        let parsed = parse_module(
+            "class Example { public() {} #private() {} }",
+            JsParserOptions::default(),
+        );
+        let class = parsed
+            .tree()
+            .syntax()
+            .descendants()
+            .find_map(AnyJsClass::cast)
+            .expect("class must parse");
+        let mut members = class.members().into_iter();
+        let public = members
+            .next()
+            .expect("public method must exist")
+            .name()
+            .expect("public method name must be valid")
+            .expect("public method must be named");
+        let private = members
+            .next()
+            .expect("private method must exist")
+            .name()
+            .expect("private method name must be valid")
+            .expect("private method must be named");
+
+        assert_eq!(public.class_member_name_matches("public"), Some(true));
+        assert_eq!(public.class_member_name_matches("#public"), Some(false));
+        assert_eq!(private.class_member_name_matches("#private"), Some(true));
+        assert_eq!(private.class_member_name_matches("private"), Some(false));
+    }
+}

--- a/crates/biome_js_syntax/src/lib.rs
+++ b/crates/biome_js_syntax/src/lib.rs
@@ -11,6 +11,7 @@ pub mod assign_ext;
 pub mod binary_like_expression;
 pub mod binding_ext;
 pub mod cast_ext;
+pub mod class_ext;
 pub mod declaration_ext;
 pub mod directive_ext;
 pub mod export_ext;

--- a/crates/biome_module_graph/src/db/type_inference/promise_classification.rs
+++ b/crates/biome_module_graph/src/db/type_inference/promise_classification.rs
@@ -10,11 +10,13 @@
 //! value or instance side used for member lookup, and the unconsumed member
 //! path. Named-member traversal examines only members declared directly on the
 //! current type. A member available only from a base type is therefore
-//! indeterminate. Function-return classification has one narrower inheritance
-//! case: an interface with no call signature may follow its single base
-//! interface. Traversal visits at most 1024 distinct classification states.
-//! Unsupported expression forms, accessors, ambiguous exports, cycles, and an
-//! exhausted work limit are indeterminate.
+//! indeterminate. A pending member path may cross a non-generic concrete class
+//! created by `new` without inspecting its constructor arguments.
+//! Function-return classification has one narrower inheritance case: an
+//! interface with no call signature may follow its single base interface.
+//! Traversal visits at most 1024 distinct classification states. Unsupported
+//! expression forms, accessors, ambiguous exports, cycles, and an exhausted
+//! work limit are indeterminate.
 
 use super::{ImportResolution, ResolutionCtx, find_value_member_type_on_demand};
 use crate::db::queries::{
@@ -23,6 +25,7 @@ use crate::db::queries::{
 use crate::js_module_info::TsBindingReferenceExt;
 use crate::module_graph::{ModuleInfo, ModuleInfoKind};
 use crate::{JsExport, JsModuleInfo, JsOwnExport, ModuleDb, ResolvedPath, SymbolFromModuleInfo};
+use biome_js_syntax::{AnyJsClass, AnyJsClassMember};
 use biome_js_type_info::{
     GlobalTypeId, ImportSymbol, Literal, RawTypeData, RawTypeId, ScopeId, TypeId, TypeMember,
     TypeReference, TypeReferenceQualifier, TypeResolverLevel, TypeofExpression, global_types,
@@ -30,7 +33,7 @@ use biome_js_type_info::{
         ReturnType, TypeData as InferredTypeData, TypeSubstitution, TypeTransformResult,
     },
 };
-use biome_rowan::Text;
+use biome_rowan::{AstNode, Text, TextRange};
 use rustc_hash::FxHashSet;
 
 const MAX_PROMISE_CLASSIFICATION_STATES: usize = 1024;
@@ -57,6 +60,66 @@ enum MemberLookupMode {
     Value,
     /// Selects instance members when the target is a class.
     Instance,
+    /// Selects a constructed instance after consuming its value-side members.
+    Constructed {
+        remaining: usize,
+        binding_range: Option<TextRange>,
+    },
+}
+
+impl MemberLookupMode {
+    fn prepend_constructed_members(self, count: usize) -> Self {
+        match self {
+            Self::Constructed { remaining, .. } => Self::Constructed {
+                remaining: remaining.saturating_add(count),
+                binding_range: None,
+            },
+            mode @ (Self::Value | Self::Instance) => mode,
+        }
+    }
+
+    fn with_class_binding(self, binding_range: TextRange) -> Self {
+        match self {
+            Self::Constructed { remaining: 0, .. } => Self::Constructed {
+                remaining: 0,
+                binding_range: Some(binding_range),
+            },
+            mode @ (Self::Value | Self::Instance | Self::Constructed { remaining: 1.., .. }) => {
+                mode
+            }
+        }
+    }
+
+    fn without_class_binding(self) -> Self {
+        match self {
+            Self::Constructed { remaining, .. } => Self::Constructed {
+                remaining,
+                binding_range: None,
+            },
+            mode @ (Self::Value | Self::Instance) => mode,
+        }
+    }
+
+    fn after_member(self) -> Self {
+        match self {
+            Self::Value | Self::Instance | Self::Constructed { remaining: 0, .. } => Self::Value,
+            Self::Constructed { remaining, .. } => Self::Constructed {
+                remaining: remaining - 1,
+                binding_range: None,
+            },
+        }
+    }
+
+    fn after_namespace_member(self) -> Option<Self> {
+        match self {
+            Self::Constructed { remaining: 0, .. } => None,
+            Self::Constructed { remaining, .. } => Some(Self::Constructed {
+                remaining: remaining - 1,
+                binding_range: None,
+            }),
+            mode @ (Self::Value | Self::Instance) => Some(mode),
+        }
+    }
 }
 
 /// The Promise-related property requested from the current target.
@@ -112,14 +175,15 @@ struct ClassificationState {
 /// Classifies a raw expression's Promise shape without inferring all module tables.
 ///
 /// The projection follows lexical bindings, imports, exports, aliases, `this`,
-/// calls, and own named members. Unsupported expression forms remain
-/// indeterminate instead of entering complete expression inference.
+/// calls, non-generic class instances created by `new`, and own named members.
+/// Unsupported expression forms remain indeterminate instead of entering
+/// complete expression inference.
 pub(in crate::db) fn classify_expression_promise(
     db: &dyn ModuleDb,
     module: ModuleInfo,
     reference: TypeReference,
 ) -> PromiseClassification {
-    classify_expression(db, module, reference, Projection::Promise)
+    classify_expression(db, module, reference, Projection::Promise, true)
 }
 
 /// Classifies whether a raw expression is an array of Promise-like values.
@@ -128,7 +192,7 @@ pub(in crate::db) fn classify_expression_array_promise(
     module: ModuleInfo,
     reference: TypeReference,
 ) -> PromiseClassification {
-    classify_expression(db, module, reference, Projection::ArrayPromise)
+    classify_expression(db, module, reference, Projection::ArrayPromise, true)
 }
 
 /// Classifies a raw expression's function return without inferring all module tables.
@@ -142,7 +206,7 @@ pub(in crate::db) fn classify_expression_function_return(
     module: ModuleInfo,
     reference: TypeReference,
 ) -> PromiseClassification {
-    classify_expression(db, module, reference, Projection::FunctionReturn)
+    classify_expression(db, module, reference, Projection::FunctionReturn, false)
 }
 
 fn classify_expression(
@@ -150,6 +214,7 @@ fn classify_expression(
     module: ModuleInfo,
     reference: TypeReference,
     projection: Projection,
+    allow_new_instance_members: bool,
 ) -> PromiseClassification {
     use PromiseClassification::{DoesNotReturnPromise, Indeterminate, ReturnsPromise};
 
@@ -258,6 +323,9 @@ fn classify_expression(
                     let Some(identifier) = qualifier_path.next() else {
                         return Indeterminate;
                     };
+                    let mode = state
+                        .mode
+                        .prepend_constructed_members(qualifier.path.len().saturating_sub(1));
                     let members: Box<[Text]> = qualifier_path
                         .cloned()
                         .chain(state.members.iter().cloned())
@@ -313,21 +381,20 @@ fn classify_expression(
                                         resolved_path: import.resolved_path.clone(),
                                         symbol: import.symbol.clone(),
                                     },
-                                    mode: state.mode,
+                                    mode: mode.without_class_binding(),
                                     members: members.clone(),
                                     projection: state.projection,
                                 };
                             }
-                            let Some(reference) = js_info
-                                .raw_binding_types
-                                .get(&binding.syntax().text_trimmed_range())
+                            let binding_range = binding.syntax().text_trimmed_range();
+                            let Some(reference) = js_info.raw_binding_types.get(&binding_range)
                             else {
                                 return Indeterminate;
                             };
                             break ClassificationState {
                                 module: state.module,
                                 target: ClassificationTarget::Reference(reference.clone()),
-                                mode: state.mode,
+                                mode: mode.with_class_binding(binding_range),
                                 members: members.clone(),
                                 projection: state.projection,
                             };
@@ -337,6 +404,9 @@ fn classify_expression(
                             continue;
                         }
 
+                        if matches!(mode, MemberLookupMode::Constructed { .. }) {
+                            return Indeterminate;
+                        }
                         let mut ctx = ResolutionCtx::new(
                             db,
                             state.module,
@@ -429,7 +499,7 @@ fn classify_expression(
                         resolved_path: import.resolved_path.clone(),
                         symbol: import.symbol.clone(),
                     },
-                    mode: state.mode,
+                    mode: state.mode.without_class_binding(),
                     members: state.members,
                     projection: state.projection,
                 },
@@ -441,6 +511,26 @@ fn classify_expression(
                 let Some(raw) = js_info.raw_types.get(type_id.index()) else {
                     return Indeterminate;
                 };
+                if matches!(
+                    state.mode,
+                    MemberLookupMode::Constructed { remaining: 0, .. }
+                ) && !(matches!(
+                    raw,
+                    RawTypeData::Class(_)
+                        | RawTypeData::Reference(_)
+                        | RawTypeData::TypeofType(_)
+                        | RawTypeData::TypeofValue(_)
+                ) || matches!(
+                    raw,
+                    RawTypeData::TypeofExpression(expression)
+                        if matches!(
+                            expression.as_ref(),
+                            TypeofExpression::StaticMember(_)
+                                | TypeofExpression::OptionalChainStaticMember(_)
+                        )
+                )) {
+                    return Indeterminate;
+                }
 
                 match raw {
                     RawTypeData::Function(function) => {
@@ -574,12 +664,17 @@ fn classify_expression(
                             ClassificationState {
                                 module: state.module,
                                 target: ClassificationTarget::Reference(expression.object.clone()),
-                                mode: MemberLookupMode::Value,
+                                mode: state.mode.prepend_constructed_members(1),
                                 members: std::iter::once(expression.member.clone())
                                     .chain(state.members.iter().cloned())
                                     .collect(),
                                 projection: state.projection,
                             }
+                        }
+                        TypeofExpression::This(_)
+                            if matches!(state.mode, MemberLookupMode::Constructed { .. }) =>
+                        {
+                            return Indeterminate;
                         }
                         TypeofExpression::This(expression) => ClassificationState {
                             module: state.module,
@@ -636,6 +731,23 @@ fn classify_expression(
                                 },
                             }
                         }
+                        TypeofExpression::New(expression)
+                            if allow_new_instance_members && !state.members.is_empty() =>
+                        {
+                            if matches!(state.mode, MemberLookupMode::Constructed { .. }) {
+                                return Indeterminate;
+                            }
+                            ClassificationState {
+                                module: state.module,
+                                target: ClassificationTarget::Reference(expression.callee.clone()),
+                                mode: MemberLookupMode::Constructed {
+                                    remaining: 0,
+                                    binding_range: None,
+                                },
+                                members: state.members,
+                                projection: state.projection,
+                            }
+                        }
                         TypeofExpression::Addition(_)
                         | TypeofExpression::Await(_)
                         | TypeofExpression::BitwiseNot(_)
@@ -653,6 +765,11 @@ fn classify_expression(
                         | TypeofExpression::Typeof(_)
                         | TypeofExpression::UnaryMinus(_) => return Indeterminate,
                     },
+                    RawTypeData::InstanceOf(_)
+                        if matches!(state.mode, MemberLookupMode::Constructed { .. }) =>
+                    {
+                        return Indeterminate;
+                    }
                     RawTypeData::InstanceOf(instance)
                         if !instance.type_parameters.is_empty()
                             && matches!(
@@ -741,6 +858,13 @@ fn classify_expression(
                         if matches!(state.projection, Projection::PromiseTarget) {
                             return DoesNotReturnPromise;
                         }
+                        if matches!(
+                            state.mode,
+                            MemberLookupMode::Constructed { remaining: 0, .. }
+                        ) && !class.type_parameters.is_empty()
+                        {
+                            return Indeterminate;
+                        }
                         let Some((name, remaining)) = state.members.split_first() else {
                             return DoesNotReturnPromise;
                         };
@@ -751,10 +875,40 @@ fn classify_expression(
                         if member.is_getter() {
                             return Indeterminate;
                         }
+                        if let MemberLookupMode::Constructed {
+                            remaining: 0,
+                            binding_range,
+                        } = state.mode
+                        {
+                            if class
+                                .members
+                                .iter()
+                                .filter(|candidate| {
+                                    candidate.has_name(name.text())
+                                        && candidate.is_static() == member.is_static()
+                                })
+                                .nth(1)
+                                .is_some()
+                            {
+                                return Indeterminate;
+                            }
+                            let Some(binding_range) = binding_range else {
+                                return Indeterminate;
+                            };
+                            let Some(false) = class_member_has_overload_signature(
+                                &js_info,
+                                type_id,
+                                binding_range,
+                                name,
+                                member.is_static(),
+                            ) else {
+                                return Indeterminate;
+                            };
+                        }
                         ClassificationState {
                             module: state.module,
                             target: ClassificationTarget::Reference(member.ty.clone()),
-                            mode: MemberLookupMode::Value,
+                            mode: state.mode.after_member(),
                             members: remaining.into(),
                             projection: state.projection,
                         }
@@ -797,7 +951,7 @@ fn classify_expression(
                             ClassificationState {
                                 module: state.module,
                                 target: ClassificationTarget::Reference(member.ty.clone()),
-                                mode: MemberLookupMode::Value,
+                                mode: state.mode.after_member(),
                                 members: remaining.into(),
                                 projection: state.projection,
                             }
@@ -817,7 +971,7 @@ fn classify_expression(
                             ClassificationState {
                                 module: state.module,
                                 target: ClassificationTarget::Reference(member.ty.clone()),
-                                mode: MemberLookupMode::Value,
+                                mode: state.mode.after_member(),
                                 members: remaining.into(),
                                 projection: state.projection,
                             }
@@ -933,7 +1087,7 @@ fn classify_expression(
                             ClassificationState {
                                 module: state.module,
                                 target: ClassificationTarget::Reference(member.ty.clone()),
-                                mode: MemberLookupMode::Value,
+                                mode: state.mode.after_member(),
                                 members: remaining.into(),
                                 projection: state.projection,
                             }
@@ -951,20 +1105,25 @@ fn classify_expression(
                 let Some(module) = db.module_for_path(path) else {
                     return DoesNotReturnPromise;
                 };
-                let (name, members) = match symbol {
+                let (name, members, mode) = match symbol {
                     ImportSymbol::All => {
                         let Some((name, remaining)) = state.members.split_first() else {
                             return Indeterminate;
                         };
-                        (name.clone(), remaining.into())
+                        let Some(mode) = state.mode.after_namespace_member() else {
+                            return Indeterminate;
+                        };
+                        (name.clone(), remaining.into(), mode)
                     }
-                    ImportSymbol::Default => (Text::new_static("default"), state.members),
-                    ImportSymbol::Named(name) => (name, state.members),
+                    ImportSymbol::Default => {
+                        (Text::new_static("default"), state.members, state.mode)
+                    }
+                    ImportSymbol::Named(name) => (name, state.members, state.mode),
                 };
                 ClassificationState {
                     module,
                     target: ClassificationTarget::Export(name),
-                    mode: state.mode,
+                    mode,
                     members,
                     projection: state.projection,
                 }
@@ -994,7 +1153,7 @@ fn classify_expression(
                         ClassificationState {
                             module,
                             target: ClassificationTarget::Reference(reference.clone()),
-                            mode: state.mode,
+                            mode: state.mode.with_class_binding(*range),
                             members: state.members,
                             projection: state.projection,
                         }
@@ -1004,7 +1163,7 @@ fn classify_expression(
                         target: ClassificationTarget::Reference(TypeReference::Resolved(
                             RawTypeId::Local(*resolved),
                         )),
-                        mode: state.mode,
+                        mode: state.mode.without_class_binding(),
                         members: state.members,
                         projection: state.projection,
                     },
@@ -1014,7 +1173,7 @@ fn classify_expression(
                             resolved_path: reexport.import.resolved_path.clone(),
                             symbol: reexport.import.symbol.clone(),
                         },
-                        mode: state.mode,
+                        mode: state.mode.without_class_binding(),
                         members: state.members,
                         projection: state.projection,
                     },
@@ -1038,10 +1197,52 @@ fn find_own_member<'a>(
     members.iter().find(|member| {
         member.has_name(name.text())
             && mode.is_none_or(|mode| match mode {
-                MemberLookupMode::Value => member.is_static(),
-                MemberLookupMode::Instance => !member.is_static(),
+                MemberLookupMode::Value | MemberLookupMode::Constructed { remaining: 1.., .. } => {
+                    member.is_static()
+                }
+                MemberLookupMode::Instance | MemberLookupMode::Constructed { remaining: 0, .. } => {
+                    !member.is_static()
+                }
             })
     })
+}
+
+fn class_member_has_overload_signature(
+    js_info: &JsModuleInfo,
+    type_id: TypeId,
+    binding_range: TextRange,
+    name: &Text,
+    is_static: bool,
+) -> Option<bool> {
+    let binding = js_info.semantic_model.as_binding_by_range(binding_range)?;
+    let TypeReference::Resolved(resolved) = js_info.raw_binding_types.get(&binding_range)? else {
+        return None;
+    };
+    if resolved.level() != TypeResolverLevel::Thin || resolved.id().index() != type_id.index() {
+        return None;
+    }
+    let class = binding
+        .syntax()
+        .ancestors()
+        .skip(1)
+        .find_map(AnyJsClass::cast)?;
+
+    for candidate in class.members() {
+        let AnyJsClassMember::TsMethodSignatureClassMember(signature) = &candidate else {
+            continue;
+        };
+        let signature_is_static = signature
+            .modifiers()
+            .into_iter()
+            .any(|modifier| modifier.as_js_static_modifier().is_some());
+        let candidate_name = signature.name().ok()?;
+        if signature_is_static == is_static
+            && candidate_name.class_member_name_matches(name.text())?
+        {
+            return Some(true);
+        }
+    }
+    Some(false)
 }
 
 fn sole_call_signature(members: &[TypeMember]) -> Result<Option<&TypeMember>, ()> {

--- a/crates/biome_module_graph/tests/spec_tests/queries.test.rs
+++ b/crates/biome_module_graph/tests/spec_tests/queries.test.rs
@@ -938,6 +938,269 @@ fn test_expression_promise_queries_follow_imported_interface_members() {
 }
 
 #[test]
+fn test_expression_promise_queries_follow_new_class_instance_members() {
+    const SOURCE: &str = r#"
+        import type { Noise } from "./noise.ts";
+        import { Tracer } from "./tracer.ts";
+        import * as tracing from "./tracer.ts";
+        declare const request: Noise;
+        const tracer = new Tracer();
+        tracer.putAnnotation("Label", request.label);
+        tracer.returnsPromise(request.label);
+        const qualifiedTracer = new tracing.Tracer();
+        qualifiedTracer.putAnnotation("Qualified", request.label);
+
+        function traceLocally() {
+            class LocalTracer {
+                putAnnotation(_value: string): void {}
+                async returnsPromise(_value: string): Promise<void> {}
+            }
+            const localTracer = new LocalTracer();
+            localTracer.putAnnotation(request.label);
+            localTracer.returnsPromise(request.label);
+        }
+    "#;
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/noise.ts".into(),
+        "export interface Noise { label: string; }",
+    );
+    fs.insert(
+        "/src/tracer.ts".into(),
+        r#"
+            export class Tracer {
+                putAnnotation(_key: string, _value: string): void {}
+                async returnsPromise(_value: string): Promise<void> {}
+            }
+        "#,
+    );
+    fs.insert("/src/index.ts".into(), SOURCE);
+
+    let db = build_js_test_module_db(
+        &fs,
+        &["/src/noise.ts", "/src/tracer.ts", "/src/index.ts"],
+        true,
+    );
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("index module must exist");
+    let noise_module = db
+        .module_for_path(Utf8Path::new("/src/noise.ts"))
+        .expect("noise module must exist");
+    let tracer_module = db
+        .module_for_path(Utf8Path::new("/src/tracer.ts"))
+        .expect("tracer module must exist");
+    let void_expression = ExpressionTypeInput::new(
+        &db,
+        module,
+        expression_range_by_source(
+            &db,
+            module,
+            SOURCE,
+            "tracer.putAnnotation(\"Label\", request.label)",
+        ),
+    );
+    let promise_expression = ExpressionTypeInput::new(
+        &db,
+        module,
+        expression_range_by_source(&db, module, SOURCE, "tracer.returnsPromise(request.label)"),
+    );
+    let callback_expression = ExpressionTypeInput::new(
+        &db,
+        module,
+        expression_range_by_source(&db, module, SOURCE, "tracer.returnsPromise"),
+    );
+    let qualified_void_expression = ExpressionTypeInput::new(
+        &db,
+        module,
+        expression_range_by_source(
+            &db,
+            module,
+            SOURCE,
+            "qualifiedTracer.putAnnotation(\"Qualified\", request.label)",
+        ),
+    );
+    let local_void_expression = ExpressionTypeInput::new(
+        &db,
+        module,
+        expression_range_by_source(
+            &db,
+            module,
+            SOURCE,
+            "localTracer.putAnnotation(request.label)",
+        ),
+    );
+    let local_promise_expression = ExpressionTypeInput::new(
+        &db,
+        module,
+        expression_range_by_source(
+            &db,
+            module,
+            SOURCE,
+            "localTracer.returnsPromise(request.label)",
+        ),
+    );
+    let noise = LocalTypeInput::new(
+        &db,
+        noise_module,
+        local_type_id_by_name(&db, noise_module, "Noise"),
+    );
+
+    db.clear_salsa_events();
+    assert_eq!(
+        infer_expression_is_promise(&db, void_expression),
+        TypeInferenceClassification::NoMatch
+    );
+    assert_eq!(
+        infer_expression_is_array_of_promises(&db, void_expression),
+        TypeInferenceClassification::NoMatch
+    );
+    assert_eq!(
+        infer_expression_is_promise(&db, promise_expression),
+        TypeInferenceClassification::Match
+    );
+    assert_eq!(
+        infer_expression_function_returns_promise(&db, callback_expression),
+        TypeInferenceClassification::Indeterminate
+    );
+    assert_eq!(
+        infer_expression_is_promise(&db, qualified_void_expression),
+        TypeInferenceClassification::NoMatch
+    );
+    assert_eq!(
+        infer_expression_is_array_of_promises(&db, qualified_void_expression),
+        TypeInferenceClassification::NoMatch
+    );
+    assert_eq!(
+        infer_expression_is_promise(&db, local_void_expression),
+        TypeInferenceClassification::NoMatch
+    );
+    assert_eq!(
+        infer_expression_is_promise(&db, local_promise_expression),
+        TypeInferenceClassification::Match
+    );
+    let events = db.take_salsa_events();
+
+    assert_function_query_was_not_run(&db, infer_expression_type, void_expression, &events);
+    assert_function_query_was_not_run(&db, infer_expression_type, promise_expression, &events);
+    assert_function_query_was_not_run(&db, infer_expression_type, callback_expression, &events);
+    assert_function_query_was_not_run(
+        &db,
+        infer_expression_type,
+        qualified_void_expression,
+        &events,
+    );
+    assert_function_query_was_not_run(&db, infer_expression_type, local_void_expression, &events);
+    assert_function_query_was_not_run(
+        &db,
+        infer_expression_type,
+        local_promise_expression,
+        &events,
+    );
+    assert_function_query_was_not_run(&db, infer_local_type, noise, &events);
+    assert_function_query_was_not_run(&db, infer_module_types, module, &events);
+    assert_function_query_was_not_run(&db, infer_module_types, noise_module, &events);
+    assert_function_query_was_not_run(&db, infer_module_types, tracer_module, &events);
+}
+
+#[test]
+fn test_expression_promise_query_keeps_constructor_dependent_members_indeterminate() {
+    const SOURCE: &str = r#"
+        import * as factoryNamespace from "./factory.ts";
+
+        class Box<T extends object> {
+            constructor(readonly value: T) {}
+            get(): T { return this.value; }
+        }
+        const box = new Box(Promise.resolve());
+        box.get();
+
+        declare const Factory: {
+            new (): { task(): Promise<void> };
+            task(): void;
+        };
+        const instance = new Factory();
+        instance.task();
+
+        class Actual {
+            static async run(): Promise<void> {}
+            run(): void {}
+        }
+        class Registry { Ctor = Actual; }
+        const registry = new Registry();
+        const actual = new registry.Ctor();
+        actual.run();
+
+        interface RegistryShape { Ctor: typeof Actual; }
+        declare const typedRegistry: RegistryShape;
+        const typedActual = new typedRegistry.Ctor();
+        typedActual.run();
+
+        class ThisRegistry {
+            Ctor = Actual;
+            create() {
+                const thisActual = new this.Ctor();
+                thisActual.run();
+            }
+        }
+
+        class Handler {
+            run(_value: string): void;
+            run(_value: number): Promise<void>;
+            run(_value: string | number): void | Promise<void> {}
+        }
+        const handler = new Handler();
+        handler.run(1);
+
+        class PrivateHandler {
+            #run(_value: string): void;
+            #run(_value: number): Promise<void>;
+            #run(_value: string | number): void | Promise<void> {}
+            static test() {
+                const privateHandler = new PrivateHandler();
+                privateHandler.#run("text");
+            }
+        }
+
+        const namespaceValue = new factoryNamespace();
+        namespaceValue.Client.send();
+    "#;
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/factory.ts".into(),
+        "export class Client { async send(): Promise<void> {} }",
+    );
+    fs.insert("/src/index.ts".into(), SOURCE);
+
+    let db = build_js_test_module_db(&fs, &["/src/factory.ts", "/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+
+    for expression in [
+        "box.get()",
+        "instance.task()",
+        "actual.run()",
+        "typedActual.run()",
+        "thisActual.run()",
+        "handler.run(1)",
+        "privateHandler.#run(\"text\")",
+        "namespaceValue.Client.send()",
+    ] {
+        let input = ExpressionTypeInput::new(
+            &db,
+            module,
+            expression_range_by_source(&db, module, SOURCE, expression),
+        );
+        assert_eq!(
+            infer_expression_is_promise(&db, input),
+            TypeInferenceClassification::Indeterminate,
+            "{expression}"
+        );
+    }
+}
+
+#[test]
 fn test_expression_promise_queries_match_unknown_node_builtin_imports() {
     const SOURCE: &str = r#"
         import fs from "node:fs/promises";


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Used a coding agent to implement and review the implementation multiple times. 

Closes https://github.com/biomejs/biome/issues/11390

The type inference was falling back to global inference when inspecting class constructors. Now we correctly query local inference for `new T()`, `new foo.T()`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added new tests

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
