### PR TITLE
fix(lint/js): mark no-this-in-static fixes unsafe

### DIFF
--- a/.changeset/twelve-llamas-ring.md
+++ b/.changeset/twelve-llamas-ring.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10278](https://github.com/biomejs/biome/issues/10278): Marked the fix for [`noThisInStatic`](https://biomejs.dev/linter/rules/no-this-in-static/) as unsafe by default.

--- a/crates/biome_js_analyze/src/lint/complexity/no_this_in_static.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_this_in_static.rs
@@ -85,7 +85,7 @@ declare_lint_rule! {
         sources: &[RuleSource::EslintMysticatea("no-this-in-static").same()],
         recommended: true,
         severity: Severity::Warning,
-        fix_kind: FixKind::Safe,
+        fix_kind: FixKind::Unsafe,
     }
 }
 

--- a/crates/biome_js_analyze/tests/specs/complexity/noThisInStatic/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noThisInStatic/invalid.js.snap
@@ -68,7 +68,7 @@ invalid.js:2:14 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i this refers to the class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
      1  1 │   export default class B extends A {
      2    │ - ····static·{·this.CONSTANT·+=·super.foo();·}
@@ -92,7 +92,7 @@ invalid.js:2:31 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i super refers to a parent class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
      1  1 │   export default class B extends A {
      2    │ - ····static·{·this.CONSTANT·+=·super.foo();·}
@@ -116,7 +116,7 @@ invalid.js:8:19 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i this refers to the class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
      6  6 │   
      7  7 │       static get property() {
@@ -142,7 +142,7 @@ invalid.js:9:26 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i super refers to a parent class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
      7  7 │       static get property() {
      8  8 │           /*before*/this/*after*/;
@@ -167,7 +167,7 @@ invalid.js:13:15 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i this refers to the class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
     11 11 │   
     12 12 │       static set property(x) {
@@ -193,7 +193,7 @@ invalid.js:14:15 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i super refers to a parent class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
     12 12 │       static set property(x) {
     13 13 │           () => this;
@@ -218,7 +218,7 @@ invalid.js:18:16 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i this refers to the class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
     16 16 │   
     17 17 │       static method() {
@@ -243,7 +243,7 @@ invalid.js:18:32 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i super refers to a parent class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
     16 16 │   
     17 17 │       static method() {
@@ -269,7 +269,7 @@ invalid.js:24:16 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i this refers to the class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
     22 22 │   class C extends A {
     23 23 │       static method() {
@@ -295,7 +295,7 @@ invalid.js:24:32 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i super refers to a parent class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
     22 22 │   class C extends A {
     23 23 │       static method() {
@@ -321,7 +321,7 @@ invalid.js:30:16 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i this refers to the class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
     28 28 │   const D = class D extends f() {
     29 29 │       static method() {
@@ -398,7 +398,7 @@ invalid.js:43:18 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i this refers to the class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
     41 41 │   class FactoryCases {
     42 42 │       static method() {
@@ -424,7 +424,7 @@ invalid.js:44:17 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i this refers to the class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
     42 42 │       static method() {
     43 43 │           new this(this);
@@ -450,7 +450,7 @@ invalid.js:45:13 lint/complexity/noThisInStatic  FIXABLE  ━━━━━━━�
   
   i this refers to the class.
   
-  i Safe fix: Use the class name instead.
+  i Unsafe fix: Use the class name instead.
   
     43 43 │           new this(this);
     44 44 │           new Foo(this);


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This marks the fixes for `noThisInStatic` as unsafe, at least for now. There are too many edge cases.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #10278
<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
