### PR TITLE
perf(analyzer): fast-path for useArraySortCompare via syntax before type inference 

### DIFF
--- a/.changeset/swift-sorts-compare.md
+++ b/.changeset/swift-sorts-compare.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Improved the performance of [`useArraySortCompare`](https://biomejs.dev/linter/rules/use-array-sort-compare/) by skipping type inference for calls to unrelated methods.

--- a/crates/biome_js_analyze/src/lint/suspicious/use_array_sort_compare.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/use_array_sort_compare.rs
@@ -61,19 +61,19 @@ impl Rule for UseArraySortCompare {
         let binding = node.callee().ok()?.omit_parentheses();
         let callee = binding.as_js_static_member_expression()?;
 
-        let call_object = callee.object().ok()?;
-        if !ctx
-            .type_of_expression(&call_object)
-            .is_some_and(|ty| ty.is_array())
-        {
-            return None;
-        }
-
         let member = callee.member().ok()?;
         let name = member.as_js_name()?;
         let token = name.value_token().ok()?;
         let call_name = token.text_trimmed();
         if call_name != "sort" && call_name != "toSorted" {
+            return None;
+        }
+
+        let call_object = callee.object().ok()?;
+        if !ctx
+            .type_of_expression(&call_object)
+            .is_some_and(|ty| ty.is_array())
+        {
             return None;
         }
 


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This fixes the poor performance of `useArraySortCompare`. This makes this rule over **`1500`** times faster (75s -> 50ms). 

This was done by first using the syntax to detect the sort function before doing type inference. This means type inference is not needed for most of the function calls in a codebase, which can be many.

Before
```
75.385s     1.404ms     0.000ns      3.844s   53711  suspicious/useArraySortCompare
```
After
```
48.505ms   451.000ns     0.000ns    26.298ms  107422  suspicious/useArraySortCompare
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

Related to #11376

## Test Plan

I ran this on a big project:

```ps1
biome check --write --unsafe  --profile-rules --only=suspicious/useArraySortCompare
```

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
N/A
