### PR TITLE
fix(grit): match named re-export specifiers

### DIFF
--- a/.changeset/dull-pants-smoke.md
+++ b/.changeset/dull-pants-smoke.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11436](https://github.com/biomejs/biome/issues/11436): GritQL snippets such as `export { $specifiers } from $source` now match named re-exports with aliases, inline `type` modifiers, and multiple specifiers.

--- a/crates/biome_grit_patterns/src/grit_target_language/js_target_language.rs
+++ b/crates/biome_grit_patterns/src/grit_target_language/js_target_language.rs
@@ -128,6 +128,7 @@ impl GritTargetLanguageImpl for JsTargetLanguage {
         kind.as_js_kind().is_some_and(|kind| {
             kind == JsSyntaxKind::JS_TEMPLATE_ELEMENT_LIST
                 || kind == JsSyntaxKind::TS_TEMPLATE_ELEMENT_LIST
+                || kind == JsSyntaxKind::JS_EXPORT_NAMED_FROM_SPECIFIER
         })
     }
 

--- a/crates/biome_grit_patterns/tests/specs/ts/export_named_from_patterns.snap
+++ b/crates/biome_grit_patterns/tests/specs/ts/export_named_from_patterns.snap
@@ -6,6 +6,10 @@ SnapshotResult {
     messages: [],
     matched_ranges: [
         "2:1-2:39",
+        "3:1-3:46",
+        "4:1-4:44",
+        "5:1-5:44",
+        "6:1-6:49",
     ],
     rewritten_files: [],
     created_files: [],

--- a/crates/biome_grit_patterns/tests/specs/ts/export_named_from_patterns.ts
+++ b/crates/biome_grit_patterns/tests/specs/ts/export_named_from_patterns.ts
@@ -1,2 +1,6 @@
 // Named re-export
 export { foo } from "../../deep/path";
+export { foo as bar } from "../../deep/path";
+export { type foo } from "../../deep/path";
+export { foo, bar } from "../../deep/path";
+export { type foo, bar } from "../../deep/path";


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
A somewhat comically small PR to fix GritQL named re-export patterns that fail on aliases, inline `type` modifiers, and multiple specifiers.

fixes #11436
<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
updated snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
