### PR TITLE
perf(markdown): scan textual whitespace runs once

### DIFF
--- a/crates/biome_markdown_parser/src/lexer/mod.rs
+++ b/crates/biome_markdown_parser/src/lexer/mod.rs
@@ -1345,6 +1345,23 @@ impl<'src> MarkdownLexer<'src> {
             }
         }
 
+        if matches!(self.current_byte(), Some(b' ' | b'\t')) {
+            let whitespace_start = self.position;
+            let mut whitespace_end = whitespace_start;
+            while whitespace_end < self.end
+                && matches!(self.source.as_bytes()[whitespace_end], b' ' | b'\t')
+            {
+                whitespace_end += 1;
+            }
+
+            if self.is_at_atx_closing_sequence_at(whitespace_end) {
+                // This may repeat the scan that ended the preceding text token. Caching the
+                // boundary in lexer state could remove the second pass if profiles justify it.
+                self.advance(whitespace_end - whitespace_start);
+                return MD_TEXTUAL_LITERAL;
+            }
+        }
+
         // Consume at least one character - ensures progress to avoid infinite loops
         let char = self.current_char_unchecked();
         self.advance(char.len_utf8());
@@ -1374,25 +1391,46 @@ impl<'src> MarkdownLexer<'src> {
                     if matches!(context, MarkdownLexContext::LinkDefinition) {
                         // In link definition context, whitespace ends the text token
                         break;
-                    } else if byte == b' ' {
-                        if self.is_at_trailing_hash_closing_whitespace() {
+                    } else if matches!(byte, b' ' | b'\t') {
+                        let whitespace_start = self.position;
+                        let mut whitespace_end = whitespace_start;
+                        while whitespace_end < self.end
+                            && matches!(self.source.as_bytes()[whitespace_end], b' ' | b'\t')
+                        {
+                            whitespace_end += 1;
+                        }
+
+                        if self.is_at_atx_closing_sequence_at(whitespace_end) {
                             break;
                         }
+
                         // Look ahead to check if this could be the start of a hard line break
                         // (2+ spaces followed by newline). Skip this check in HeadingContent
                         // context: headings don't produce hard breaks (§4.2), so trailing
                         // spaces should stay as ordinary text for the parser to handle.
                         if !matches!(context, MarkdownLexContext::HeadingContent)
-                            && self.is_potential_hard_line_break()
+                            && (whitespace_end == self.end
+                                || matches!(
+                                    self.source.as_bytes()[whitespace_end],
+                                    b'\n' | b'\r'
+                                ))
                         {
-                            break;
+                            let mut trailing_spaces_start = whitespace_end;
+                            while trailing_spaces_start > whitespace_start
+                                && self.source.as_bytes()[trailing_spaces_start - 1] == b' '
+                            {
+                                trailing_spaces_start -= 1;
+                            }
+
+                            if whitespace_end - trailing_spaces_start
+                                >= MIN_HARD_BREAK_TRAILING_SPACES
+                            {
+                                self.advance(trailing_spaces_start - whitespace_start);
+                                break;
+                            }
                         }
-                        self.advance(1);
-                    } else if byte == b'\t' {
-                        if self.is_at_trailing_hash_closing_whitespace() {
-                            break;
-                        }
-                        self.advance(1);
+
+                        self.advance(whitespace_end - whitespace_start);
                     } else {
                         // Stop at newlines (\n, \r)
                         break;
@@ -1515,53 +1553,6 @@ impl<'src> MarkdownLexer<'src> {
         matches!(bytes[pos], b' ' | b'\t' | b'\n' | b'\r')
     }
 
-    /// Returns true if the current whitespace is the start of a closing ATX hash sequence.
-    ///
-    /// Pattern: spaces/tabs + one or more `#` + optional spaces/tabs + newline/EOF.
-    fn is_at_trailing_hash_closing_whitespace(&self) -> bool {
-        let mut i = self.position;
-        let bytes = self.source.as_bytes();
-        let len = self.end;
-
-        let mut saw_ws = false;
-        while i < len {
-            let b = bytes[i];
-            if b == b' ' || b == b'\t' {
-                saw_ws = true;
-                i += 1;
-            } else {
-                break;
-            }
-        }
-
-        if !saw_ws {
-            return false;
-        }
-
-        if i >= len || bytes[i] != b'#' {
-            return false;
-        }
-
-        while i < len && bytes[i] == b'#' {
-            i += 1;
-        }
-
-        while i < len {
-            let b = bytes[i];
-            if b == b' ' || b == b'\t' {
-                i += 1;
-            } else {
-                break;
-            }
-        }
-
-        if i >= len {
-            return true;
-        }
-
-        matches!(bytes[i], b'\n' | b'\r')
-    }
-
     /// Returns true if a `#` at the current position can be heading syntax:
     /// it opens a heading at the start of a line (§4.2) or closes one at the
     /// end. Anywhere else `#` is plain text.
@@ -1633,20 +1624,25 @@ impl<'src> MarkdownLexer<'src> {
     /// `## title ##` (§4.2). Only space and tab count as padding here;
     /// any other character makes the hashes plain text.
     fn is_at_atx_closing_sequence(&self) -> bool {
-        if self.current_byte() != Some(b'#') {
+        self.is_at_atx_closing_sequence_at(self.position)
+    }
+
+    fn is_at_atx_closing_sequence_at(&self, position: usize) -> bool {
+        let bytes = self.source.as_bytes();
+        if position >= self.end || bytes[position] != b'#' {
             return false;
         }
 
-        let mut offset = 0;
-        while let Some(b'#') = self.byte_at(offset) {
-            offset += 1;
+        let mut position = position;
+        while position < self.end && bytes[position] == b'#' {
+            position += 1;
         }
 
-        while matches!(self.byte_at(offset), Some(byte) if is_space_or_tab_byte(byte)) {
-            offset += 1;
+        while position < self.end && is_space_or_tab_byte(bytes[position]) {
+            position += 1;
         }
 
-        matches!(self.byte_at(offset), None | Some(b'\n' | b'\r'))
+        position == self.end || matches!(bytes[position], b'\n' | b'\r')
     }
 
     /// Check if current position starts a potential hard line break pattern.

--- a/crates/biome_markdown_parser/src/lexer/tests.rs
+++ b/crates/biome_markdown_parser/src/lexer/tests.rs
@@ -422,6 +422,39 @@ fn hard_line_break_many_trailing_spaces() {
 }
 
 #[test]
+fn textual_long_whitespace() {
+    let source = format!("left{}right", " ".repeat(4096));
+
+    assert_lex! {
+        source.as_str(),
+        MD_TEXTUAL_LITERAL:4105,
+    }
+}
+
+#[test]
+fn closing_hashes_after_mixed_whitespace() {
+    assert_lex! {
+        MarkdownLexContext::HeadingContent,
+        "heading \t ##\n",
+        MD_TEXTUAL_LITERAL:7,
+        MD_TEXTUAL_LITERAL:3,
+        HASH:1,
+        HASH:1,
+        NEWLINE:1,
+    }
+}
+
+#[test]
+fn hard_line_break_after_tab() {
+    assert_lex! {
+        "text\t  \nmore",
+        MD_TEXTUAL_LITERAL:5,
+        MD_HARD_LINE_LITERAL:3,
+        MD_TEXTUAL_LITERAL:4,
+    }
+}
+
+#[test]
 fn hard_line_break_backslash_newline() {
     // Backslash followed by newline is a hard line break
     assert_lex! {

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/atx_heading_trailing_hash.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/atx_heading_trailing_hash.md.snap
@@ -82,7 +82,7 @@ MdRoot {
             },
             after: MdHashList [
                 MdHash {
-                    hash_token: HASH@22..26 "#" [Whitespace(" "), Whitespace(" "), Whitespace(" ")] [],
+                    hash_token: HASH@22..26 "#" [Whitespace("   ")] [],
                 },
             ],
         },
@@ -150,7 +150,7 @@ MdRoot {
             0: MD_TEXTUAL_LITERAL@16..22 "   foo" [] []
       3: MD_HASH_LIST@22..26
         0: MD_HASH@22..26
-          0: HASH@22..26 "#" [Whitespace(" "), Whitespace(" "), Whitespace(" ")] []
+          0: HASH@22..26 "#" [Whitespace("   ")] []
     5: MD_NEWLINE@26..27
       0: NEWLINE@26..27 "\n" [] []
     6: MD_PARAGRAPH@27..32


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
    Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
    Please provide enough information so that others can review your PR.
    Once created, your PR will be automatically labeled according to changed files.
    Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
My clanker explains the fix as:

> Scans each whitespace run once while preserving hard-break and closing-heading token boundaries, eliminating
quadratic Markdown lexing

My understanding is that when the lexer is building `MD_TEXTUAL_LITERAL`, it needs to look ahead at the spaces. For example, 2 words with a bunch of spaces in between is ordinary text:

```
hello······world
```

but 2 or more spaces at the end of a line have a different meaning, triggering a hard line break:

```
hello··
world
```

In the lexer, there's 2 functions that would look ahead to make these checks, `is_potential_hard_line_break()`, and `is_at_trailing_hash_closing_whitespace()`. Internally, these functions have their own loops that look ahead. The consequence is that for a sequence of `n` spaces, it would examine the spaces `n × (n + 1) / 2` times.

This also changes the parsing a little bit to emit less tokens for whitespace.

implemented by gpt 5.6 sol
<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>