### PR TITLE
fix(noGlobalAssign): do not report assignments to bindings from Vue setup script

### DIFF
--- a/.changeset/vue-script-setup-no-global-assign.md
+++ b/.changeset/vue-script-setup-no-global-assign.md
@@ -1,0 +1,17 @@
+---
+"@biomejs/biome": patch
+---
+
+`noGlobalAssign` no longer reports assignments to a Vue `<script setup>` binding from a template expression, when the binding's name happens to match a built-in global (e.g. `open`, `parent`, `top`).
+
+For example, this no longer triggers a diagnostic:
+
+```vue
+<script setup>
+const open = defineModel();
+</script>
+
+<template>
+  <button @click="open = !open">Toggle</button>
+</template>
+```

--- a/crates/biome_js_analyze/src/lint/suspicious/no_global_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_global_assign.rs
@@ -1,5 +1,6 @@
 use crate::globals::is_js_global;
 
+use crate::services::embedded::EmbeddedService;
 use crate::services::semantic::Semantic;
 use biome_analyze::RuleSource;
 use biome_analyze::{Rule, RuleDiagnostic, context::RuleContext, declare_lint_rule};
@@ -61,7 +62,15 @@ impl Rule for NoGlobalAssign {
         if !ctx.model().is_unresolved_reference(assignment) {
             return None;
         }
+        let embedded = ctx
+            .get_service::<EmbeddedService>()
+            .expect("embedded service");
         let token = assignment.name_token().ok()?;
+
+        if embedded.contains_binding(token.token_text_trimmed()) {
+            return None;
+        }
+
         is_js_global(token.text_trimmed()).then(|| token.text_trimmed_range())
     }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_global_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_global_assign.rs
