### PR TITLE
feat(cli): add `--git` flag to init command

### DIFF
--- a/.changeset/add-init-git-flag.md
+++ b/.changeset/add-init-git-flag.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": minor
+---
+
+Added a `--git` flag to `biome init`. The flag enables Git VCS integration and sets `vcs.useIgnoreFile` to `true` in the generated configuration, even when the command runs outside a Git repository.

--- a/crates/biome_cli/src/commands/init.rs
+++ b/crates/biome_cli/src/commands/init.rs
@@ -8,13 +8,18 @@ use biome_fs::{ConfigName, FileSystem};
 use biome_service::configuration::create_config;
 use camino::Utf8Path;
 
-pub(crate) fn init(session: CliSession, emit_jsonc: bool) -> Result<(), CliDiagnostic> {
+pub(crate) fn init(
+    session: CliSession,
+    emit_jsonc: bool,
+    should_enable_git_integration: bool,
+) -> Result<(), CliDiagnostic> {
     let fs = session.app.workspace.fs();
     let working_directory = fs.working_directory().unwrap_or_default();
     let mut config = Configuration::init();
     let mut vcs_enabled = false;
     let mut dist_enabled = false;
-    if is_inside_git_repository(fs, &working_directory)
+    if should_enable_git_integration
+        || is_inside_git_repository(fs, &working_directory)
         || fs.path_exists(&working_directory.join(IGNORE_FILE_NAME))
         || fs.path_exists(&working_directory.join(GIT_IGNORE_FILE_NAME))
     {
@@ -44,6 +49,7 @@ pub(crate) fn init(session: CliSession, emit_jsonc: bool) -> Result<(), CliDiagn
     let diagnostic = InitDiagnostic {
         dist_enabled,
         vcs_enabled,
+        git_integration_requested: should_enable_git_integration,
         file_created,
     };
     session.app.console.log(markup! {{BiomeLogo}"\n"});
@@ -106,6 +112,7 @@ impl Display for BiomeLogo {
 struct InitDiagnostic {
     dist_enabled: bool,
     vcs_enabled: bool,
+    git_integration_requested: bool,
     file_created: &'static str,
 }
 
@@ -135,9 +142,15 @@ impl Display for InitDiagnostic {
     Your project configuration. See "<Hyperlink href="https://biomejs.dev/reference/configuration">"https://biomejs.dev/reference/configuration"</Hyperlink>})?;
 
         if self.vcs_enabled {
-            f.write_markup(markup!{
-                "\n\nFound a Git repository or ignore file. Biome enabled "<Hyperlink href="https://biomejs.dev/guides/integrate-in-vcs">"VCS integration."</Hyperlink>
-            })?;
+            if self.git_integration_requested {
+                f.write_markup(markup!{
+                    "\n\nBiome enabled "<Hyperlink href="https://biomejs.dev/guides/integrate-in-vcs">"Git VCS integration."</Hyperlink>
+                })?;
+            } else {
+                f.write_markup(markup!{
+                    "\n\nFound a Git repository or ignore file. Biome enabled "<Hyperlink href="https://biomejs.dev/guides/integrate-in-vcs">"VCS integration."</Hyperlink>
+                })?;
+            }
         }
 
         if self.dist_enabled {

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -523,11 +523,15 @@ pub enum BiomeCommand {
 
     /// Creates a default Biome configuration file in the current working directory.
     #[bpaf(command)]
-    Init(
+    Init {
         /// Creates `biome.jsonc` instead of `biome.json`.
         #[bpaf(long("jsonc"), switch)]
-        bool,
-    ),
+        jsonc: bool,
+
+        /// Enables Git VCS integration and respects Git ignore files.
+        #[bpaf(long("git"), switch)]
+        git: bool,
+    },
     /// Inspects Biome state without modifying files.
     #[bpaf(command)]
     Inspect {
@@ -717,7 +721,7 @@ impl BiomeCommand {
             | Self::Upgrade
             | Self::Start { .. }
             | Self::Stop
-            | Self::Init(_)
+            | Self::Init { .. }
             | Self::Explain { .. }
             | Self::RunServer { .. }
             | Self::Clean { .. }
@@ -740,7 +744,7 @@ impl BiomeCommand {
             | Self::LspProxy { .. }
             | Self::Start { .. }
             | Self::Stop
-            | Self::Init(_)
+            | Self::Init { .. }
             | Self::Inspect { .. }
             | Self::Explain { .. }
             | Self::RunServer { .. }

--- a/crates/biome_cli/src/lib.rs
+++ b/crates/biome_cli/src/lib.rs
@@ -274,7 +274,7 @@ impl<'app> CliSession<'app> {
                 }),
             ),
             BiomeCommand::Explain { doc } => commands::explain::explain(self, doc),
-            BiomeCommand::Init(emit_jsonc) => commands::init::init(self, emit_jsonc),
+            BiomeCommand::Init { jsonc, git } => commands::init::init(self, jsonc, git),
             BiomeCommand::Inspect {
                 cli_options,
                 sub_command,

--- a/crates/biome_cli/tests/commands/init.rs
+++ b/crates/biome_cli/tests/commands/init.rs
@@ -62,6 +62,23 @@ fn enables_vcs_inside_git_repository() {
 }
 
 #[test]
+fn enables_vcs_with_git_flag() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let (fs, result) = run_cli(fs, &mut console, Args::from(["init", "--git"].as_slice()));
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "enables_vcs_with_git_flag",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
 fn creates_config_jsonc_file() {
     let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();

--- a/crates/biome_cli/tests/snapshots/main_cases_help/init_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_help/init_help.snap
@@ -7,10 +7,11 @@ expression: redactor(content)
 ```block
 Creates a default Biome configuration file in the current working directory.
 
-Usage: init [--jsonc]
+Usage: init [--jsonc] [--git]
 
 Available options:
         --jsonc  Creates `biome.jsonc` instead of `biome.json`.
+        --git    Enables Git VCS integration and respects Git ignore files.
     -h, --help   Prints help information
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_init/enables_vcs_with_git_flag.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_init/enables_vcs_with_git_flag.snap
@@ -1,0 +1,110 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+assertion_line: 577
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "$schema": "https://biomejs.dev/schemas/0.0.0/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "tab"
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "preset": "recommended"
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double"
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}
+```
+
+# Emitted Messages
+
+```block
+                       ▄
+                      ▄██
+                     ▄████
+                    ▄██████
+                   ▄████████
+                  ▄██████████
+                 ▄████████████
+                ▄██████████████
+               ▄████████████████                  ██████▄
+              ▄██████████████████                 ██   ██  ▄▄
+              ▀▀▀       ▀▀▀▀██████                ██   ██      ▄██████▄  ██▄    ▄██   ▄██████▄
+                             ██████               ██████▀  ██  ██    ██  ██ █  █ ██  ██      ██
+              ▄▄▄▄████▄▄▄    ███████              ██   ██  ██  ██    ██  ██  ██  ██  ██▀▀▀▀▀▀▀▀
+          ▄▄█████████████   █████████             ██   ██  ██  ██    ██  ██      ██  ██
+        ▄███████████████    ██████████            ██████▀  ██  ▀██████▀  ██      ██   ▀██████▀
+      ▄█████████████████   ▄███████████
+     ███████████▀▀▀▀▀▀▀▀   █████████████            T O O L C H A I N   O F   T H E   W E B
+   ▄█████████▀             ██████████████
+  ▄████████▀     ▄▄▄▄▄▄▄  ████████████████
+  ████████    ▄▄███████████████████████████
+ ████████▄   ▄██████████████████████████████
+ ████████████████████████████████████████████
+ █████████████████████████████████████████████
+ ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+
+```
+
+```block
+init ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Welcome to Biome! Let's get you started...
+    
+    Files created 
+    
+      - biome.json
+        Your project configuration. See https://biomejs.dev/reference/configuration
+    
+    Biome enabled Git VCS integration.
+    
+    Next Steps 
+    
+      1. Setup an editor extension
+         Get live errors as you type and format when you save.
+         Learn more at https://biomejs.dev/editors/first-party-extensions/
+    
+      2. Try a command
+         biome check  checks formatting, import sorting, and lint rules.
+         biome --help displays the available commands.
+    
+      3. Migrate from ESLint and Prettier
+         biome migrate eslint   migrates your ESLint configuration to Biome.
+         biome migrate prettier migrates your Prettier configuration to Biome.
+    
+      4. Read the documentation
+         Find guides and documentation at https://biomejs.dev/guides/getting-started/
+    
+      5. Get involved with the community
+         Ask questions and contribute on GitHub: https://github.com/biomejs/biome
+         Seek for help on Discord: https://biomejs.dev/chat
+  
+  
+
+```


### PR DESCRIPTION
> [!NOTE]
> Generated with AI assistance

## Summary

This PR adds a `--git` flag to the `biome init` command to enable the git VCS integration explicitly, even when not running from within a git repository.

It builds on top of #11477 

## Test Plan

- Tests should be green

## Docs

No website documentation is planned because `--git` is discoverable through `biome init --help`, and the generated CLI reference will include the new flag automatically.
