### PR TITLE
perf(markdown): inline common word group atom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1508,6 +1508,7 @@ dependencies = [
  "schemars",
  "serde",
  "similar-asserts",
+ "smallvec",
  "tests_macros",
 ]
 

--- a/crates/biome_markdown_formatter/Cargo.toml
+++ b/crates/biome_markdown_formatter/Cargo.toml
@@ -19,6 +19,7 @@ biome_markdown_syntax    = { workspace = true }
 biome_rowan              = { workspace = true }
 schemars                 = { workspace = true, optional = true }
 serde                    = { workspace = true, features = ["derive"], optional = true }
+smallvec                 = { workspace = true }
 
 [dev-dependencies]
 biome_configuration   = { path = "../biome_configuration" }

--- a/crates/biome_markdown_formatter/src/words.rs
+++ b/crates/biome_markdown_formatter/src/words.rs
@@ -5,6 +5,7 @@ use biome_markdown_syntax::{
     emphasis_ext::{MdEmphasisFence, MdItalicFence},
 };
 use biome_rowan::{AstNode, AstNodeList, SyntaxResult, TextRange, TextSize, TokenText};
+use smallvec::SmallVec;
 
 use crate::markdown::auxiliary::quote_prefix::FormatMdQuotePrefixOptions;
 use crate::{AsFormat, MarkdownFormatContext, MarkdownFormatter, format_removed, format_replaced};
@@ -74,7 +75,7 @@ enum WordGroupEscape {
 /// Adjacent prose atoms that cannot be separated by whitespace or a line break.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct WordGroup {
-    atoms: Vec<ProseAtom>,
+    atoms: SmallVec<[ProseAtom; 1]>,
     escape: WordGroupEscape,
 }
 


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
    Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
    Please provide enough information so that others can review your PR.
    Once created, your PR will be automatically labeled according to changed files.
    Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This reduces heap allocs in the markdown formatter.

implemented by gpt 5.6 sol
<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
no snapshot changes

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>