@@ -7,6 +7,7 @@ use biome_analyze::{Rule, RuleDiagnostic, context::RuleContext, declare_lint_rul
 use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_syntax::{JsIdentifierAssignment, TextRange};
+use biome_languages::JsFileSource;
 use biome_rule_options::no_global_assign::NoGlobalAssignOptions;
 
 declare_lint_rule! {
@@ -62,13 +63,22 @@ impl Rule for NoGlobalAssign {
         if !ctx.model().is_unresolved_reference(assignment) {
             return None;
         }
-        let embedded = ctx
-            .get_service::<EmbeddedService>()
-            .expect("embedded service");
         let token = assignment.name_token().ok()?;
 
-        if embedded.contains_binding(token.token_text_trimmed()) {
-            return None;
+        // Only trust a same-named binding declared elsewhere in the document's
+        // embeds (e.g. a Vue `<script setup>` top-level binding) when this
+        // reference itself lives in a non-source embed (e.g. a template
+        // expression). Source embeds (`<script>`, `<script setup>`) have their
+        // own binding resolution and aren't necessarily able to see each
+        // other's bindings (e.g. plain `<script>` can't see `<script setup>`
+        // locals), so trusting it there would hide genuine global assignments.
+        if !ctx.source_type::<JsFileSource>().is_embedded_source() {
+            let embedded = ctx
+                .get_service::<EmbeddedService>()
+                .expect("embedded service");
+            if embedded.contains_binding(token.token_text_trimmed()) {
+                return None;
+            }
         }
 
         is_js_global(token.text_trimmed()).then(|| token.text_trimmed_range())

--- a/crates/biome_js_analyze/src/lint/suspicious/no_global_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_global_assign.rs
@@ -65,13 +65,10 @@ impl Rule for NoGlobalAssign {
         }
         let token = assignment.name_token().ok()?;
 
-        // Only trust a same-named binding declared elsewhere in the document's
-        // embeds (e.g. a Vue `<script setup>` top-level binding) when this
-        // reference itself lives in a non-source embed (e.g. a template
-        // expression). Source embeds (`<script>`, `<script setup>`) have their
-        // own binding resolution and aren't necessarily able to see each
-        // other's bindings (e.g. plain `<script>` can't see `<script setup>`
-        // locals), so trusting it there would hide genuine global assignments.
+        // Only trust a cross-embed binding from non-source embeds like template
+        // expressions. Source embeds (e.g. Vue's `<script>` and `<script setup>`)
+        // don't necessarily see each other's bindings, so trusting it there
+        // would hide genuine global assignments.
         if !ctx.source_type::<JsFileSource>().is_embedded_source() {
             let embedded = ctx
                 .get_service::<EmbeddedService>()

--- a/crates/biome_js_analyze/tests/specs/suspicious/noGlobalAssign/invalid-vue-script-vs-script-setup.vue
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noGlobalAssign/invalid-vue-script-vs-script-setup.vue
@@ -1,0 +1,13 @@
+<!-- should generate diagnostics -->
+<script setup>
+const open = defineModel();
+open = true;
+</script>
+
+<script>
+open = true;
+</script>
+
+<template>
+  <button @click="open = !open">Swap</button>
+</template>

--- a/crates/biome_js_analyze/tests/specs/suspicious/noGlobalAssign/invalid-vue-script-vs-script-setup.vue.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noGlobalAssign/invalid-vue-script-vs-script-setup.vue.snap
@@ -1,0 +1,38 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid-vue-script-vs-script-setup.vue
+---
+# Input
+```vue
+<!-- should generate diagnostics -->
+<script setup>
+const open = defineModel();
+open = true;
+</script>
+
+<script>
+open = true;
+</script>
+
+<template>
+  <button @click="open = !open">Swap</button>
+</template>
+
+```
+
+# Diagnostics
+```
+invalid-vue-script-vs-script-setup.vue:8:1 lint/suspicious/noGlobalAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A global variable should not be reassigned.
+  
+     7 │ <script>
+   > 8 │ open = true;
+       │ ^^^^
+     9 │ </script>
+    10 │ 
+  
+  i Assigning to a global variable can override essential functionality.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noGlobalAssign/invalid-vue-undeclared-global.vue
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noGlobalAssign/invalid-vue-undeclared-global.vue
@@ -1,0 +1,6 @@
+<script setup>
+</script>
+
+<template>
+  <button @click="window = {}">Break</button>
+</template>

--- a/crates/biome_js_analyze/tests/specs/suspicious/noGlobalAssign/invalid-vue-undeclared-global.vue
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noGlobalAssign/invalid-vue-undeclared-global.vue
@@ -1,3 +1,4 @@
+<!-- should generate diagnostics -->
 <script setup>
 </script>
 

--- a/crates/biome_js_analyze/tests/specs/suspicious/noGlobalAssign/invalid-vue-undeclared-global.vue.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noGlobalAssign/invalid-vue-undeclared-global.vue.snap
@@ -1,0 +1,31 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid-vue-undeclared-global.vue
+---
+# Input
+```vue
+<script setup>
+</script>
+
+<template>
+  <button @click="window = {}">Break</button>
+</template>
+
+```
+
+# Diagnostics
+```
+invalid-vue-undeclared-global.vue:5:19 lint/suspicious/noGlobalAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × A global variable should not be reassigned.
+  
+    4 │ <template>
+  > 5 │   <button @click="window = {}">Break</button>
+      │                   ^^^^^^
+    6 │ </template>
+    7 │ 
+  
+  i Assigning to a global variable can override essential functionality.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noGlobalAssign/invalid-vue-undeclared-global.vue.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noGlobalAssign/invalid-vue-undeclared-global.vue.snap
@@ -4,6 +4,7 @@ expression: invalid-vue-undeclared-global.vue
 ---
 # Input
 ```vue
+<!-- should generate diagnostics -->
 <script setup>
 </script>
 
@@ -15,15 +16,15 @@ expression: invalid-vue-undeclared-global.vue
 
 # Diagnostics
 ```
-invalid-vue-undeclared-global.vue:5:19 lint/suspicious/noGlobalAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid-vue-undeclared-global.vue:6:19 lint/suspicious/noGlobalAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × A global variable should not be reassigned.
   
-    4 │ <template>
-  > 5 │   <button @click="window = {}">Break</button>
+    5 │ <template>
+  > 6 │   <button @click="window = {}">Break</button>
       │                   ^^^^^^
-    6 │ </template>
-    7 │ 
+    7 │ </template>
+    8 │ 
   
   i Assigning to a global variable can override essential functionality.
   

--- a/crates/biome_js_analyze/tests/specs/suspicious/noGlobalAssign/valid-vue-script-setup-binding.vue
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noGlobalAssign/valid-vue-script-setup-binding.vue
@@ -1,0 +1,8 @@
+<!-- should not generate diagnostics -->
+<script setup>
+const open = defineModel();
+</script>
+
+<template>
+  <button @click="open = !open">Toggle</button>
+</template>

--- a/crates/biome_js_analyze/tests/specs/suspicious/noGlobalAssign/valid-vue-script-setup-binding.vue.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noGlobalAssign/valid-vue-script-setup-binding.vue.snap
@@ -1,0 +1,16 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid-vue-script-setup-binding.vue
+---
+# Input
+```vue
+<!-- should not generate diagnostics -->
+<script setup>
+const open = defineModel();
+</script>
+
+<template>
+  <button @click="open = !open">Toggle</button>
+</template>
+
+```


### PR DESCRIPTION
> Claude Sonnet has been used in the creation of this PR. The code has been reviewed by a human.

## Summary

https://biomejs.dev/playground/?lintRules=noGlobalAssign&tab=formatter&pane=Diagnostics&language=vue#code=PABzAGMAcgBpAHAAdAAgAHMAZQB0AHUAcAA%2BAAoAYwBvAG4AcwB0ACAAbwBwAGUAbgAgAD0AIABkAGUAZgBpAG4AZQBNAG8AZABlAGwAKAApADsACgA8AC8AcwBjAHIAaQBwAHQAPgAKAAoAPAB0AGUAbQBwAGwAYQB0AGUAPgAKACAAIAA8AGIAdQB0AHQAbwBuACAAQABjAGwAaQBjAGsAPQAiAG8AcABlAG4AIAA9ACAAIQBvAHAAZQBuACIAPgBUAG8AZwBnAGwAZQA8AC8AYgB1AHQAdABvAG4APgAKADwALwB0AGUAbQBwAGwAYQB0AGUAPgA%3D

This should not flag `open` as global assign and instead just accept it. The assignment itself might look weird as it re-assigns a `const`. `defineModel` is a Vue compiler macro and compiles to something else under the hood. This is the syntax used to assign a new value to a model.

Vue playground example showcasing it working:

https://play.vuejs.org/#eNp9kU1LAzEQhv9KzEmh7goVD3Vb/KAHBT+w4ikgazqtabNJSCbbhbL/3cmurT1IySUz7zOTdyZbfutcVkfgI14E6ZVDFgCjmwgjrQnIrAPDxmwOC2Xgyc5Bn55dC1PkPU0cBQiV0yUCRYwVyriIrD6vEj0WPLUQnOW9+hURrWE3Uiu5/lXpgZOemsw2pSvyHqKCIj/onQ4fcAxkbaGW2SpYQ8a3qa/g0lZOafAvDhVZF3zEOiVppdZ289jl0EcY7PLyG+T6n/wqNCkn+KuHAL4Gwfcaln4J2MvT2TM0dN+LNHPURB8R3yBYHZPHHruLZk62D7jO7UPlrEdllu9h2iCYsBsqGU1k2/GC0+/dHxn9z+4wu+zqhGlpi58YPsCnrrTCq+wiG/L2B+ZcrfI=

## Test Plan

Snapshot tests have been added for a positive and negative case.