### PR TITLE
perf(markdown): reduce parser rescans

### DIFF
--- a/crates/biome_markdown_parser/benches/markdown_parser.rs
+++ b/crates/biome_markdown_parser/benches/markdown_parser.rs
@@ -57,12 +57,51 @@ fn load_fixtures() -> Vec<(String, String, String)> {
         }
     }
 
+    cases.extend(generated_fixtures());
+
     assert!(
         !cases.is_empty(),
         "no markdown benchmark fixtures found in {fixtures_root:?}"
     );
     cases.sort_unstable_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
     cases
+}
+
+fn generated_fixtures() -> Vec<(String, String, String)> {
+    let mut late_definitions = String::with_capacity(32 * 1024);
+    for _ in 0..1024 {
+        late_definitions.push_str("plain paragraph without links\n\n");
+    }
+    late_definitions.push_str("[link][ref]\n\n[ref]: /url\n");
+
+    let emphasis = "***emphasis*** ".repeat(4096);
+    let malformed_autolinks = "<invalid".repeat(8192);
+    let html_block = format!("<script>\n{}</script>\n", "const value = 1;\n".repeat(4096));
+    let indented_code_blank_run = format!("    start\n{}    end\n", "\n".repeat(512));
+
+    vec![
+        (
+            "generated".to_string(),
+            "late-definitions.md".to_string(),
+            late_definitions,
+        ),
+        ("generated".to_string(), "emphasis.md".to_string(), emphasis),
+        (
+            "generated".to_string(),
+            "malformed-autolinks.md".to_string(),
+            malformed_autolinks,
+        ),
+        (
+            "generated".to_string(),
+            "html-block.md".to_string(),
+            html_block,
+        ),
+        (
+            "generated".to_string(),
+            "indented-code-blank-run.md".to_string(),
+            indented_code_blank_run,
+        ),
+    ]
 }
 
 fn bench_parser(criterion: &mut Criterion) {

--- a/crates/biome_markdown_parser/benches/markdown_parser.rs
+++ b/crates/biome_markdown_parser/benches/markdown_parser.rs
@@ -57,51 +57,12 @@ fn load_fixtures() -> Vec<(String, String, String)> {
         }
     }
 
-    cases.extend(generated_fixtures());
-
     assert!(
         !cases.is_empty(),
         "no markdown benchmark fixtures found in {fixtures_root:?}"
     );
     cases.sort_unstable_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
     cases
