### PR TITLE
fix(parse/js): disambiguate parenthesized object expressions

### DIFF
--- a/.changeset/true-rules-tie.md
+++ b/.changeset/true-rules-tie.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11464](https://github.com/biomejs/biome/issues/11464): Biome now parses parenthesized object literals returned from arrow functions when they contain a conditional expression and a nested arrow function.

--- a/crates/biome_js_parser/src/syntax/function.rs
+++ b/crates/biome_js_parser/src/syntax/function.rs
@@ -736,7 +736,11 @@ fn is_parenthesized_arrow_function_expression_impl(
                 // Rest parameter '(...a' is certainly not a parenthesized expression
                 T![...] => IsParenthesizedArrowFunctionExpression::True,
                 // '([ ...', '({ ... } can either be a parenthesized object or array expression or a destructing parameter
-                T!['['] | T!['{'] => IsParenthesizedArrowFunctionExpression::Unknown,
+                T!['['] | T!['{'] => match token_after_parenthesized_group(p, n) {
+                    T![=>] => IsParenthesizedArrowFunctionExpression::True,
+                    T![:] => IsParenthesizedArrowFunctionExpression::Unknown,
+                    _ => IsParenthesizedArrowFunctionExpression::False,
+                },
 
                 // '(@' can be a decorator or a parenthesized arrow function
                 T![@] => IsParenthesizedArrowFunctionExpression::Unknown,
@@ -902,7 +906,7 @@ fn is_arrow_function_with_single_parameter(p: &mut JsParser) -> bool {
     }
 }
 
-// True if the `(...)` group at the current position is immediately followed by `=>`.
+// Returns the token after the `(...)` group at `start_offset`.
 //
 // Used to tell destructured arrow params apart from a parenthesized expression:
 //   ({ a, b }) =>   // followed by `=>` — these are params
@@ -910,21 +914,21 @@ fn is_arrow_function_with_single_parameter(p: &mut JsParser) -> bool {
 //
 // Tracks how many `(` are open at once so the first `)` that closes the outermost
 // paren is the one checked for `=>`. Without this, `(a: () => T) =>` would stop
-// at the inner `)` and return false.
-fn is_paren_group_followed_by_fat_arrow(p: &mut JsParser) -> bool {
-    debug_assert!(p.at(T!['(']));
+// at the inner `)` and return the wrong token.
+fn token_after_parenthesized_group(p: &mut JsParser, start_offset: usize) -> JsSyntaxKind {
+    debug_assert!(p.nth_at(start_offset, T!['(']));
     let mut depth: u32 = 0;
-    let mut offset: usize = 0;
+    let mut offset = start_offset;
     loop {
         match p.nth(offset) {
             T!['('] => depth += 1,
             T![')'] => {
                 depth -= 1;
                 if depth == 0 {
-                    return p.nth_at(offset + 1, T![=>]);
+                    return p.nth(offset + 1);
                 }
             }
-            EOF => return false,
+            EOF => return EOF,
             _ => {}
         }
         offset += 1;
@@ -968,7 +972,7 @@ fn parse_arrow_body(
             if context.is_in_conditional_consequent()
                 && matches!(p.cur(), T!['('])
                 && matches!(p.nth(1), T!['{'] | T!['['])
-                && !is_paren_group_followed_by_fat_arrow(p)
+                && token_after_parenthesized_group(p, 0) != T![=>]
             {
                 parse_assignment_expression_or_higher_no_arrow(p, body_context)
             } else {

--- a/crates/biome_js_parser/tests/js_test_suite/error/unclosed_parenthesized_object_arrow_body.js
+++ b/crates/biome_js_parser/tests/js_test_suite/error/unclosed_parenthesized_object_arrow_body.js
@@ -1,0 +1,2 @@
+const value = () => ({ key: 1 };
+const after = 2;

--- a/crates/biome_js_parser/tests/js_test_suite/error/unclosed_parenthesized_object_arrow_body.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/unclosed_parenthesized_object_arrow_body.js.snap
@@ -1,0 +1,171 @@
+---
+source: crates/biome_js_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```js
+const value = () => ({ key: 1 };
+const after = 2;
+
+```
+
+
+## AST
+
+```
+JsModule {
+    bom_token: missing (optional),
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsVariableStatement {
+            declaration: JsVariableDeclaration {
+                await_token: missing (optional),
+                kind: CONST_KW@0..6 "const" [] [Whitespace(" ")],
+                declarators: JsVariableDeclaratorList [
+                    JsVariableDeclarator {
+                        id: JsIdentifierBinding {
+                            name_token: IDENT@6..12 "value" [] [Whitespace(" ")],
+                        },
+                        variable_annotation: missing (optional),
+                        initializer: JsInitializerClause {
+                            eq_token: EQ@12..14 "=" [] [Whitespace(" ")],
+                            expression: JsArrowFunctionExpression {
+                                async_token: missing (optional),
+                                type_parameters: missing (optional),
+                                parameters: JsParameters {
+                                    l_paren_token: L_PAREN@14..15 "(" [] [],
+                                    items: JsParameterList [],
+                                    r_paren_token: R_PAREN@15..17 ")" [] [Whitespace(" ")],
+                                },
+                                return_type_annotation: missing (optional),
+                                fat_arrow_token: FAT_ARROW@17..20 "=>" [] [Whitespace(" ")],
+                                body: JsParenthesizedExpression {
+                                    l_paren_token: L_PAREN@20..21 "(" [] [],
+                                    expression: JsObjectExpression {
+                                        l_curly_token: L_CURLY@21..23 "{" [] [Whitespace(" ")],
+                                        members: JsObjectMemberList [
+                                            JsPropertyObjectMember {
+                                                name: JsLiteralMemberName {
+                                                    value: IDENT@23..26 "key" [] [],
+                                                },
+                                                colon_token: COLON@26..28 ":" [] [Whitespace(" ")],
+                                                value: JsNumberLiteralExpression {
+                                                    value_token: JS_NUMBER_LITERAL@28..30 "1" [] [Whitespace(" ")],
+                                                },
+                                            },
+                                        ],
+                                        r_curly_token: R_CURLY@30..31 "}" [] [],
+                                    },
+                                    r_paren_token: missing (required),
+                                },
+                            },
+                        },
+                    },
+                ],
+            },
+            semicolon_token: SEMICOLON@31..32 ";" [] [],
+        },
+        JsVariableStatement {
+            declaration: JsVariableDeclaration {
+                await_token: missing (optional),
+                kind: CONST_KW@32..39 "const" [Newline("\n")] [Whitespace(" ")],
+                declarators: JsVariableDeclaratorList [
+                    JsVariableDeclarator {
+                        id: JsIdentifierBinding {
+                            name_token: IDENT@39..45 "after" [] [Whitespace(" ")],
+                        },
+                        variable_annotation: missing (optional),
+                        initializer: JsInitializerClause {
+                            eq_token: EQ@45..47 "=" [] [Whitespace(" ")],
+                            expression: JsNumberLiteralExpression {
+                                value_token: JS_NUMBER_LITERAL@47..48 "2" [] [],
+                            },
+                        },
+                    },
+                ],
+            },
+            semicolon_token: SEMICOLON@48..49 ";" [] [],
+        },
+    ],
+    eof_token: EOF@49..50 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: JS_MODULE@0..50
+  0: (empty)
+  1: (empty)
+  2: JS_DIRECTIVE_LIST@0..0
+  3: JS_MODULE_ITEM_LIST@0..49
+    0: JS_VARIABLE_STATEMENT@0..32
+      0: JS_VARIABLE_DECLARATION@0..31
+        0: (empty)
+        1: CONST_KW@0..6 "const" [] [Whitespace(" ")]
+        2: JS_VARIABLE_DECLARATOR_LIST@6..31
+          0: JS_VARIABLE_DECLARATOR@6..31
+            0: JS_IDENTIFIER_BINDING@6..12
+              0: IDENT@6..12 "value" [] [Whitespace(" ")]
+            1: (empty)
+            2: JS_INITIALIZER_CLAUSE@12..31
+              0: EQ@12..14 "=" [] [Whitespace(" ")]
+              1: JS_ARROW_FUNCTION_EXPRESSION@14..31
+                0: (empty)
+                1: (empty)
+                2: JS_PARAMETERS@14..17
+                  0: L_PAREN@14..15 "(" [] []
+                  1: JS_PARAMETER_LIST@15..15
+                  2: R_PAREN@15..17 ")" [] [Whitespace(" ")]
+                3: (empty)
+                4: FAT_ARROW@17..20 "=>" [] [Whitespace(" ")]
+                5: JS_PARENTHESIZED_EXPRESSION@20..31
+                  0: L_PAREN@20..21 "(" [] []
+                  1: JS_OBJECT_EXPRESSION@21..31
+                    0: L_CURLY@21..23 "{" [] [Whitespace(" ")]
+                    1: JS_OBJECT_MEMBER_LIST@23..30
+                      0: JS_PROPERTY_OBJECT_MEMBER@23..30
+                        0: JS_LITERAL_MEMBER_NAME@23..26
+                          0: IDENT@23..26 "key" [] []
+                        1: COLON@26..28 ":" [] [Whitespace(" ")]
+                        2: JS_NUMBER_LITERAL_EXPRESSION@28..30
+                          0: JS_NUMBER_LITERAL@28..30 "1" [] [Whitespace(" ")]
+                    2: R_CURLY@30..31 "}" [] []
+                  2: (empty)
+      1: SEMICOLON@31..32 ";" [] []
+    1: JS_VARIABLE_STATEMENT@32..49
+      0: JS_VARIABLE_DECLARATION@32..48
+        0: (empty)
+        1: CONST_KW@32..39 "const" [Newline("\n")] [Whitespace(" ")]
+        2: JS_VARIABLE_DECLARATOR_LIST@39..48
+          0: JS_VARIABLE_DECLARATOR@39..48
+            0: JS_IDENTIFIER_BINDING@39..45
+              0: IDENT@39..45 "after" [] [Whitespace(" ")]
+            1: (empty)
+            2: JS_INITIALIZER_CLAUSE@45..48
+              0: EQ@45..47 "=" [] [Whitespace(" ")]
+              1: JS_NUMBER_LITERAL_EXPRESSION@47..48
+                0: JS_NUMBER_LITERAL@47..48 "2" [] []
+      1: SEMICOLON@48..49 ";" [] []
+  4: EOF@49..50 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+unclosed_parenthesized_object_arrow_body.js:1:32 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `)` but instead found `;`
+  
+  > 1 │ const value = () => ({ key: 1 };
+      │                                ^
+    2 │ const after = 2;
+    3 │ 
+  
+  i Remove ;
+  
+```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/conditional_in_test_with_arrow_in_alternate.ts
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/conditional_in_test_with_arrow_in_alternate.ts
@@ -1,0 +1,4 @@
+declare function tool(x: { f: (o: { output: { error: string } | { items: { k: string }[] } }) => unknown }): unknown;
+export const t = tool({
+	f: ({ output }) => ({ v: "error" in output ? output : { items: output.items.map((i) => ({ k: i.k })) } }),
+});

--- a/crates/biome_js_parser/tests/js_test_suite/ok/conditional_in_test_with_arrow_in_alternate.ts.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/conditional_in_test_with_arrow_in_alternate.ts.snap
@@ -1,0 +1,656 @@
+---
+source: crates/biome_js_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```ts
+declare function tool(x: { f: (o: { output: { error: string } | { items: { k: string }[] } }) => unknown }): unknown;
+export const t = tool({
+	f: ({ output }) => ({ v: "error" in output ? output : { items: output.items.map((i) => ({ k: i.k })) } }),
+});
+
+```
+
+
+## AST
+
+```
+JsModule {
+    bom_token: missing (optional),
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        TsDeclareStatement {
+            declare_token: DECLARE_KW@0..8 "declare" [] [Whitespace(" ")],
+            declaration: TsDeclareFunctionDeclaration {
+                async_token: missing (optional),
+                function_token: FUNCTION_KW@8..17 "function" [] [Whitespace(" ")],
+                id: JsIdentifierBinding {
+                    name_token: IDENT@17..21 "tool" [] [],
+                },
+                type_parameters: missing (optional),
+                parameters: JsParameters {
+                    l_paren_token: L_PAREN@21..22 "(" [] [],
+                    items: JsParameterList [
+                        JsFormalParameter {
+                            decorators: JsDecoratorList [],
+                            binding: JsIdentifierBinding {
+                                name_token: IDENT@22..23 "x" [] [],
+                            },
+                            question_mark_token: missing (optional),
+                            type_annotation: TsTypeAnnotation {
+                                colon_token: COLON@23..25 ":" [] [Whitespace(" ")],
+                                ty: TsObjectType {
+                                    l_curly_token: L_CURLY@25..27 "{" [] [Whitespace(" ")],
+                                    members: TsTypeMemberList [
+                                        TsPropertySignatureTypeMember {
+                                            readonly_token: missing (optional),
+                                            name: JsLiteralMemberName {
+                                                value: IDENT@27..28 "f" [] [],
+                                            },
+                                            optional_token: missing (optional),
+                                            type_annotation: TsTypeAnnotation {
+                                                colon_token: COLON@28..30 ":" [] [Whitespace(" ")],
+                                                ty: TsFunctionType {
+                                                    type_parameters: missing (optional),
+                                                    parameters: JsParameters {
+                                                        l_paren_token: L_PAREN@30..31 "(" [] [],
+                                                        items: JsParameterList [
+                                                            JsFormalParameter {
+                                                                decorators: JsDecoratorList [],
+                                                                binding: JsIdentifierBinding {
+                                                                    name_token: IDENT@31..32 "o" [] [],
+                                                                },
+                                                                question_mark_token: missing (optional),
+                                                                type_annotation: TsTypeAnnotation {
+                                                                    colon_token: COLON@32..34 ":" [] [Whitespace(" ")],
+                                                                    ty: TsObjectType {
+                                                                        l_curly_token: L_CURLY@34..36 "{" [] [Whitespace(" ")],
+                                                                        members: TsTypeMemberList [
+                                                                            TsPropertySignatureTypeMember {
+                                                                                readonly_token: missing (optional),
+                                                                                name: JsLiteralMemberName {
+                                                                                    value: IDENT@36..42 "output" [] [],
+                                                                                },
+                                                                                optional_token: missing (optional),
+                                                                                type_annotation: TsTypeAnnotation {
+                                                                                    colon_token: COLON@42..44 ":" [] [Whitespace(" ")],
+                                                                                    ty: TsUnionType {
+                                                                                        leading_separator_token: missing (optional),
+                                                                                        types: TsUnionTypeVariantList [
+                                                                                            TsObjectType {
+                                                                                                l_curly_token: L_CURLY@44..46 "{" [] [Whitespace(" ")],
+                                                                                                members: TsTypeMemberList [
+                                                                                                    TsPropertySignatureTypeMember {
+                                                                                                        readonly_token: missing (optional),
+                                                                                                        name: JsLiteralMemberName {
+                                                                                                            value: IDENT@46..51 "error" [] [],
+                                                                                                        },
+                                                                                                        optional_token: missing (optional),
+                                                                                                        type_annotation: TsTypeAnnotation {
+                                                                                                            colon_token: COLON@51..53 ":" [] [Whitespace(" ")],
+                                                                                                            ty: TsStringType {
+                                                                                                                string_token: STRING_KW@53..60 "string" [] [Whitespace(" ")],
+                                                                                                            },
+                                                                                                        },
+                                                                                                        separator_token: missing (optional),
+                                                                                                    },
+                                                                                                ],
+                                                                                                r_curly_token: R_CURLY@60..62 "}" [] [Whitespace(" ")],
+                                                                                            },
+                                                                                            PIPE@62..64 "|" [] [Whitespace(" ")],
+                                                                                            TsObjectType {
+                                                                                                l_curly_token: L_CURLY@64..66 "{" [] [Whitespace(" ")],
+                                                                                                members: TsTypeMemberList [
+                                                                                                    TsPropertySignatureTypeMember {
+                                                                                                        readonly_token: missing (optional),
+                                                                                                        name: JsLiteralMemberName {
+                                                                                                            value: IDENT@66..71 "items" [] [],
+                                                                                                        },
+                                                                                                        optional_token: missing (optional),
+                                                                                                        type_annotation: TsTypeAnnotation {
+                                                                                                            colon_token: COLON@71..73 ":" [] [Whitespace(" ")],
+                                                                                                            ty: TsArrayType {
+                                                                                                                element_type: TsObjectType {
+                                                                                                                    l_curly_token: L_CURLY@73..75 "{" [] [Whitespace(" ")],
+                                                                                                                    members: TsTypeMemberList [
+                                                                                                                        TsPropertySignatureTypeMember {
+                                                                                                                            readonly_token: missing (optional),
+                                                                                                                            name: JsLiteralMemberName {
+                                                                                                                                value: IDENT@75..76 "k" [] [],
+                                                                                                                            },
+                                                                                                                            optional_token: missing (optional),
+                                                                                                                            type_annotation: TsTypeAnnotation {
+                                                                                                                                colon_token: COLON@76..78 ":" [] [Whitespace(" ")],
+                                                                                                                                ty: TsStringType {
+                                                                                                                                    string_token: STRING_KW@78..85 "string" [] [Whitespace(" ")],
+                                                                                                                                },
+                                                                                                                            },
+                                                                                                                            separator_token: missing (optional),
+                                                                                                                        },
+                                                                                                                    ],
+                                                                                                                    r_curly_token: R_CURLY@85..86 "}" [] [],
+                                                                                                                },
+                                                                                                                l_brack_token: L_BRACK@86..87 "[" [] [],
+                                                                                                                r_brack_token: R_BRACK@87..89 "]" [] [Whitespace(" ")],
+                                                                                                            },
+                                                                                                        },
+                                                                                                        separator_token: missing (optional),
+                                                                                                    },
+                                                                                                ],
+                                                                                                r_curly_token: R_CURLY@89..91 "}" [] [Whitespace(" ")],
+                                                                                            },
+                                                                                        ],
+                                                                                    },
+                                                                                },
+                                                                                separator_token: missing (optional),
+                                                                            },
+                                                                        ],
+                                                                        r_curly_token: R_CURLY@91..92 "}" [] [],
+                                                                    },
+                                                                },
+                                                                initializer: missing (optional),
+                                                            },
+                                                        ],
+                                                        r_paren_token: R_PAREN@92..94 ")" [] [Whitespace(" ")],
+                                                    },
+                                                    fat_arrow_token: FAT_ARROW@94..97 "=>" [] [Whitespace(" ")],
+                                                    return_type: TsUnknownType {
+                                                        unknown_token: UNKNOWN_KW@97..105 "unknown" [] [Whitespace(" ")],
+                                                    },
+                                                },
+                                            },
+                                            separator_token: missing (optional),
+                                        },
+                                    ],
+                                    r_curly_token: R_CURLY@105..106 "}" [] [],
+                                },
+                            },
+                            initializer: missing (optional),
+                        },
+                    ],
+                    r_paren_token: R_PAREN@106..107 ")" [] [],
+                },
+                return_type_annotation: TsReturnTypeAnnotation {
+                    colon_token: COLON@107..109 ":" [] [Whitespace(" ")],
+                    ty: TsUnknownType {
+                        unknown_token: UNKNOWN_KW@109..116 "unknown" [] [],
+                    },
+                },
+                semicolon_token: SEMICOLON@116..117 ";" [] [],
+            },
+        },
+        JsExport {
+            decorators: JsDecoratorList [],
+            export_token: EXPORT_KW@117..125 "export" [Newline("\n")] [Whitespace(" ")],
+            export_clause: JsVariableDeclarationClause {
+                declaration: JsVariableDeclaration {
+                    await_token: missing (optional),
+                    kind: CONST_KW@125..131 "const" [] [Whitespace(" ")],
+                    declarators: JsVariableDeclaratorList [
+                        JsVariableDeclarator {
+                            id: JsIdentifierBinding {
+                                name_token: IDENT@131..133 "t" [] [Whitespace(" ")],
+                            },
+                            variable_annotation: missing (optional),
+                            initializer: JsInitializerClause {
+                                eq_token: EQ@133..135 "=" [] [Whitespace(" ")],
+                                expression: JsCallExpression {
+                                    callee: JsIdentifierExpression {
+                                        name: JsReferenceIdentifier {
+                                            value_token: IDENT@135..139 "tool" [] [],
+                                        },
+                                    },
+                                    optional_chain_token: missing (optional),
+                                    type_arguments: missing (optional),
+                                    arguments: JsCallArguments {
+                                        l_paren_token: L_PAREN@139..140 "(" [] [],
+                                        args: JsCallArgumentList [
+                                            JsObjectExpression {
+                                                l_curly_token: L_CURLY@140..141 "{" [] [],
+                                                members: JsObjectMemberList [
+                                                    JsPropertyObjectMember {
+                                                        name: JsLiteralMemberName {
+                                                            value: IDENT@141..144 "f" [Newline("\n"), Whitespace("\t")] [],
+                                                        },
+                                                        colon_token: COLON@144..146 ":" [] [Whitespace(" ")],
+                                                        value: JsArrowFunctionExpression {
+                                                            async_token: missing (optional),
+                                                            type_parameters: missing (optional),
+                                                            parameters: JsParameters {
+                                                                l_paren_token: L_PAREN@146..147 "(" [] [],
+                                                                items: JsParameterList [
+                                                                    JsFormalParameter {
+                                                                        decorators: JsDecoratorList [],
+                                                                        binding: JsObjectBindingPattern {
+                                                                            l_curly_token: L_CURLY@147..149 "{" [] [Whitespace(" ")],
+                                                                            properties: JsObjectBindingPatternPropertyList [
+                                                                                JsObjectBindingPatternShorthandProperty {
+                                                                                    identifier: JsIdentifierBinding {
+                                                                                        name_token: IDENT@149..156 "output" [] [Whitespace(" ")],
+                                                                                    },
+                                                                                    init: missing (optional),
+                                                                                },
+                                                                            ],
+                                                                            r_curly_token: R_CURLY@156..157 "}" [] [],
+                                                                        },
+                                                                        question_mark_token: missing (optional),
+                                                                        type_annotation: missing (optional),
+                                                                        initializer: missing (optional),
+                                                                    },
+                                                                ],
+                                                                r_paren_token: R_PAREN@157..159 ")" [] [Whitespace(" ")],
+                                                            },
+                                                            return_type_annotation: missing (optional),
+                                                            fat_arrow_token: FAT_ARROW@159..162 "=>" [] [Whitespace(" ")],
+                                                            body: JsParenthesizedExpression {
+                                                                l_paren_token: L_PAREN@162..163 "(" [] [],
+                                                                expression: JsObjectExpression {
+                                                                    l_curly_token: L_CURLY@163..165 "{" [] [Whitespace(" ")],
+                                                                    members: JsObjectMemberList [
+                                                                        JsPropertyObjectMember {
+                                                                            name: JsLiteralMemberName {
+                                                                                value: IDENT@165..166 "v" [] [],
+                                                                            },
+                                                                            colon_token: COLON@166..168 ":" [] [Whitespace(" ")],
+                                                                            value: JsConditionalExpression {
+                                                                                test: JsInExpression {
+                                                                                    property: JsStringLiteralExpression {
+                                                                                        value_token: JS_STRING_LITERAL@168..176 "\"error\"" [] [Whitespace(" ")],
+                                                                                    },
+                                                                                    in_token: IN_KW@176..179 "in" [] [Whitespace(" ")],
+                                                                                    object: JsIdentifierExpression {
+                                                                                        name: JsReferenceIdentifier {
+                                                                                            value_token: IDENT@179..186 "output" [] [Whitespace(" ")],
+                                                                                        },
+                                                                                    },
+                                                                                },
+                                                                                question_mark_token: QUESTION@186..188 "?" [] [Whitespace(" ")],
+                                                                                consequent: JsIdentifierExpression {
+                                                                                    name: JsReferenceIdentifier {
+                                                                                        value_token: IDENT@188..195 "output" [] [Whitespace(" ")],
+                                                                                    },
+                                                                                },
+                                                                                colon_token: COLON@195..197 ":" [] [Whitespace(" ")],
+                                                                                alternate: JsObjectExpression {
+                                                                                    l_curly_token: L_CURLY@197..199 "{" [] [Whitespace(" ")],
+                                                                                    members: JsObjectMemberList [
+                                                                                        JsPropertyObjectMember {
+                                                                                            name: JsLiteralMemberName {
+                                                                                                value: IDENT@199..204 "items" [] [],
+                                                                                            },
+                                                                                            colon_token: COLON@204..206 ":" [] [Whitespace(" ")],
+                                                                                            value: JsCallExpression {
+                                                                                                callee: JsStaticMemberExpression {
+                                                                                                    object: JsStaticMemberExpression {
+                                                                                                        object: JsIdentifierExpression {
+                                                                                                            name: JsReferenceIdentifier {
+                                                                                                                value_token: IDENT@206..212 "output" [] [],
+                                                                                                            },
+                                                                                                        },
+                                                                                                        operator_token: DOT@212..213 "." [] [],
+                                                                                                        member: JsName {
+                                                                                                            value_token: IDENT@213..218 "items" [] [],
+                                                                                                        },
+                                                                                                    },
+                                                                                                    operator_token: DOT@218..219 "." [] [],
+                                                                                                    member: JsName {
+                                                                                                        value_token: IDENT@219..222 "map" [] [],
+                                                                                                    },
+                                                                                                },
+                                                                                                optional_chain_token: missing (optional),
+                                                                                                type_arguments: missing (optional),
+                                                                                                arguments: JsCallArguments {
+                                                                                                    l_paren_token: L_PAREN@222..223 "(" [] [],
+                                                                                                    args: JsCallArgumentList [
+                                                                                                        JsArrowFunctionExpression {
+                                                                                                            async_token: missing (optional),
+                                                                                                            type_parameters: missing (optional),
+                                                                                                            parameters: JsParameters {
+                                                                                                                l_paren_token: L_PAREN@223..224 "(" [] [],
+                                                                                                                items: JsParameterList [
+                                                                                                                    JsFormalParameter {
+                                                                                                                        decorators: JsDecoratorList [],
+                                                                                                                        binding: JsIdentifierBinding {
+                                                                                                                            name_token: IDENT@224..225 "i" [] [],
+                                                                                                                        },
+                                                                                                                        question_mark_token: missing (optional),
+                                                                                                                        type_annotation: missing (optional),
+                                                                                                                        initializer: missing (optional),
+                                                                                                                    },
+                                                                                                                ],
+                                                                                                                r_paren_token: R_PAREN@225..227 ")" [] [Whitespace(" ")],
+                                                                                                            },
+                                                                                                            return_type_annotation: missing (optional),
+                                                                                                            fat_arrow_token: FAT_ARROW@227..230 "=>" [] [Whitespace(" ")],
+                                                                                                            body: JsParenthesizedExpression {
+                                                                                                                l_paren_token: L_PAREN@230..231 "(" [] [],
+                                                                                                                expression: JsObjectExpression {
+                                                                                                                    l_curly_token: L_CURLY@231..233 "{" [] [Whitespace(" ")],
+                                                                                                                    members: JsObjectMemberList [
+                                                                                                                        JsPropertyObjectMember {
+                                                                                                                            name: JsLiteralMemberName {
+                                                                                                                                value: IDENT@233..234 "k" [] [],
+                                                                                                                            },
+                                                                                                                            colon_token: COLON@234..236 ":" [] [Whitespace(" ")],
+                                                                                                                            value: JsStaticMemberExpression {
+                                                                                                                                object: JsIdentifierExpression {
+                                                                                                                                    name: JsReferenceIdentifier {
+                                                                                                                                        value_token: IDENT@236..237 "i" [] [],
+                                                                                                                                    },
+                                                                                                                                },
+                                                                                                                                operator_token: DOT@237..238 "." [] [],
+                                                                                                                                member: JsName {
+                                                                                                                                    value_token: IDENT@238..240 "k" [] [Whitespace(" ")],
+                                                                                                                                },
+                                                                                                                            },
+                                                                                                                        },
+                                                                                                                    ],
+                                                                                                                    r_curly_token: R_CURLY@240..241 "}" [] [],
+                                                                                                                },
+                                                                                                                r_paren_token: R_PAREN@241..242 ")" [] [],
+                                                                                                            },
+                                                                                                        },
+                                                                                                    ],
+                                                                                                    r_paren_token: R_PAREN@242..244 ")" [] [Whitespace(" ")],
+                                                                                                },
+                                                                                            },
+                                                                                        },
+                                                                                    ],
+                                                                                    r_curly_token: R_CURLY@244..246 "}" [] [Whitespace(" ")],
+                                                                                },
+                                                                            },
+                                                                        },
+                                                                    ],
+                                                                    r_curly_token: R_CURLY@246..247 "}" [] [],
+                                                                },
+                                                                r_paren_token: R_PAREN@247..248 ")" [] [],
+                                                            },
+                                                        },
+                                                    },
+                                                    COMMA@248..249 "," [] [],
+                                                ],
+                                                r_curly_token: R_CURLY@249..251 "}" [Newline("\n")] [],
+                                            },
+                                        ],
+                                        r_paren_token: R_PAREN@251..252 ")" [] [],
+                                    },
+                                },
+                            },
+                        },
+                    ],
+                },
+                semicolon_token: SEMICOLON@252..253 ";" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@253..254 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: JS_MODULE@0..254
+  0: (empty)
+  1: (empty)
+  2: JS_DIRECTIVE_LIST@0..0
+  3: JS_MODULE_ITEM_LIST@0..253
+    0: TS_DECLARE_STATEMENT@0..117
+      0: DECLARE_KW@0..8 "declare" [] [Whitespace(" ")]
+      1: TS_DECLARE_FUNCTION_DECLARATION@8..117
+        0: (empty)
+        1: FUNCTION_KW@8..17 "function" [] [Whitespace(" ")]
+        2: JS_IDENTIFIER_BINDING@17..21
+          0: IDENT@17..21 "tool" [] []
+        3: (empty)
+        4: JS_PARAMETERS@21..107
+          0: L_PAREN@21..22 "(" [] []
+          1: JS_PARAMETER_LIST@22..106
+            0: JS_FORMAL_PARAMETER@22..106
+              0: JS_DECORATOR_LIST@22..22
+              1: JS_IDENTIFIER_BINDING@22..23
+                0: IDENT@22..23 "x" [] []
+              2: (empty)
+              3: TS_TYPE_ANNOTATION@23..106
+                0: COLON@23..25 ":" [] [Whitespace(" ")]
+                1: TS_OBJECT_TYPE@25..106
+                  0: L_CURLY@25..27 "{" [] [Whitespace(" ")]
+                  1: TS_TYPE_MEMBER_LIST@27..105
+                    0: TS_PROPERTY_SIGNATURE_TYPE_MEMBER@27..105
+                      0: (empty)
+                      1: JS_LITERAL_MEMBER_NAME@27..28
+                        0: IDENT@27..28 "f" [] []
+                      2: (empty)
+                      3: TS_TYPE_ANNOTATION@28..105
+                        0: COLON@28..30 ":" [] [Whitespace(" ")]
+                        1: TS_FUNCTION_TYPE@30..105
+                          0: (empty)
+                          1: JS_PARAMETERS@30..94
+                            0: L_PAREN@30..31 "(" [] []
+                            1: JS_PARAMETER_LIST@31..92
+                              0: JS_FORMAL_PARAMETER@31..92
+                                0: JS_DECORATOR_LIST@31..31
+                                1: JS_IDENTIFIER_BINDING@31..32
+                                  0: IDENT@31..32 "o" [] []
+                                2: (empty)
+                                3: TS_TYPE_ANNOTATION@32..92
+                                  0: COLON@32..34 ":" [] [Whitespace(" ")]
+                                  1: TS_OBJECT_TYPE@34..92
+                                    0: L_CURLY@34..36 "{" [] [Whitespace(" ")]
+                                    1: TS_TYPE_MEMBER_LIST@36..91
+                                      0: TS_PROPERTY_SIGNATURE_TYPE_MEMBER@36..91
+                                        0: (empty)
+                                        1: JS_LITERAL_MEMBER_NAME@36..42
+                                          0: IDENT@36..42 "output" [] []
+                                        2: (empty)
+                                        3: TS_TYPE_ANNOTATION@42..91
+                                          0: COLON@42..44 ":" [] [Whitespace(" ")]
+                                          1: TS_UNION_TYPE@44..91
+                                            0: (empty)
+                                            1: TS_UNION_TYPE_VARIANT_LIST@44..91
+                                              0: TS_OBJECT_TYPE@44..62
+                                                0: L_CURLY@44..46 "{" [] [Whitespace(" ")]
+                                                1: TS_TYPE_MEMBER_LIST@46..60
+                                                  0: TS_PROPERTY_SIGNATURE_TYPE_MEMBER@46..60
+                                                    0: (empty)
+                                                    1: JS_LITERAL_MEMBER_NAME@46..51
+                                                      0: IDENT@46..51 "error" [] []
+                                                    2: (empty)
+                                                    3: TS_TYPE_ANNOTATION@51..60
+                                                      0: COLON@51..53 ":" [] [Whitespace(" ")]
+                                                      1: TS_STRING_TYPE@53..60
+                                                        0: STRING_KW@53..60 "string" [] [Whitespace(" ")]
+                                                    4: (empty)
+                                                2: R_CURLY@60..62 "}" [] [Whitespace(" ")]
+                                              1: PIPE@62..64 "|" [] [Whitespace(" ")]
+                                              2: TS_OBJECT_TYPE@64..91
+                                                0: L_CURLY@64..66 "{" [] [Whitespace(" ")]
+                                                1: TS_TYPE_MEMBER_LIST@66..89
+                                                  0: TS_PROPERTY_SIGNATURE_TYPE_MEMBER@66..89
+                                                    0: (empty)
+                                                    1: JS_LITERAL_MEMBER_NAME@66..71
+                                                      0: IDENT@66..71 "items" [] []
+                                                    2: (empty)
+                                                    3: TS_TYPE_ANNOTATION@71..89
+                                                      0: COLON@71..73 ":" [] [Whitespace(" ")]
+                                                      1: TS_ARRAY_TYPE@73..89
+                                                        0: TS_OBJECT_TYPE@73..86
+                                                          0: L_CURLY@73..75 "{" [] [Whitespace(" ")]
+                                                          1: TS_TYPE_MEMBER_LIST@75..85
+                                                            0: TS_PROPERTY_SIGNATURE_TYPE_MEMBER@75..85
+                                                              0: (empty)
+                                                              1: JS_LITERAL_MEMBER_NAME@75..76
+                                                                0: IDENT@75..76 "k" [] []
+                                                              2: (empty)
+                                                              3: TS_TYPE_ANNOTATION@76..85
+                                                                0: COLON@76..78 ":" [] [Whitespace(" ")]
+                                                                1: TS_STRING_TYPE@78..85
+                                                                  0: STRING_KW@78..85 "string" [] [Whitespace(" ")]
+                                                              4: (empty)
+                                                          2: R_CURLY@85..86 "}" [] []
+                                                        1: L_BRACK@86..87 "[" [] []
+                                                        2: R_BRACK@87..89 "]" [] [Whitespace(" ")]
+                                                    4: (empty)
+                                                2: R_CURLY@89..91 "}" [] [Whitespace(" ")]
+                                        4: (empty)
+                                    2: R_CURLY@91..92 "}" [] []
+                                4: (empty)
+                            2: R_PAREN@92..94 ")" [] [Whitespace(" ")]
+                          2: FAT_ARROW@94..97 "=>" [] [Whitespace(" ")]
+                          3: TS_UNKNOWN_TYPE@97..105
+                            0: UNKNOWN_KW@97..105 "unknown" [] [Whitespace(" ")]
+                      4: (empty)
+                  2: R_CURLY@105..106 "}" [] []
+              4: (empty)
+          2: R_PAREN@106..107 ")" [] []
+        5: TS_RETURN_TYPE_ANNOTATION@107..116
+          0: COLON@107..109 ":" [] [Whitespace(" ")]
+          1: TS_UNKNOWN_TYPE@109..116
+            0: UNKNOWN_KW@109..116 "unknown" [] []
+        6: SEMICOLON@116..117 ";" [] []
+    1: JS_EXPORT@117..253
+      0: JS_DECORATOR_LIST@117..117
+      1: EXPORT_KW@117..125 "export" [Newline("\n")] [Whitespace(" ")]
+      2: JS_VARIABLE_DECLARATION_CLAUSE@125..253
+        0: JS_VARIABLE_DECLARATION@125..252
+          0: (empty)
+          1: CONST_KW@125..131 "const" [] [Whitespace(" ")]
+          2: JS_VARIABLE_DECLARATOR_LIST@131..252
+            0: JS_VARIABLE_DECLARATOR@131..252
+              0: JS_IDENTIFIER_BINDING@131..133
+                0: IDENT@131..133 "t" [] [Whitespace(" ")]
+              1: (empty)
+              2: JS_INITIALIZER_CLAUSE@133..252
+                0: EQ@133..135 "=" [] [Whitespace(" ")]
+                1: JS_CALL_EXPRESSION@135..252
+                  0: JS_IDENTIFIER_EXPRESSION@135..139
+                    0: JS_REFERENCE_IDENTIFIER@135..139
+                      0: IDENT@135..139 "tool" [] []
+                  1: (empty)
+                  2: (empty)
+                  3: JS_CALL_ARGUMENTS@139..252
+                    0: L_PAREN@139..140 "(" [] []
+                    1: JS_CALL_ARGUMENT_LIST@140..251
+                      0: JS_OBJECT_EXPRESSION@140..251
+                        0: L_CURLY@140..141 "{" [] []
+                        1: JS_OBJECT_MEMBER_LIST@141..249
+                          0: JS_PROPERTY_OBJECT_MEMBER@141..248
+                            0: JS_LITERAL_MEMBER_NAME@141..144
+                              0: IDENT@141..144 "f" [Newline("\n"), Whitespace("\t")] []
+                            1: COLON@144..146 ":" [] [Whitespace(" ")]
+                            2: JS_ARROW_FUNCTION_EXPRESSION@146..248
+                              0: (empty)
+                              1: (empty)
+                              2: JS_PARAMETERS@146..159
+                                0: L_PAREN@146..147 "(" [] []
+                                1: JS_PARAMETER_LIST@147..157
+                                  0: JS_FORMAL_PARAMETER@147..157
+                                    0: JS_DECORATOR_LIST@147..147
+                                    1: JS_OBJECT_BINDING_PATTERN@147..157
+                                      0: L_CURLY@147..149 "{" [] [Whitespace(" ")]
+                                      1: JS_OBJECT_BINDING_PATTERN_PROPERTY_LIST@149..156
+                                        0: JS_OBJECT_BINDING_PATTERN_SHORTHAND_PROPERTY@149..156
+                                          0: JS_IDENTIFIER_BINDING@149..156
+                                            0: IDENT@149..156 "output" [] [Whitespace(" ")]
+                                          1: (empty)
+                                      2: R_CURLY@156..157 "}" [] []
+                                    2: (empty)
+                                    3: (empty)
+                                    4: (empty)
+                                2: R_PAREN@157..159 ")" [] [Whitespace(" ")]
+                              3: (empty)
+                              4: FAT_ARROW@159..162 "=>" [] [Whitespace(" ")]
+                              5: JS_PARENTHESIZED_EXPRESSION@162..248
+                                0: L_PAREN@162..163 "(" [] []
+                                1: JS_OBJECT_EXPRESSION@163..247
+                                  0: L_CURLY@163..165 "{" [] [Whitespace(" ")]
+                                  1: JS_OBJECT_MEMBER_LIST@165..246
+                                    0: JS_PROPERTY_OBJECT_MEMBER@165..246
+                                      0: JS_LITERAL_MEMBER_NAME@165..166
+                                        0: IDENT@165..166 "v" [] []
+                                      1: COLON@166..168 ":" [] [Whitespace(" ")]
+                                      2: JS_CONDITIONAL_EXPRESSION@168..246
+                                        0: JS_IN_EXPRESSION@168..186
+                                          0: JS_STRING_LITERAL_EXPRESSION@168..176
+                                            0: JS_STRING_LITERAL@168..176 "\"error\"" [] [Whitespace(" ")]
+                                          1: IN_KW@176..179 "in" [] [Whitespace(" ")]
+                                          2: JS_IDENTIFIER_EXPRESSION@179..186
+                                            0: JS_REFERENCE_IDENTIFIER@179..186
+                                              0: IDENT@179..186 "output" [] [Whitespace(" ")]
+                                        1: QUESTION@186..188 "?" [] [Whitespace(" ")]
+                                        2: JS_IDENTIFIER_EXPRESSION@188..195
+                                          0: JS_REFERENCE_IDENTIFIER@188..195
+                                            0: IDENT@188..195 "output" [] [Whitespace(" ")]
+                                        3: COLON@195..197 ":" [] [Whitespace(" ")]
+                                        4: JS_OBJECT_EXPRESSION@197..246
+                                          0: L_CURLY@197..199 "{" [] [Whitespace(" ")]
+                                          1: JS_OBJECT_MEMBER_LIST@199..244
+                                            0: JS_PROPERTY_OBJECT_MEMBER@199..244
+                                              0: JS_LITERAL_MEMBER_NAME@199..204
+                                                0: IDENT@199..204 "items" [] []
+                                              1: COLON@204..206 ":" [] [Whitespace(" ")]
+                                              2: JS_CALL_EXPRESSION@206..244
+                                                0: JS_STATIC_MEMBER_EXPRESSION@206..222
+                                                  0: JS_STATIC_MEMBER_EXPRESSION@206..218
+                                                    0: JS_IDENTIFIER_EXPRESSION@206..212
+                                                      0: JS_REFERENCE_IDENTIFIER@206..212
+                                                        0: IDENT@206..212 "output" [] []
+                                                    1: DOT@212..213 "." [] []
+                                                    2: JS_NAME@213..218
+                                                      0: IDENT@213..218 "items" [] []
+                                                  1: DOT@218..219 "." [] []
+                                                  2: JS_NAME@219..222
+                                                    0: IDENT@219..222 "map" [] []
+                                                1: (empty)
+                                                2: (empty)
+                                                3: JS_CALL_ARGUMENTS@222..244
+                                                  0: L_PAREN@222..223 "(" [] []
+                                                  1: JS_CALL_ARGUMENT_LIST@223..242
+                                                    0: JS_ARROW_FUNCTION_EXPRESSION@223..242
+                                                      0: (empty)
+                                                      1: (empty)
+                                                      2: JS_PARAMETERS@223..227
+                                                        0: L_PAREN@223..224 "(" [] []
+                                                        1: JS_PARAMETER_LIST@224..225
+                                                          0: JS_FORMAL_PARAMETER@224..225
+                                                            0: JS_DECORATOR_LIST@224..224
+                                                            1: JS_IDENTIFIER_BINDING@224..225
+                                                              0: IDENT@224..225 "i" [] []
+                                                            2: (empty)
+                                                            3: (empty)
+                                                            4: (empty)
+                                                        2: R_PAREN@225..227 ")" [] [Whitespace(" ")]
+                                                      3: (empty)
+                                                      4: FAT_ARROW@227..230 "=>" [] [Whitespace(" ")]
+                                                      5: JS_PARENTHESIZED_EXPRESSION@230..242
+                                                        0: L_PAREN@230..231 "(" [] []
+                                                        1: JS_OBJECT_EXPRESSION@231..241
+                                                          0: L_CURLY@231..233 "{" [] [Whitespace(" ")]
+                                                          1: JS_OBJECT_MEMBER_LIST@233..240
+                                                            0: JS_PROPERTY_OBJECT_MEMBER@233..240
+                                                              0: JS_LITERAL_MEMBER_NAME@233..234
+                                                                0: IDENT@233..234 "k" [] []
+                                                              1: COLON@234..236 ":" [] [Whitespace(" ")]
+                                                              2: JS_STATIC_MEMBER_EXPRESSION@236..240
+                                                                0: JS_IDENTIFIER_EXPRESSION@236..237
+                                                                  0: JS_REFERENCE_IDENTIFIER@236..237
+                                                                    0: IDENT@236..237 "i" [] []
+                                                                1: DOT@237..238 "." [] []
+                                                                2: JS_NAME@238..240
+                                                                  0: IDENT@238..240 "k" [] [Whitespace(" ")]
+                                                          2: R_CURLY@240..241 "}" [] []
+                                                        2: R_PAREN@241..242 ")" [] []
+                                                  2: R_PAREN@242..244 ")" [] [Whitespace(" ")]
+                                          2: R_CURLY@244..246 "}" [] [Whitespace(" ")]
+                                  2: R_CURLY@246..247 "}" [] []
+                                2: R_PAREN@247..248 ")" [] []
+                          1: COMMA@248..249 "," [] []
+                        2: R_CURLY@249..251 "}" [Newline("\n")] []
+                    2: R_PAREN@251..252 ")" [] []
+        1: SEMICOLON@252..253 ";" [] []
+  4: EOF@253..254 "" [Newline("\n")] []
+
+```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/conditional_with_nested_arrow_in_alternate.ts
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/conditional_with_nested_arrow_in_alternate.ts
@@ -1,0 +1,2 @@
+const apply = (callback: (n: number) => number) => callback(1);
+const fn = (flag: boolean) => ({ value: flag ? flag : { result: apply((n) => n) } });

--- a/crates/biome_js_parser/tests/js_test_suite/ok/conditional_with_nested_arrow_in_alternate.ts.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/conditional_with_nested_arrow_in_alternate.ts.snap
@@ -1,0 +1,399 @@
+---
+source: crates/biome_js_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```ts
+const apply = (callback: (n: number) => number) => callback(1);
+const fn = (flag: boolean) => ({ value: flag ? flag : { result: apply((n) => n) } });
+
+```
+
+
+## AST
+
+```
+JsModule {
+    bom_token: missing (optional),
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsVariableStatement {
+            declaration: JsVariableDeclaration {
+                await_token: missing (optional),
+                kind: CONST_KW@0..6 "const" [] [Whitespace(" ")],
+                declarators: JsVariableDeclaratorList [
+                    JsVariableDeclarator {
+                        id: JsIdentifierBinding {
+                            name_token: IDENT@6..12 "apply" [] [Whitespace(" ")],
+                        },
+                        variable_annotation: missing (optional),
+                        initializer: JsInitializerClause {
+                            eq_token: EQ@12..14 "=" [] [Whitespace(" ")],
+                            expression: JsArrowFunctionExpression {
+                                async_token: missing (optional),
+                                type_parameters: missing (optional),
+                                parameters: JsParameters {
+                                    l_paren_token: L_PAREN@14..15 "(" [] [],
+                                    items: JsParameterList [
+                                        JsFormalParameter {
+                                            decorators: JsDecoratorList [],
+                                            binding: JsIdentifierBinding {
+                                                name_token: IDENT@15..23 "callback" [] [],
+                                            },
+                                            question_mark_token: missing (optional),
+                                            type_annotation: TsTypeAnnotation {
+                                                colon_token: COLON@23..25 ":" [] [Whitespace(" ")],
+                                                ty: TsFunctionType {
+                                                    type_parameters: missing (optional),
+                                                    parameters: JsParameters {
+                                                        l_paren_token: L_PAREN@25..26 "(" [] [],
+                                                        items: JsParameterList [
+                                                            JsFormalParameter {
+                                                                decorators: JsDecoratorList [],
+                                                                binding: JsIdentifierBinding {
+                                                                    name_token: IDENT@26..27 "n" [] [],
+                                                                },
+                                                                question_mark_token: missing (optional),
+                                                                type_annotation: TsTypeAnnotation {
+                                                                    colon_token: COLON@27..29 ":" [] [Whitespace(" ")],
+                                                                    ty: TsNumberType {
+                                                                        number_token: NUMBER_KW@29..35 "number" [] [],
+                                                                    },
+                                                                },
+                                                                initializer: missing (optional),
+                                                            },
+                                                        ],
+                                                        r_paren_token: R_PAREN@35..37 ")" [] [Whitespace(" ")],
+                                                    },
+                                                    fat_arrow_token: FAT_ARROW@37..40 "=>" [] [Whitespace(" ")],
+                                                    return_type: TsNumberType {
+                                                        number_token: NUMBER_KW@40..46 "number" [] [],
+                                                    },
+                                                },
+                                            },
+                                            initializer: missing (optional),
+                                        },
+                                    ],
+                                    r_paren_token: R_PAREN@46..48 ")" [] [Whitespace(" ")],
+                                },
+                                return_type_annotation: missing (optional),
+                                fat_arrow_token: FAT_ARROW@48..51 "=>" [] [Whitespace(" ")],
+                                body: JsCallExpression {
+                                    callee: JsIdentifierExpression {
+                                        name: JsReferenceIdentifier {
+                                            value_token: IDENT@51..59 "callback" [] [],
+                                        },
+                                    },
+                                    optional_chain_token: missing (optional),
+                                    type_arguments: missing (optional),
+                                    arguments: JsCallArguments {
+                                        l_paren_token: L_PAREN@59..60 "(" [] [],
+                                        args: JsCallArgumentList [
+                                            JsNumberLiteralExpression {
+                                                value_token: JS_NUMBER_LITERAL@60..61 "1" [] [],
+                                            },
+                                        ],
+                                        r_paren_token: R_PAREN@61..62 ")" [] [],
+                                    },
+                                },
+                            },
+                        },
+                    },
+                ],
+            },
+            semicolon_token: SEMICOLON@62..63 ";" [] [],
+        },
+        JsVariableStatement {
+            declaration: JsVariableDeclaration {
+                await_token: missing (optional),
+                kind: CONST_KW@63..70 "const" [Newline("\n")] [Whitespace(" ")],
+                declarators: JsVariableDeclaratorList [
+                    JsVariableDeclarator {
+                        id: JsIdentifierBinding {
+                            name_token: IDENT@70..73 "fn" [] [Whitespace(" ")],
+                        },
+                        variable_annotation: missing (optional),
+                        initializer: JsInitializerClause {
+                            eq_token: EQ@73..75 "=" [] [Whitespace(" ")],
+                            expression: JsArrowFunctionExpression {
+                                async_token: missing (optional),
+                                type_parameters: missing (optional),
+                                parameters: JsParameters {
+                                    l_paren_token: L_PAREN@75..76 "(" [] [],
+                                    items: JsParameterList [
+                                        JsFormalParameter {
+                                            decorators: JsDecoratorList [],
+                                            binding: JsIdentifierBinding {
+                                                name_token: IDENT@76..80 "flag" [] [],
+                                            },
+                                            question_mark_token: missing (optional),
+                                            type_annotation: TsTypeAnnotation {
+                                                colon_token: COLON@80..82 ":" [] [Whitespace(" ")],
+                                                ty: TsBooleanType {
+                                                    boolean_token: BOOLEAN_KW@82..89 "boolean" [] [],
+                                                },
+                                            },
+                                            initializer: missing (optional),
+                                        },
+                                    ],
+                                    r_paren_token: R_PAREN@89..91 ")" [] [Whitespace(" ")],
+                                },
+                                return_type_annotation: missing (optional),
+                                fat_arrow_token: FAT_ARROW@91..94 "=>" [] [Whitespace(" ")],
+                                body: JsParenthesizedExpression {
+                                    l_paren_token: L_PAREN@94..95 "(" [] [],
+                                    expression: JsObjectExpression {
+                                        l_curly_token: L_CURLY@95..97 "{" [] [Whitespace(" ")],
+                                        members: JsObjectMemberList [
+                                            JsPropertyObjectMember {
+                                                name: JsLiteralMemberName {
+                                                    value: IDENT@97..102 "value" [] [],
+                                                },
+                                                colon_token: COLON@102..104 ":" [] [Whitespace(" ")],
+                                                value: JsConditionalExpression {
+                                                    test: JsIdentifierExpression {
+                                                        name: JsReferenceIdentifier {
+                                                            value_token: IDENT@104..109 "flag" [] [Whitespace(" ")],
+                                                        },
+                                                    },
+                                                    question_mark_token: QUESTION@109..111 "?" [] [Whitespace(" ")],
+                                                    consequent: JsIdentifierExpression {
+                                                        name: JsReferenceIdentifier {
+                                                            value_token: IDENT@111..116 "flag" [] [Whitespace(" ")],
+                                                        },
+                                                    },
+                                                    colon_token: COLON@116..118 ":" [] [Whitespace(" ")],
+                                                    alternate: JsObjectExpression {
+                                                        l_curly_token: L_CURLY@118..120 "{" [] [Whitespace(" ")],
+                                                        members: JsObjectMemberList [
+                                                            JsPropertyObjectMember {
+                                                                name: JsLiteralMemberName {
+                                                                    value: IDENT@120..126 "result" [] [],
+                                                                },
+                                                                colon_token: COLON@126..128 ":" [] [Whitespace(" ")],
+                                                                value: JsCallExpression {
+                                                                    callee: JsIdentifierExpression {
+                                                                        name: JsReferenceIdentifier {
+                                                                            value_token: IDENT@128..133 "apply" [] [],
+                                                                        },
+                                                                    },
+                                                                    optional_chain_token: missing (optional),
+                                                                    type_arguments: missing (optional),
+                                                                    arguments: JsCallArguments {
+                                                                        l_paren_token: L_PAREN@133..134 "(" [] [],
+                                                                        args: JsCallArgumentList [
+                                                                            JsArrowFunctionExpression {
+                                                                                async_token: missing (optional),
+                                                                                type_parameters: missing (optional),
+                                                                                parameters: JsParameters {
+                                                                                    l_paren_token: L_PAREN@134..135 "(" [] [],
+                                                                                    items: JsParameterList [
+                                                                                        JsFormalParameter {
+                                                                                            decorators: JsDecoratorList [],
+                                                                                            binding: JsIdentifierBinding {
+                                                                                                name_token: IDENT@135..136 "n" [] [],
+                                                                                            },
+                                                                                            question_mark_token: missing (optional),
+                                                                                            type_annotation: missing (optional),
+                                                                                            initializer: missing (optional),
+                                                                                        },
+                                                                                    ],
+                                                                                    r_paren_token: R_PAREN@136..138 ")" [] [Whitespace(" ")],
+                                                                                },
+                                                                                return_type_annotation: missing (optional),
+                                                                                fat_arrow_token: FAT_ARROW@138..141 "=>" [] [Whitespace(" ")],
+                                                                                body: JsIdentifierExpression {
+                                                                                    name: JsReferenceIdentifier {
+                                                                                        value_token: IDENT@141..142 "n" [] [],
+                                                                                    },
+                                                                                },
+                                                                            },
+                                                                        ],
+                                                                        r_paren_token: R_PAREN@142..144 ")" [] [Whitespace(" ")],
+                                                                    },
+                                                                },
+                                                            },
+                                                        ],
+                                                        r_curly_token: R_CURLY@144..146 "}" [] [Whitespace(" ")],
+                                                    },
+                                                },
+                                            },
+                                        ],
+                                        r_curly_token: R_CURLY@146..147 "}" [] [],
+                                    },
+                                    r_paren_token: R_PAREN@147..148 ")" [] [],
+                                },
+                            },
+                        },
+                    },
+                ],
+            },
+            semicolon_token: SEMICOLON@148..149 ";" [] [],
+        },
+    ],
+    eof_token: EOF@149..150 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: JS_MODULE@0..150
+  0: (empty)
+  1: (empty)
+  2: JS_DIRECTIVE_LIST@0..0
+  3: JS_MODULE_ITEM_LIST@0..149
+    0: JS_VARIABLE_STATEMENT@0..63
+      0: JS_VARIABLE_DECLARATION@0..62
+        0: (empty)
+        1: CONST_KW@0..6 "const" [] [Whitespace(" ")]
+        2: JS_VARIABLE_DECLARATOR_LIST@6..62
+          0: JS_VARIABLE_DECLARATOR@6..62
+            0: JS_IDENTIFIER_BINDING@6..12
+              0: IDENT@6..12 "apply" [] [Whitespace(" ")]
+            1: (empty)
+            2: JS_INITIALIZER_CLAUSE@12..62
+              0: EQ@12..14 "=" [] [Whitespace(" ")]
+              1: JS_ARROW_FUNCTION_EXPRESSION@14..62
+                0: (empty)
+                1: (empty)
+                2: JS_PARAMETERS@14..48
+                  0: L_PAREN@14..15 "(" [] []
+                  1: JS_PARAMETER_LIST@15..46
+                    0: JS_FORMAL_PARAMETER@15..46
+                      0: JS_DECORATOR_LIST@15..15
+                      1: JS_IDENTIFIER_BINDING@15..23
+                        0: IDENT@15..23 "callback" [] []
+                      2: (empty)
+                      3: TS_TYPE_ANNOTATION@23..46
+                        0: COLON@23..25 ":" [] [Whitespace(" ")]
+                        1: TS_FUNCTION_TYPE@25..46
+                          0: (empty)
+                          1: JS_PARAMETERS@25..37
+                            0: L_PAREN@25..26 "(" [] []
+                            1: JS_PARAMETER_LIST@26..35
+                              0: JS_FORMAL_PARAMETER@26..35
+                                0: JS_DECORATOR_LIST@26..26
+                                1: JS_IDENTIFIER_BINDING@26..27
+                                  0: IDENT@26..27 "n" [] []
+                                2: (empty)
+                                3: TS_TYPE_ANNOTATION@27..35
+                                  0: COLON@27..29 ":" [] [Whitespace(" ")]
+                                  1: TS_NUMBER_TYPE@29..35
+                                    0: NUMBER_KW@29..35 "number" [] []
+                                4: (empty)
+                            2: R_PAREN@35..37 ")" [] [Whitespace(" ")]
+                          2: FAT_ARROW@37..40 "=>" [] [Whitespace(" ")]
+                          3: TS_NUMBER_TYPE@40..46
+                            0: NUMBER_KW@40..46 "number" [] []
+                      4: (empty)
+                  2: R_PAREN@46..48 ")" [] [Whitespace(" ")]
+                3: (empty)
+                4: FAT_ARROW@48..51 "=>" [] [Whitespace(" ")]
+                5: JS_CALL_EXPRESSION@51..62
+                  0: JS_IDENTIFIER_EXPRESSION@51..59
+                    0: JS_REFERENCE_IDENTIFIER@51..59
+                      0: IDENT@51..59 "callback" [] []
+                  1: (empty)
+                  2: (empty)
+                  3: JS_CALL_ARGUMENTS@59..62
+                    0: L_PAREN@59..60 "(" [] []
+                    1: JS_CALL_ARGUMENT_LIST@60..61
+                      0: JS_NUMBER_LITERAL_EXPRESSION@60..61
+                        0: JS_NUMBER_LITERAL@60..61 "1" [] []
+                    2: R_PAREN@61..62 ")" [] []
+      1: SEMICOLON@62..63 ";" [] []
+    1: JS_VARIABLE_STATEMENT@63..149
+      0: JS_VARIABLE_DECLARATION@63..148
+        0: (empty)
+        1: CONST_KW@63..70 "const" [Newline("\n")] [Whitespace(" ")]
+        2: JS_VARIABLE_DECLARATOR_LIST@70..148
+          0: JS_VARIABLE_DECLARATOR@70..148
+            0: JS_IDENTIFIER_BINDING@70..73
+              0: IDENT@70..73 "fn" [] [Whitespace(" ")]
+            1: (empty)
+            2: JS_INITIALIZER_CLAUSE@73..148
+              0: EQ@73..75 "=" [] [Whitespace(" ")]
+              1: JS_ARROW_FUNCTION_EXPRESSION@75..148
+                0: (empty)
+                1: (empty)
+                2: JS_PARAMETERS@75..91
+                  0: L_PAREN@75..76 "(" [] []
+                  1: JS_PARAMETER_LIST@76..89
+                    0: JS_FORMAL_PARAMETER@76..89
+                      0: JS_DECORATOR_LIST@76..76
+                      1: JS_IDENTIFIER_BINDING@76..80
+                        0: IDENT@76..80 "flag" [] []
+                      2: (empty)
+                      3: TS_TYPE_ANNOTATION@80..89
+                        0: COLON@80..82 ":" [] [Whitespace(" ")]
+                        1: TS_BOOLEAN_TYPE@82..89
+                          0: BOOLEAN_KW@82..89 "boolean" [] []
+                      4: (empty)
+                  2: R_PAREN@89..91 ")" [] [Whitespace(" ")]
+                3: (empty)
+                4: FAT_ARROW@91..94 "=>" [] [Whitespace(" ")]
+                5: JS_PARENTHESIZED_EXPRESSION@94..148
+                  0: L_PAREN@94..95 "(" [] []
+                  1: JS_OBJECT_EXPRESSION@95..147
+                    0: L_CURLY@95..97 "{" [] [Whitespace(" ")]
+                    1: JS_OBJECT_MEMBER_LIST@97..146
+                      0: JS_PROPERTY_OBJECT_MEMBER@97..146
+                        0: JS_LITERAL_MEMBER_NAME@97..102
+                          0: IDENT@97..102 "value" [] []
+                        1: COLON@102..104 ":" [] [Whitespace(" ")]
+                        2: JS_CONDITIONAL_EXPRESSION@104..146
+                          0: JS_IDENTIFIER_EXPRESSION@104..109
+                            0: JS_REFERENCE_IDENTIFIER@104..109
+                              0: IDENT@104..109 "flag" [] [Whitespace(" ")]
+                          1: QUESTION@109..111 "?" [] [Whitespace(" ")]
+                          2: JS_IDENTIFIER_EXPRESSION@111..116
+                            0: JS_REFERENCE_IDENTIFIER@111..116
+                              0: IDENT@111..116 "flag" [] [Whitespace(" ")]
+                          3: COLON@116..118 ":" [] [Whitespace(" ")]
+                          4: JS_OBJECT_EXPRESSION@118..146
+                            0: L_CURLY@118..120 "{" [] [Whitespace(" ")]
+                            1: JS_OBJECT_MEMBER_LIST@120..144
+                              0: JS_PROPERTY_OBJECT_MEMBER@120..144
+                                0: JS_LITERAL_MEMBER_NAME@120..126
+                                  0: IDENT@120..126 "result" [] []
+                                1: COLON@126..128 ":" [] [Whitespace(" ")]
+                                2: JS_CALL_EXPRESSION@128..144
+                                  0: JS_IDENTIFIER_EXPRESSION@128..133
+                                    0: JS_REFERENCE_IDENTIFIER@128..133
+                                      0: IDENT@128..133 "apply" [] []
+                                  1: (empty)
+                                  2: (empty)
+                                  3: JS_CALL_ARGUMENTS@133..144
+                                    0: L_PAREN@133..134 "(" [] []
+                                    1: JS_CALL_ARGUMENT_LIST@134..142
+                                      0: JS_ARROW_FUNCTION_EXPRESSION@134..142
+                                        0: (empty)
+                                        1: (empty)
+                                        2: JS_PARAMETERS@134..138
+                                          0: L_PAREN@134..135 "(" [] []
+                                          1: JS_PARAMETER_LIST@135..136
+                                            0: JS_FORMAL_PARAMETER@135..136
+                                              0: JS_DECORATOR_LIST@135..135
+                                              1: JS_IDENTIFIER_BINDING@135..136
+                                                0: IDENT@135..136 "n" [] []
+                                              2: (empty)
+                                              3: (empty)
+                                              4: (empty)
+                                          2: R_PAREN@136..138 ")" [] [Whitespace(" ")]
+                                        3: (empty)
+                                        4: FAT_ARROW@138..141 "=>" [] [Whitespace(" ")]
+                                        5: JS_IDENTIFIER_EXPRESSION@141..142
+                                          0: JS_REFERENCE_IDENTIFIER@141..142
+                                            0: IDENT@141..142 "n" [] []
+                                    2: R_PAREN@142..144 ")" [] [Whitespace(" ")]
+                            2: R_CURLY@144..146 "}" [] [Whitespace(" ")]
+                    2: R_CURLY@146..147 "}" [] []
+                  2: R_PAREN@147..148 ")" [] []
+      1: SEMICOLON@148..149 ";" [] []
+  4: EOF@149..150 "" [Newline("\n")] []
+
+```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This fixes a parsing bug. My clanker explains it as:

> Biome mistook a parenthesized object returned by an arrow function for another arrow function’s parameter list when the object contained a conditional expression followed by a nested arrow.

implemented by gpt 5.6 sol

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #11464

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
