### PR TITLE
fix(html): ignore punctuation in Vue attribute casing

### DIFF
--- a/.changeset/long-geckos-admire.md
+++ b/.changeset/long-geckos-admire.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10776](https://github.com/biomejs/biome/issues/10776): [`useVueHyphenatedAttributes`](https://biomejs.dev/linter/rules/use-vue-hyphenated-attributes/) no longer reports lowercase attribute names containing punctuation, such as `pt:header:data-test-id` and `some_attr`.

--- a/crates/biome_html_analyze/src/lint/style/use_vue_hyphenated_attributes.rs
+++ b/crates/biome_html_analyze/src/lint/style/use_vue_hyphenated_attributes.rs
@@ -3,7 +3,9 @@ use biome_analyze::{
     declare_lint_rule,
 };
 use biome_console::markup;
-use biome_html_syntax::{AnyHtmlAttribute, SVG_EXCLUSIVE_ELEMENTS, element_ext::AnyHtmlTagElement};
+use biome_html_syntax::{
+    AnyHtmlAttribute, SVG_EXCLUSIVE_TAG_NAMES, element_ext::AnyHtmlTagElement,
+};
 use biome_languages::HtmlFileSource;
 use biome_rowan::{AstNode, AstNodeList, TokenText};
 use biome_rule_options::use_vue_hyphenated_attributes::UseVueHyphenatedAttributesOptions;
@@ -12,17 +14,16 @@ use biome_string_case::Case;
 use crate::HtmlRuleAction;
 
 declare_lint_rule! {
-    /// Enforce hyphenated (kebab-case) attribute names in Vue templates.
+    /// Disallow uppercase letters in Vue template attribute names.
     ///
     /// Vue style guide recommends using hyphenated attribute (and prop) names in templates to
     /// keep them consistent and distinguish them from JavaScript identifiers written in camelCase/PascalCase.
     ///
-    /// This rule flags attributes that are detected as camelCase, PascalCase, CONSTANT_CASE, snake_case
-    /// or that contain any uppercase ASCII letter. It uses Biome's internal `Case::identify` helper.
+    /// Like the upstream ESLint rule, this rule flags attribute names that contain uppercase letters.
+    /// It doesn't require exact kebab-case, so punctuation such as colons and underscores is allowed.
     ///
     /// Allowed:
-    /// - kebab-case attributes (e.g. `data-test-id`)
-    /// - pure lowercase single word attributes (e.g. `class`, `id`)
+    /// - names without uppercase letters (e.g. `data-test-id`, `pt:header:id`, `some_attr`)
     ///
     /// ## Examples
     ///
@@ -42,6 +43,7 @@ declare_lint_rule! {
     /// <div data-test-id="x"></div>
     /// <div class="foo"></div>
     /// <MyComp :some-prop="x" />
+    /// <MyComp pt:header:data-test-id="x" />
     /// ```
     ///
     /// ## Options
@@ -50,7 +52,7 @@ declare_lint_rule! {
     ///
     /// ### `ignore`
     ///
-    /// A list of attribute names that should be ignored by the rule (they won't be required to be hyphenated).
+    /// A list of attribute names that should be exempt from the uppercase-letter check.
     /// Use this when you have a fixed set of camelCase / PascalCase prop names you intentionally allow.
     ///
     /// ```json,options
@@ -69,8 +71,8 @@ declare_lint_rule! {
     ///
     /// ### `ignoreTags`
     ///
-    /// A list of tag names whose attributes should be skipped entirely.
-    /// This is useful for third-party or internal components that deliberately expose non‑hyphenated prop names.
+    /// A list of tag names whose attributes should be exempt from the uppercase-letter check.
+    /// This is useful for third-party or internal components that deliberately expose camelCase or PascalCase prop names.
     ///
     /// ```json,options
     /// {
@@ -134,7 +136,7 @@ impl Rule for UseVueHyphenatedAttributes {
             {
                 continue;
             }
-            if !is_hyphenated(attr_name.text()) {
+            if contains_uppercase(attr_name.text()) {
                 violations.push(attribute.clone());
             }
         }
@@ -162,7 +164,16 @@ impl Rule for UseVueHyphenatedAttributes {
 
     fn action(ctx: &RuleContext<Self>, state: &Self::State) -> Option<HtmlRuleAction> {
         let name = extract_attribute_name(state)?;
-        let suggested = Case::Kebab.convert(name.text());
+        let name = name.text();
+
+        // In Vue, colons can be meaningful parts of plain attribute names, such as PrimeVue
+        // pass-through attributes. `Case::Kebab.convert` would replace them with hyphens, so
+        // don't offer a fix that could change the attribute's meaning.
+        if name.contains(':') {
+            return None;
+        }
+
+        let suggested = Case::Kebab.convert(name);
 
         // Start a batch mutation
         let mut mutation = biome_rowan::BatchMutationExt::begin(ctx.root());
@@ -273,17 +284,15 @@ fn extract_attribute_name(attr: &AnyHtmlAttribute) -> Option<TokenText> {
     None
 }
 
-fn is_hyphenated(name: &str) -> bool {
-    // Treat pure lowercase and kebab-case as valid.
-    matches!(Case::identify(name, true), Case::Kebab | Case::Lower)
+fn contains_uppercase(name: &str) -> bool {
+    // Don't use `Case::identify`: it classifies names by their exact case shape, while the
+    // upstream rule's default "always" mode only checks for uppercase letters. Punctuation is
+    // therefore neutral rather than evidence that the rule should report an attribute.
+    name.chars().any(char::is_uppercase)
 }
 
 fn is_svg_element(element: &AnyHtmlTagElement) -> bool {
-    let Some(tag_name) = element.tag_name() else {
-        return false;
-    };
-
-    SVG_EXCLUSIVE_ELEMENTS
-        .binary_search(&tag_name.text())
-        .is_ok()
+    element
+        .tag_name_kind()
+        .is_some_and(|kind| SVG_EXCLUSIVE_TAG_NAMES.contains(kind))
 }

--- a/crates/biome_html_analyze/tests/specs/style/useVueHyphenatedAttributes/invalid.vue
+++ b/crates/biome_html_analyze/tests/specs/style/useVueHyphenatedAttributes/invalid.vue
@@ -4,7 +4,7 @@
 <div someAttr="x"></div>
 <div SomeAttr="x"></div>
 <div SOME_ATTR="x"></div>
-<div some_attr="x"></div>
+<Panel pt:header:dataTestId="testId" />
 
 <!-- Vue v-bind: long-form and shorthand with non-hyphenated names -->
 <div v-bind:fooBar="true"></div>

--- a/crates/biome_html_analyze/tests/specs/style/useVueHyphenatedAttributes/invalid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/style/useVueHyphenatedAttributes/invalid.vue.snap
@@ -10,7 +10,7 @@ expression: invalid.vue
 <div someAttr="x"></div>
 <div SomeAttr="x"></div>
 <div SOME_ATTR="x"></div>
-<div some_attr="x"></div>
+<Panel pt:header:dataTestId="testId" />
 
 <!-- Vue v-bind: long-form and shorthand with non-hyphenated names -->
 <div v-bind:fooBar="true"></div>
@@ -60,7 +60,7 @@ invalid.vue:5:6 lint/style/useVueHyphenatedAttributes  FIXABLE  ━━━━━�
   > 5 │ <div SomeAttr="x"></div>
       │      ^^^^^^^^^^^^
     6 │ <div SOME_ATTR="x"></div>
-    7 │ <div some_attr="x"></div>
+    7 │ <Panel pt:header:dataTestId="testId" />
   
   i The Vue style guide recommends using hyphenated attribute (and prop) names in templates to keep them consistent.
   
@@ -71,7 +71,7 @@ invalid.vue:5:6 lint/style/useVueHyphenatedAttributes  FIXABLE  ━━━━━�
      5    │ - <div·SomeAttr="x"></div>
         5 │ + <div·some-attr="x"></div>
      6  6 │   <div SOME_ATTR="x"></div>
-     7  7 │   <div some_attr="x"></div>
+     7  7 │   <Panel pt:header:dataTestId="testId" />
   
 
 ```
@@ -85,7 +85,7 @@ invalid.vue:6:6 lint/style/useVueHyphenatedAttributes  FIXABLE  ━━━━━�
     5 │ <div SomeAttr="x"></div>
   > 6 │ <div SOME_ATTR="x"></div>
       │      ^^^^^^^^^^^^^
-    7 │ <div some_attr="x"></div>
+    7 │ <Panel pt:header:dataTestId="testId" />
     8 │ 
   
   i The Vue style guide recommends using hyphenated attribute (and prop) names in templates to keep them consistent.
@@ -96,34 +96,25 @@ invalid.vue:6:6 lint/style/useVueHyphenatedAttributes  FIXABLE  ━━━━━�
      5  5 │   <div SomeAttr="x"></div>
      6    │ - <div·SOME_ATTR="x"></div>
         6 │ + <div·some-attr="x"></div>
-     7  7 │   <div some_attr="x"></div>
+     7  7 │   <Panel pt:header:dataTestId="testId" />
      8  8 │   
   
 
 ```
 
 ```
-invalid.vue:7:6 lint/style/useVueHyphenatedAttributes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.vue:7:8 lint/style/useVueHyphenatedAttributes ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Attribute some_attr should be hyphenated (kebab-case).
+  i Attribute pt:header:dataTestId should be hyphenated (kebab-case).
   
     5 │ <div SomeAttr="x"></div>
     6 │ <div SOME_ATTR="x"></div>
-  > 7 │ <div some_attr="x"></div>
-      │      ^^^^^^^^^^^^^
+  > 7 │ <Panel pt:header:dataTestId="testId" />
+      │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     8 │ 
     9 │ <!-- Vue v-bind: long-form and shorthand with non-hyphenated names -->
   
   i The Vue style guide recommends using hyphenated attribute (and prop) names in templates to keep them consistent.
-  
-  i Unsafe fix: Rename the attribute to some-attr.
-  
-     5  5 │   <div SomeAttr="x"></div>
-     6  6 │   <div SOME_ATTR="x"></div>
-     7    │ - <div·some_attr="x"></div>
-        7 │ + <div·some-attr="x"></div>
-     8  8 │   
-     9  9 │   <!-- Vue v-bind: long-form and shorthand with non-hyphenated names -->
   
 
 ```

--- a/crates/biome_html_analyze/tests/specs/style/useVueHyphenatedAttributes/valid.vue
+++ b/crates/biome_html_analyze/tests/specs/style/useVueHyphenatedAttributes/valid.vue
@@ -1,8 +1,8 @@
 <!-- should not generate diagnostics -->
 
 <template>
-  <!-- Plain HTML attributes: lowercase and kebab-case are valid -->
-  <div class="container" id="root" data-test-id="z" aria-label="label" some-attr="ok"></div>
+  <!-- Plain HTML attributes without uppercase letters are valid -->
+  <div class="container" id="root" data-test-id="z" aria-label="label" some-attr="ok" some_attr="ok"></div>
 
   <!-- v-bind with static hyphenated argument -->
   <div v-bind:foo-bar="bar"></div>
@@ -22,6 +22,7 @@
 
   <!-- Additional valid attributes -->
   <input type="text" aria-label="user-name" data-user-id="123" />
+  <Panel pt:root:class="border border-solid" pt:header:id="headerId" pt:header:data-test-id="testId" />
 
   <!-- SVG attributes are not Vue props -->
   <svg version="1" viewBox="0 0 320 180" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#">

--- a/crates/biome_html_analyze/tests/specs/style/useVueHyphenatedAttributes/valid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/style/useVueHyphenatedAttributes/valid.vue.snap
@@ -7,8 +7,8 @@ expression: valid.vue
 <!-- should not generate diagnostics -->
 
 <template>
-  <!-- Plain HTML attributes: lowercase and kebab-case are valid -->
-  <div class="container" id="root" data-test-id="z" aria-label="label" some-attr="ok"></div>
+  <!-- Plain HTML attributes without uppercase letters are valid -->
+  <div class="container" id="root" data-test-id="z" aria-label="label" some-attr="ok" some_attr="ok"></div>
 
   <!-- v-bind with static hyphenated argument -->
   <div v-bind:foo-bar="bar"></div>
@@ -28,6 +28,7 @@ expression: valid.vue
 
   <!-- Additional valid attributes -->
   <input type="text" aria-label="user-name" data-user-id="123" />
+  <Panel pt:root:class="border border-solid" pt:header:id="headerId" pt:header:data-test-id="testId" />
 
   <!-- SVG attributes are not Vue props -->
   <svg version="1" viewBox="0 0 320 180" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#">

--- a/crates/biome_html_syntax/src/svg.rs
+++ b/crates/biome_html_syntax/src/svg.rs
@@ -1,3 +1,21 @@
+use crate::HtmlSyntaxKind::{
+    self, ALT_GLYPH_DEF_KW, ALT_GLYPH_ITEM_KW, ALT_GLYPH_KW, ANIMATE_COLOR_KW, ANIMATE_KW,
+    ANIMATE_MOTION_KW, ANIMATE_TRANSFORM_KW, CIRCLE_KW, CLIP_PATH_KW, COLOR_PROFILE_KW, CURSOR_KW,
+    DEFS_KW, DESC_KW, DISCARD_KW, ELLIPSE_KW, FE_BLEND_KW, FE_COLOR_MATRIX_KW,
+    FE_COMPONENT_TRANSFER_KW, FE_COMPOSITE_KW, FE_CONVOLVE_MATRIX_KW, FE_DIFFUSE_LIGHTING_KW,
+    FE_DISPLACEMENT_MAP_KW, FE_DISTANT_LIGHT_KW, FE_DROP_SHADOW_KW, FE_FLOOD_KW, FE_FUNC_A_KW,
+    FE_FUNC_B_KW, FE_FUNC_G_KW, FE_FUNC_R_KW, FE_GAUSSIAN_BLUR_KW, FE_IMAGE_KW, FE_MERGE_KW,
+    FE_MERGE_NODE_KW, FE_MORPHOLOGY_KW, FE_OFFSET_KW, FE_POINT_LIGHT_KW, FE_SPECULAR_LIGHTING_KW,
+    FE_SPOT_LIGHT_KW, FE_TILE_KW, FE_TURBULENCE_KW, FILTER_KW, FONT_FACE_FORMAT_KW, FONT_FACE_KW,
+    FONT_FACE_NAME_KW, FONT_FACE_SRC_KW, FONT_FACE_URI_KW, FONT_KW, FOREIGN_OBJECT_KW, G_KW,
+    GLYPH_KW, GLYPH_REF_KW, HATCH_KW, HATCHPATH_KW, HKERN_KW, IMAGE_KW, LINE_KW,
+    LINEAR_GRADIENT_KW, MARKER_KW, MASK_KW, MESH_KW, MESHGRADIENT_KW, MESHPATCH_KW, MESHROW_KW,
+    METADATA_KW, MISSING_GLYPH_KW, MPATH_KW, PATH_KW, PATTERN_KW, POLYGON_KW, POLYLINE_KW,
+    RADIAL_GRADIENT_KW, RECT_KW, SET_KW, SOLIDCOLOR_KW, STOP_KW, SVG_KW, SWITCH_KW, SYMBOL_KW,
+    TEXT_KW, TEXT_PATH_KW, TREF_KW, TSPAN_KW, USE_KW, VIEW_KW, VKERN_KW,
+};
+use biome_parser::{TokenSet, token_set};
+
 /// Elements that should only appear in SVG contexts, and not in HTML contexts.
 pub const SVG_EXCLUSIVE_ELEMENTS: &[&str] = &[
     "altGlyph",
@@ -87,9 +105,99 @@ pub const SVG_EXCLUSIVE_ELEMENTS: &[&str] = &[
     "vkern",
 ];
 
+/// Tag-name token kinds for elements that should only appear in SVG contexts.
+pub const SVG_EXCLUSIVE_TAG_NAMES: TokenSet<HtmlSyntaxKind> = token_set!(
+    ALT_GLYPH_KW,
+    ALT_GLYPH_DEF_KW,
+    ALT_GLYPH_ITEM_KW,
+    ANIMATE_KW,
+    ANIMATE_COLOR_KW,
+    ANIMATE_MOTION_KW,
+    ANIMATE_TRANSFORM_KW,
+    CIRCLE_KW,
+    CLIP_PATH_KW,
+    COLOR_PROFILE_KW,
+    CURSOR_KW,
+    DEFS_KW,
+    DESC_KW,
+    DISCARD_KW,
+    ELLIPSE_KW,
+    FE_BLEND_KW,
+    FE_COLOR_MATRIX_KW,
+    FE_COMPONENT_TRANSFER_KW,
+    FE_COMPOSITE_KW,
+    FE_CONVOLVE_MATRIX_KW,
+    FE_DIFFUSE_LIGHTING_KW,
+    FE_DISPLACEMENT_MAP_KW,
+    FE_DISTANT_LIGHT_KW,
+    FE_DROP_SHADOW_KW,
+    FE_FLOOD_KW,
+    FE_FUNC_A_KW,
+    FE_FUNC_B_KW,
+    FE_FUNC_G_KW,
+    FE_FUNC_R_KW,
+    FE_GAUSSIAN_BLUR_KW,
+    FE_IMAGE_KW,
+    FE_MERGE_KW,
+    FE_MERGE_NODE_KW,
+    FE_MORPHOLOGY_KW,
+    FE_OFFSET_KW,
+    FE_POINT_LIGHT_KW,
+    FE_SPECULAR_LIGHTING_KW,
+    FE_SPOT_LIGHT_KW,
+    FE_TILE_KW,
+    FE_TURBULENCE_KW,
+    FILTER_KW,
+    FONT_KW,
+    FONT_FACE_KW,
+    FONT_FACE_FORMAT_KW,
+    FONT_FACE_NAME_KW,
+    FONT_FACE_SRC_KW,
+    FONT_FACE_URI_KW,
+    FOREIGN_OBJECT_KW,
+    G_KW,
+    GLYPH_KW,
+    GLYPH_REF_KW,
+    HATCH_KW,
+    HATCHPATH_KW,
+    HKERN_KW,
+    IMAGE_KW,
+    LINE_KW,
+    LINEAR_GRADIENT_KW,
+    MARKER_KW,
+    MASK_KW,
+    MESH_KW,
+    MESHGRADIENT_KW,
+    MESHPATCH_KW,
+    MESHROW_KW,
+    METADATA_KW,
+    MISSING_GLYPH_KW,
+    MPATH_KW,
+    PATH_KW,
+    PATTERN_KW,
+    POLYGON_KW,
+    POLYLINE_KW,
+    RADIAL_GRADIENT_KW,
+    RECT_KW,
+    SET_KW,
+    SOLIDCOLOR_KW,
+    STOP_KW,
+    SVG_KW,
+    SWITCH_KW,
+    SYMBOL_KW,
+    TEXT_KW,
+    TEXT_PATH_KW,
+    TREF_KW,
+    TSPAN_KW,
+    USE_KW,
+    VIEW_KW,
+    VKERN_KW,
+);
+
 #[cfg(test)]
 mod tests {
-    use super::SVG_EXCLUSIVE_ELEMENTS;
+    use super::{SVG_EXCLUSIVE_ELEMENTS, SVG_EXCLUSIVE_TAG_NAMES};
+    use crate::HtmlSyntaxKind;
 
     #[test]
     fn svg_exclusive_elements_are_sorted() {
@@ -98,5 +206,24 @@ mod tests {
                 .windows(2)
                 .all(|elements| elements[0] < elements[1])
         );
+    }
+
+    #[test]
+    fn svg_exclusive_tag_names_match_elements() {
+        for element in SVG_EXCLUSIVE_ELEMENTS {
+            let Some(kind) = HtmlSyntaxKind::from_keyword(element) else {
+                panic!("`{element}` should be a keyword");
+            };
+            assert!(
+                SVG_EXCLUSIVE_TAG_NAMES.contains(kind),
+                "`{element}` should be an SVG-exclusive tag name"
+            );
+        }
+
+        let tag_name_count = (0..=HtmlSyntaxKind::__LAST as u16)
+            .map(HtmlSyntaxKind::from)
+            .filter(|kind| SVG_EXCLUSIVE_TAG_NAMES.contains(*kind))
+            .count();
+        assert_eq!(tag_name_count, SVG_EXCLUSIVE_ELEMENTS.len());
     }
 }

--- a/crates/biome_rule_options/src/use_vue_hyphenated_attributes.rs
+++ b/crates/biome_rule_options/src/use_vue_hyphenated_attributes.rs
@@ -5,9 +5,9 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields, default)]
 pub struct UseVueHyphenatedAttributesOptions {
-    /// List of attribute names to ignore when checking for hyphenated attributes.
+    /// List of attribute names to ignore when checking for uppercase letters.
     pub ignore: Option<FxHashSet<String>>,
 
-    /// List of HTML tags to ignore when checking for hyphenated attributes.
+    /// List of HTML tags whose attributes should not be checked for uppercase letters.
     pub ignore_tags: Option<FxHashSet<String>>,
 }

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -3470,7 +3470,7 @@ See https://biomejs.dev/linter/rules/use-vue-define-macros-order
 	 */
 	useVueDefineMacrosOrder?: UseVueDefineMacrosOrderConfiguration;
 	/**
-	* Enforce hyphenated (kebab-case) attribute names in Vue templates.
+	* Disallow uppercase letters in Vue template attribute names.
 See https://biomejs.dev/linter/rules/use-vue-hyphenated-attributes 
 	 */
 	useVueHyphenatedAttributes?: UseVueHyphenatedAttributesConfiguration;
@@ -9132,11 +9132,11 @@ export interface UseVueDefineMacrosOrderOptions {
 }
 export interface UseVueHyphenatedAttributesOptions {
 	/**
-	 * List of attribute names to ignore when checking for hyphenated attributes.
+	 * List of attribute names to ignore when checking for uppercase letters.
 	 */
 	ignore?: string[];
 	/**
-	 * List of HTML tags to ignore when checking for hyphenated attributes.
+	 * List of HTML tags whose attributes should not be checked for uppercase letters.
 	 */
 	ignoreTags?: string[];
 }

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -14010,7 +14010,7 @@
 					]
 				},
 				"useVueHyphenatedAttributes": {
-					"description": "Enforce hyphenated (kebab-case) attribute names in Vue templates.\nSee https://biomejs.dev/linter/rules/use-vue-hyphenated-attributes",
+					"description": "Disallow uppercase letters in Vue template attribute names.\nSee https://biomejs.dev/linter/rules/use-vue-hyphenated-attributes",
 					"anyOf": [
 						{ "$ref": "#/$defs/UseVueHyphenatedAttributesConfiguration" },
 						{ "type": "null" }
@@ -17157,14 +17157,14 @@
 			"type": "object",
 			"properties": {
 				"ignore": {
-					"description": "List of attribute names to ignore when checking for hyphenated attributes.",
+					"description": "List of attribute names to ignore when checking for uppercase letters.",
 					"type": ["array", "null"],
 					"default": null,
 					"items": { "type": "string" },
 					"uniqueItems": true
 				},
 				"ignoreTags": {
-					"description": "List of HTML tags to ignore when checking for hyphenated attributes.",
+					"description": "List of HTML tags whose attributes should not be checked for uppercase letters.",
 					"type": ["array", "null"],
 					"default": null,
 					"items": { "type": "string" },


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This loosens useVueHyphenatedAttributes a bit so that it acts more like the source rule.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #10776

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
