### PR TITLE
perf(format/markdown): avoid quadratic list formatting

### DIFF
--- a/crates/biome_markdown_formatter/src/bullet_list.rs
+++ b/crates/biome_markdown_formatter/src/bullet_list.rs
@@ -18,7 +18,7 @@ use biome_markdown_syntax::thematic_break_ext::MdThematicBreakMarker;
 use biome_markdown_syntax::{
     AnyMdBlock, AnyMdCodeBlock, AnyMdInline, AnyMdLeafBlock, MarkdownLanguage, MdBlockList,
     MdBullet, MdBulletFields, MdBulletList, MdBulletListItem, MdContinuationIndent,
-    MdIndentCodeBlock, MdIndentTokenList, MdOrderedListItem, MdQuotePrefix,
+    MdIndentTokenList, MdOrderedListItem, MdQuotePrefix,
 };
 use biome_rowan::{AstNode, AstNodeList, AstNodeListIterator, Direction};
 use std::collections::VecDeque;
@@ -212,8 +212,9 @@ fn is_nested(list: &MdBulletList) -> bool {
 
 /// Checks whether the indentation before the marker needs to be kept.
 ///
-/// Nested lists discard this indentation. A top-level list keeps it when the
-/// bullet item is followed by a blank line and an indented code block.
+/// Nested lists discard this indentation. A top-level list keeps it when its
+/// next content sibling is an indented code block. Newline and quote-prefix
+/// siblings between the list and code block do not contain document content.
 ///
 /// ```md
 ///  -    one
@@ -223,21 +224,29 @@ fn is_nested(list: &MdBulletList) -> bool {
 ///
 /// Source: <https://spec.commonmark.org/dingus/?text=%20-%20%20%20%20one%0A%0A%20%20%20%20%20two%0A>
 fn should_keep_pre_marker(list: &MdBulletList) -> bool {
-    !is_nested(list)
-        && list
-            .syntax()
-            .ancestors()
-            .find(|ancestor| {
-                MdBulletListItem::can_cast(ancestor.kind())
-                    || MdOrderedListItem::can_cast(ancestor.kind())
-            })
-            .is_some_and(|list_item| {
-                list_item
-                    .siblings(Direction::Next)
-                    // Sibling iteration begins with `list_item` itself.
-                    .skip(1)
-                    .any(|sibling| MdIndentCodeBlock::can_cast(sibling.kind()))
-            })
+    if is_nested(list) {
+        return false;
+    }
+
+    let Some(list_item) = list.syntax().ancestors().find(|ancestor| {
+        MdBulletListItem::can_cast(ancestor.kind()) || MdOrderedListItem::can_cast(ancestor.kind())
+    }) else {
+        return false;
+    };
+
+    for sibling in list_item.siblings(Direction::Next).skip(1) {
+        let Some(block) = AnyMdBlock::cast(sibling) else {
+            return false;
+        };
+
+        match block {
+            block if block.is_newline() => {}
+            AnyMdBlock::MdQuotePrefix(_) => {}
+            block => return block.is_indent_block(),
+        }
+    }
+
+    false
 }
 
 impl Format<MarkdownFormatContext> for ListBullet {

--- a/crates/biome_markdown_formatter/tests/specs/markdown/list_pre_marker_indent.md
+++ b/crates/biome_markdown_formatter/tests/specs/markdown/list_pre_marker_indent.md
@@ -1,0 +1,55 @@
+ -    direct unordered
+
+     indented code
+
+---
+
+ -    before paragraph
+
+paragraph
+
+    unrelated indented code
+
+---
+
+ -    before heading
+
+# heading
+
+    unrelated indented code
+
+---
+
+ 1.    direct ordered
+
+      indented code
+
+---
+
+ 1.    ordered before paragraph
+
+paragraph
+
+    unrelated indented code
+
+---
+
+>  -    direct quoted
+>
+>      indented code
+
+---
+
+>  -    quoted before paragraph
+>
+> paragraph
+>
+>     unrelated indented code
+
+---
+
+ -    first loose item
+
+ -    second loose item
+
+     indented code

--- a/crates/biome_markdown_formatter/tests/specs/markdown/list_pre_marker_indent.md.snap
+++ b/crates/biome_markdown_formatter/tests/specs/markdown/list_pre_marker_indent.md.snap
@@ -1,0 +1,127 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: markdown/list_pre_marker_indent.md
+---
+
+# Input
+
+```md
+ -    direct unordered
+
+     indented code
+
+---
+
+ -    before paragraph
+
+paragraph
+
+    unrelated indented code
+
+---
+
+ -    before heading
+
+# heading
+
+    unrelated indented code
+
+---
+
+ 1.    direct ordered
+
+      indented code
+
+---
+
+ 1.    ordered before paragraph
+
+paragraph
+
+    unrelated indented code
+
+---
+
+>  -    direct quoted
+>
+>      indented code
+
+---
+
+>  -    quoted before paragraph
+>
+> paragraph
+>
+>     unrelated indented code
+
+---
+
+ -    first loose item
+
+ -    second loose item
+
+     indented code
+
+```
+
+
+# Formatted
+
+```md
+ -    direct unordered
+
+     indented code
+
+---
+
+-    before paragraph
+
+paragraph
+
+    unrelated indented code
+
+---
+
+-    before heading
+
+# heading
+
+    unrelated indented code
+
+---
+
+ 1.    direct ordered
+
+      indented code
+
+---
+
+1.    ordered before paragraph
+
+paragraph
+
+    unrelated indented code
+
+---
+
+>  -    direct quoted
+>
+>      indented code
+
+---
+
+> -    quoted before paragraph
+>
+> paragraph
+>
+>     unrelated indented code
+
+---
+
+ -    first loose item
+
+ -    second loose item
+
+     indented code
+
+```

--- a/crates/biome_markdown_formatter/tests/specs/prettier/markdown/list/followed-by-indented-things.md.snap
+++ b/crates/biome_markdown_formatter/tests/specs/prettier/markdown/list/followed-by-indented-things.md.snap
@@ -148,7 +148,7 @@ info: markdown/list/followed-by-indented-things.md
 ```diff
 --- Prettier
 +++ Biome
-@@ -1,101 +1,98 @@
+@@ -1,43 +1,42 @@
 -- foo
 -
 +-    foo
@@ -174,10 +174,10 @@ info: markdown/list/followed-by-indented-things.md
  ---
  
 -- foo
-+ -  foo
++-  foo
  
 -      indented code block in bullet
-+        indented code block in bullet
++       indented code block in bullet
  
  ---
  
@@ -205,27 +205,23 @@ info: markdown/list/followed-by-indented-things.md
  
  ---
  
--1.  foo
-+  1.  foo
- 
--        indented code block in numbered item
-+          indented code block in numbered item
+@@ -46,56 +45,54 @@
+         indented code block in numbered item
  
  ---
- 
+-
 -- [ ] foo
+ 
 +-    [] foo
  
--
      top level indented code block
  
  ---
  
 -- [ ] foo
-+   - [] foo
++- [] foo
  
--      indented code block in checkbox item
-+         indented code block in checkbox item
+       indented code block in checkbox item
  
  ---
  
@@ -297,23 +293,23 @@ info: markdown/list/followed-by-indented-things.md
  ---
  
 -- item 1
-+   -    item 1
-+        > quote
- 
+-
 -  > quote
 -
 -  text
--
++   -    item 1
++        > quote
+ 
 +        text
  
      top level indented code block
  
  ---
--
+ 
 -- item 1
 -  - item 1-1
 -  - item 1-2
- 
+-
 -
 -      indented code block
 -
@@ -354,9 +350,9 @@ info: markdown/list/followed-by-indented-things.md
 
 ---
 
- -  foo
+-  foo
 
-        indented code block in bullet
+       indented code block in bullet
 
 ---
 
@@ -378,9 +374,9 @@ info: markdown/list/followed-by-indented-things.md
 
 ---
 
-  1.  foo
+1.  foo
 
-          indented code block in numbered item
+        indented code block in numbered item
 
 ---
 
@@ -390,9 +386,9 @@ info: markdown/list/followed-by-indented-things.md
 
 ---
 
-   - [] foo
+- [] foo
 
-         indented code block in checkbox item
+      indented code block in checkbox item
 
 ---
 


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This builds on #11466, and fixes another quadratic computation issue. It reduces the amount of times siblings are checked.

implemented by gpt 5.6 sol

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
no snapshot changes

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
