### PR TITLE
fix(format/html/vue): preserve Vue interpolation adjacency

### DIFF
--- a/.changeset/lovely-bees-thank.md
+++ b/.changeset/lovely-bees-thank.md
@@ -1,0 +1,14 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10330](https://github.com/biomejs/biome/issues/10330): Vue interpolation delimiters now stay attached to whitespace-sensitive element boundaries and adjacent inline siblings, wrapping their expression when needed to fit the configured line width. Interpolations followed by text now also converge after one formatting pass.
+
+```diff
+-<v-btn v-if="store.state.user" variant="text" to="/my-rooms"
+-  >{{ $t("nav.my-rooms") }}</v-btn
+->
++<v-btn v-if="store.state.user" variant="text" to="/my-rooms">{{
++  $t("nav.my-rooms")
++}}</v-btn>
+```

--- a/crates/biome_html_formatter/src/html/auxiliary/double_text_expression.rs
+++ b/crates/biome_html_formatter/src/html/auxiliary/double_text_expression.rs
@@ -1,9 +1,25 @@
 use crate::prelude::*;
-use biome_formatter::write;
+use biome_formatter::{FormatRuleWithOptions, write};
 use biome_html_syntax::{HtmlDoubleTextExpression, HtmlDoubleTextExpressionFields};
 
 #[derive(Debug, Clone, Default)]
-pub(crate) struct FormatHtmlDoubleTextExpression;
+pub(crate) struct FormatHtmlDoubleTextExpression {
+    r_double_curly_borrowed: bool,
+}
+
+pub(crate) struct FormatHtmlDoubleTextExpressionOptions {
+    pub r_double_curly_borrowed: bool,
+}
+
+impl FormatRuleWithOptions<HtmlDoubleTextExpression> for FormatHtmlDoubleTextExpression {
+    type Options = FormatHtmlDoubleTextExpressionOptions;
+
+    fn with_options(mut self, options: Self::Options) -> Self {
+        self.r_double_curly_borrowed = options.r_double_curly_borrowed;
+        self
+    }
+}
+
 impl FormatNodeRule<HtmlDoubleTextExpression> for FormatHtmlDoubleTextExpression {
     fn fmt_fields(
         &self,
@@ -20,11 +36,12 @@ impl FormatNodeRule<HtmlDoubleTextExpression> for FormatHtmlDoubleTextExpression
             f,
             [
                 l_double_curly_token.format(),
-                space(),
-                expression.format(),
-                space(),
-                r_double_curly_token.format(),
+                soft_space_or_block_indent(&expression.format()),
             ]
-        )
+        )?;
+        if !self.r_double_curly_borrowed {
+            write!(f, [r_double_curly_token.format()])?;
+        }
+        Ok(())
     }
 }

--- a/crates/biome_html_formatter/src/html/lists/element_list.rs
+++ b/crates/biome_html_formatter/src/html/lists/element_list.rs
@@ -185,6 +185,9 @@
 use crate::utils::children::DisplayHtmlChildSequence;
 use crate::{
     html::auxiliary::{
+        double_text_expression::{
+            FormatHtmlDoubleTextExpression, FormatHtmlDoubleTextExpressionOptions,
+        },
         element::{FormatHtmlElement, FormatHtmlElementOptions},
         self_closing_element::{FormatHtmlSelfClosingElement, FormatHtmlSelfClosingElementOptions},
     },
@@ -417,6 +420,10 @@ impl FormatHtmlElementList {
                 children.pop();
             }
         }
