### PR TITLE
perf(markdown): reduce checks and string allocations

### DIFF
--- a/crates/biome_markdown_parser/src/syntax/inline/links.rs
+++ b/crates/biome_markdown_parser/src/syntax/inline/links.rs
@@ -75,12 +75,10 @@ pub(crate) fn parse_inline_link(p: &mut MarkdownParser) -> ParsedSyntax {
     parse_link_or_reference(p)
 }
 
-/// Parse image starting with `![` - dispatches to inline image or reference image.
+/// Parses an image as an inline image or a full, collapsed, or shortcut reference image.
 ///
-/// After parsing `![alt]`:
-/// - If followed by `(` → inline image `![alt](url)`
-/// - If followed by `[` → reference image `![alt][label]` or `![alt][]`
-/// - Otherwise → shortcut reference image `![alt]`
+/// `![alt](url)` produces an inline image. `![alt][label]`, `![alt][]`, and
+/// `![alt]` produce reference images.
 pub(crate) fn parse_image_or_reference(p: &mut MarkdownParser) -> ParsedSyntax {
     parse_link_or_image(p, LinkParseKind::Image)
 }
@@ -391,15 +389,23 @@ fn abort_link_parse(
 // #endregion
 
 struct ReferenceLinkLookahead {
-    label_raw: String,
+    label_range: TextRange,
     is_shortcut: bool,
 }
 
 impl ReferenceLinkLookahead {
     fn is_defined(&self, p: &MarkdownParser) -> bool {
-        let normalized = normalize_reference_label(&self.label_raw);
+        let Some(label) = source_text_for_range(p.source().source_text(), self.label_range) else {
+            return false;
+        };
+        let normalized = normalize_reference_label(label);
         p.has_link_reference_definition(normalized.as_ref())
     }
+}
+
+#[inline]
+fn source_text_for_range(source: &str, range: TextRange) -> Option<&str> {
+    source.get(usize::from(range.start())..usize::from(range.end()))
 }
 
 fn lookahead_reference_link(p: &mut MarkdownParser) -> Option<ReferenceLinkLookahead> {
@@ -428,13 +434,7 @@ fn lookahead_reference_common(
 
         p.bump(L_BRACK);
 
-        let link_text = collect_link_text(p)?;
-
-        // Link text must be non-empty after normalization (e.g., `[\n ]` normalizes to empty)
-        let normalized_link = normalize_reference_label(&link_text);
-        if normalized_link.is_empty() {
-            return None;
-        }
+        let link_range = collect_link_text(p)?;
 
         p.bump(R_BRACK);
 
@@ -445,30 +445,41 @@ fn lookahead_reference_common(
             return None;
         }
 
+        // Link text must be non-empty after normalization (e.g., `[\n ]` normalizes to empty)
+        if normalize_reference_label(source_text_for_range(p.source().source_text(), link_range)?)
+            .is_empty()
+        {
+            return None;
+        }
+
         if p.at(L_BRACK) {
             p.bump(L_BRACK);
-            let label_text = collect_label_text_simple(p);
-            if let Some(label_text) = label_text {
-                let label = if label_text.is_empty() {
-                    link_text.clone()
+            let label_range = collect_label_text_simple(p);
+            if let Some(label_range) = label_range {
+                let label_range = if label_range.is_empty() {
+                    link_range
                 } else {
                     // Explicit label must also normalize to non-empty
-                    let normalized_label = normalize_reference_label(&label_text);
-                    if normalized_label.is_empty() {
+                    if normalize_reference_label(source_text_for_range(
+                        p.source().source_text(),
+                        label_range,
+                    )?)
+                    .is_empty()
+                    {
                         return None;
                     }
-                    label_text
+                    label_range
                 };
                 p.bump(R_BRACK);
                 return Some(ReferenceLinkLookahead {
-                    label_raw: label,
+                    label_range,
                     is_shortcut: false,
                 });
             }
         }
 
         Some(ReferenceLinkLookahead {
-            label_raw: link_text,
+            label_range: link_range,
             is_shortcut: true,
         })
     })
@@ -483,8 +494,8 @@ fn lookahead_reference_common(
 ///
 /// We stop at the first R_BRACK token (unescaped `]`). Escaped brackets like `\]`
 /// are lexed as MD_TEXTUAL_LITERAL, not R_BRACK, so they're included in the label.
-fn collect_label_text_simple(p: &mut MarkdownParser) -> Option<String> {
-    let mut text = String::new();
+fn collect_label_text_simple(p: &mut MarkdownParser) -> Option<TextRange> {
+    let start = p.cur_range().start();
 
     loop {
         if p.at(T![EOF]) || p.at_inline_end() {
@@ -500,10 +511,9 @@ fn collect_label_text_simple(p: &mut MarkdownParser) -> Option<String> {
         // Note: Escaped brackets (`\]`) are lexed as MD_TEXTUAL_LITERAL,
         // not R_BRACK, so they're correctly included in the label text.
         if p.at(R_BRACK) {
-            return Some(text);
+            return Some(TextRange::new(start, p.cur_range().start()));
         }
 
-        text.push_str(p.cur_text());
         p.bump(p.cur());
     }
 }
@@ -511,8 +521,8 @@ fn collect_label_text_simple(p: &mut MarkdownParser) -> Option<String> {
 /// Collect text for link text (e.g., the `text` in `[text](url)` or `[text][label]`).
 /// Per CommonMark, link text CAN contain inline elements - code spans, autolinks, HTML.
 /// `]` inside these constructs does NOT close the link text.
-fn collect_link_text(p: &mut MarkdownParser) -> Option<String> {
-    let mut text = String::new();
+fn collect_link_text(p: &mut MarkdownParser) -> Option<TextRange> {
+    let start = p.cur_range().start();
     let mut bracket_depth = 0usize;
 
     loop {
@@ -529,7 +539,6 @@ fn collect_link_text(p: &mut MarkdownParser) -> Option<String> {
         // Per CommonMark, `]` inside code spans doesn't terminate link text.
         if p.at(BACKTICK) {
             let opening_count = p.cur_text().len();
-            text.push_str(p.cur_text());
             p.bump(p.cur());
 
             // Find matching closing backticks
@@ -539,12 +548,10 @@ fn collect_link_text(p: &mut MarkdownParser) -> Option<String> {
                     break; // Blank line terminates
                 }
                 if p.at(BACKTICK) && p.cur_text().len() == opening_count {
-                    text.push_str(p.cur_text());
                     p.bump(p.cur());
                     found_close = true;
                     break;
                 }
-                text.push_str(p.cur_text());
                 p.bump(p.cur());
             }
             if !found_close {
@@ -557,7 +564,6 @@ fn collect_link_text(p: &mut MarkdownParser) -> Option<String> {
         // Autolinks and inline HTML can contain `]` - skip them entirely.
         // Per CommonMark, `]` inside `<...>` constructs doesn't terminate link text.
         if p.at(L_ANGLE) {
-            text.push_str(p.cur_text());
             p.bump(p.cur());
 
             // Consume until `>` or newline
@@ -566,11 +572,9 @@ fn collect_link_text(p: &mut MarkdownParser) -> Option<String> {
                     // Newlines end autolinks/HTML tags
                     break;
                 }
-                text.push_str(p.cur_text());
                 p.bump(p.cur());
             }
             if p.at(R_ANGLE) {
-                text.push_str(p.cur_text());
                 p.bump(p.cur());
             }
             continue;
@@ -578,22 +582,19 @@ fn collect_link_text(p: &mut MarkdownParser) -> Option<String> {
 
         if p.at(L_BRACK) {
             bracket_depth += 1;
-            text.push_str(p.cur_text());
             p.bump(p.cur());
             continue;
         }
 
         if p.at(R_BRACK) {
             if bracket_depth == 0 {
-                return Some(text);
+                return Some(TextRange::new(start, p.cur_range().start()));
             }
             bracket_depth -= 1;
-            text.push_str(p.cur_text());
             p.bump(p.cur());
             continue;
         }
 
-        text.push_str(p.cur_text());
         p.bump(p.cur());
     }
 }
@@ -822,14 +823,4 @@ fn parse_title_content(p: &mut MarkdownParser, close_char: Option<char>) {
 
         bump_textual_link_def(p);
     }
-}
-
-/// Parse inline image (`![alt](url)`).
-///
-/// Grammar: `MdInlineImage = '!' '[' alt: MdInlineItemList ']' '(' source: MdInlineItemList ')'`
-///
-/// Note: This is kept for backwards compatibility but `parse_image_or_reference`
-/// is the preferred entry point for image parsing.
-pub(crate) fn parse_inline_image(p: &mut MarkdownParser) -> ParsedSyntax {
-    parse_image_or_reference(p)
 }

--- a/crates/biome_markdown_parser/src/syntax/inline/mod.rs
+++ b/crates/biome_markdown_parser/src/syntax/inline/mod.rs
@@ -222,7 +222,7 @@ fn parse_any_inline_no_links(p: &mut MarkdownParser) -> ParsedSyntax {
     }
 
     if p.at(BANG) && p.nth_at(1, L_BRACK) {
-        return links::parse_inline_image(p);
+        return links::parse_image_or_reference(p);
     }
 
     parse_any_inline(p)
@@ -268,7 +268,7 @@ pub(crate) fn parse_any_inline(p: &mut MarkdownParser) -> ParsedSyntax {
         }
     } else if p.at(BANG) && p.nth_at(1, L_BRACK) {
         // Try image, fall back to literal text if parsing fails
-        let result = links::parse_inline_image(p);
+        let result = links::parse_image_or_reference(p);
         if result.is_absent() {
             super::parse_textual(p)
         } else {

--- a/crates/biome_markdown_parser/src/syntax/link_block.rs
+++ b/crates/biome_markdown_parser/src/syntax/link_block.rs
@@ -43,14 +43,17 @@ const MAX_LABEL_LENGTH: usize = 999;
 ///
 /// We use token-based lookahead to verify the pattern: `[label]: destination`
 /// where label doesn't contain unescaped `]` or `[`, and is followed by `:`.
+#[inline]
 pub(crate) fn at_link_block(p: &mut MarkdownParser) -> bool {
     p.lookahead(|p| at_link_block_start_impl(p) && is_valid_link_definition_lookahead(p))
 }
 
+#[inline]
 pub(crate) fn at_link_block_start(p: &mut MarkdownParser) -> bool {
     p.lookahead(at_link_block_start_impl)
 }
 
+#[inline]
 fn at_link_block_start_impl(p: &mut MarkdownParser) -> bool {
     if !p.at_line_start() && !p.at_start_of_input() {
         return false;
@@ -190,11 +193,13 @@ fn is_valid_link_definition_lookahead(p: &mut MarkdownParser) -> bool {
 }
 
 /// Skip whitespace tokens (spaces/tabs) in lookahead.
+#[inline]
 fn skip_whitespace_tokens(p: &mut MarkdownParser) {
     skip_whitespace_tokens_tracked(p);
 }
 
 /// Skip whitespace tokens (spaces/tabs) in lookahead and return whether any were skipped.
+#[inline]
 fn skip_whitespace_tokens_tracked(p: &mut MarkdownParser) -> bool {
     let mut skipped = false;
     while !p.at(EOF) && !p.at(NEWLINE) && is_space_or_tab_token(p) {
@@ -207,6 +212,7 @@ fn skip_whitespace_tokens_tracked(p: &mut MarkdownParser) -> bool {
 /// Check if at a title start token.
 /// Text-based checks cover both L_PAREN tokens (LinkDefinition context)
 /// and plain-text tokens starting with `(` (Regular context).
+#[inline]
 fn at_title_start(p: &MarkdownParser) -> bool {
     let text = p.cur_text();
     text.starts_with('"') || text.starts_with('\'') || text.starts_with('(')

--- a/crates/biome_markdown_parser/src/syntax/mod.rs
+++ b/crates/biome_markdown_parser/src/syntax/mod.rs
@@ -1859,6 +1859,36 @@ pub(crate) fn at_block_interrupt(p: &mut MarkdownParser) -> bool {
         return false;
     }
 
+    if !can_start_block_interrupt(p) {
+        return false;
+    }
+
+    at_unindented_block_interrupt(p)
+}
+
+#[inline]
+fn can_start_block_interrupt(p: &MarkdownParser) -> bool {
+    use biome_unicode_table::{
+        Dispatch::{DIG, HAS, IDT, LSS, MIN, MOR, MUL, PLS, TLD, TPL, ZER},
+        lookup_byte,
+    };
+
+    let Some(byte) = p
+        .source_after_current()
+        .bytes()
+        .find(|byte| !matches!(*byte, b' ' | b'\t'))
+    else {
+        return false;
+    };
+
+    match lookup_byte(byte) {
+        HAS | TPL | TLD | MOR | LSS | MIN | MUL | PLS | ZER | DIG => true,
+        IDT => byte == b'_',
+        _ => false,
+    }
+}
+
+fn at_unindented_block_interrupt(p: &mut MarkdownParser) -> bool {
     // ATX heading: # at line start (must have space/tab after per CommonMark §4.2)
     // Use checkpoint to look ahead and verify it's a valid heading
     if at_header(p) {

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/at_block_interrupt_candidate_starts.md
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/at_block_interrupt_candidate_starts.md
@@ -1,0 +1,21 @@
+before heading
+[ordinary
+![ordinary
+# heading
+
+before fence
+```
+fence
+```
+
+before quote
+> quote
+
+before thematic
+***
+
+before list
+- item
+
+before HTML
+<div></div>

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/at_block_interrupt_candidate_starts.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/at_block_interrupt_candidate_starts.md.snap
@@ -1,0 +1,369 @@
+---
+source: crates/biome_markdown_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```
+before heading
+[ordinary
+![ordinary
+# heading
+
+before fence
+```
+fence
+```
+
+before quote
+> quote
+
+before thematic
+***
+
+before list
+- item
+
+before HTML
+<div></div>
+
+```
+
+
+## AST
+
+```
+MdRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    value: MdBlockList [
+        MdParagraph {
+            list: MdInlineItemList [
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@0..14 "before heading" [] [],
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@14..15 "\n" [] [],
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@15..24 "[ordinary" [] [],
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@24..25 "\n" [] [],
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@25..26 "!" [] [],
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@26..35 "[ordinary" [] [],
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@35..36 "\n" [] [],
+                },
+            ],
+        },
+        MdHeader {
+            indent: MdIndentTokenList [],
+            before: MdHashList [
+                MdHash {
+                    hash_token: HASH@36..37 "#" [] [],
+                },
+            ],
+            content: MdParagraph {
+                list: MdInlineItemList [
+                    MdTextual {
+                        value_token: MD_TEXTUAL_LITERAL@37..45 " heading" [] [],
+                    },
+                ],
+            },
+            after: MdHashList [],
+        },
+        MdNewline {
+            value_token: NEWLINE@45..46 "\n" [] [],
+        },
+        MdNewline {
+            value_token: NEWLINE@46..47 "\n" [] [],
+        },
+        MdParagraph {
+            list: MdInlineItemList [
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@47..59 "before fence" [] [],
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@59..60 "\n" [] [],
+                },
+            ],
+        },
+        MdFencedCodeBlock {
+            indent: MdIndentTokenList [],
+            l_fence: TRIPLE_BACKTICK@60..63 "```" [] [],
+            code_list: MdCodeNameList [],
+            content: MdInlineItemList [
+                MdCodeContent {
+                    value_token: MD_CODE_LITERAL@63..70 "\nfence\n" [] [],
+                },
+            ],
+            r_fence_indent: MdIndentTokenList [],
+            r_fence: TRIPLE_BACKTICK@70..73 "```" [] [],
+        },
+        MdNewline {
+            value_token: NEWLINE@73..74 "\n" [] [],
+        },
+        MdNewline {
+            value_token: NEWLINE@74..75 "\n" [] [],
+        },
+        MdParagraph {
+            list: MdInlineItemList [
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@75..87 "before quote" [] [],
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@87..88 "\n" [] [],
+                },
+            ],
+        },
+        MdQuote {
+            prefix: MdQuotePrefix {
+                pre_marker_indent: MdQuoteIndentList [],
+                marker_token: R_ANGLE@88..89 ">" [] [],
+                post_marker_space_token: MD_QUOTE_POST_MARKER_SPACE@89..90 " " [] [],
+            },
+            content: MdBlockList [
+                MdParagraph {
+                    list: MdInlineItemList [
+                        MdTextual {
+                            value_token: MD_TEXTUAL_LITERAL@90..95 "quote" [] [],
+                        },
+                        MdTextual {
+                            value_token: MD_TEXTUAL_LITERAL@95..96 "\n" [] [],
+                        },
+                    ],
+                },
+            ],
+        },
+        MdNewline {
+            value_token: NEWLINE@96..97 "\n" [] [],
+        },
+        MdParagraph {
+            list: MdInlineItemList [
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@97..112 "before thematic" [] [],
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@112..113 "\n" [] [],
+                },
+            ],
+        },
+        MdThematicBreakBlock {
+            parts: MdThematicBreakPartList [
+                MdThematicBreakChar {
+                    value: STAR@113..114 "*" [] [],
+                },
+                MdThematicBreakChar {
+                    value: STAR@114..115 "*" [] [],
+                },
+                MdThematicBreakChar {
+                    value: STAR@115..116 "*" [] [],
+                },
+            ],
+        },
+        MdNewline {
+            value_token: NEWLINE@116..117 "\n" [] [],
+        },
+        MdNewline {
+            value_token: NEWLINE@117..118 "\n" [] [],
+        },
+        MdParagraph {
+            list: MdInlineItemList [
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@118..129 "before list" [] [],
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@129..130 "\n" [] [],
+                },
+            ],
+        },
+        MdBulletListItem {
+            md_bullet_list: MdBulletList [
+                MdBullet {
+                    prefix: MdListMarkerPrefix {
+                        pre_marker_indent: MdIndentTokenList [],
+                        marker: MINUS@130..131 "-" [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@131..132 " " [] [],
+                        content_indent: MdIndentTokenList [],
+                    },
+                    content: MdBlockList [
+                        MdParagraph {
+                            list: MdInlineItemList [
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@132..136 "item" [] [],
+                                },
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@136..137 "\n" [] [],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+        MdNewline {
+            value_token: NEWLINE@137..138 "\n" [] [],
+        },
+        MdParagraph {
+            list: MdInlineItemList [
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@138..149 "before HTML" [] [],
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@149..150 "\n" [] [],
+                },
+            ],
+        },
+        MdHtmlBlock {
+            indent: MdIndentTokenList [],
+            content: MdHtmlContent {
+                value_token: MD_HTML_LITERAL@150..161 "<div></div>" [] [],
+            },
+        },
+        MdNewline {
+            value_token: NEWLINE@161..162 "\n" [] [],
+        },
+    ],
+    eof_token: EOF@162..162 "" [] [],
+}
+```
+
+## CST
+
+```
+0: MD_ROOT@0..162
+  0: (empty)
+  1: (empty)
+  2: MD_BLOCK_LIST@0..162
+    0: MD_PARAGRAPH@0..36
+      0: MD_INLINE_ITEM_LIST@0..36
+        0: MD_TEXTUAL@0..14
+          0: MD_TEXTUAL_LITERAL@0..14 "before heading" [] []
+        1: MD_TEXTUAL@14..15
+          0: MD_TEXTUAL_LITERAL@14..15 "\n" [] []
+        2: MD_TEXTUAL@15..24
+          0: MD_TEXTUAL_LITERAL@15..24 "[ordinary" [] []
+        3: MD_TEXTUAL@24..25
+          0: MD_TEXTUAL_LITERAL@24..25 "\n" [] []
+        4: MD_TEXTUAL@25..26
+          0: MD_TEXTUAL_LITERAL@25..26 "!" [] []
+        5: MD_TEXTUAL@26..35
+          0: MD_TEXTUAL_LITERAL@26..35 "[ordinary" [] []
+        6: MD_TEXTUAL@35..36
+          0: MD_TEXTUAL_LITERAL@35..36 "\n" [] []
+    1: MD_HEADER@36..45
+      0: MD_INDENT_TOKEN_LIST@36..36
+      1: MD_HASH_LIST@36..37
+        0: MD_HASH@36..37
+          0: HASH@36..37 "#" [] []
+      2: MD_PARAGRAPH@37..45
+        0: MD_INLINE_ITEM_LIST@37..45
+          0: MD_TEXTUAL@37..45
+            0: MD_TEXTUAL_LITERAL@37..45 " heading" [] []
+      3: MD_HASH_LIST@45..45
+    2: MD_NEWLINE@45..46
+      0: NEWLINE@45..46 "\n" [] []
+    3: MD_NEWLINE@46..47
+      0: NEWLINE@46..47 "\n" [] []
+    4: MD_PARAGRAPH@47..60
+      0: MD_INLINE_ITEM_LIST@47..60
+        0: MD_TEXTUAL@47..59
+          0: MD_TEXTUAL_LITERAL@47..59 "before fence" [] []
+        1: MD_TEXTUAL@59..60
+          0: MD_TEXTUAL_LITERAL@59..60 "\n" [] []
+    5: MD_FENCED_CODE_BLOCK@60..73
+      0: MD_INDENT_TOKEN_LIST@60..60
+      1: TRIPLE_BACKTICK@60..63 "```" [] []
+      2: MD_CODE_NAME_LIST@63..63
+      3: MD_INLINE_ITEM_LIST@63..70
+        0: MD_CODE_CONTENT@63..70
+          0: MD_CODE_LITERAL@63..70 "\nfence\n" [] []
+      4: MD_INDENT_TOKEN_LIST@70..70
+      5: TRIPLE_BACKTICK@70..73 "```" [] []
+    6: MD_NEWLINE@73..74
+      0: NEWLINE@73..74 "\n" [] []
+    7: MD_NEWLINE@74..75
+      0: NEWLINE@74..75 "\n" [] []
+    8: MD_PARAGRAPH@75..88
+      0: MD_INLINE_ITEM_LIST@75..88
+        0: MD_TEXTUAL@75..87
+          0: MD_TEXTUAL_LITERAL@75..87 "before quote" [] []
+        1: MD_TEXTUAL@87..88
+          0: MD_TEXTUAL_LITERAL@87..88 "\n" [] []
+    9: MD_QUOTE@88..96
+      0: MD_QUOTE_PREFIX@88..90
+        0: MD_QUOTE_INDENT_LIST@88..88
+        1: R_ANGLE@88..89 ">" [] []
+        2: MD_QUOTE_POST_MARKER_SPACE@89..90 " " [] []
+      1: MD_BLOCK_LIST@90..96
+        0: MD_PARAGRAPH@90..96
+          0: MD_INLINE_ITEM_LIST@90..96
+            0: MD_TEXTUAL@90..95
+              0: MD_TEXTUAL_LITERAL@90..95 "quote" [] []
+            1: MD_TEXTUAL@95..96
+              0: MD_TEXTUAL_LITERAL@95..96 "\n" [] []
+    10: MD_NEWLINE@96..97
+      0: NEWLINE@96..97 "\n" [] []
+    11: MD_PARAGRAPH@97..113
+      0: MD_INLINE_ITEM_LIST@97..113
+        0: MD_TEXTUAL@97..112
+          0: MD_TEXTUAL_LITERAL@97..112 "before thematic" [] []
+        1: MD_TEXTUAL@112..113
+          0: MD_TEXTUAL_LITERAL@112..113 "\n" [] []
+    12: MD_THEMATIC_BREAK_BLOCK@113..116
+      0: MD_THEMATIC_BREAK_PART_LIST@113..116
+        0: MD_THEMATIC_BREAK_CHAR@113..114
+          0: STAR@113..114 "*" [] []
+        1: MD_THEMATIC_BREAK_CHAR@114..115
+          0: STAR@114..115 "*" [] []
+        2: MD_THEMATIC_BREAK_CHAR@115..116
+          0: STAR@115..116 "*" [] []
+    13: MD_NEWLINE@116..117
+      0: NEWLINE@116..117 "\n" [] []
+    14: MD_NEWLINE@117..118
+      0: NEWLINE@117..118 "\n" [] []
+    15: MD_PARAGRAPH@118..130
+      0: MD_INLINE_ITEM_LIST@118..130
+        0: MD_TEXTUAL@118..129
+          0: MD_TEXTUAL_LITERAL@118..129 "before list" [] []
+        1: MD_TEXTUAL@129..130
+          0: MD_TEXTUAL_LITERAL@129..130 "\n" [] []
+    16: MD_BULLET_LIST_ITEM@130..137
+      0: MD_BULLET_LIST@130..137
+        0: MD_BULLET@130..137
+          0: MD_LIST_MARKER_PREFIX@130..132
+            0: MD_INDENT_TOKEN_LIST@130..130
+            1: MINUS@130..131 "-" [] []
+            2: MD_LIST_POST_MARKER_SPACE@131..132 " " [] []
+            3: MD_INDENT_TOKEN_LIST@132..132
+          1: MD_BLOCK_LIST@132..137
+            0: MD_PARAGRAPH@132..137
+              0: MD_INLINE_ITEM_LIST@132..137
+                0: MD_TEXTUAL@132..136
+                  0: MD_TEXTUAL_LITERAL@132..136 "item" [] []
+                1: MD_TEXTUAL@136..137
+                  0: MD_TEXTUAL_LITERAL@136..137 "\n" [] []
+    17: MD_NEWLINE@137..138
+      0: NEWLINE@137..138 "\n" [] []
+    18: MD_PARAGRAPH@138..150
+      0: MD_INLINE_ITEM_LIST@138..150
+        0: MD_TEXTUAL@138..149
+          0: MD_TEXTUAL_LITERAL@138..149 "before HTML" [] []
+        1: MD_TEXTUAL@149..150
+          0: MD_TEXTUAL_LITERAL@149..150 "\n" [] []
+    19: MD_HTML_BLOCK@150..161
+      0: MD_INDENT_TOKEN_LIST@150..150
+      1: MD_HTML_CONTENT@150..161
+        0: MD_HTML_LITERAL@150..161 "<div></div>" [] []
+    20: MD_NEWLINE@161..162
+      0: NEWLINE@161..162 "\n" [] []
+  3: EOF@162..162 "" [] []
+
+```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/reference_link_lookahead_ranges.md
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/reference_link_lookahead_ranges.md
@@ -1,0 +1,23 @@
+[link [foo [bar]]][nested]
+
+[nested]: /nested
+
+[foo `]` bar][code]
+
+[code]: /code
+
+[foo <span data-value="]">][html]
+
+[html]: /html
+
+[foo][ref\[]
+
+[ref\[]: /escaped
+
+[Foo][]
+
+[foo]: /collapsed
+
+![Foo][]
+
+[foo]: /image

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/reference_link_lookahead_ranges.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/reference_link_lookahead_ranges.md.snap
@@ -1,0 +1,673 @@
+---
+source: crates/biome_markdown_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```
+[link [foo [bar]]][nested]
+
+[nested]: /nested
+
+[foo `]` bar][code]
+
+[code]: /code
+
+[foo <span data-value="]">][html]
+
+[html]: /html
+
+[foo][ref\[]
+
+[ref\[]: /escaped
+
+[Foo][]
+
+[foo]: /collapsed
+
+![Foo][]
+
+[foo]: /image
+
+```
+
+
+## AST
+
+```
+MdRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    value: MdBlockList [
+        MdParagraph {
+            list: MdInlineItemList [
+                MdReferenceLink {
+                    l_brack_token: L_BRACK@0..1 "[" [] [],
+                    text: MdInlineItemList [
+                        MdTextual {
+                            value_token: MD_TEXTUAL_LITERAL@1..6 "link " [] [],
+                        },
+                        MdTextual {
+                            value_token: MD_TEXTUAL_LITERAL@6..11 "[foo " [] [],
+                        },
+                        MdTextual {
+                            value_token: MD_TEXTUAL_LITERAL@11..15 "[bar" [] [],
+                        },
+                        MdTextual {
+                            value_token: MD_TEXTUAL_LITERAL@15..16 "]" [] [],
+                        },
+                        MdTextual {
+                            value_token: MD_TEXTUAL_LITERAL@16..17 "]" [] [],
+                        },
+                    ],
+                    r_brack_token: R_BRACK@17..18 "]" [] [],
+                    label: MdReferenceLinkLabel {
+                        l_brack_token: L_BRACK@18..19 "[" [] [],
+                        label: MdInlineItemList [
+                            MdTextual {
+                                value_token: MD_TEXTUAL_LITERAL@19..25 "nested" [] [],
+                            },
+                        ],
+                        r_brack_token: R_BRACK@25..26 "]" [] [],
+                    },
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@26..27 "\n" [] [],
+                },
+            ],
+        },
+        MdNewline {
+            value_token: NEWLINE@27..28 "\n" [] [],
+        },
+        MdLinkReferenceDefinition {
+            indent: MdIndentTokenList [],
+            l_brack_token: L_BRACK@28..29 "[" [] [],
+            label: MdLinkLabel {
+                content: MdInlineItemList [
+                    MdTextual {
+                        value_token: MD_TEXTUAL_LITERAL@29..35 "nested" [] [],
+                    },
+                ],
+            },
+            r_brack_token: R_BRACK@35..36 "]" [] [],
+            colon_token: COLON@36..37 ":" [] [],
+            destination: MdLinkDestination {
+                content: MdInlineItemList [
+                    MdTextual {
+                        value_token: MD_TEXTUAL_LITERAL@37..38 " " [] [],
+                    },
+                    MdTextual {
+                        value_token: MD_TEXTUAL_LITERAL@38..45 "/nested" [] [],
+                    },
+                ],
+            },
+            title: missing (optional),
+        },
+        MdNewline {
+            value_token: NEWLINE@45..46 "\n" [] [],
+        },
+        MdNewline {
+            value_token: NEWLINE@46..47 "\n" [] [],
+        },
+        MdParagraph {
+            list: MdInlineItemList [
+                MdReferenceLink {
+                    l_brack_token: L_BRACK@47..48 "[" [] [],
+                    text: MdInlineItemList [
+                        MdTextual {
+                            value_token: MD_TEXTUAL_LITERAL@48..52 "foo " [] [],
+                        },
+                        MdInlineCode {
+                            l_tick_token: BACKTICK@52..53 "`" [] [],
+                            content: MdInlineItemList [
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@53..54 "]" [] [],
+                                },
+                            ],
+                            r_tick_token: BACKTICK@54..55 "`" [] [],
+                        },
+                        MdTextual {
+                            value_token: MD_TEXTUAL_LITERAL@55..59 " bar" [] [],
+                        },
+                    ],
+                    r_brack_token: R_BRACK@59..60 "]" [] [],
+                    label: MdReferenceLinkLabel {
+                        l_brack_token: L_BRACK@60..61 "[" [] [],
+                        label: MdInlineItemList [
+                            MdTextual {
+                                value_token: MD_TEXTUAL_LITERAL@61..65 "code" [] [],
+                            },
+                        ],
+                        r_brack_token: R_BRACK@65..66 "]" [] [],
+                    },
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@66..67 "\n" [] [],
+                },
+            ],
+        },
+        MdNewline {
+            value_token: NEWLINE@67..68 "\n" [] [],
+        },
+        MdLinkReferenceDefinition {
+            indent: MdIndentTokenList [],
+            l_brack_token: L_BRACK@68..69 "[" [] [],
+            label: MdLinkLabel {
+                content: MdInlineItemList [
+                    MdTextual {
+                        value_token: MD_TEXTUAL_LITERAL@69..73 "code" [] [],
+                    },
+                ],
+            },
+            r_brack_token: R_BRACK@73..74 "]" [] [],
+            colon_token: COLON@74..75 ":" [] [],
+            destination: MdLinkDestination {
+                content: MdInlineItemList [
+                    MdTextual {
+                        value_token: MD_TEXTUAL_LITERAL@75..76 " " [] [],
+                    },
+                    MdTextual {
+                        value_token: MD_TEXTUAL_LITERAL@76..81 "/code" [] [],
+                    },
+                ],
+            },
+            title: missing (optional),
+        },
+        MdNewline {
+            value_token: NEWLINE@81..82 "\n" [] [],
+        },
+        MdNewline {
+            value_token: NEWLINE@82..83 "\n" [] [],
+        },
+        MdParagraph {
+            list: MdInlineItemList [
+                MdReferenceLink {
+                    l_brack_token: L_BRACK@83..84 "[" [] [],
+                    text: MdInlineItemList [
+                        MdTextual {
+                            value_token: MD_TEXTUAL_LITERAL@84..88 "foo " [] [],
+                        },
+                        MdInlineHtml {
+                            value_token: MD_HTML_LITERAL@88..109 "<span data-value=\"]\">" [] [],
+                        },
+                    ],
+                    r_brack_token: R_BRACK@109..110 "]" [] [],
+                    label: MdReferenceLinkLabel {
+                        l_brack_token: L_BRACK@110..111 "[" [] [],
+                        label: MdInlineItemList [
+                            MdTextual {
+                                value_token: MD_TEXTUAL_LITERAL@111..115 "html" [] [],
+                            },
+                        ],
+                        r_brack_token: R_BRACK@115..116 "]" [] [],
+                    },
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@116..117 "\n" [] [],
+                },
+            ],
+        },
+        MdNewline {
+            value_token: NEWLINE@117..118 "\n" [] [],
+        },
+        MdLinkReferenceDefinition {
+            indent: MdIndentTokenList [],
+            l_brack_token: L_BRACK@118..119 "[" [] [],
+            label: MdLinkLabel {
+                content: MdInlineItemList [
+                    MdTextual {
+                        value_token: MD_TEXTUAL_LITERAL@119..123 "html" [] [],
+                    },
+                ],
+            },
+            r_brack_token: R_BRACK@123..124 "]" [] [],
+            colon_token: COLON@124..125 ":" [] [],
+            destination: MdLinkDestination {
+                content: MdInlineItemList [
+                    MdTextual {
+                        value_token: MD_TEXTUAL_LITERAL@125..126 " " [] [],
+                    },
+                    MdTextual {
+                        value_token: MD_TEXTUAL_LITERAL@126..131 "/html" [] [],
+                    },
+                ],
+            },
+            title: missing (optional),
+        },
+        MdNewline {
+            value_token: NEWLINE@131..132 "\n" [] [],
+        },
+        MdNewline {
+            value_token: NEWLINE@132..133 "\n" [] [],
+        },
+        MdParagraph {
+            list: MdInlineItemList [
+                MdReferenceLink {
+                    l_brack_token: L_BRACK@133..134 "[" [] [],
+                    text: MdInlineItemList [
+                        MdTextual {
+                            value_token: MD_TEXTUAL_LITERAL@134..137 "foo" [] [],
+                        },
+                    ],
+                    r_brack_token: R_BRACK@137..138 "]" [] [],
+                    label: MdReferenceLinkLabel {
+                        l_brack_token: L_BRACK@138..139 "[" [] [],
+                        label: MdInlineItemList [
+                            MdTextual {
+                                value_token: MD_TEXTUAL_LITERAL@139..142 "ref" [] [],
+                            },
+                            MdTextual {
+                                value_token: MD_TEXTUAL_LITERAL@142..144 "\\[" [] [],
+                            },
+                        ],
+                        r_brack_token: R_BRACK@144..145 "]" [] [],
+                    },
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@145..146 "\n" [] [],
+                },
+            ],
+        },
+        MdNewline {
+            value_token: NEWLINE@146..147 "\n" [] [],
+        },
+        MdLinkReferenceDefinition {
+            indent: MdIndentTokenList [],
+            l_brack_token: L_BRACK@147..148 "[" [] [],
+            label: MdLinkLabel {
+                content: MdInlineItemList [
+                    MdTextual {
+                        value_token: MD_TEXTUAL_LITERAL@148..151 "ref" [] [],
+                    },
+                    MdTextual {
+                        value_token: MD_TEXTUAL_LITERAL@151..153 "\\[" [] [],
+                    },
+                ],
+            },
+            r_brack_token: R_BRACK@153..154 "]" [] [],
+            colon_token: COLON@154..155 ":" [] [],
+            destination: MdLinkDestination {
+                content: MdInlineItemList [
+                    MdTextual {
+                        value_token: MD_TEXTUAL_LITERAL@155..156 " " [] [],
+                    },
+                    MdTextual {
+                        value_token: MD_TEXTUAL_LITERAL@156..164 "/escaped" [] [],
+                    },
+                ],
+            },
+            title: missing (optional),
+        },
+        MdNewline {
+            value_token: NEWLINE@164..165 "\n" [] [],
+        },
+        MdNewline {
+            value_token: NEWLINE@165..166 "\n" [] [],
+        },
+        MdParagraph {
+            list: MdInlineItemList [
+                MdReferenceLink {
+                    l_brack_token: L_BRACK@166..167 "[" [] [],
+                    text: MdInlineItemList [
+                        MdTextual {
+                            value_token: MD_TEXTUAL_LITERAL@167..170 "Foo" [] [],
+                        },
+                    ],
+                    r_brack_token: R_BRACK@170..171 "]" [] [],
+                    label: MdReferenceLinkLabel {
+                        l_brack_token: L_BRACK@171..172 "[" [] [],
+                        label: MdInlineItemList [],
+                        r_brack_token: R_BRACK@172..173 "]" [] [],
+                    },
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@173..174 "\n" [] [],
+                },
+            ],
+        },
+        MdNewline {
+            value_token: NEWLINE@174..175 "\n" [] [],
+        },
+        MdLinkReferenceDefinition {
+            indent: MdIndentTokenList [],
+            l_brack_token: L_BRACK@175..176 "[" [] [],
+            label: MdLinkLabel {
+                content: MdInlineItemList [
+                    MdTextual {
+                        value_token: MD_TEXTUAL_LITERAL@176..179 "foo" [] [],
+                    },
+                ],
+            },
+            r_brack_token: R_BRACK@179..180 "]" [] [],
+            colon_token: COLON@180..181 ":" [] [],
+            destination: MdLinkDestination {
+                content: MdInlineItemList [
+                    MdTextual {
+                        value_token: MD_TEXTUAL_LITERAL@181..182 " " [] [],
+                    },
+                    MdTextual {
+                        value_token: MD_TEXTUAL_LITERAL@182..192 "/collapsed" [] [],
+                    },
+                ],
+            },
+            title: missing (optional),
+        },
+        MdNewline {
+            value_token: NEWLINE@192..193 "\n" [] [],
+        },
+        MdNewline {
+            value_token: NEWLINE@193..194 "\n" [] [],
+        },
+        MdParagraph {
+            list: MdInlineItemList [
+                MdReferenceImage {
+                    excl_token: BANG@194..195 "!" [] [],
+                    l_brack_token: L_BRACK@195..196 "[" [] [],
+                    alt: MdInlineItemList [
+                        MdTextual {
+                            value_token: MD_TEXTUAL_LITERAL@196..199 "Foo" [] [],
+                        },
+                    ],
+                    r_brack_token: R_BRACK@199..200 "]" [] [],
+                    label: MdReferenceLinkLabel {
+                        l_brack_token: L_BRACK@200..201 "[" [] [],
+                        label: MdInlineItemList [],
+                        r_brack_token: R_BRACK@201..202 "]" [] [],
+                    },
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@202..203 "\n" [] [],
+                },
+            ],
+        },
+        MdNewline {
+            value_token: NEWLINE@203..204 "\n" [] [],
+        },
+        MdLinkReferenceDefinition {
+            indent: MdIndentTokenList [],
+            l_brack_token: L_BRACK@204..205 "[" [] [],
+            label: MdLinkLabel {
+                content: MdInlineItemList [
+                    MdTextual {
+                        value_token: MD_TEXTUAL_LITERAL@205..208 "foo" [] [],
+                    },
+                ],
+            },
+            r_brack_token: R_BRACK@208..209 "]" [] [],
+            colon_token: COLON@209..210 ":" [] [],
+            destination: MdLinkDestination {
+                content: MdInlineItemList [
+                    MdTextual {
+                        value_token: MD_TEXTUAL_LITERAL@210..211 " " [] [],
+                    },
+                    MdTextual {
+                        value_token: MD_TEXTUAL_LITERAL@211..217 "/image" [] [],
+                    },
+                ],
+            },
+            title: missing (optional),
+        },
+        MdNewline {
+            value_token: NEWLINE@217..218 "\n" [] [],
+        },
+    ],
+    eof_token: EOF@218..218 "" [] [],
+}
+```
+
+## CST
+
+```
+0: MD_ROOT@0..218
+  0: (empty)
+  1: (empty)
+  2: MD_BLOCK_LIST@0..218
+    0: MD_PARAGRAPH@0..27
+      0: MD_INLINE_ITEM_LIST@0..27
+        0: MD_REFERENCE_LINK@0..26
+          0: L_BRACK@0..1 "[" [] []
+          1: MD_INLINE_ITEM_LIST@1..17
+            0: MD_TEXTUAL@1..6
+              0: MD_TEXTUAL_LITERAL@1..6 "link " [] []
+            1: MD_TEXTUAL@6..11
+              0: MD_TEXTUAL_LITERAL@6..11 "[foo " [] []
+            2: MD_TEXTUAL@11..15
+              0: MD_TEXTUAL_LITERAL@11..15 "[bar" [] []
+            3: MD_TEXTUAL@15..16
+              0: MD_TEXTUAL_LITERAL@15..16 "]" [] []
+            4: MD_TEXTUAL@16..17
+              0: MD_TEXTUAL_LITERAL@16..17 "]" [] []
+          2: R_BRACK@17..18 "]" [] []
+          3: MD_REFERENCE_LINK_LABEL@18..26
+            0: L_BRACK@18..19 "[" [] []
+            1: MD_INLINE_ITEM_LIST@19..25
+              0: MD_TEXTUAL@19..25
+                0: MD_TEXTUAL_LITERAL@19..25 "nested" [] []
+            2: R_BRACK@25..26 "]" [] []
+        1: MD_TEXTUAL@26..27
+          0: MD_TEXTUAL_LITERAL@26..27 "\n" [] []
+    1: MD_NEWLINE@27..28
+      0: NEWLINE@27..28 "\n" [] []
+    2: MD_LINK_REFERENCE_DEFINITION@28..45
+      0: MD_INDENT_TOKEN_LIST@28..28
+      1: L_BRACK@28..29 "[" [] []
+      2: MD_LINK_LABEL@29..35
+        0: MD_INLINE_ITEM_LIST@29..35
+          0: MD_TEXTUAL@29..35
+            0: MD_TEXTUAL_LITERAL@29..35 "nested" [] []
+      3: R_BRACK@35..36 "]" [] []
+      4: COLON@36..37 ":" [] []
+      5: MD_LINK_DESTINATION@37..45
+        0: MD_INLINE_ITEM_LIST@37..45
+          0: MD_TEXTUAL@37..38
+            0: MD_TEXTUAL_LITERAL@37..38 " " [] []
+          1: MD_TEXTUAL@38..45
+            0: MD_TEXTUAL_LITERAL@38..45 "/nested" [] []
+      6: (empty)
+    3: MD_NEWLINE@45..46
+      0: NEWLINE@45..46 "\n" [] []
+    4: MD_NEWLINE@46..47
+      0: NEWLINE@46..47 "\n" [] []
+    5: MD_PARAGRAPH@47..67
+      0: MD_INLINE_ITEM_LIST@47..67
+        0: MD_REFERENCE_LINK@47..66
+          0: L_BRACK@47..48 "[" [] []
+          1: MD_INLINE_ITEM_LIST@48..59
+            0: MD_TEXTUAL@48..52
+              0: MD_TEXTUAL_LITERAL@48..52 "foo " [] []
+            1: MD_INLINE_CODE@52..55
+              0: BACKTICK@52..53 "`" [] []
+              1: MD_INLINE_ITEM_LIST@53..54
+                0: MD_TEXTUAL@53..54
+                  0: MD_TEXTUAL_LITERAL@53..54 "]" [] []
+              2: BACKTICK@54..55 "`" [] []
+            2: MD_TEXTUAL@55..59
+              0: MD_TEXTUAL_LITERAL@55..59 " bar" [] []
+          2: R_BRACK@59..60 "]" [] []
+          3: MD_REFERENCE_LINK_LABEL@60..66
+            0: L_BRACK@60..61 "[" [] []
+            1: MD_INLINE_ITEM_LIST@61..65
+              0: MD_TEXTUAL@61..65
+                0: MD_TEXTUAL_LITERAL@61..65 "code" [] []
+            2: R_BRACK@65..66 "]" [] []
+        1: MD_TEXTUAL@66..67
+          0: MD_TEXTUAL_LITERAL@66..67 "\n" [] []
+    6: MD_NEWLINE@67..68
+      0: NEWLINE@67..68 "\n" [] []
+    7: MD_LINK_REFERENCE_DEFINITION@68..81
+      0: MD_INDENT_TOKEN_LIST@68..68
+      1: L_BRACK@68..69 "[" [] []
+      2: MD_LINK_LABEL@69..73
+        0: MD_INLINE_ITEM_LIST@69..73
+          0: MD_TEXTUAL@69..73
+            0: MD_TEXTUAL_LITERAL@69..73 "code" [] []
+      3: R_BRACK@73..74 "]" [] []
+      4: COLON@74..75 ":" [] []
+      5: MD_LINK_DESTINATION@75..81
+        0: MD_INLINE_ITEM_LIST@75..81
+          0: MD_TEXTUAL@75..76
+            0: MD_TEXTUAL_LITERAL@75..76 " " [] []
+          1: MD_TEXTUAL@76..81
+            0: MD_TEXTUAL_LITERAL@76..81 "/code" [] []
+      6: (empty)
+    8: MD_NEWLINE@81..82
+      0: NEWLINE@81..82 "\n" [] []
+    9: MD_NEWLINE@82..83
+      0: NEWLINE@82..83 "\n" [] []
+    10: MD_PARAGRAPH@83..117
+      0: MD_INLINE_ITEM_LIST@83..117
+        0: MD_REFERENCE_LINK@83..116
+          0: L_BRACK@83..84 "[" [] []
+          1: MD_INLINE_ITEM_LIST@84..109
+            0: MD_TEXTUAL@84..88
+              0: MD_TEXTUAL_LITERAL@84..88 "foo " [] []
+            1: MD_INLINE_HTML@88..109
+              0: MD_HTML_LITERAL@88..109 "<span data-value=\"]\">" [] []
+          2: R_BRACK@109..110 "]" [] []
+          3: MD_REFERENCE_LINK_LABEL@110..116
+            0: L_BRACK@110..111 "[" [] []
+            1: MD_INLINE_ITEM_LIST@111..115
+              0: MD_TEXTUAL@111..115
+                0: MD_TEXTUAL_LITERAL@111..115 "html" [] []
+            2: R_BRACK@115..116 "]" [] []
+        1: MD_TEXTUAL@116..117
+          0: MD_TEXTUAL_LITERAL@116..117 "\n" [] []
+    11: MD_NEWLINE@117..118
+      0: NEWLINE@117..118 "\n" [] []
+    12: MD_LINK_REFERENCE_DEFINITION@118..131
+      0: MD_INDENT_TOKEN_LIST@118..118
+      1: L_BRACK@118..119 "[" [] []
+      2: MD_LINK_LABEL@119..123
+        0: MD_INLINE_ITEM_LIST@119..123
+          0: MD_TEXTUAL@119..123
+            0: MD_TEXTUAL_LITERAL@119..123 "html" [] []
+      3: R_BRACK@123..124 "]" [] []
+      4: COLON@124..125 ":" [] []
+      5: MD_LINK_DESTINATION@125..131
+        0: MD_INLINE_ITEM_LIST@125..131
+          0: MD_TEXTUAL@125..126
+            0: MD_TEXTUAL_LITERAL@125..126 " " [] []
+          1: MD_TEXTUAL@126..131
+            0: MD_TEXTUAL_LITERAL@126..131 "/html" [] []
+      6: (empty)
+    13: MD_NEWLINE@131..132
+      0: NEWLINE@131..132 "\n" [] []
+    14: MD_NEWLINE@132..133
+      0: NEWLINE@132..133 "\n" [] []
+    15: MD_PARAGRAPH@133..146
+      0: MD_INLINE_ITEM_LIST@133..146
+        0: MD_REFERENCE_LINK@133..145
+          0: L_BRACK@133..134 "[" [] []
+          1: MD_INLINE_ITEM_LIST@134..137
+            0: MD_TEXTUAL@134..137
+              0: MD_TEXTUAL_LITERAL@134..137 "foo" [] []
+          2: R_BRACK@137..138 "]" [] []
+          3: MD_REFERENCE_LINK_LABEL@138..145
+            0: L_BRACK@138..139 "[" [] []
+            1: MD_INLINE_ITEM_LIST@139..144
+              0: MD_TEXTUAL@139..142
+                0: MD_TEXTUAL_LITERAL@139..142 "ref" [] []
+              1: MD_TEXTUAL@142..144
+                0: MD_TEXTUAL_LITERAL@142..144 "\\[" [] []
+            2: R_BRACK@144..145 "]" [] []
+        1: MD_TEXTUAL@145..146
+          0: MD_TEXTUAL_LITERAL@145..146 "\n" [] []
+    16: MD_NEWLINE@146..147
+      0: NEWLINE@146..147 "\n" [] []
+    17: MD_LINK_REFERENCE_DEFINITION@147..164
+      0: MD_INDENT_TOKEN_LIST@147..147
+      1: L_BRACK@147..148 "[" [] []
+      2: MD_LINK_LABEL@148..153
+        0: MD_INLINE_ITEM_LIST@148..153
+          0: MD_TEXTUAL@148..151
+            0: MD_TEXTUAL_LITERAL@148..151 "ref" [] []
+          1: MD_TEXTUAL@151..153
+            0: MD_TEXTUAL_LITERAL@151..153 "\\[" [] []
+      3: R_BRACK@153..154 "]" [] []
+      4: COLON@154..155 ":" [] []
+      5: MD_LINK_DESTINATION@155..164
+        0: MD_INLINE_ITEM_LIST@155..164
+          0: MD_TEXTUAL@155..156
+            0: MD_TEXTUAL_LITERAL@155..156 " " [] []
+          1: MD_TEXTUAL@156..164
+            0: MD_TEXTUAL_LITERAL@156..164 "/escaped" [] []
+      6: (empty)
+    18: MD_NEWLINE@164..165
+      0: NEWLINE@164..165 "\n" [] []
+    19: MD_NEWLINE@165..166
+      0: NEWLINE@165..166 "\n" [] []
+    20: MD_PARAGRAPH@166..174
+      0: MD_INLINE_ITEM_LIST@166..174
+        0: MD_REFERENCE_LINK@166..173
+          0: L_BRACK@166..167 "[" [] []
+          1: MD_INLINE_ITEM_LIST@167..170
+            0: MD_TEXTUAL@167..170
+              0: MD_TEXTUAL_LITERAL@167..170 "Foo" [] []
+          2: R_BRACK@170..171 "]" [] []
+          3: MD_REFERENCE_LINK_LABEL@171..173
+            0: L_BRACK@171..172 "[" [] []
+            1: MD_INLINE_ITEM_LIST@172..172
+            2: R_BRACK@172..173 "]" [] []
+        1: MD_TEXTUAL@173..174
+          0: MD_TEXTUAL_LITERAL@173..174 "\n" [] []
+    21: MD_NEWLINE@174..175
+      0: NEWLINE@174..175 "\n" [] []
+    22: MD_LINK_REFERENCE_DEFINITION@175..192
+      0: MD_INDENT_TOKEN_LIST@175..175
+      1: L_BRACK@175..176 "[" [] []
+      2: MD_LINK_LABEL@176..179
+        0: MD_INLINE_ITEM_LIST@176..179
+          0: MD_TEXTUAL@176..179
+            0: MD_TEXTUAL_LITERAL@176..179 "foo" [] []
+      3: R_BRACK@179..180 "]" [] []
+      4: COLON@180..181 ":" [] []
+      5: MD_LINK_DESTINATION@181..192
+        0: MD_INLINE_ITEM_LIST@181..192
+          0: MD_TEXTUAL@181..182
+            0: MD_TEXTUAL_LITERAL@181..182 " " [] []
+          1: MD_TEXTUAL@182..192
+            0: MD_TEXTUAL_LITERAL@182..192 "/collapsed" [] []
+      6: (empty)
+    23: MD_NEWLINE@192..193
+      0: NEWLINE@192..193 "\n" [] []
+    24: MD_NEWLINE@193..194
+      0: NEWLINE@193..194 "\n" [] []
+    25: MD_PARAGRAPH@194..203
+      0: MD_INLINE_ITEM_LIST@194..203
+        0: MD_REFERENCE_IMAGE@194..202
+          0: BANG@194..195 "!" [] []
+          1: L_BRACK@195..196 "[" [] []
+          2: MD_INLINE_ITEM_LIST@196..199
+            0: MD_TEXTUAL@196..199
+              0: MD_TEXTUAL_LITERAL@196..199 "Foo" [] []
+          3: R_BRACK@199..200 "]" [] []
+          4: MD_REFERENCE_LINK_LABEL@200..202
+            0: L_BRACK@200..201 "[" [] []
+            1: MD_INLINE_ITEM_LIST@201..201
+            2: R_BRACK@201..202 "]" [] []
+        1: MD_TEXTUAL@202..203
+          0: MD_TEXTUAL_LITERAL@202..203 "\n" [] []
+    26: MD_NEWLINE@203..204
+      0: NEWLINE@203..204 "\n" [] []
+    27: MD_LINK_REFERENCE_DEFINITION@204..217
+      0: MD_INDENT_TOKEN_LIST@204..204
+      1: L_BRACK@204..205 "[" [] []
+      2: MD_LINK_LABEL@205..208
+        0: MD_INLINE_ITEM_LIST@205..208
+          0: MD_TEXTUAL@205..208
+            0: MD_TEXTUAL_LITERAL@205..208 "foo" [] []
+      3: R_BRACK@208..209 "]" [] []
+      4: COLON@209..210 ":" [] []
+      5: MD_LINK_DESTINATION@210..217
+        0: MD_INLINE_ITEM_LIST@210..217
+          0: MD_TEXTUAL@210..211
+            0: MD_TEXTUAL_LITERAL@210..211 " " [] []
+          1: MD_TEXTUAL@211..217
+            0: MD_TEXTUAL_LITERAL@211..217 "/image" [] []
+      6: (empty)
+    28: MD_NEWLINE@217..218
+      0: NEWLINE@217..218 "\n" [] []
+  3: EOF@218..218 "" [] []
+
+```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

The function `is_at_block_interrupt` is expensive, so it was optimised to favour an early return with a minimal check of characters.

Removed the use of `String` in favour of ranges.

Added some `inline` to small functions

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Green CI. Hopefully some savings

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
