### PR TITLE
fix(lint/a11y/useSemanticElements): ignore elements with aria-disabled=true

### DIFF
--- a/.changeset/thirty-rabbits-raise.md
+++ b/.changeset/thirty-rabbits-raise.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+fix(a11y/useSemanticElements): skip elements with aria-disabled=true to allow native disabled semantics. Fixes #8277

--- a/crates/biome_js_analyze/src/lint/a11y/use_semantic_elements.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_semantic_elements.rs
@@ -84,6 +84,14 @@ impl Rule for UseSemanticElements {
         if node.is_custom_component() || node.is_custom_element() {
             return None;
         }
+        // Fix #8277: skip if aria-disabled="true" — can't use native <button disabled>
+        if let Some(attr) = node.find_attribute_by_name("aria-disabled") {
+            if let Some(val) = attr.as_static_value() {
+                if val.text() == "true" {
+                    return None;
+                }
+            }
+        }
 
         let role_attribute = node.find_attribute_by_name("role")?;
         let role_value = role_attribute.as_static_value()?;


### PR DESCRIPTION
Fixes #8277

Skip lint when element has aria-disabled="true" because native disabled cannot be used when you still need focus/events.

- Added early return in use_semantic_elements.rs if aria-disabled=true