-}
-
-fn generated_fixtures() -> Vec<(String, String, String)> {
-    let mut late_definitions = String::with_capacity(32 * 1024);
-    for _ in 0..1024 {
-        late_definitions.push_str("plain paragraph without links\n\n");
-    }
-    late_definitions.push_str("[link][ref]\n\n[ref]: /url\n");
-
-    let emphasis = "***emphasis*** ".repeat(4096);
-    let malformed_autolinks = "<invalid".repeat(8192);
-    let html_block = format!("<script>\n{}</script>\n", "const value = 1;\n".repeat(4096));
-    let indented_code_blank_run = format!("    start\n{}    end\n", "\n".repeat(512));
-
-    vec![
-        (
-            "generated".to_string(),
-            "late-definitions.md".to_string(),
-            late_definitions,
-        ),
-        ("generated".to_string(), "emphasis.md".to_string(), emphasis),
-        (
-            "generated".to_string(),
-            "malformed-autolinks.md".to_string(),
-            malformed_autolinks,
-        ),
-        (
-            "generated".to_string(),
-            "html-block.md".to_string(),
-            html_block,
-        ),
-        (
-            "generated".to_string(),
-            "indented-code-blank-run.md".to_string(),
-            indented_code_blank_run,
-        ),
-    ]
 }
 
 fn bench_parser(criterion: &mut Criterion) {

--- a/crates/biome_markdown_parser/src/inline_phase.rs
+++ b/crates/biome_markdown_parser/src/inline_phase.rs
@@ -120,6 +120,7 @@ pub(crate) fn parse_deferred_inlines(
     true
 }
 
+#[inline]
 fn should_reparse_deferred_inline(
     source: &str,
     deferred: &DeferredInline,

--- a/crates/biome_markdown_parser/src/inline_phase.rs
+++ b/crates/biome_markdown_parser/src/inline_phase.rs
@@ -45,7 +45,14 @@ pub(crate) fn parse_deferred_inlines(
     let mut replacements = Vec::new();
 
     for deferred in &output.deferred_inlines {
-        if deferred.definitions_len() == output.link_reference_definitions.len() {
+        let Some(should_reparse) = should_reparse_deferred_inline(
+            source,
+            deferred,
+            output.link_reference_definitions.len(),
+        ) else {
+            return false;
+        };
+        if !should_reparse {
             continue;
         }
 
@@ -63,6 +70,11 @@ pub(crate) fn parse_deferred_inlines(
             deferred.source_range(),
             fragment,
         ));
+    }
+
+    if replacements.is_empty() {
+        output.deferred_inlines.clear();
+        return true;
     }
 
     let mut events = Vec::with_capacity(output.events.len());
@@ -106,6 +118,20 @@ pub(crate) fn parse_deferred_inlines(
     output.deferred_inlines.clear();
 
     true
+}
+
+fn should_reparse_deferred_inline(
+    source: &str,
+    deferred: &DeferredInline,
+    definitions_len: usize,
+) -> Option<bool> {
+    if deferred.definitions_len() == definitions_len {
+        return Some(false);
+    }
+
+    let range = deferred.source_range();
+    let source = source.get(usize::from(range.start())..usize::from(range.end()))?;
+    Some(source.as_bytes().contains(&b'['))
 }
 
 fn validate_deferred_inlines(source: &str, output: &MarkdownParserOutput) -> bool {

--- a/crates/biome_markdown_parser/src/lexer/mod.rs
+++ b/crates/biome_markdown_parser/src/lexer/mod.rs
@@ -12,6 +12,7 @@ use biome_parser::lexer::{
 use biome_rowan::{SyntaxKind, TextRange, TextSize};
 use biome_unicode_table::Dispatch::{self, AMP, *};
 use biome_unicode_table::{is_unicode_punctuation, lookup_byte};
+use std::cell::Cell;
 
 use crate::syntax::{
     MAX_BLOCK_PREFIX_INDENT, MAX_ORDERED_LIST_MARKER_DIGITS, MIN_FENCE_RUN_LENGTH,
@@ -120,6 +121,7 @@ pub(crate) struct MarkdownLexer<'src> {
     /// position and the token kind, set by the parser after measuring the
     /// span.
     relex_span: Option<(usize, MarkdownSyntaxKind)>,
+    frontmatter_fence: Cell<Option<(usize, usize)>>,
 }
 
 impl<'src> Lexer<'src> for MarkdownLexer<'src> {
@@ -272,6 +274,7 @@ impl<'src> MarkdownLexer<'src> {
             diagnostics: vec![],
             force_ordered_list_marker: false,
             relex_span: None,
+            frontmatter_fence: Cell::new(None),
         }
     }
 
@@ -284,7 +287,18 @@ impl<'src> MarkdownLexer<'src> {
     }
 
     pub fn has_frontmatter_closing_fence(&self) -> bool {
-        self.find_frontmatter_fence(self.position).is_some()
+        if self
+            .frontmatter_fence
+            .get()
+            .is_some_and(|(start, _)| start == self.position)
+        {
+            return true;
+        }
+
+        let fence = self.find_frontmatter_fence(self.position);
+        self.frontmatter_fence
+            .set(fence.map(|fence| (self.position, fence)));
+        fence.is_some()
     }
 
     /// Sets the target for the next [MarkdownReLexContext::Span] re-lex.
@@ -742,7 +756,11 @@ impl<'src> MarkdownLexer<'src> {
         }
 
         self.position = self
-            .find_frontmatter_fence(self.position)
+            .frontmatter_fence
+            .take()
+            .map(|(_, fence)| fence)
+            .filter(|fence| *fence >= self.position)
+            .or_else(|| self.find_frontmatter_fence(self.position))
             .unwrap_or(self.end);
         MD_FRONTMATTER_LITERAL
     }

--- a/crates/biome_markdown_parser/src/lexer/mod.rs
+++ b/crates/biome_markdown_parser/src/lexer/mod.rs
@@ -781,6 +781,7 @@ impl<'src> MarkdownLexer<'src> {
             .then_some(position - start)
     }
 
+    #[inline]
     fn find_frontmatter_fence(&self, start: usize) -> Option<usize> {
         let source = self.source.as_bytes();
         let mut position = start;

--- a/crates/biome_markdown_parser/src/syntax/html_block.rs
+++ b/crates/biome_markdown_parser/src/syntax/html_block.rs
@@ -372,15 +372,10 @@ fn advance_until_terminator(
     terminator: &str,
     case_insensitive: bool,
 ) -> TextSize {
-    let mut line = String::new();
     let mut end = p.cur_range().start();
 
     while !p.at(EOF) {
         if p.at(NEWLINE) {
-            if line_contains(&line, terminator, case_insensitive) {
-                break;
-            }
-            line.clear();
             p.bump_any();
             // Check container boundary after consuming newline
             if at_container_boundary(p) {
@@ -392,9 +387,12 @@ fn advance_until_terminator(
 
         // Content is literal text: consume the whole rest of the line at once.
         p.re_lex(MarkdownReLexContext::CodeInfoString);
-        line.push_str(p.cur_text());
+        let has_terminator = line_contains(p.cur_text(), terminator, case_insensitive);
         p.bump_any();
         end = p.cur_range().start();
+        if has_terminator {
+            break;
+        }
     }
 
     end
@@ -426,8 +424,7 @@ fn line_contains(line: &str, needle: &str, case_insensitive: bool) -> bool {
 
 fn skip_container_prefixes(p: &mut MarkdownParser) {
     let quote_depth = p.state().block_quote_depth;
-    if quote_depth > 0 && has_quote_prefix(p, quote_depth) {
-        consume_quote_prefix_without_virtual(p, quote_depth);
+    if quote_depth > 0 && consume_quote_prefix_without_virtual(p, quote_depth) {
         p.state_mut().virtual_line_start = Some(p.cur_range().start());
     }
 

--- a/crates/biome_markdown_parser/src/syntax/inline/emphasis.rs
+++ b/crates/biome_markdown_parser/src/syntax/inline/emphasis.rs
@@ -507,31 +507,24 @@ impl EmphasisContext {
         expect_strong: bool,
     ) -> Option<OpenerMatch<'_>> {
         let token_end = token_start + token_len;
-        let mut best: Option<OpenerMatch<'_>> = None;
+        let first_match = self
+            .matches
+            .partition_point(|m| m.opener_start + self.base_offset < token_start);
 
-        for m in &self.matches {
-            // Filter by expected emphasis type
-            if m.is_strong != expect_strong {
-                continue;
-            }
-
+        for m in &self.matches[first_match..] {
             let abs_opener = m.opener_start + self.base_offset;
-            if abs_opener >= token_start && abs_opener < token_end {
-                let candidate = OpenerMatch {
+            if abs_opener >= token_end {
+                break;
+            }
+            if m.is_strong == expect_strong {
+                return Some(OpenerMatch {
                     matched: m,
                     prefix_len: abs_opener - token_start,
-                };
-                // Pick the earliest match (smallest prefix_len)
-                if best
-                    .as_ref()
-                    .is_none_or(|b| candidate.prefix_len < b.prefix_len)
-                {
-                    best = Some(candidate);
-                }
+                });
             }
         }
 
-        best
+        None
     }
 }
 

--- a/crates/biome_markdown_parser/src/syntax/inline/html.rs
+++ b/crates/biome_markdown_parser/src/syntax/inline/html.rs
@@ -545,6 +545,19 @@ fn is_email_autolink(text: &str) -> bool {
     true
 }
 
+fn autolink_content(source: &str) -> Option<&str> {
+    let bytes = source.as_bytes();
+    if bytes.first() != Some(&b'<') {
+        return None;
+    }
+
+    let after_open = &source[1..];
+    let close_pos = after_open
+        .bytes()
+        .position(|byte| matches!(byte, b'>' | b'\n' | b'\r' | b'<'))?;
+    (after_open.as_bytes()[close_pos] == b'>').then_some(&after_open[..close_pos])
+}
+
 /// Parse an autolink (`<https://example.com>` or `<user@example.com>`).
 ///
 /// Grammar: MdAutolink = '<' value: MdInlineItemList '>'
@@ -558,16 +571,10 @@ pub(crate) fn parse_autolink(p: &mut MarkdownParser) -> ParsedSyntax {
 
     let content_len = {
         let source = p.source_after_current();
-        let after_open = &source[1..];
-        let close_pos = match after_open.find('>') {
-            Some(pos) => pos,
-            None => return Absent,
+        let Some(content) = autolink_content(source) else {
+            return Absent;
         };
-        let content = &after_open[..close_pos];
-        if content.contains('\n')
-            || content.contains('\r')
-            || (!is_uri_autolink(content) && !is_email_autolink(content))
-        {
+        if !is_uri_autolink(content) && !is_email_autolink(content) {
             return Absent;
         }
         content.len()

--- a/crates/biome_markdown_parser/src/syntax/inline/html.rs
+++ b/crates/biome_markdown_parser/src/syntax/inline/html.rs
@@ -545,6 +545,7 @@ fn is_email_autolink(text: &str) -> bool {
     true
 }
 
+#[inline]
 fn autolink_content(source: &str) -> Option<&str> {
     let bytes = source.as_bytes();
     if bytes.first() != Some(&b'<') {

--- a/crates/biome_markdown_parser/src/syntax/link_block.rs
+++ b/crates/biome_markdown_parser/src/syntax/link_block.rs
@@ -27,7 +27,6 @@ use biome_rowan::TextRange;
 
 use crate::MarkdownParser;
 use crate::lexer::MarkdownLexContext;
-use crate::syntax::reference::normalize_reference_label;
 use crate::syntax::{
     LinkDestinationKind, MAX_BLOCK_PREFIX_INDENT, MAX_LINK_DESTINATION_PAREN_DEPTH,
     ParenDepthResult, ends_with_unescaped_close, get_title_close_char, is_space_or_tab_token,
@@ -45,27 +44,24 @@ const MAX_LABEL_LENGTH: usize = 999;
 /// We use token-based lookahead to verify the pattern: `[label]: destination`
 /// where label doesn't contain unescaped `]` or `[`, and is followed by `:`.
 pub(crate) fn at_link_block(p: &mut MarkdownParser) -> bool {
-    p.lookahead(|p| {
-        // Must be at line start (or start of input)
-        if !p.at_line_start() && !p.at_start_of_input() {
-            return false;
-        }
+    p.lookahead(|p| at_link_block_start_impl(p) && is_valid_link_definition_lookahead(p))
+}
 
-        // Check for up to 3 spaces of indentation (more means indented code block)
-        if p.line_start_leading_indent() > MAX_BLOCK_PREFIX_INDENT {
-            return false;
-        }
+pub(crate) fn at_link_block_start(p: &mut MarkdownParser) -> bool {
+    p.lookahead(at_link_block_start_impl)
+}
 
-        p.skip_line_indent(MAX_BLOCK_PREFIX_INDENT);
+fn at_link_block_start_impl(p: &mut MarkdownParser) -> bool {
+    if !p.at_line_start() && !p.at_start_of_input() {
+        return false;
+    }
 
-        // Must start with `[`
-        if !p.at(L_BRACK) {
-            return false;
-        }
+    if p.line_start_leading_indent() > MAX_BLOCK_PREFIX_INDENT {
+        return false;
+    }
 
-        // Use token-based lookahead to verify this is a valid link reference definition
-        is_valid_link_definition_lookahead(p)
-    })
+    p.skip_line_indent(MAX_BLOCK_PREFIX_INDENT);
+    p.at(L_BRACK)
 }
 
 /// Token-based lookahead to verify a link reference definition.
@@ -81,9 +77,8 @@ fn is_valid_link_definition_lookahead(p: &mut MarkdownParser) -> bool {
     p.bump_any();
 
     // Parse label: consume tokens until ] or invalid state
-    // Also collect the label text for normalization check.
     let mut label_len = 0;
-    let mut label_text = String::new();
+    let mut has_non_whitespace = false;
     loop {
         if p.at(EOF) {
             return false;
@@ -99,7 +94,7 @@ fn is_valid_link_definition_lookahead(p: &mut MarkdownParser) -> bool {
         }
 
         let text = p.cur_text();
-        label_text.push_str(text);
+        has_non_whitespace |= text.chars().any(|c| !c.is_whitespace());
 
         // Check for escape sequences
         if text.starts_with('\\') && text.len() > 1 {
@@ -114,14 +109,8 @@ fn is_valid_link_definition_lookahead(p: &mut MarkdownParser) -> bool {
         p.bump_any();
     }
 
-    // Label must be non-empty
-    if label_len == 0 {
-        return false;
-    }
-
-    // Label must also be non-empty after normalization (e.g., `[\n ]` normalizes to empty)
-    let normalized = normalize_reference_label(&label_text);
-    if normalized.is_empty() {
+    // Label must be non-empty after normalization (e.g., `[\n ]` normalizes to empty).
+    if label_len == 0 || !has_non_whitespace {
         return false;
     }
 

--- a/crates/biome_markdown_parser/src/syntax/list.rs
+++ b/crates/biome_markdown_parser/src/syntax/list.rs
@@ -44,7 +44,7 @@ use crate::lexer::MarkdownReLexContext;
 use crate::syntax::fenced_code_block::parse_fenced_code_block;
 use crate::syntax::header::parse_header;
 use crate::syntax::html_block::{at_html_block, parse_html_block};
-use crate::syntax::link_block::{at_link_block, parse_link_block};
+use crate::syntax::link_block::{at_link_block, at_link_block_start, parse_link_block};
 use crate::syntax::parse_error::list_nesting_too_deep;
 use crate::syntax::quote::{
     at_quote_indented_code_start, consume_quote_prefix, consume_quote_prefix_without_virtual,
@@ -2164,8 +2164,7 @@ fn parse_first_line_blocks(
     }
 
     // Link reference definition
-    let link_block_start =
-        p.lookahead(|p| with_virtual_line_start(p, p.cur_range().start(), at_link_block));
+    let link_block_start = with_virtual_line_start(p, p.cur_range().start(), at_link_block_start);
 
     if link_block_start {
         let parsed = with_virtual_line_start(p, p.cur_range().start(), parse_link_block);

--- a/crates/biome_markdown_parser/src/syntax/mod.rs
+++ b/crates/biome_markdown_parser/src/syntax/mod.rs
@@ -52,7 +52,7 @@ use frontmatter::parse_frontmatter;
 use header::{at_header, parse_header};
 use html_block::{at_html_block, at_html_block_interrupt, parse_html_block};
 use inline::EmphasisContext;
-use link_block::{at_link_block, parse_link_block};
+use link_block::{at_link_block_start, parse_link_block};
 use list::{
     at_bullet_list_item, at_order_list_item, at_sibling_list_marker,
     marker_followed_by_whitespace_or_eol, parse_bullet_list_item, parse_order_list_item,
@@ -373,7 +373,7 @@ pub(crate) fn parse_any_block_with_indent_code_policy(
         }
     } else if at_html_block(p) {
         parse_html_block(p)
-    } else if at_link_block(p) {
+    } else if at_link_block_start(p) {
         // Try to parse as link reference definition
         // Use try_parse to fall back to paragraph if not a valid definition
         let link_result = try_parse(p, |p| {
@@ -1067,10 +1067,9 @@ fn is_quote_blank_line_from_current(p: &mut MarkdownParser, quote_depth: usize) 
         if is_quote_only_blank_line_from_source(p, quote_depth) {
             return true;
         }
-        if !has_quote_prefix(p, quote_depth) {
+        if !consume_quote_prefix_without_virtual(p, quote_depth) {
             return false;
         }
-        consume_quote_prefix_without_virtual(p, quote_depth);
         while p.at(MD_TEXTUAL_LITERAL) && p.cur_text().chars().all(|c| c == ' ' || c == '\t') {
             p.bump(MD_TEXTUAL_LITERAL);
         }
@@ -1387,7 +1386,7 @@ pub(crate) fn parse_inline_item_list(p: &mut MarkdownParser) {
     let m = p.start();
     let prev_emphasis_context = set_inline_emphasis_context(p);
     let quote_depth = p.state().block_quote_depth;
-    if quote_depth > 0 && p.at_line_start() && has_quote_prefix(p, quote_depth) {
+    if quote_depth > 0 && p.at_line_start() {
         consume_quote_prefix(p, quote_depth);
     }
     let inline_start: usize = p.cur_range().start().into();

--- a/crates/biome_markdown_parser/src/syntax/quote.rs
+++ b/crates/biome_markdown_parser/src/syntax/quote.rs
@@ -344,8 +344,7 @@ impl QuoteBlockList {
 
         if !self.first_line && !p.at(NEWLINE) && (p.at_line_start() || p.has_preceding_line_break())
         {
-            if has_quote_prefix(p, self.depth) {
-                consume_quote_prefix(p, self.depth);
+            if consume_quote_prefix(p, self.depth) {
                 relex_after_quote_prefix_consumed(p);
                 self.line_started_with_prefix = true;
             } else {
@@ -658,12 +657,10 @@ fn parse_code_block_newline(p: &mut MarkdownParser, depth: usize) -> bool {
         return false;
     }
 
-    if !has_quote_prefix(p, depth) {
-        return false;
-    }
-
     let continues_code_block = p.lookahead(|p| {
-        consume_quote_prefix(p, depth);
+        if !consume_quote_prefix(p, depth) {
+            return false;
+        }
 
         // Blank lines (consecutive newlines) are allowed in indented code.
         if p.at(NEWLINE) {
@@ -725,20 +722,32 @@ pub(crate) fn has_quote_prefix(p: &mut MarkdownParser, depth: usize) -> bool {
 }
 
 pub(crate) fn consume_quote_prefix(p: &mut MarkdownParser, depth: usize) -> bool {
-    if depth == 0 || !has_quote_prefix(p, depth) {
+    if depth == 0 {
         return false;
     }
 
-    consume_quote_prefix_impl(p, depth, true)
+    let checkpoint = p.checkpoint();
+    if consume_quote_prefix_impl(p, depth, true) {
+        true
+    } else {
+        p.rewind(checkpoint);
+        false
+    }
 }
 
 /// Consume quote prefix tokens without updating virtual line start.
 pub(crate) fn consume_quote_prefix_without_virtual(p: &mut MarkdownParser, depth: usize) -> bool {
-    if depth == 0 || !has_quote_prefix(p, depth) {
+    if depth == 0 {
         return false;
     }
 
-    consume_quote_prefix_impl(p, depth, false)
+    let checkpoint = p.checkpoint();
+    if consume_quote_prefix_impl(p, depth, false) {
+        true
+    } else {
+        p.rewind(checkpoint);
+        false
+    }
 }
 
 fn consume_quote_prefix_impl(

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/inline_and_html_block.md
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/inline_and_html_block.md
@@ -1,0 +1,11 @@
+Plain text before a definition.
+
+***Nested emphasis*** and <https://example.com> <invalid<autolink>.
+
+<script>
+const value = "<tag>";
+</script>
+
+[link][ref]
+
+[ref]: /url

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/inline_and_html_block.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/inline_and_html_block.md.snap
@@ -1,0 +1,258 @@
+---
+source: crates/biome_markdown_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```
+Plain text before a definition.
+
+***Nested emphasis*** and <https://example.com> <invalid<autolink>.
+
+<script>
+const value = "<tag>";
+</script>
+
+[link][ref]
+
+[ref]: /url
+
+```
+
+
+## AST
+
+```
+MdRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    value: MdBlockList [
+        MdParagraph {
+            list: MdInlineItemList [
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@0..31 "Plain text before a definition." [] [],
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@31..32 "\n" [] [],
+                },
+            ],
+        },
+        MdNewline {
+            value_token: NEWLINE@32..33 "\n" [] [],
+        },
+        MdParagraph {
+            list: MdInlineItemList [
+                MdInlineItalic {
+                    l_fence: STAR@33..34 "*" [] [],
+                    content: MdInlineItemList [
+                        MdInlineEmphasis {
+                            l_fence: DOUBLE_STAR@34..36 "**" [] [],
+                            content: MdInlineItemList [
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@36..51 "Nested emphasis" [] [],
+                                },
+                            ],
+                            r_fence: DOUBLE_STAR@51..53 "**" [] [],
+                        },
+                    ],
+                    r_fence: STAR@53..54 "*" [] [],
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@54..59 " and " [] [],
+                },
+                MdAutolink {
+                    l_angle_token: L_ANGLE@59..60 "<" [] [],
+                    value: MdInlineItemList [
+                        MdTextual {
+                            value_token: MD_TEXTUAL_LITERAL@60..79 "https://example.com" [] [],
+                        },
+                    ],
+                    r_angle_token: R_ANGLE@79..80 ">" [] [],
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@80..81 " " [] [],
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@81..89 "<invalid" [] [],
+                },
+                MdInlineHtml {
+                    value_token: MD_HTML_LITERAL@89..99 "<autolink>" [] [],
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@99..100 "." [] [],
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@100..101 "\n" [] [],
+                },
+            ],
+        },
+        MdNewline {
+            value_token: NEWLINE@101..102 "\n" [] [],
+        },
+        MdHtmlBlock {
+            indent: MdIndentTokenList [],
+            content: MdHtmlContent {
+                value_token: MD_HTML_LITERAL@102..143 "<script>\nconst value = \"<tag>\";\n</script>" [] [],
+            },
+        },
+        MdNewline {
+            value_token: NEWLINE@143..144 "\n" [] [],
+        },
+        MdNewline {
+            value_token: NEWLINE@144..145 "\n" [] [],
+        },
+        MdParagraph {
+            list: MdInlineItemList [
+                MdReferenceLink {
+                    l_brack_token: L_BRACK@145..146 "[" [] [],
+                    text: MdInlineItemList [
+                        MdTextual {
+                            value_token: MD_TEXTUAL_LITERAL@146..150 "link" [] [],
+                        },
+                    ],
+                    r_brack_token: R_BRACK@150..151 "]" [] [],
+                    label: MdReferenceLinkLabel {
+                        l_brack_token: L_BRACK@151..152 "[" [] [],
+                        label: MdInlineItemList [
+                            MdTextual {
+                                value_token: MD_TEXTUAL_LITERAL@152..155 "ref" [] [],
+                            },
+                        ],
+                        r_brack_token: R_BRACK@155..156 "]" [] [],
+                    },
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@156..157 "\n" [] [],
+                },
+            ],
+        },
+        MdNewline {
+            value_token: NEWLINE@157..158 "\n" [] [],
+        },
+        MdLinkReferenceDefinition {
+            indent: MdIndentTokenList [],
+            l_brack_token: L_BRACK@158..159 "[" [] [],
+            label: MdLinkLabel {
+                content: MdInlineItemList [
+                    MdTextual {
+                        value_token: MD_TEXTUAL_LITERAL@159..162 "ref" [] [],
+                    },
+                ],
+            },
+            r_brack_token: R_BRACK@162..163 "]" [] [],
+            colon_token: COLON@163..164 ":" [] [],
+            destination: MdLinkDestination {
+                content: MdInlineItemList [
+                    MdTextual {
+                        value_token: MD_TEXTUAL_LITERAL@164..165 " " [] [],
+                    },
+                    MdTextual {
+                        value_token: MD_TEXTUAL_LITERAL@165..169 "/url" [] [],
+                    },
+                ],
+            },
+            title: missing (optional),
+        },
+        MdNewline {
+            value_token: NEWLINE@169..170 "\n" [] [],
+        },
+    ],
+    eof_token: EOF@170..170 "" [] [],
+}
+```
+
+## CST
+
+```
+0: MD_ROOT@0..170
+  0: (empty)
+  1: (empty)
+  2: MD_BLOCK_LIST@0..170
+    0: MD_PARAGRAPH@0..32
+      0: MD_INLINE_ITEM_LIST@0..32
+        0: MD_TEXTUAL@0..31
+          0: MD_TEXTUAL_LITERAL@0..31 "Plain text before a definition." [] []
+        1: MD_TEXTUAL@31..32
+          0: MD_TEXTUAL_LITERAL@31..32 "\n" [] []
+    1: MD_NEWLINE@32..33
+      0: NEWLINE@32..33 "\n" [] []
+    2: MD_PARAGRAPH@33..101
+      0: MD_INLINE_ITEM_LIST@33..101
+        0: MD_INLINE_ITALIC@33..54
+          0: STAR@33..34 "*" [] []
+          1: MD_INLINE_ITEM_LIST@34..53
+            0: MD_INLINE_EMPHASIS@34..53
+              0: DOUBLE_STAR@34..36 "**" [] []
+              1: MD_INLINE_ITEM_LIST@36..51
+                0: MD_TEXTUAL@36..51
+                  0: MD_TEXTUAL_LITERAL@36..51 "Nested emphasis" [] []
+              2: DOUBLE_STAR@51..53 "**" [] []
+          2: STAR@53..54 "*" [] []
+        1: MD_TEXTUAL@54..59
+          0: MD_TEXTUAL_LITERAL@54..59 " and " [] []
+        2: MD_AUTOLINK@59..80
+          0: L_ANGLE@59..60 "<" [] []
+          1: MD_INLINE_ITEM_LIST@60..79
+            0: MD_TEXTUAL@60..79
+              0: MD_TEXTUAL_LITERAL@60..79 "https://example.com" [] []
+          2: R_ANGLE@79..80 ">" [] []
+        3: MD_TEXTUAL@80..81
+          0: MD_TEXTUAL_LITERAL@80..81 " " [] []
+        4: MD_TEXTUAL@81..89
+          0: MD_TEXTUAL_LITERAL@81..89 "<invalid" [] []
+        5: MD_INLINE_HTML@89..99
+          0: MD_HTML_LITERAL@89..99 "<autolink>" [] []
+        6: MD_TEXTUAL@99..100
+          0: MD_TEXTUAL_LITERAL@99..100 "." [] []
+        7: MD_TEXTUAL@100..101
+          0: MD_TEXTUAL_LITERAL@100..101 "\n" [] []
+    3: MD_NEWLINE@101..102
+      0: NEWLINE@101..102 "\n" [] []
+    4: MD_HTML_BLOCK@102..143
+      0: MD_INDENT_TOKEN_LIST@102..102
+      1: MD_HTML_CONTENT@102..143
+        0: MD_HTML_LITERAL@102..143 "<script>\nconst value = \"<tag>\";\n</script>" [] []
+    5: MD_NEWLINE@143..144
+      0: NEWLINE@143..144 "\n" [] []
+    6: MD_NEWLINE@144..145
+      0: NEWLINE@144..145 "\n" [] []
+    7: MD_PARAGRAPH@145..157
+      0: MD_INLINE_ITEM_LIST@145..157
+        0: MD_REFERENCE_LINK@145..156
+          0: L_BRACK@145..146 "[" [] []
+          1: MD_INLINE_ITEM_LIST@146..150
+            0: MD_TEXTUAL@146..150
+              0: MD_TEXTUAL_LITERAL@146..150 "link" [] []
+          2: R_BRACK@150..151 "]" [] []
+          3: MD_REFERENCE_LINK_LABEL@151..156
+            0: L_BRACK@151..152 "[" [] []
+            1: MD_INLINE_ITEM_LIST@152..155
+              0: MD_TEXTUAL@152..155
+                0: MD_TEXTUAL_LITERAL@152..155 "ref" [] []
+            2: R_BRACK@155..156 "]" [] []
+        1: MD_TEXTUAL@156..157
+          0: MD_TEXTUAL_LITERAL@156..157 "\n" [] []
+    8: MD_NEWLINE@157..158
+      0: NEWLINE@157..158 "\n" [] []
+    9: MD_LINK_REFERENCE_DEFINITION@158..169
+      0: MD_INDENT_TOKEN_LIST@158..158
+      1: L_BRACK@158..159 "[" [] []
+      2: MD_LINK_LABEL@159..162
+        0: MD_INLINE_ITEM_LIST@159..162
+          0: MD_TEXTUAL@159..162
+            0: MD_TEXTUAL_LITERAL@159..162 "ref" [] []
+      3: R_BRACK@162..163 "]" [] []
+      4: COLON@163..164 ":" [] []
+      5: MD_LINK_DESTINATION@164..169
+        0: MD_INLINE_ITEM_LIST@164..169
+          0: MD_TEXTUAL@164..165
+            0: MD_TEXTUAL_LITERAL@164..165 " " [] []
+          1: MD_TEXTUAL@165..169
+            0: MD_TEXTUAL_LITERAL@165..169 "/url" [] []
+      6: (empty)
+    10: MD_NEWLINE@169..170
+      0: NEWLINE@169..170 "\n" [] []
+  3: EOF@170..170 "" [] []
+
+```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR attempts to reduce the parse rescans of the markdown parser.

Created via AI agent. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Current CI should pass

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