+        let has_inline_double_text_expression = self.is_container_whitespace_sensitive
+            && !has_leading_newline
+            && !had_trailing_newline
+            && has_single_double_text_expression_child(&children);
 
         let formatted_children = format_with(|f| {
             // Print borrowed opening `>` token
@@ -490,6 +497,7 @@ impl FormatHtmlElementList {
             // A following element or word prints the borrowed closing `>` so any break occurs
             // inside the preceding tag rather than between whitespace-sensitive siblings.
             let mut borrowed_sibling_r_angle: Option<HtmlSyntaxToken> = None;
+            let mut borrowed_sibling_interpolation_end: Option<HtmlSyntaxToken> = None;
             let mut borrowed_closing_tag = self.borrowed_tokens.borrowed_closing_tag.as_ref();
 
             let mut is_first_child = true;
@@ -696,6 +704,11 @@ impl FormatHtmlElementList {
                                 // If we're already multiline, keep words after block-like elements on their own line.
                                 child_breaks = true;
                                 write!(f, [hard_line_break()])?;
+                            } else if !self.is_container_whitespace_sensitive
+                                && is_double_text_expression(last_elem)
+                                && matches!(children_iter.peek(), Some(HtmlChild::Word(_)))
+                            {
+                                write!(f, [space()])?;
                             } else if last_css_display.is_externally_whitespace_sensitive(f) {
                                 // For whitespace-sensitive elements, use soft_line_break_or_space
                                 // so the space is preserved in flat mode
@@ -895,19 +908,53 @@ impl FormatHtmlElementList {
 
                         // Take any borrowed `>` from the previous sibling element
                         let current_borrowed_r_angle = borrowed_sibling_r_angle.take();
+                        let current_borrowed_interpolation_end =
+                            borrowed_sibling_interpolation_end.take();
 
                         let next_can_borrow = next_is_adjacent_inline
                             && matches!(
                                 children_iter.peek(),
                                 Some(HtmlChild::NonText(AnyHtmlElement::HtmlElement(_)))
                             );
+                        let next_can_borrow_interpolation_end = next_is_adjacent_inline
+                            && matches!(
+                                children_iter.peek(),
+                                Some(HtmlChild::NonText(
+                                    AnyHtmlElement::HtmlElement(_)
+                                        | AnyHtmlElement::HtmlSelfClosingElement(_)
+                                ))
+                            );
 
-                        // Create the element formatter with borrowing options
-                        let element_format = format_element_with_borrowing(
-                            non_text,
-                            current_borrowed_r_angle,
-                            next_can_borrow || next_word_borrows_r_angle,
-                        );
+                        let r_double_curly_borrowed = next_can_borrow_interpolation_end
+                            && is_double_text_expression(non_text);
+                        let element_format = format_with(|f| {
+                            if let Some(token) = &current_borrowed_interpolation_end {
+                                write!(f, [token.format()])?;
+                            }
+                            if let AnyHtmlElement::AnyHtmlContent(
+                                AnyHtmlContent::AnyHtmlTextExpression(
+                                    AnyHtmlTextExpression::HtmlDoubleTextExpression(expression),
+                                ),
+                            ) = non_text
+                            {
+                                FormatNodeRule::fmt_fields(
+                                    &FormatHtmlDoubleTextExpression::default().with_options(
+                                        FormatHtmlDoubleTextExpressionOptions {
+                                            r_double_curly_borrowed,
+                                        },
+                                    ),
+                                    expression,
+                                    f,
+                                )
+                            } else {
+                                format_element_with_borrowing(
+                                    non_text,
+                                    current_borrowed_r_angle.clone(),
+                                    next_can_borrow || next_word_borrows_r_angle,
+                                )
+                                .fmt(f)
+                            }
+                        });
 
                         if needs_outer_group {
                             // Wrap inline element in outer group with `line` before it.
@@ -987,7 +1034,18 @@ impl FormatHtmlElementList {
                             }
                             // Wrap conditional break with element in a group
                             // to match Prettier's pattern: group([ifBreak("", softline), element])
-                            if let Some(prev_id) = conditional_leading_break_group_id {
+                            if has_inline_double_text_expression
+                                && conditional_leading_break_group_id.is_none()
+                            {
+                                write!(
+                                    f,
+                                    [
+                                        &memoized,
+                                        format_separator(SeparatorPlacement::InsideGroup),
+                                        format_separator(SeparatorPlacement::OutsideGroup)
+                                    ]
+                                )?;
+                            } else if let Some(prev_id) = conditional_leading_break_group_id {
                                 write!(
                                     f,
                                     [group(&format_args![
@@ -1024,7 +1082,16 @@ impl FormatHtmlElementList {
                             prev_inline_group_id = None;
                         }
 
-                        if next_can_borrow || next_word_borrows_r_angle {
+                        if r_double_curly_borrowed {
+                            borrowed_sibling_interpolation_end = match non_text {
+                                AnyHtmlElement::AnyHtmlContent(
+                                    AnyHtmlContent::AnyHtmlTextExpression(
+                                        AnyHtmlTextExpression::HtmlDoubleTextExpression(expression),
+                                    ),
+                                ) => expression.r_double_curly_token().ok(),
+                                _ => None,
+                            };
+                        } else if next_can_borrow || next_word_borrows_r_angle {
                             // Store the closing r_angle token from this element for the next sibling
                             borrowed_sibling_r_angle = non_text.closing_r_angle_token();
                         }
@@ -1056,6 +1123,23 @@ impl FormatHtmlElementList {
 
         if is_root {
             write!(f, [&formatted_children])
+        } else if has_inline_double_text_expression
+            && let Some(opening_tag_group) = self.opening_tag_group
+        {
+            write!(
+                f,
+                [
+                    indent_if_group_breaks(
+                        &format_args![
+                            if_group_breaks(&soft_line_break())
+                                .with_group_id(Some(opening_tag_group)),
+                            &formatted_children
+                        ],
+                        opening_tag_group
+                    ),
+                    if_group_breaks(&soft_line_break()).with_group_id(Some(opening_tag_group))
+                ]
+            )
         } else {
             write!(f, [&soft_block_indent(&formatted_children)])
         }
@@ -1088,6 +1172,25 @@ fn has_single_interpolation_child(children: &[HtmlChild]) -> bool {
     };
 
     meaningful_children.next().is_none()
+}
+
+fn has_single_double_text_expression_child(children: &[HtmlChild]) -> bool {
+    let mut meaningful_children = children.iter().filter(|child| !child.is_any_whitespace());
+
+    let Some(HtmlChild::NonText(element)) = meaningful_children.next() else {
+        return false;
+    };
+
+    is_double_text_expression(element) && meaningful_children.next().is_none()
+}
+
+fn is_double_text_expression(element: &AnyHtmlElement) -> bool {
+    matches!(
+        element,
+        AnyHtmlElement::AnyHtmlContent(AnyHtmlContent::AnyHtmlTextExpression(
+            AnyHtmlTextExpression::HtmlDoubleTextExpression(_)
+        ))
+    )
 }
 
 fn format_partial_closing_tag(

--- a/crates/biome_html_formatter/tests/specs/html/text_expressions/expressions.vue.snap
+++ b/crates/biome_html_formatter/tests/specs/html/text_expressions/expressions.vue.snap
@@ -20,9 +20,11 @@ info: text_expressions/expressions.vue
 
 ```vue
 <template>
-	{{ x => {
+	{{
+		x => {
 	return "hello"
-} }}
+}
+	}}
 </template>
 
 ```

--- a/crates/biome_html_formatter/tests/specs/html/vue/issue-10330-siblings.vue
+++ b/crates/biome_html_formatter/tests/specs/html/vue/issue-10330-siblings.vue
@@ -1,0 +1,71 @@
+<template>
+	<span>{{ value }}<em>suffix</em></span>
+</template>
+
+<template>
+	<span>{{ value }}<em aria-label="a very long label that forces the adjacent sibling to wrap">suffix</em></span>
+</template>
+
+<template>
+	<span>{{ value }}<InlineComponent aria-label="a very long label that forces the adjacent sibling to wrap" /></span>
+</template>
+
+<template>
+	<span><em aria-label="a very long label that forces the adjacent sibling to wrap">prefix</em>{{ value }}</span>
+</template>
+
+<template>
+	<span><InlineComponent aria-label="a very long label that forces the adjacent sibling to wrap" />{{ value }}</span>
+</template>
+
+<template>
+	<span><em aria-label="a very long label that forces the previous sibling to wrap">prefix</em>{{ value }}<strong aria-label="a very long label that forces the next sibling to wrap">suffix</strong></span>
+</template>
+
+<template>
+	<span><em aria-label="a very long label that forces the previous sibling to wrap">prefix</em> {{ value }} <strong aria-label="a very long label that forces the next sibling to wrap">suffix</strong></span>
+</template>
+
+<template>
+	<span>
+		<em aria-label="a very long label that forces the previous sibling to wrap">prefix</em>
+		{{ value }}
+		<strong aria-label="a very long label that forces the next sibling to wrap">suffix</strong>
+	</span>
+</template>
+
+<template>
+	<span>{{ aVeryLongValueNameThatForcesTheInterpolationToWrap }}<em>suffix</em></span>
+</template>
+
+<template>
+	<span>{{ aVeryLongValueNameThatForcesTheInterpolationToWrap }}aLongTextSiblingThatMustStayAttached</span>
+</template>
+
+<template>
+	<span>aLongTextSiblingThatMustStayAttached{{ aVeryLongValueNameThatForcesTheInterpolationToWrap }}</span>
+</template>
+
+<template>
+	<div>{{ value }}<section aria-label="a very long label that forces the adjacent block sibling to wrap">suffix</section></div>
+</template>
+
+<template>
+	<span>{{ value }}<!-- note --><em aria-label="a very long label that forces the adjacent sibling to wrap">suffix</em></span>
+</template>
+
+<template>
+	<span><em aria-label="a very long label that forces the adjacent sibling to wrap">prefix</em><!-- note -->{{ value }}</span>
+</template>
+
+<template>
+	<span><em aria-label="a very long label that forces the previous sibling to wrap">prefix</em><!-- before -->{{ value }}<!-- after --><strong aria-label="a very long label that forces the next sibling to wrap">suffix</strong></span>
+</template>
+
+<template>
+	<span>{{ /* comment */ value }}<em aria-label="a very long label that forces the adjacent sibling to wrap">suffix</em></span>
+</template>
+
+<template>
+	<div>Magni consectetur in et molestias neque esse voluptatibus voluptas. {{ some_variable }} Eum quia nihil nulla esse. Dolorem asperiores vero est error</div>
+</template>

--- a/crates/biome_html_formatter/tests/specs/html/vue/issue-10330-siblings.vue.snap
+++ b/crates/biome_html_formatter/tests/specs/html/vue/issue-10330-siblings.vue.snap
@@ -1,0 +1,241 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: vue/issue-10330-siblings.vue
+---
+
+# Input
+
+```vue
+<template>
+	<span>{{ value }}<em>suffix</em></span>
+</template>
+
+<template>
+	<span>{{ value }}<em aria-label="a very long label that forces the adjacent sibling to wrap">suffix</em></span>
+</template>
+
+<template>
+	<span>{{ value }}<InlineComponent aria-label="a very long label that forces the adjacent sibling to wrap" /></span>
+</template>
+
+<template>
+	<span><em aria-label="a very long label that forces the adjacent sibling to wrap">prefix</em>{{ value }}</span>
+</template>
+
+<template>
+	<span><InlineComponent aria-label="a very long label that forces the adjacent sibling to wrap" />{{ value }}</span>
+</template>
+
+<template>
+	<span><em aria-label="a very long label that forces the previous sibling to wrap">prefix</em>{{ value }}<strong aria-label="a very long label that forces the next sibling to wrap">suffix</strong></span>
+</template>
+
+<template>
+	<span><em aria-label="a very long label that forces the previous sibling to wrap">prefix</em> {{ value }} <strong aria-label="a very long label that forces the next sibling to wrap">suffix</strong></span>
+</template>
+
+<template>
+	<span>
+		<em aria-label="a very long label that forces the previous sibling to wrap">prefix</em>
+		{{ value }}
+		<strong aria-label="a very long label that forces the next sibling to wrap">suffix</strong>
+	</span>
+</template>
+
+<template>
+	<span>{{ aVeryLongValueNameThatForcesTheInterpolationToWrap }}<em>suffix</em></span>
+</template>
+
+<template>
+	<span>{{ aVeryLongValueNameThatForcesTheInterpolationToWrap }}aLongTextSiblingThatMustStayAttached</span>
+</template>
+
+<template>
+	<span>aLongTextSiblingThatMustStayAttached{{ aVeryLongValueNameThatForcesTheInterpolationToWrap }}</span>
+</template>
+
+<template>
+	<div>{{ value }}<section aria-label="a very long label that forces the adjacent block sibling to wrap">suffix</section></div>
+</template>
+
+<template>
+	<span>{{ value }}<!-- note --><em aria-label="a very long label that forces the adjacent sibling to wrap">suffix</em></span>
+</template>
+
+<template>
+	<span><em aria-label="a very long label that forces the adjacent sibling to wrap">prefix</em><!-- note -->{{ value }}</span>
+</template>
+
+<template>
+	<span><em aria-label="a very long label that forces the previous sibling to wrap">prefix</em><!-- before -->{{ value }}<!-- after --><strong aria-label="a very long label that forces the next sibling to wrap">suffix</strong></span>
+</template>
+
+<template>
+	<span>{{ /* comment */ value }}<em aria-label="a very long label that forces the adjacent sibling to wrap">suffix</em></span>
+</template>
+
+<template>
+	<div>Magni consectetur in et molestias neque esse voluptatibus voluptas. {{ some_variable }} Eum quia nihil nulla esse. Dolorem asperiores vero est error</div>
+</template>
+
+```
+
+
+# Formatted
+
+```vue
+<template>
+	<span>{{ value }}<em>suffix</em></span>
+</template>
+
+<template>
+	<span
+		>{{ value
+		}}<em
+			aria-label="a very long label that forces the adjacent sibling to wrap"
+			>suffix</em
+		></span
+	>
+</template>
+
+<template>
+	<span
+		>{{ value
+		}}<InlineComponent
+			aria-label="a very long label that forces the adjacent sibling to wrap"
+		/></span
+	>
+</template>
+
+<template>
+	<span
+		><em aria-label="a very long label that forces the adjacent sibling to wrap"
+			>prefix</em
+		>{{ value }}</span
+	>
+</template>
+
+<template>
+	<span
+		><InlineComponent
+			aria-label="a very long label that forces the adjacent sibling to wrap"
+		/>{{ value }}</span
+	>
+</template>
+
+<template>
+	<span
+		><em aria-label="a very long label that forces the previous sibling to wrap"
+			>prefix</em
+		>{{ value
+		}}<strong
+			aria-label="a very long label that forces the next sibling to wrap"
+			>suffix</strong
+		></span
+	>
+</template>
+
+<template>
+	<span
+		><em aria-label="a very long label that forces the previous sibling to wrap"
+			>prefix</em
+		> {{ value }}
+		<strong aria-label="a very long label that forces the next sibling to wrap"
+			>suffix</strong
+		></span
+	>
+</template>
+
+<template>
+	<span>
+		<em aria-label="a very long label that forces the previous sibling to wrap"
+			>prefix</em
+		>
+		{{ value }}
+		<strong aria-label="a very long label that forces the next sibling to wrap"
+			>suffix</strong
+		>
+	</span>
+</template>
+
+<template>
+	<span
+		>{{ aVeryLongValueNameThatForcesTheInterpolationToWrap
+		}}<em>suffix</em></span
+	>
+</template>
+
+<template>
+	<span
+		>{{
+			aVeryLongValueNameThatForcesTheInterpolationToWrap
+		}}aLongTextSiblingThatMustStayAttached</span
+	>
+</template>
+
+<template>
+	<span
+		>aLongTextSiblingThatMustStayAttached{{
+			aVeryLongValueNameThatForcesTheInterpolationToWrap
+		}}</span
+	>
+</template>
+
+<template>
+	<div>
+		{{ value }}
+		<section
+			aria-label="a very long label that forces the adjacent block sibling to wrap"
+		>
+			suffix
+		</section>
+	</div>
+</template>
+
+<template>
+	<span
+		>{{ value }}<!-- note --><em
+			aria-label="a very long label that forces the adjacent sibling to wrap"
+			>suffix</em
+		></span
+	>
+</template>
+
+<template>
+	<span
+		><em aria-label="a very long label that forces the adjacent sibling to wrap"
+			>prefix</em
+		><!-- note -->{{ value }}</span
+	>
+</template>
+
+<template>
+	<span
+		><em aria-label="a very long label that forces the previous sibling to wrap"
+			>prefix</em
+		><!-- before -->{{ value }}<!-- after --><strong
+			aria-label="a very long label that forces the next sibling to wrap"
+			>suffix</strong
+		></span
+	>
+</template>
+
+<template>
+	<span
+		>{{ /* comment */ value
+		}}<em
+			aria-label="a very long label that forces the adjacent sibling to wrap"
+			>suffix</em
+		></span
+	>
+</template>
+
+<template>
+	<div>
+		Magni consectetur in et molestias neque esse voluptatibus voluptas.
+		{{ some_variable }} Eum quia nihil nulla esse. Dolorem asperiores vero est
+		error
+	</div>
+</template>
+
+```

--- a/crates/biome_html_formatter/tests/specs/html/vue/issue-10330.vue
+++ b/crates/biome_html_formatter/tests/specs/html/vue/issue-10330.vue
@@ -1,0 +1,29 @@
+<template>
+<div>
+<span>
+<div>
+<v-btn v-if="store.state.user" variant="text" to="/my-rooms">{{
+	$t("nav.my-rooms")
+}}</v-btn>
+</div>
+</span>
+</div>
+</template>
+
+<template>
+	<v-btn v-if="store.state.user" variant="text" to="/my-rooms">{{ $t("nav.my-rooms") }}</v-btn>
+</template>
+
+<template>
+	<v-btn>{{
+		value
+	}}</v-btn>
+</template>
+
+<template>
+	<span>{{ value }}<em aria-label="a very long label that forces the adjacent sibling to wrap">suffix</em></span>
+</template>
+
+<template>
+	<span>{{ value }}<img alt="a very long label that forces the adjacent sibling to wrap" /></span>
+</template>

--- a/crates/biome_html_formatter/tests/specs/html/vue/issue-10330.vue.snap
+++ b/crates/biome_html_formatter/tests/specs/html/vue/issue-10330.vue.snap
@@ -1,0 +1,86 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: vue/issue-10330.vue
+---
+
+# Input
+
+```vue
+<template>
+<div>
+<span>
+<div>
+<v-btn v-if="store.state.user" variant="text" to="/my-rooms">{{
+	$t("nav.my-rooms")
+}}</v-btn>
+</div>
+</span>
+</div>
+</template>
+
+<template>
+	<v-btn v-if="store.state.user" variant="text" to="/my-rooms">{{ $t("nav.my-rooms") }}</v-btn>
+</template>
+
+<template>
+	<v-btn>{{
+		value
+	}}</v-btn>
+</template>
+
+<template>
+	<span>{{ value }}<em aria-label="a very long label that forces the adjacent sibling to wrap">suffix</em></span>
+</template>
+
+<template>
+	<span>{{ value }}<img alt="a very long label that forces the adjacent sibling to wrap" /></span>
+</template>
+
+```
+
+
+# Formatted
+
+```vue
+<template>
+	<div>
+		<span>
+			<div>
+				<v-btn v-if="store.state.user" variant="text" to="/my-rooms">{{
+					$t("nav.my-rooms")
+				}}</v-btn>
+			</div>
+		</span>
+	</div>
+</template>
+
+<template>
+	<v-btn v-if="store.state.user" variant="text" to="/my-rooms">{{
+		$t("nav.my-rooms")
+	}}</v-btn>
+</template>
+
+<template>
+	<v-btn>{{ value }}</v-btn>
+</template>
+
+<template>
+	<span
+		>{{ value
+		}}<em
+			aria-label="a very long label that forces the adjacent sibling to wrap"
+			>suffix</em
+		></span
+	>
+</template>
+
+<template>
+	<span
+		>{{ value
+		}}<img
+			alt="a very long label that forces the adjacent sibling to wrap"
+		></span
+	>
+</template>
+
+```

--- a/crates/biome_html_formatter/tests/specs/prettier/vue/interpolation/bitwise-or-operator.vue.snap
+++ b/crates/biome_html_formatter/tests/specs/prettier/vue/interpolation/bitwise-or-operator.vue.snap
@@ -28,27 +28,25 @@ info: vue/interpolation/bitwise-or-operator.vue
 ```diff
 --- Prettier
 +++ Biome
-@@ -1,16 +1,11 @@
- <template>
+@@ -2,15 +2,12 @@
    <div>
--    {{
--      fn(
+     {{
+       fn(
 -        bitwise |
 -          or |
 -          operator |
 -          a_long_long_long_long_long_long_long_long_long_long_variable,
-+    {{ fn(
 +        bitwise | or | operator | a_long_long_long_long_long_long_long_long_long_long_variable
        )
 -        | filter1
 -        | filter2
 -        | filter3
 -        | filter4
--    }}
 +      | filter1
 +      | filter2
 +      | filter3
-+      | filter4 }}
++      | filter4
+     }}
    </div>
  </template>
 ```
@@ -58,18 +56,20 @@ info: vue/interpolation/bitwise-or-operator.vue
 ```vue
 <template>
   <div>
-    {{ fn(
+    {{
+      fn(
         bitwise | or | operator | a_long_long_long_long_long_long_long_long_long_long_variable
       )
       | filter1
       | filter2
       | filter3
-      | filter4 }}
+      | filter4
+    }}
   </div>
 </template>
 ```
 
 # Lines exceeding max width of 80 characters
 ```
-    4:         bitwise | or | operator | a_long_long_long_long_long_long_long_long_long_long_variable
+    5:         bitwise | or | operator | a_long_long_long_long_long_long_long_long_long_long_variable
 ```

--- a/crates/biome_html_formatter/tests/specs/prettier/vue/ts-expression/comment.vue.snap
+++ b/crates/biome_html_formatter/tests/specs/prettier/vue/ts-expression/comment.vue.snap
@@ -26,7 +26,7 @@ info: vue/ts-expression/comment.vue
 ```diff
 --- Prettier
 +++ Biome
-@@ -1,20 +1,13 @@
+@@ -1,19 +1,14 @@
  <template>
    <div
      v-if="
@@ -44,14 +44,13 @@ info: vue/ts-expression/comment.vue
      "
 +    :format="   /* leading comment */ myFunc( /* NOTE: I like banana */ o as unknown ) /* trailing comment */"
    >
--    {{
+     {{
 -      /* leading comment */ (file as /* NOTE: I like sushi */ mymodule.Folder)
 -        .deadline /* trailing comment */
--    }}
-+    {{ /* leading comment */ (   file as /* NOTE: I like sushi */   mymodule.Folder   ).deadline /* trailing comment */ }}
++      /* leading comment */ (   file as /* NOTE: I like sushi */   mymodule.Folder   ).deadline /* trailing comment */
+     }}
    </div>
  </template>
- 
 ```
 
 # Output
@@ -66,7 +65,9 @@ info: vue/ts-expression/comment.vue
     "
     :format="   /* leading comment */ myFunc( /* NOTE: I like banana */ o as unknown ) /* trailing comment */"
   >
-    {{ /* leading comment */ (   file as /* NOTE: I like sushi */   mymodule.Folder   ).deadline /* trailing comment */ }}
+    {{
+      /* leading comment */ (   file as /* NOTE: I like sushi */   mymodule.Folder   ).deadline /* trailing comment */
+    }}
   </div>
 </template>
 
@@ -76,5 +77,5 @@ info: vue/ts-expression/comment.vue
 # Lines exceeding max width of 80 characters
 ```
     8:     :format="   /* leading comment */ myFunc( /* NOTE: I like banana */ o as unknown ) /* trailing comment */"
-   10:     {{ /* leading comment */ (   file as /* NOTE: I like sushi */   mymodule.Folder   ).deadline /* trailing comment */ }}
+   11:       /* leading comment */ (   file as /* NOTE: I like sushi */   mymodule.Folder   ).deadline /* trailing comment */
 ```

--- a/crates/biome_html_formatter/tests/specs/prettier/vue/ts-expression/filter.vue.snap
+++ b/crates/biome_html_formatter/tests/specs/prettier/vue/ts-expression/filter.vue.snap
@@ -34,17 +34,16 @@ info: vue/ts-expression/filter.vue
 ```diff
 --- Prettier
 +++ Biome
-@@ -4,39 +4,24 @@
- <template>
+@@ -5,38 +5,25 @@
    <div>
      <div class="allowed">
--      {{
+       {{
 -        value
 -          | thisIsARealSuperLongFilterPipe("arg1", arg2 as unknown)
 -          | anotherPipeLongJustForFun
 -          | pipeTheThird
--      }}
-+      {{ value | thisIsARealSuperLongFilterPipe("arg1", arg2 as unknown) | anotherPipeLongJustForFun | pipeTheThird }}
++        value | thisIsARealSuperLongFilterPipe("arg1", arg2 as unknown) | anotherPipeLongJustForFun | pipeTheThird
+       }}
      </div>
      <div
        class="allowed"
@@ -94,7 +93,9 @@ info: vue/ts-expression/filter.vue
 <template>
   <div>
     <div class="allowed">
-      {{ value | thisIsARealSuperLongFilterPipe("arg1", arg2 as unknown) | anotherPipeLongJustForFun | pipeTheThird }}
+      {{
+        value | thisIsARealSuperLongFilterPipe("arg1", arg2 as unknown) | anotherPipeLongJustForFun | pipeTheThird
+      }}
     </div>
     <div
       class="allowed"
@@ -119,8 +120,8 @@ info: vue/ts-expression/filter.vue
 
 # Lines exceeding max width of 80 characters
 ```
-    7:       {{ value | thisIsARealSuperLongFilterPipe("arg1", arg2 as unknown) | anotherPipeLongJustForFun | pipeTheThird }}
-   12:       value | thisIsARealSuperLongFilterPipe("arg1", arg2 as unknown) | anotherPipeLongJustForFun | pipeTheThird
-   18:       value | thisIsARealSuperLongFilterPipe("arg1", arg2 as unknown) | anotherPipeLongJustForFun | pipeTheThird'
-   23:       value | thisIsARealSuperLongBitwiseOr("arg1", arg2 as unknown) | anotherBitwiseOrLongJustForFun | bitwiseOrTheThird
+    8:         value | thisIsARealSuperLongFilterPipe("arg1", arg2 as unknown) | anotherPipeLongJustForFun | pipeTheThird
+   14:       value | thisIsARealSuperLongFilterPipe("arg1", arg2 as unknown) | anotherPipeLongJustForFun | pipeTheThird
+   20:       value | thisIsARealSuperLongFilterPipe("arg1", arg2 as unknown) | anotherPipeLongJustForFun | pipeTheThird'
+   25:       value | thisIsARealSuperLongBitwiseOr("arg1", arg2 as unknown) | anotherBitwiseOrLongJustForFun | bitwiseOrTheThird
 ```

--- a/crates/biome_html_formatter/tests/specs/prettier/vue/vue/filter.vue.snap
+++ b/crates/biome_html_formatter/tests/specs/prettier/vue/vue/filter.vue.snap
@@ -22,12 +22,14 @@ info: vue/vue/filter.vue
 ```diff
 --- Prettier
 +++ Biome
-@@ -1,7 +1,7 @@
+@@ -1,7 +1,9 @@
  <!-- vue filters are only allowed in v-bind and interpolation -->
  <template>
    <div class="allowed">
 -    {{value | thisIsARealSuperLongFilterPipe("arg1", arg2) | anotherPipeLongJustForFun | pipeTheThird}}
-+    {{ value | thisIsARealSuperLongFilterPipe("arg1", arg2) | anotherPipeLongJustForFun | pipeTheThird }}
++    {{
++      value | thisIsARealSuperLongFilterPipe("arg1", arg2) | anotherPipeLongJustForFun | pipeTheThird
++    }}
    </div>
    <div
      class="allowed"
@@ -39,7 +41,9 @@ info: vue/vue/filter.vue
 <!-- vue filters are only allowed in v-bind and interpolation -->
 <template>
   <div class="allowed">
-    {{ value | thisIsARealSuperLongFilterPipe("arg1", arg2) | anotherPipeLongJustForFun | pipeTheThird }}
+    {{
+      value | thisIsARealSuperLongFilterPipe("arg1", arg2) | anotherPipeLongJustForFun | pipeTheThird
+    }}
   </div>
   <div
     class="allowed"
@@ -58,8 +62,8 @@ info: vue/vue/filter.vue
 
 # Lines exceeding max width of 80 characters
 ```
-    4:     {{ value | thisIsARealSuperLongFilterPipe("arg1", arg2) | anotherPipeLongJustForFun | pipeTheThird }}
-    8:     v-bind:something='value | thisIsARealSuperLongFilterPipe("arg1", arg2) | anotherPipeLongJustForFun | pipeTheThird'
-   12:     :class='value | thisIsARealSuperLongFilterPipe("arg1", arg2) | anotherPipeLongJustForFun | pipeTheThird'
-   16:     v-if='value | thisIsARealSuperLongBitwiseOr("arg1", arg2) | anotherBitwiseOrLongJustForFun | bitwiseOrTheThird'
+    5:       value | thisIsARealSuperLongFilterPipe("arg1", arg2) | anotherPipeLongJustForFun | pipeTheThird
+   10:     v-bind:something='value | thisIsARealSuperLongFilterPipe("arg1", arg2) | anotherPipeLongJustForFun | pipeTheThird'
+   14:     :class='value | thisIsARealSuperLongFilterPipe("arg1", arg2) | anotherPipeLongJustForFun | pipeTheThird'
+   18:     v-if='value | thisIsARealSuperLongBitwiseOr("arg1", arg2) | anotherBitwiseOrLongJustForFun | bitwiseOrTheThird'
 ```

--- a/crates/biome_html_formatter/tests/specs/prettier/vue/vue/interpolations.vue.snap
+++ b/crates/biome_html_formatter/tests/specs/prettier/vue/vue/interpolations.vue.snap
@@ -68,39 +68,165 @@ x => {
 ```
 
 
-# Error
-```text
-reformat: output mismatch
---- re-formatted
-+++ formatted
-@@ -5,16 +5,15 @@
+# Prettier differences
+
+```diff
+--- Prettier
++++ Biome
+@@ -1,57 +1,44 @@
+ <template>
+   <div>
+     Fuga magnam facilis. Voluptatem quaerat porro.{{
+-
+-
+-x => {
++      x => {
+     const hello = 'world'
      return hello;
- } }}
-     Magni consectetur in et molestias neque esse voluptatibus voluptas.
--    {{ some_variable }}
+ }
+-
+-
+-
+-    }}
+-    Magni consectetur in et molestias neque esse voluptatibus voluptas.
+-    {{  
+-    
+-    
+-    some_variable 
+-
+-
+-
+-    }}
 -    Eum quia nihil nulla esse. Dolorem asperiores vero est error
++    }} Magni consectetur in et molestias neque esse voluptatibus voluptas.
 +    {{ some_variable }} Eum quia nihil nulla esse. Dolorem asperiores vero est
 +    error
-     {{ preserve
+     {{
+-
+-                    preserve
++      preserve
  
                      invalid
                      
-                     interpolation }}
-     reprehenderit voluptates minus
--    {{ console.log(  short_interpolation ) }}
--    nemo.
+                     interpolation
+-
+     }}
+-    reprehenderit voluptates minus {{console.log(  short_interpolation )}} nemo.
++    reprehenderit voluptates minus
 +    {{ console.log(  short_interpolation ) }} nemo.
    </div>
  
    <script type="text/jsx">
-@@ -47,7 +46,6 @@
+-    export default {
+-      render (h) {
+-        return (
+-          <ul
+-            class={{
+-              'a': b,
+-              'c': d,
+-              "e": f
+-            }}
+-          >
+-            { this.xyz }
+-          </ul>
+-      )
+-    };
+-  </script>
++  export default {
++    render (h) {
++      return (
++        <ul
++          class={{
++            'a': b,
++            'c': d,
++            "e": f
++          }}
++        >
++          { this.xyz }
++        </ul>
++    )
++  };
++</script>
+ 
+   <div>
+-    1234567890123456789012345678901234567890123456789012345678901234567890{{ something
++    1234567890123456789012345678901234567890123456789012345678901234567890{{
++      something
+     }}1234567890
+   </div>
+   <div>
+@@ -59,8 +46,9 @@
+     {{ something }}1234567890
+   </div>
+   <div>
+-    1234567890123456789012345678901234567890123456789012345678901234567890{{ something }}
+-    1234567890
++    1234567890123456789012345678901234567890123456789012345678901234567890{{
++      something
++    }} 1234567890
    </div>
    <div>
      1234567890123456789012345678901234567890123456789012345678901234567890
--    {{ something }}
--    1234567890
-+    {{ something }} 1234567890
-   </div>
- </template>
+```
 
+# Output
+
+```vue
+<template>
+  <div>
+    Fuga magnam facilis. Voluptatem quaerat porro.{{
+      x => {
+    const hello = 'world'
+    return hello;
+}
+    }} Magni consectetur in et molestias neque esse voluptatibus voluptas.
+    {{ some_variable }} Eum quia nihil nulla esse. Dolorem asperiores vero est
+    error
+    {{
+      preserve
+
+                    invalid
+                    
+                    interpolation
+    }}
+    reprehenderit voluptates minus
+    {{ console.log(  short_interpolation ) }} nemo.
+  </div>
+
+  <script type="text/jsx">
+  export default {
+    render (h) {
+      return (
+        <ul
+          class={{
+            'a': b,
+            'c': d,
+            "e": f
+          }}
+        >
+          { this.xyz }
+        </ul>
+    )
+  };
+</script>
+
+  <div>
+    1234567890123456789012345678901234567890123456789012345678901234567890{{
+      something
+    }}1234567890
+  </div>
+  <div>
+    1234567890123456789012345678901234567890123456789012345678901234567890
+    {{ something }}1234567890
+  </div>
+  <div>
+    1234567890123456789012345678901234567890123456789012345678901234567890{{
+      something
+    }} 1234567890
+  </div>
+  <div>
+    1234567890123456789012345678901234567890123456789012345678901234567890
+    {{ something }} 1234567890
+  </div>
+</template>
 ```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This essentially implements token borrowing for interpolations to preserve whitespace sensitivity. Both parent and sibling whitespace sensitivity is handled.

verified against prettier's behavior with our prettier-compare tool

implemented by gpt 5.6 sol
<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #10330
<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

snapshots, and slight prettier snapshot improvements

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
