### PR TITLE
fix(lint): recognize Astro JSX shorthand href in useValidAnchor

### DIFF
--- a/.changeset/astro-anchor-shorthand.md
+++ b/.changeset/astro-anchor-shorthand.md
@@ -1,5 +1,5 @@
 ---
-@biomejs/biome: patch
+"@biomejs/biome": patch
 ---
 
-Fixed [`useValidAnchor`](https://biomejs.dev/linter/rules/use-valid-anchor/) so Astro JSX shorthand attributes like `<a {href}>` inside expressions are treated as a valid `href`.
+Fixed [#11496](https://github.com/biomejs/biome/issues/11496): [`useValidAnchor`](https://biomejs.dev/linter/rules/use-valid-anchor/) now treats Astro JSX shorthand attributes like `<a {href}>` as a valid `href`.

--- a/.changeset/astro-anchor-shorthand.md
+++ b/.changeset/astro-anchor-shorthand.md
@@ -1,0 +1,5 @@
+---
+@biomejs/biome: patch
+---
+
+Fixed [`useValidAnchor`](https://biomejs.dev/linter/rules/use-valid-anchor/) so Astro JSX shorthand attributes like `<a {href}>` inside expressions are treated as a valid `href`.

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAnchor/astro/valid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAnchor/astro/valid.astro
@@ -2,6 +2,7 @@
 <a href="#id">ok</a>
 <a href="https://example.com">ok</a>
 <a href={somewhere}>ok</a>
+<a {href}>ok</a>
 <Link href={somewhere}>ok</Link>
 <Link href="https://example.com">ok</Link>
 <Link href="#">ok</Link>

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAnchor/astro/valid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAnchor/astro/valid.astro
@@ -2,7 +2,7 @@
 <a href="#id">ok</a>
 <a href="https://example.com">ok</a>
 <a href={somewhere}>ok</a>
-<a {href}>ok</a>
 <Link href={somewhere}>ok</Link>
 <Link href="https://example.com">ok</Link>
 <Link href="#">ok</Link>
+<a {href}>ok</a>

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAnchor/astro/valid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAnchor/astro/valid.astro.snap
@@ -8,9 +8,9 @@ expression: valid.astro
 <a href="#id">ok</a>
 <a href="https://example.com">ok</a>
 <a href={somewhere}>ok</a>
-<a {href}>ok</a>
 <Link href={somewhere}>ok</Link>
 <Link href="https://example.com">ok</Link>
 <Link href="#">ok</Link>
+<a {href}>ok</a>
 
 ```

--- a/crates/biome_html_analyze/tests/specs/a11y/useValidAnchor/astro/valid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useValidAnchor/astro/valid.astro.snap
@@ -8,6 +8,7 @@ expression: valid.astro
 <a href="#id">ok</a>
 <a href="https://example.com">ok</a>
 <a href={somewhere}>ok</a>
+<a {href}>ok</a>
 <Link href={somewhere}>ok</Link>
 <Link href="https://example.com">ok</Link>
 <Link href="#">ok</Link>

--- a/crates/biome_js_analyze/src/lint/a11y/use_valid_anchor.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_valid_anchor.rs
@@ -155,11 +155,11 @@ impl Rule for UseValidAnchor {
         let name = node.name().ok()?.name_value_token().ok()?;
 
         if name.text_trimmed() == "a" {
-            if node.has_shorthand_attribute("href") {
+            let anchor_attribute = node.find_attribute_by_name("href");
+            if anchor_attribute.is_none() && node.has_shorthand_attribute("href") {
                 return None;
             }
 
-            let anchor_attribute = node.find_attribute_by_name("href");
             let on_click_attribute = node.find_attribute_by_name("onClick");
 
             match (anchor_attribute, on_click_attribute) {

--- a/crates/biome_js_analyze/src/lint/a11y/use_valid_anchor.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_valid_anchor.rs
@@ -155,6 +155,10 @@ impl Rule for UseValidAnchor {
         let name = node.name().ok()?.name_value_token().ok()?;
 
         if name.text_trimmed() == "a" {
+            if node.has_shorthand_attribute("href") {
+                return None;
+            }
+
             let anchor_attribute = node.find_attribute_by_name("href");
             let on_click_attribute = node.find_attribute_by_name("onClick");
 

--- a/crates/biome_js_analyze/tests/specs/a11y/useValidAnchor/invalid_issue_11496.astro
+++ b/crates/biome_js_analyze/tests/specs/a11y/useValidAnchor/invalid_issue_11496.astro
@@ -1,0 +1,8 @@
+<!-- should generate diagnostics -->
+{
+	(
+		<>
+			<a {href} href="javascript:void(0)">bad</a>
+		</>
+	)
+}

--- a/crates/biome_js_analyze/tests/specs/a11y/useValidAnchor/invalid_issue_11496.astro.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/useValidAnchor/invalid_issue_11496.astro.snap
@@ -1,0 +1,36 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid_issue_11496.astro
+---
+# Input
+```astro
+<!-- should generate diagnostics -->
+{
+	(
+		<>
+			<a {href} href="javascript:void(0)">bad</a>
+		</>
+	)
+}
+
+```
+
+# Diagnostics
+```
+invalid_issue_11496.astro:5:14 lint/a11y/useValidAnchor ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Provide a valid value for the attribute href.
+  
+    3 │ 	(
+    4 │ 		<>
+  > 5 │ 			<a {href} href="javascript:void(0)">bad</a>
+      │ 			          ^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │ 		</>
+    7 │ 	)
+  
+  i The href attribute should be a valid a URL
+  
+  i Check this thorough explanation to better understand the context.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/a11y/useValidAnchor/valid_issue_11496.astro
+++ b/crates/biome_js_analyze/tests/specs/a11y/useValidAnchor/valid_issue_11496.astro
@@ -1,0 +1,16 @@
+---
+const href = "https://example.com";
+---
+
+<!-- should not generate diagnostics -->
+<a href="https://example.com">ok</a>
+<a {href}>ok</a>
+
+{
+	(
+		<>
+			<a href="https://example.com">ok</a>
+			<a {href}>ok</a>
+		</>
+	)
+}

--- a/crates/biome_js_analyze/tests/specs/a11y/useValidAnchor/valid_issue_11496.astro
+++ b/crates/biome_js_analyze/tests/specs/a11y/useValidAnchor/valid_issue_11496.astro
@@ -1,7 +1,3 @@
----
-const href = "https://example.com";
----
-
 <!-- should not generate diagnostics -->
 <a href="https://example.com">ok</a>
 <a {href}>ok</a>

--- a/crates/biome_js_analyze/tests/specs/a11y/useValidAnchor/valid_issue_11496.astro.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/useValidAnchor/valid_issue_11496.astro.snap
@@ -4,10 +4,6 @@ expression: valid_issue_11496.astro
 ---
 # Input
 ```astro
----
-const href = "https://example.com";
----
-
 <!-- should not generate diagnostics -->
 <a href="https://example.com">ok</a>
 <a {href}>ok</a>

--- a/crates/biome_js_analyze/tests/specs/a11y/useValidAnchor/valid_issue_11496.astro.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/useValidAnchor/valid_issue_11496.astro.snap
@@ -1,0 +1,24 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid_issue_11496.astro
+---
+# Input
+```astro
+---
+const href = "https://example.com";
+---
+
+<!-- should not generate diagnostics -->
+<a href="https://example.com">ok</a>
+<a {href}>ok</a>
+
+{
+	(
+		<>
+			<a href="https://example.com">ok</a>
+			<a {href}>ok</a>
+		</>
+	)
+}
+
+```

--- a/crates/biome_js_syntax/src/jsx_ext.rs
+++ b/crates/biome_js_syntax/src/jsx_ext.rs
@@ -326,6 +326,19 @@ impl JsxAttributeList {
         })
     }
 
+    pub fn has_shorthand_attribute(&self, name_to_lookup: &str) -> bool {
+        self.iter().any(|attribute| {
+            let AnyJsxAttribute::JsxShorthandAttribute(attribute) = attribute else {
+                return false;
+            };
+            attribute
+                .name()
+                .ok()
+                .and_then(|name| name.value_token().ok())
+                .is_some_and(|token| token.text_trimmed() == name_to_lookup)
+        })
+    }
+
     pub fn has_trailing_spread_prop(&self, current_attribute: &JsxAttribute) -> bool {
         let mut current_attribute_found = false;
         for attribute in self {
@@ -559,6 +572,10 @@ impl AnyJsxElement {
         self.attributes()
             .into_iter()
             .any(|attribute| matches!(attribute, AnyJsxAttribute::JsxSpreadAttribute(_)))
+    }
+
+    pub fn has_shorthand_attribute(&self, name_to_lookup: &str) -> bool {
+        self.attributes().has_shorthand_attribute(name_to_lookup)
     }
 
     pub fn has_trailing_spread_prop(&self, current_attribute: &JsxAttribute) -> bool {


### PR DESCRIPTION
## Summary

Fixes #11496.

`useValidAnchor` already treated normal `href` attributes, but Astro JSX shorthand (`<a {href}>`) inside expressions is parsed as `JsxShorthandAttribute`, so the rule still reported a missing `href`.

This adds `has_shorthand_attribute` and skips the diagnostic when `{href}` is present.

AI assistance: Cursor helped implement and test the fix; I reviewed and verified the change.

## Test Plan

- Added `valid_issue_11496.astro` covering template + expression shorthand cases
- Existing Astro `valid.astro` fixture updated

## Docs

N/A (bug fix for an existing rule)

Made with [Cursor](https://cursor.com)