### PR TITLE
perf(markdown): reduce checks

### DIFF
--- a/crates/biome_markdown_parser/src/syntax/list.rs
+++ b/crates/biome_markdown_parser/src/syntax/list.rs
@@ -38,6 +38,10 @@ use biome_parser::parse_recovery::{ParseRecoveryTokenSet, RecoveryResult};
 use biome_parser::prelude::ParsedSyntax::{self, *};
 use biome_parser::prelude::{CompletedMarker, Marker, ParseDiagnostic, TokenSet};
 use biome_parser::{Parser, token_set};
+use biome_unicode_table::{
+    Dispatch::{BTO, DIG, HAS, IDT, LSS, MIN, MOR, MUL, PLS, TLD, TPL, ZER},
+    lookup_byte,
+};
 
 use crate::MarkdownParser;
 use crate::lexer::MarkdownReLexContext;
@@ -2123,8 +2127,11 @@ fn parse_first_line_blocks(
     }
 
     let block_start_byte = first_non_indent_byte(p);
+    let block_start_dispatch = block_start_byte.map(lookup_byte);
+    let block_start_is_underscore =
+        matches!(block_start_dispatch, Some(IDT)) && block_start_byte == Some(b'_');
 
-    let fenced_code_start = matches!(block_start_byte, Some(b'`' | b'~'))
+    let fenced_code_start = matches!(block_start_dispatch, Some(TPL | TLD))
         && p.lookahead(|p| {
             while p.at(MD_TEXTUAL_LITERAL) && is_whitespace_only(p.cur_text()) {
                 p.bump(MD_TEXTUAL_LITERAL);
@@ -2143,7 +2150,7 @@ fn parse_first_line_blocks(
         }
     }
 
-    let html_block_start = matches!(block_start_byte, Some(b'<'))
+    let html_block_start = matches!(block_start_dispatch, Some(LSS))
         && p.lookahead(|p| with_virtual_line_start(p, p.cur_range().start(), at_html_block));
 
     if html_block_start {
@@ -2154,15 +2161,15 @@ fn parse_first_line_blocks(
         }
     }
 
-    if matches!(block_start_byte, Some(b'#')) && parse_first_line_atx_heading(p, state) {
+    if matches!(block_start_dispatch, Some(HAS)) && parse_first_line_atx_heading(p, state) {
         return LoopAction::Continue;
     }
 
-    if matches!(block_start_byte, Some(b'>')) && parse_first_line_blockquote(p, state) {
+    if matches!(block_start_dispatch, Some(MOR)) && parse_first_line_blockquote(p, state) {
         return LoopAction::Continue;
     }
 
-    let link_block_start = matches!(block_start_byte, Some(b'['))
+    let link_block_start = matches!(block_start_dispatch, Some(BTO))
         && with_virtual_line_start(p, p.cur_range().start(), at_link_block_start);
 
     if link_block_start {
@@ -2179,7 +2186,8 @@ fn parse_first_line_blocks(
         }
     }
 
-    let is_thematic_break = matches!(block_start_byte, Some(b'-' | b'*' | b'_'))
+    let is_thematic_break = (matches!(block_start_dispatch, Some(MIN | MUL))
+        || block_start_is_underscore)
         && p.lookahead(|p| {
             while p.at(MD_TEXTUAL_LITERAL) && is_whitespace_only(p.cur_text()) {
                 p.bump(MD_TEXTUAL_LITERAL);
@@ -2195,7 +2203,7 @@ fn parse_first_line_blocks(
         return LoopAction::Continue;
     }
 
-    let nested_marker = if matches!(block_start_byte, Some(b'-' | b'*' | b'+' | b'0'..=b'9')) {
+    let nested_marker = if matches!(block_start_dispatch, Some(MIN | MUL | PLS | ZER | DIG)) {
         p.lookahead(|p| {
             while p.at(MD_TEXTUAL_LITERAL) && is_whitespace_only(p.cur_text()) {
                 p.bump(MD_TEXTUAL_LITERAL);

--- a/crates/biome_markdown_parser/src/syntax/list.rs
+++ b/crates/biome_markdown_parser/src/syntax/list.rs
@@ -55,8 +55,8 @@ use crate::syntax::with_virtual_line_start;
 use crate::syntax::{
     INDENT_CODE_BLOCK_SPACES, MAX_BLOCK_PREFIX_INDENT, MAX_ORDERED_LIST_MARKER_DIGITS,
     MIN_FENCE_RUN_LENGTH, MIN_THEMATIC_BREAK_RUN, TAB_STOP_SPACES, at_block_interrupt,
-    at_indent_code_block, is_ordered_list_starts_with_one, is_paragraph_like, is_whitespace_only,
-    parse_empty_paragraph,
+    at_indent_code_block, first_non_indent_byte, is_ordered_list_starts_with_one,
+    is_paragraph_like, is_whitespace_only, parse_empty_paragraph,
 };
 use crate::syntax::{parse_any_block_with_indent_code_policy, parse_paragraph};
 use biome_rowan::{TextRange, TextSize};
@@ -2122,16 +2122,18 @@ fn parse_first_line_blocks(
         return LoopAction::FallThrough;
     }
 
-    // Fenced code block
-    let fenced_code_start = p.lookahead(|p| {
-        while p.at(MD_TEXTUAL_LITERAL) && is_whitespace_only(p.cur_text()) {
-            p.bump(MD_TEXTUAL_LITERAL);
-        }
-        if p.at(TRIPLE_BACKTICK) || p.at(TRIPLE_TILDE) {
-            return true;
-        }
-        (p.at(BACKTICK) || p.at(TILDE)) && p.cur_text().len() >= MIN_FENCE_RUN_LENGTH
-    });
+    let block_start_byte = first_non_indent_byte(p);
+
+    let fenced_code_start = matches!(block_start_byte, Some(b'`' | b'~'))
+        && p.lookahead(|p| {
+            while p.at(MD_TEXTUAL_LITERAL) && is_whitespace_only(p.cur_text()) {
+                p.bump(MD_TEXTUAL_LITERAL);
+            }
+            if p.at(TRIPLE_BACKTICK) || p.at(TRIPLE_TILDE) {
+                return true;
+            }
+            (p.at(BACKTICK) || p.at(TILDE)) && p.cur_text().len() >= MIN_FENCE_RUN_LENGTH
+        });
 
     if fenced_code_start {
         let parsed = with_virtual_line_start(p, p.cur_range().start(), parse_fenced_code_block);
@@ -2141,9 +2143,8 @@ fn parse_first_line_blocks(
         }
     }
 
-    // HTML block
-    let html_block_start =
-        p.lookahead(|p| with_virtual_line_start(p, p.cur_range().start(), at_html_block));
+    let html_block_start = matches!(block_start_byte, Some(b'<'))
+        && p.lookahead(|p| with_virtual_line_start(p, p.cur_range().start(), at_html_block));
 
     if html_block_start {
         let parsed = with_virtual_line_start(p, p.cur_range().start(), parse_html_block);
@@ -2153,18 +2154,16 @@ fn parse_first_line_blocks(
         }
     }
 
-    // ATX heading
-    if parse_first_line_atx_heading(p, state) {
+    if matches!(block_start_byte, Some(b'#')) && parse_first_line_atx_heading(p, state) {
         return LoopAction::Continue;
     }
 
-    // Blockquote
-    if parse_first_line_blockquote(p, state) {
+    if matches!(block_start_byte, Some(b'>')) && parse_first_line_blockquote(p, state) {
         return LoopAction::Continue;
     }
 
-    // Link reference definition
-    let link_block_start = with_virtual_line_start(p, p.cur_range().start(), at_link_block_start);
+    let link_block_start = matches!(block_start_byte, Some(b'['))
+        && with_virtual_line_start(p, p.cur_range().start(), at_link_block_start);
 
     if link_block_start {
         let parsed = with_virtual_line_start(p, p.cur_range().start(), parse_link_block);
@@ -2180,55 +2179,59 @@ fn parse_first_line_blocks(
         }
     }
 
-    // Thematic break (check BEFORE nested list markers per CommonMark §4.1)
-    let is_thematic_break = p.lookahead(|p| {
-        while p.at(MD_TEXTUAL_LITERAL) && is_whitespace_only(p.cur_text()) {
-            p.bump(MD_TEXTUAL_LITERAL);
-        }
-        if p.at(MD_THEMATIC_BREAK_LITERAL) {
-            return true;
-        }
-        is_thematic_break_pattern(p)
-    });
+    let is_thematic_break = matches!(block_start_byte, Some(b'-' | b'*' | b'_'))
+        && p.lookahead(|p| {
+            while p.at(MD_TEXTUAL_LITERAL) && is_whitespace_only(p.cur_text()) {
+                p.bump(MD_TEXTUAL_LITERAL);
+            }
+            if p.at(MD_THEMATIC_BREAK_LITERAL) {
+                return true;
+            }
+            is_thematic_break_pattern(p)
+        });
 
     if is_thematic_break && parse_thematic_break_block(p).is_present() {
         state.record_first_line_block();
         return LoopAction::Continue;
     }
 
-    // Nested list
-    let nested_marker = p.lookahead(|p| {
-        while p.at(MD_TEXTUAL_LITERAL) && is_whitespace_only(p.cur_text()) {
-            p.bump(MD_TEXTUAL_LITERAL);
-        }
+    let nested_marker = if matches!(block_start_byte, Some(b'-' | b'*' | b'+' | b'0'..=b'9')) {
+        p.lookahead(|p| {
+            while p.at(MD_TEXTUAL_LITERAL) && is_whitespace_only(p.cur_text()) {
+                p.bump(MD_TEXTUAL_LITERAL);
+            }
 
-        if p.at(MD_ORDERED_LIST_MARKER) {
-            p.bump(MD_ORDERED_LIST_MARKER);
-            return marker_followed_by_whitespace_or_eol(p).then_some(NestedListMarker::Ordered);
-        }
+            if p.at(MD_ORDERED_LIST_MARKER) {
+                p.bump(MD_ORDERED_LIST_MARKER);
+                return marker_followed_by_whitespace_or_eol(p)
+                    .then_some(NestedListMarker::Ordered);
+            }
 
-        if p.at(MD_SETEXT_UNDERLINE_LITERAL) && is_single_dash_setext_marker(p.cur_text()) {
-            p.bump(MD_SETEXT_UNDERLINE_LITERAL);
-            return marker_followed_by_whitespace_or_eol(p).then_some(NestedListMarker::Bullet);
-        }
+            if p.at(MD_SETEXT_UNDERLINE_LITERAL) && is_single_dash_setext_marker(p.cur_text()) {
+                p.bump(MD_SETEXT_UNDERLINE_LITERAL);
+                return marker_followed_by_whitespace_or_eol(p).then_some(NestedListMarker::Bullet);
+            }
 
-        if p.at(T![-]) || p.at(T![*]) || p.at(T![+]) {
-            p.bump(p.cur());
-            return marker_followed_by_whitespace_or_eol(p).then_some(NestedListMarker::Bullet);
-        }
+            if p.at(T![-]) || p.at(T![*]) || p.at(T![+]) {
+                p.bump(p.cur());
+                return marker_followed_by_whitespace_or_eol(p).then_some(NestedListMarker::Bullet);
+            }
 
-        if p.at(MD_TEXTUAL_LITERAL) && is_textual_bullet_marker(p.cur_text()) {
-            p.bump(MD_TEXTUAL_LITERAL);
-            return marker_followed_by_whitespace_or_eol(p).then_some(NestedListMarker::Bullet);
-        }
+            if p.at(MD_TEXTUAL_LITERAL) && is_textual_bullet_marker(p.cur_text()) {
+                p.bump(MD_TEXTUAL_LITERAL);
+                return marker_followed_by_whitespace_or_eol(p).then_some(NestedListMarker::Bullet);
+            }
 
-        if p.at(MD_TEXTUAL_LITERAL) && textual_starts_with_ordered_marker(p.cur_text()) {
-            p.bump(MD_TEXTUAL_LITERAL);
-            return Some(NestedListMarker::Ordered);
-        }
+            if p.at(MD_TEXTUAL_LITERAL) && textual_starts_with_ordered_marker(p.cur_text()) {
+                p.bump(MD_TEXTUAL_LITERAL);
+                return Some(NestedListMarker::Ordered);
+            }
 
+            None
+        })
+    } else {
         None
-    });
+    };
 
     if let Some(nested_marker) = nested_marker {
         let prev_virtual = p.state().virtual_line_start;

--- a/crates/biome_markdown_parser/src/syntax/mod.rs
+++ b/crates/biome_markdown_parser/src/syntax/mod.rs
@@ -44,6 +44,10 @@ use biome_parser::{
     token_set,
 };
 use biome_rowan::TextSize;
+use biome_unicode_table::{
+    Dispatch::{self, BTO, DIG, HAS, IDT, LSS, MIN, MOR, MUL, PLS, TLD, TPL, ZER},
+    lookup_byte,
+};
 use fenced_code_block::{
     at_fenced_code_block, info_string_has_backtick, parse_fenced_code_block,
     parse_fenced_code_block_force,
@@ -325,12 +329,16 @@ pub(crate) fn parse_any_block_with_indent_code_policy(
         parse_indent_code_block(p)
     } else {
         let block_start_byte = first_non_indent_byte(p);
+        let block_start_dispatch = block_start_byte.map(lookup_byte);
+        let block_start_is_underscore =
+            matches!(block_start_dispatch, Some(IDT)) && block_start_byte == Some(b'_');
 
-        if matches!(block_start_byte, Some(b'`' | b'~')) && at_fenced_code_block(p) {
+        if matches!(block_start_dispatch, Some(TPL | TLD)) && at_fenced_code_block(p) {
             parse_fenced_code_block(p)
-        } else if matches!(block_start_byte, Some(b'`' | b'~')) && line_starts_with_fence(p) {
+        } else if matches!(block_start_dispatch, Some(TPL | TLD)) && line_starts_with_fence(p) {
             parse_fenced_code_block_force(p)
-        } else if matches!(block_start_byte, Some(b'-' | b'*' | b'_')) && at_thematic_break_block(p)
+        } else if (matches!(block_start_dispatch, Some(MIN | MUL)) || block_start_is_underscore)
+            && at_thematic_break_block(p)
         {
             let break_block = try_parse(p, |p| {
                 let break_block = parse_thematic_break_block(p);
@@ -344,16 +352,16 @@ pub(crate) fn parse_any_block_with_indent_code_policy(
             } else {
                 parse_paragraph(p)
             }
-        } else if matches!(block_start_byte, Some(b'#')) && at_header(p) {
+        } else if matches!(block_start_dispatch, Some(HAS)) && at_header(p) {
             match parse_header(p) {
                 Present(header) => Present(header),
                 Absent => parse_paragraph(p),
             }
-        } else if matches!(block_start_byte, Some(b'>')) && at_quote(p) {
+        } else if matches!(block_start_dispatch, Some(MOR)) && at_quote(p) {
             parse_quote(p)
-        } else if matches!(block_start_byte, Some(b'-' | b'*' | b'+')) && at_bullet_list_item(p) {
+        } else if matches!(block_start_dispatch, Some(MIN | MUL | PLS)) && at_bullet_list_item(p) {
             parse_bullet_list_item(p)
-        } else if matches!(block_start_byte, Some(b'0'..=b'9'))
+        } else if matches!(block_start_dispatch, Some(ZER | DIG))
             && (at_order_list_item(p) || at_order_list_item_textual(p))
         {
             // After a link reference definition with no intervening blank line,
@@ -384,9 +392,9 @@ pub(crate) fn parse_any_block_with_indent_code_policy(
                     parsed
                 }
             }
-        } else if matches!(block_start_byte, Some(b'<')) && at_html_block(p) {
+        } else if matches!(block_start_dispatch, Some(LSS)) && at_html_block(p) {
             parse_html_block(p)
-        } else if matches!(block_start_byte, Some(b'[')) && at_link_block_start(p) {
+        } else if matches!(block_start_dispatch, Some(BTO)) && at_link_block_start(p) {
             // Try to parse as link reference definition
             // Use try_parse to fall back to paragraph if not a valid definition
             let link_result = try_parse(p, |p| {
@@ -1848,8 +1856,9 @@ fn consume_partial_quote_prefix_lookahead(p: &mut MarkdownParser, depth: usize) 
 ///
 /// - Bullet lists can interrupt paragraphs if item has content OR marker is followed by blank line
 /// - Ordered lists can interrupt paragraphs ONLY if starting with `1` AND not empty
+#[inline]
 pub(crate) fn at_block_interrupt(p: &mut MarkdownParser) -> bool {
-    let Some(byte) = block_interrupt_candidate(p) else {
+    let Some((byte, dispatch)) = block_interrupt_candidate(p) else {
         return false;
     };
 
@@ -1877,35 +1886,34 @@ pub(crate) fn at_block_interrupt(p: &mut MarkdownParser) -> bool {
         return false;
     }
 
-    at_unindented_block_interrupt(p, byte)
+    at_unindented_block_interrupt(p, byte, dispatch)
 }
 
 #[inline]
-fn block_interrupt_candidate(p: &MarkdownParser) -> Option<u8> {
+fn block_interrupt_candidate(p: &MarkdownParser) -> Option<(u8, Dispatch)> {
     let byte = first_non_indent_byte(p)?;
-    is_block_interrupt_start_byte(byte).then_some(byte)
+    let dispatch = lookup_byte(byte);
+    is_block_interrupt_start_byte(byte, dispatch).then_some((byte, dispatch))
 }
 
 #[inline]
-fn is_block_interrupt_start_byte(byte: u8) -> bool {
-    use biome_unicode_table::{
-        Dispatch::{DIG, HAS, IDT, LSS, MIN, MOR, MUL, PLS, TLD, TPL, ZER},
-        lookup_byte,
-    };
-
-    match lookup_byte(byte) {
+fn is_block_interrupt_start_byte(byte: u8, dispatch: Dispatch) -> bool {
+    match dispatch {
         HAS | TPL | TLD | MOR | LSS | MIN | MUL | PLS | ZER | DIG => true,
         IDT => byte == b'_',
         _ => false,
     }
 }
 
-fn at_unindented_block_interrupt(p: &mut MarkdownParser, byte: u8) -> bool {
-    if matches!(byte, b'-' | b'*' | b'_') && at_thematic_break_block(p) {
+#[inline]
+fn at_unindented_block_interrupt(p: &mut MarkdownParser, byte: u8, dispatch: Dispatch) -> bool {
+    let thematic_break_start = matches!(dispatch, MIN | MUL) || (dispatch == IDT && byte == b'_');
+
+    if thematic_break_start && at_thematic_break_block(p) {
         return true;
     }
 
-    if matches!(byte, b'-' | b'*' | b'+')
+    if matches!(dispatch, MIN | MUL | PLS)
         && (at_bullet_list_item(p) || at_bullet_list_item_at_any_indent(p))
     {
         let in_list = p.state().list_nesting_depth > 0;
@@ -1914,18 +1922,18 @@ fn at_unindented_block_interrupt(p: &mut MarkdownParser, byte: u8) -> bool {
         }
     }
 
-    if byte.is_ascii_digit()
+    if matches!(dispatch, ZER | DIG)
         && (at_order_list_item(p) || at_order_list_item_at_any_indent(p))
         && can_ordered_marker_interrupt_paragraph(p)
     {
         return true;
     }
 
-    match byte {
-        b'#' => at_header(p) && is_valid_atx_heading_start(p),
-        b'`' | b'~' => at_fenced_code_block(p),
-        b'>' => at_quote(p),
-        b'<' => at_html_block_interrupt(p),
+    match dispatch {
+        HAS => at_header(p) && is_valid_atx_heading_start(p),
+        TPL | TLD => at_fenced_code_block(p),
+        MOR => at_quote(p),
+        LSS => at_html_block_interrupt(p),
         _ => false,
     }
 }

--- a/crates/biome_markdown_parser/src/syntax/mod.rs
+++ b/crates/biome_markdown_parser/src/syntax/mod.rs
@@ -81,6 +81,13 @@ pub(crate) fn is_space_or_tab_token(p: &MarkdownParser) -> bool {
     !text.is_empty() && text.chars().all(|c| c == ' ' || c == '\t')
 }
 
+#[inline]
+pub(crate) fn first_non_indent_byte(p: &MarkdownParser) -> Option<u8> {
+    p.source_after_current()
+        .bytes()
+        .find(|byte| !matches!(*byte, b' ' | b'\t'))
+}
+
 /// Get the closing delimiter for a CommonMark link title (§4.7, §6.3).
 ///
 /// A link title appears after the destination in link reference definitions
@@ -316,118 +323,125 @@ pub(crate) fn parse_any_block_with_indent_code_policy(
 
     let parsed = if allow_indent_code_block && at_indent_code_block(p) {
         parse_indent_code_block(p)
-    } else if at_fenced_code_block(p) {
-        parse_fenced_code_block(p)
-    } else if line_starts_with_fence(p) {
-        parse_fenced_code_block_force(p)
-    } else if at_thematic_break_block(p) {
-        let break_block = try_parse(p, |p| {
-            let break_block = parse_thematic_break_block(p);
-            if break_block.is_absent() {
-                return Err(());
-            }
-            Ok(break_block)
-        });
-        if let Ok(parsed) = break_block {
-            parsed
-        } else {
-            parse_paragraph(p)
-        }
-    } else if at_header(p) {
-        match parse_header(p) {
-            Present(header) => Present(header),
-            Absent => parse_paragraph(p),
-        }
-    } else if at_quote(p) {
-        parse_quote(p)
-    } else if at_bullet_list_item(p) {
-        parse_bullet_list_item(p)
-    } else if at_order_list_item(p) || at_order_list_item_textual(p) {
-        // After a link reference definition with no intervening blank line,
-        // CommonMark treats the next line as paragraph continuation unless it
-        // begins a paragraph-interrupting block. Ordered lists with a starting
-        // number other than 1 cannot interrupt a paragraph (§5.2), so fall
-        // back to paragraph parsing.
-        if p.state().link_reference_definition_continuation
-            && p.state().list_nesting_depth == 0
-            && !is_ordered_list_starts_with_one(p)
-        {
-            parse_paragraph(p)
-        } else {
-            let forced = if !at_order_list_item(p) && at_order_list_item_textual(p) {
-                p.set_force_ordered_list_marker(true);
-                p.force_relex_regular();
-                true
-            } else {
-                false
-            };
-            let parsed = parse_order_list_item(p);
-            if forced {
-                p.set_force_ordered_list_marker(false);
-            }
-            if parsed.is_absent() {
-                parse_paragraph(p)
-            } else {
-                parsed
-            }
-        }
-    } else if at_html_block(p) {
-        parse_html_block(p)
-    } else if at_link_block_start(p) {
-        // Try to parse as link reference definition
-        // Use try_parse to fall back to paragraph if not a valid definition
-        let link_result = try_parse(p, |p| {
-            let link = parse_link_block(p);
-            if link.is_absent() {
-                return Err(());
-            }
-            Ok(link)
-        });
-        if let Ok(parsed) = link_result {
-            p.state_mut().link_reference_definition_continuation = true;
-            if link_reference_definition_before_dash_thematic_break(p) {
-                Present(parse_empty_paragraph(p))
-            } else {
-                parsed
-            }
-        } else {
-            parse_paragraph(p)
-        }
-    } else if at_block_interrupt(p) {
-        // We see a block interrupt but didn't match a concrete block above.
-        // This can happen when list item indentation is still active.
-        if at_bullet_list_item_at_any_indent(p) {
-            let prev_required = p.state().list_item_required_indent;
-            let prev_virtual = p.state().virtual_line_start;
-            p.state_mut().list_item_required_indent = 0;
-            p.state_mut().virtual_line_start = Some(p.cur_range().start());
-            let parsed = parse_bullet_list_item(p);
-            p.state_mut().list_item_required_indent = prev_required;
-            p.state_mut().virtual_line_start = prev_virtual;
-            if parsed.is_present() {
-                parsed
-            } else {
-                parse_paragraph(p)
-            }
-        } else if at_order_list_item_at_any_indent(p) {
-            let prev_required = p.state().list_item_required_indent;
-            let prev_virtual = p.state().virtual_line_start;
-            p.state_mut().list_item_required_indent = 0;
-            p.state_mut().virtual_line_start = Some(p.cur_range().start());
-            let parsed = parse_order_list_item(p);
-            p.state_mut().list_item_required_indent = prev_required;
-            p.state_mut().virtual_line_start = prev_virtual;
-            if parsed.is_present() {
-                parsed
-            } else {
-                parse_paragraph(p)
-            }
-        } else {
-            parse_paragraph(p)
-        }
     } else {
-        // Default fallback: parse as paragraph
-        parse_paragraph(p)
+        let block_start_byte = first_non_indent_byte(p);
+
+        if matches!(block_start_byte, Some(b'`' | b'~')) && at_fenced_code_block(p) {
+            parse_fenced_code_block(p)
+        } else if matches!(block_start_byte, Some(b'`' | b'~')) && line_starts_with_fence(p) {
+            parse_fenced_code_block_force(p)
+        } else if matches!(block_start_byte, Some(b'-' | b'*' | b'_')) && at_thematic_break_block(p)
+        {
+            let break_block = try_parse(p, |p| {
+                let break_block = parse_thematic_break_block(p);
+                if break_block.is_absent() {
+                    return Err(());
+                }
+                Ok(break_block)
+            });
+            if let Ok(parsed) = break_block {
+                parsed
+            } else {
+                parse_paragraph(p)
+            }
+        } else if matches!(block_start_byte, Some(b'#')) && at_header(p) {
+            match parse_header(p) {
+                Present(header) => Present(header),
+                Absent => parse_paragraph(p),
+            }
+        } else if matches!(block_start_byte, Some(b'>')) && at_quote(p) {
+            parse_quote(p)
+        } else if matches!(block_start_byte, Some(b'-' | b'*' | b'+')) && at_bullet_list_item(p) {
+            parse_bullet_list_item(p)
+        } else if matches!(block_start_byte, Some(b'0'..=b'9'))
+            && (at_order_list_item(p) || at_order_list_item_textual(p))
+        {
+            // After a link reference definition with no intervening blank line,
+            // CommonMark treats the next line as paragraph continuation unless it
+            // begins a paragraph-interrupting block. Ordered lists with a starting
+            // number other than 1 cannot interrupt a paragraph (§5.2), so fall
+            // back to paragraph parsing.
+            if p.state().link_reference_definition_continuation
+                && p.state().list_nesting_depth == 0
+                && !is_ordered_list_starts_with_one(p)
+            {
+                parse_paragraph(p)
+            } else {
+                let forced = if !at_order_list_item(p) && at_order_list_item_textual(p) {
+                    p.set_force_ordered_list_marker(true);
+                    p.force_relex_regular();
+                    true
+                } else {
+                    false
+                };
+                let parsed = parse_order_list_item(p);
+                if forced {
+                    p.set_force_ordered_list_marker(false);
+                }
+                if parsed.is_absent() {
+                    parse_paragraph(p)
+                } else {
+                    parsed
+                }
+            }
+        } else if matches!(block_start_byte, Some(b'<')) && at_html_block(p) {
+            parse_html_block(p)
+        } else if matches!(block_start_byte, Some(b'[')) && at_link_block_start(p) {
+            // Try to parse as link reference definition
+            // Use try_parse to fall back to paragraph if not a valid definition
+            let link_result = try_parse(p, |p| {
+                let link = parse_link_block(p);
+                if link.is_absent() {
+                    return Err(());
+                }
+                Ok(link)
+            });
+            if let Ok(parsed) = link_result {
+                p.state_mut().link_reference_definition_continuation = true;
+                if link_reference_definition_before_dash_thematic_break(p) {
+                    Present(parse_empty_paragraph(p))
+                } else {
+                    parsed
+                }
+            } else {
+                parse_paragraph(p)
+            }
+        } else if at_block_interrupt(p) {
+            // We see a block interrupt but didn't match a concrete block above.
+            // This can happen when list item indentation is still active.
+            if at_bullet_list_item_at_any_indent(p) {
+                let prev_required = p.state().list_item_required_indent;
+                let prev_virtual = p.state().virtual_line_start;
+                p.state_mut().list_item_required_indent = 0;
+                p.state_mut().virtual_line_start = Some(p.cur_range().start());
+                let parsed = parse_bullet_list_item(p);
+                p.state_mut().list_item_required_indent = prev_required;
+                p.state_mut().virtual_line_start = prev_virtual;
+                if parsed.is_present() {
+                    parsed
+                } else {
+                    parse_paragraph(p)
+                }
+            } else if at_order_list_item_at_any_indent(p) {
+                let prev_required = p.state().list_item_required_indent;
+                let prev_virtual = p.state().virtual_line_start;
+                p.state_mut().list_item_required_indent = 0;
+                p.state_mut().virtual_line_start = Some(p.cur_range().start());
+                let parsed = parse_order_list_item(p);
+                p.state_mut().list_item_required_indent = prev_required;
+                p.state_mut().virtual_line_start = prev_virtual;
+                if parsed.is_present() {
+                    parsed
+                } else {
+                    parse_paragraph(p)
+                }
+            } else {
+                parse_paragraph(p)
+            }
+        } else {
+            // Default fallback: parse as paragraph
+            parse_paragraph(p)
+        }
     };
 
     if start == p.cur_range().start() {
@@ -1835,6 +1849,10 @@ fn consume_partial_quote_prefix_lookahead(p: &mut MarkdownParser, depth: usize) 
 /// - Bullet lists can interrupt paragraphs if item has content OR marker is followed by blank line
 /// - Ordered lists can interrupt paragraphs ONLY if starting with `1` AND not empty
 pub(crate) fn at_block_interrupt(p: &mut MarkdownParser) -> bool {
+    let Some(byte) = block_interrupt_candidate(p) else {
+        return false;
+    };
+
     // Per CommonMark, lines indented 4+ spaces cannot start block constructs
     // that interrupt paragraphs - they would be indented code blocks.
     // Tabs count as 4 spaces per CommonMark §2.2.
@@ -1859,26 +1877,20 @@ pub(crate) fn at_block_interrupt(p: &mut MarkdownParser) -> bool {
         return false;
     }
 
-    if !can_start_block_interrupt(p) {
-        return false;
-    }
-
-    at_unindented_block_interrupt(p)
+    at_unindented_block_interrupt(p, byte)
 }
 
 #[inline]
-fn can_start_block_interrupt(p: &MarkdownParser) -> bool {
+fn block_interrupt_candidate(p: &MarkdownParser) -> Option<u8> {
+    let byte = first_non_indent_byte(p)?;
+    is_block_interrupt_start_byte(byte).then_some(byte)
+}
+
+#[inline]
+fn is_block_interrupt_start_byte(byte: u8) -> bool {
     use biome_unicode_table::{
         Dispatch::{DIG, HAS, IDT, LSS, MIN, MOR, MUL, PLS, TLD, TPL, ZER},
         lookup_byte,
-    };
-
-    let Some(byte) = p
-        .source_after_current()
-        .bytes()
-        .find(|byte| !matches!(*byte, b' ' | b'\t'))
-    else {
-        return false;
     };
 
     match lookup_byte(byte) {
@@ -1888,56 +1900,34 @@ fn can_start_block_interrupt(p: &MarkdownParser) -> bool {
     }
 }
 
-fn at_unindented_block_interrupt(p: &mut MarkdownParser) -> bool {
-    // ATX heading: # at line start (must have space/tab after per CommonMark §4.2)
-    // Use checkpoint to look ahead and verify it's a valid heading
-    if at_header(p) {
-        return is_valid_atx_heading_start(p);
-    }
-
-    // Fenced code block (``` or ~~~) - lexer already ensures line start
-    if at_fenced_code_block(p) {
+fn at_unindented_block_interrupt(p: &mut MarkdownParser, byte: u8) -> bool {
+    if matches!(byte, b'-' | b'*' | b'_') && at_thematic_break_block(p) {
         return true;
     }
 
-    // Block quote (>)
-    if at_quote(p) {
-        return true;
-    }
-
-    // Thematic break (---, ***, ___) - lexer already ensures line start
-    if at_thematic_break_block(p) {
-        return true;
-    }
-
-    // Bullet list item (-, *, +)
-    // Per CommonMark §5.2: bullet lists can interrupt paragraphs only if the
-    // item has content (non-empty). Empty markers cannot interrupt paragraphs.
-    // When inside a list, we also need to check for list items at ANY indent
-    // (not just at the current context's indent) because a less-indented list
-    // marker would end the current list item and start a sibling/parent item.
-    if at_bullet_list_item(p) || at_bullet_list_item_at_any_indent(p) {
+    if matches!(byte, b'-' | b'*' | b'+')
+        && (at_bullet_list_item(p) || at_bullet_list_item_at_any_indent(p))
+    {
         let in_list = p.state().list_nesting_depth > 0;
         if in_list || can_bullet_interrupt_paragraph(p) {
             return true;
         }
     }
 
-    // Ordered markers may interrupt paragraphs only when they start with `1`
-    // and are non-empty (§5.2). In list context, a marker physically before
-    // required_indent is a sibling/parent boundary and is allowed.
-    if (at_order_list_item(p) || at_order_list_item_at_any_indent(p))
+    if byte.is_ascii_digit()
+        && (at_order_list_item(p) || at_order_list_item_at_any_indent(p))
         && can_ordered_marker_interrupt_paragraph(p)
     {
         return true;
     }
 
-    // HTML block (type 7 does not interrupt paragraphs)
-    if at_html_block_interrupt(p) {
-        return true;
+    match byte {
+        b'#' => at_header(p) && is_valid_atx_heading_start(p),
+        b'`' | b'~' => at_fenced_code_block(p),
+        b'>' => at_quote(p),
+        b'<' => at_html_block_interrupt(p),
+        _ => false,
     }
-
-    false
 }
 
 /// Check if the current token looks like a list marker when lexed as textual content.

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/at_block_interrupt_candidate_starts.md
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/at_block_interrupt_candidate_starts.md
@@ -8,14 +8,25 @@ before fence
 fence
 ```
 
+before tilde fence
+~~~
+fence
+~~~
+
 before quote
 > quote
 
 before thematic
 ***
 
+before underscore thematic
+___
+
 before list
 - item
+
+before plus list
++ item
 
 before HTML
 <div></div>

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/at_block_interrupt_candidate_starts.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/at_block_interrupt_candidate_starts.md.snap
@@ -16,14 +16,25 @@ before fence
 fence
 ```
 
+before tilde fence
+~~~
+fence
+~~~
+
 before quote
 > quote
 
 before thematic
 ***
 
+before underscore thematic
+___
+
 before list
 - item
+
+before plus list
++ item
 
 before HTML
 <div></div>
@@ -116,71 +127,128 @@ MdRoot {
         MdParagraph {
             list: MdInlineItemList [
                 MdTextual {
-                    value_token: MD_TEXTUAL_LITERAL@75..87 "before quote" [] [],
+                    value_token: MD_TEXTUAL_LITERAL@75..93 "before tilde fence" [] [],
                 },
                 MdTextual {
-                    value_token: MD_TEXTUAL_LITERAL@87..88 "\n" [] [],
+                    value_token: MD_TEXTUAL_LITERAL@93..94 "\n" [] [],
+                },
+            ],
+        },
+        MdFencedCodeBlock {
+            indent: MdIndentTokenList [],
+            l_fence: TRIPLE_TILDE@94..97 "~~~" [] [],
+            code_list: MdCodeNameList [],
+            content: MdInlineItemList [
+                MdCodeContent {
+                    value_token: MD_CODE_LITERAL@97..104 "\nfence\n" [] [],
+                },
+            ],
+            r_fence_indent: MdIndentTokenList [],
+            r_fence: TRIPLE_TILDE@104..107 "~~~" [] [],
+        },
+        MdNewline {
+            value_token: NEWLINE@107..108 "\n" [] [],
+        },
+        MdNewline {
+            value_token: NEWLINE@108..109 "\n" [] [],
+        },
+        MdParagraph {
+            list: MdInlineItemList [
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@109..121 "before quote" [] [],
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@121..122 "\n" [] [],
                 },
             ],
         },
         MdQuote {
             prefix: MdQuotePrefix {
                 pre_marker_indent: MdQuoteIndentList [],
-                marker_token: R_ANGLE@88..89 ">" [] [],
-                post_marker_space_token: MD_QUOTE_POST_MARKER_SPACE@89..90 " " [] [],
+                marker_token: R_ANGLE@122..123 ">" [] [],
+                post_marker_space_token: MD_QUOTE_POST_MARKER_SPACE@123..124 " " [] [],
             },
             content: MdBlockList [
                 MdParagraph {
                     list: MdInlineItemList [
                         MdTextual {
-                            value_token: MD_TEXTUAL_LITERAL@90..95 "quote" [] [],
+                            value_token: MD_TEXTUAL_LITERAL@124..129 "quote" [] [],
                         },
                         MdTextual {
-                            value_token: MD_TEXTUAL_LITERAL@95..96 "\n" [] [],
+                            value_token: MD_TEXTUAL_LITERAL@129..130 "\n" [] [],
                         },
                     ],
                 },
             ],
         },
         MdNewline {
-            value_token: NEWLINE@96..97 "\n" [] [],
+            value_token: NEWLINE@130..131 "\n" [] [],
         },
         MdParagraph {
             list: MdInlineItemList [
                 MdTextual {
-                    value_token: MD_TEXTUAL_LITERAL@97..112 "before thematic" [] [],
+                    value_token: MD_TEXTUAL_LITERAL@131..146 "before thematic" [] [],
                 },
                 MdTextual {
-                    value_token: MD_TEXTUAL_LITERAL@112..113 "\n" [] [],
+                    value_token: MD_TEXTUAL_LITERAL@146..147 "\n" [] [],
                 },
             ],
         },
         MdThematicBreakBlock {
             parts: MdThematicBreakPartList [
                 MdThematicBreakChar {
-                    value: STAR@113..114 "*" [] [],
+                    value: STAR@147..148 "*" [] [],
                 },
                 MdThematicBreakChar {
-                    value: STAR@114..115 "*" [] [],
+                    value: STAR@148..149 "*" [] [],
                 },
                 MdThematicBreakChar {
-                    value: STAR@115..116 "*" [] [],
+                    value: STAR@149..150 "*" [] [],
                 },
             ],
         },
         MdNewline {
-            value_token: NEWLINE@116..117 "\n" [] [],
+            value_token: NEWLINE@150..151 "\n" [] [],
         },
         MdNewline {
-            value_token: NEWLINE@117..118 "\n" [] [],
+            value_token: NEWLINE@151..152 "\n" [] [],
         },
         MdParagraph {
             list: MdInlineItemList [
                 MdTextual {
-                    value_token: MD_TEXTUAL_LITERAL@118..129 "before list" [] [],
+                    value_token: MD_TEXTUAL_LITERAL@152..178 "before underscore thematic" [] [],
                 },
                 MdTextual {
-                    value_token: MD_TEXTUAL_LITERAL@129..130 "\n" [] [],
+                    value_token: MD_TEXTUAL_LITERAL@178..179 "\n" [] [],
+                },
+            ],
+        },
+        MdThematicBreakBlock {
+            parts: MdThematicBreakPartList [
+                MdThematicBreakChar {
+                    value: UNDERSCORE@179..180 "_" [] [],
+                },
+                MdThematicBreakChar {
+                    value: UNDERSCORE@180..181 "_" [] [],
+                },
+                MdThematicBreakChar {
+                    value: UNDERSCORE@181..182 "_" [] [],
+                },
+            ],
+        },
+        MdNewline {
+            value_token: NEWLINE@182..183 "\n" [] [],
+        },
+        MdNewline {
+            value_token: NEWLINE@183..184 "\n" [] [],
+        },
+        MdParagraph {
+            list: MdInlineItemList [
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@184..195 "before list" [] [],
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@195..196 "\n" [] [],
                 },
             ],
         },
@@ -189,18 +257,18 @@ MdRoot {
                 MdBullet {
                     prefix: MdListMarkerPrefix {
                         pre_marker_indent: MdIndentTokenList [],
-                        marker: MINUS@130..131 "-" [] [],
-                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@131..132 " " [] [],
+                        marker: MINUS@196..197 "-" [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@197..198 " " [] [],
                         content_indent: MdIndentTokenList [],
                     },
                     content: MdBlockList [
                         MdParagraph {
                             list: MdInlineItemList [
                                 MdTextual {
-                                    value_token: MD_TEXTUAL_LITERAL@132..136 "item" [] [],
+                                    value_token: MD_TEXTUAL_LITERAL@198..202 "item" [] [],
                                 },
                                 MdTextual {
-                                    value_token: MD_TEXTUAL_LITERAL@136..137 "\n" [] [],
+                                    value_token: MD_TEXTUAL_LITERAL@202..203 "\n" [] [],
                                 },
                             ],
                         },
@@ -209,39 +277,76 @@ MdRoot {
             ],
         },
         MdNewline {
-            value_token: NEWLINE@137..138 "\n" [] [],
+            value_token: NEWLINE@203..204 "\n" [] [],
         },
         MdParagraph {
             list: MdInlineItemList [
                 MdTextual {
-                    value_token: MD_TEXTUAL_LITERAL@138..149 "before HTML" [] [],
+                    value_token: MD_TEXTUAL_LITERAL@204..220 "before plus list" [] [],
                 },
                 MdTextual {
-                    value_token: MD_TEXTUAL_LITERAL@149..150 "\n" [] [],
+                    value_token: MD_TEXTUAL_LITERAL@220..221 "\n" [] [],
+                },
+            ],
+        },
+        MdBulletListItem {
+            md_bullet_list: MdBulletList [
+                MdBullet {
+                    prefix: MdListMarkerPrefix {
+                        pre_marker_indent: MdIndentTokenList [],
+                        marker: PLUS@221..222 "+" [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@222..223 " " [] [],
+                        content_indent: MdIndentTokenList [],
+                    },
+                    content: MdBlockList [
+                        MdParagraph {
+                            list: MdInlineItemList [
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@223..227 "item" [] [],
+                                },
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@227..228 "\n" [] [],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+        MdNewline {
+            value_token: NEWLINE@228..229 "\n" [] [],
+        },
+        MdParagraph {
+            list: MdInlineItemList [
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@229..240 "before HTML" [] [],
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@240..241 "\n" [] [],
                 },
             ],
         },
         MdHtmlBlock {
             indent: MdIndentTokenList [],
             content: MdHtmlContent {
-                value_token: MD_HTML_LITERAL@150..161 "<div></div>" [] [],
+                value_token: MD_HTML_LITERAL@241..252 "<div></div>" [] [],
             },
         },
         MdNewline {
-            value_token: NEWLINE@161..162 "\n" [] [],
+            value_token: NEWLINE@252..253 "\n" [] [],
         },
     ],
-    eof_token: EOF@162..162 "" [] [],
+    eof_token: EOF@253..253 "" [] [],
 }
 ```
 
 ## CST
 
 ```
-0: MD_ROOT@0..162
+0: MD_ROOT@0..253
   0: (empty)
   1: (empty)
-  2: MD_BLOCK_LIST@0..162
+  2: MD_BLOCK_LIST@0..253
     0: MD_PARAGRAPH@0..36
       0: MD_INLINE_ITEM_LIST@0..36
         0: MD_TEXTUAL@0..14
@@ -291,79 +396,139 @@ MdRoot {
       0: NEWLINE@73..74 "\n" [] []
     7: MD_NEWLINE@74..75
       0: NEWLINE@74..75 "\n" [] []
-    8: MD_PARAGRAPH@75..88
-      0: MD_INLINE_ITEM_LIST@75..88
-        0: MD_TEXTUAL@75..87
-          0: MD_TEXTUAL_LITERAL@75..87 "before quote" [] []
-        1: MD_TEXTUAL@87..88
-          0: MD_TEXTUAL_LITERAL@87..88 "\n" [] []
-    9: MD_QUOTE@88..96
-      0: MD_QUOTE_PREFIX@88..90
-        0: MD_QUOTE_INDENT_LIST@88..88
-        1: R_ANGLE@88..89 ">" [] []
-        2: MD_QUOTE_POST_MARKER_SPACE@89..90 " " [] []
-      1: MD_BLOCK_LIST@90..96
-        0: MD_PARAGRAPH@90..96
-          0: MD_INLINE_ITEM_LIST@90..96
-            0: MD_TEXTUAL@90..95
-              0: MD_TEXTUAL_LITERAL@90..95 "quote" [] []
-            1: MD_TEXTUAL@95..96
-              0: MD_TEXTUAL_LITERAL@95..96 "\n" [] []
-    10: MD_NEWLINE@96..97
-      0: NEWLINE@96..97 "\n" [] []
-    11: MD_PARAGRAPH@97..113
-      0: MD_INLINE_ITEM_LIST@97..113
-        0: MD_TEXTUAL@97..112
-          0: MD_TEXTUAL_LITERAL@97..112 "before thematic" [] []
-        1: MD_TEXTUAL@112..113
-          0: MD_TEXTUAL_LITERAL@112..113 "\n" [] []
-    12: MD_THEMATIC_BREAK_BLOCK@113..116
-      0: MD_THEMATIC_BREAK_PART_LIST@113..116
-        0: MD_THEMATIC_BREAK_CHAR@113..114
-          0: STAR@113..114 "*" [] []
-        1: MD_THEMATIC_BREAK_CHAR@114..115
-          0: STAR@114..115 "*" [] []
-        2: MD_THEMATIC_BREAK_CHAR@115..116
-          0: STAR@115..116 "*" [] []
-    13: MD_NEWLINE@116..117
-      0: NEWLINE@116..117 "\n" [] []
-    14: MD_NEWLINE@117..118
-      0: NEWLINE@117..118 "\n" [] []
-    15: MD_PARAGRAPH@118..130
-      0: MD_INLINE_ITEM_LIST@118..130
-        0: MD_TEXTUAL@118..129
-          0: MD_TEXTUAL_LITERAL@118..129 "before list" [] []
-        1: MD_TEXTUAL@129..130
-          0: MD_TEXTUAL_LITERAL@129..130 "\n" [] []
-    16: MD_BULLET_LIST_ITEM@130..137
-      0: MD_BULLET_LIST@130..137
-        0: MD_BULLET@130..137
-          0: MD_LIST_MARKER_PREFIX@130..132
-            0: MD_INDENT_TOKEN_LIST@130..130
-            1: MINUS@130..131 "-" [] []
-            2: MD_LIST_POST_MARKER_SPACE@131..132 " " [] []
-            3: MD_INDENT_TOKEN_LIST@132..132
-          1: MD_BLOCK_LIST@132..137
-            0: MD_PARAGRAPH@132..137
-              0: MD_INLINE_ITEM_LIST@132..137
-                0: MD_TEXTUAL@132..136
-                  0: MD_TEXTUAL_LITERAL@132..136 "item" [] []
-                1: MD_TEXTUAL@136..137
-                  0: MD_TEXTUAL_LITERAL@136..137 "\n" [] []
-    17: MD_NEWLINE@137..138
-      0: NEWLINE@137..138 "\n" [] []
-    18: MD_PARAGRAPH@138..150
-      0: MD_INLINE_ITEM_LIST@138..150
-        0: MD_TEXTUAL@138..149
-          0: MD_TEXTUAL_LITERAL@138..149 "before HTML" [] []
-        1: MD_TEXTUAL@149..150
-          0: MD_TEXTUAL_LITERAL@149..150 "\n" [] []
-    19: MD_HTML_BLOCK@150..161
-      0: MD_INDENT_TOKEN_LIST@150..150
-      1: MD_HTML_CONTENT@150..161
-        0: MD_HTML_LITERAL@150..161 "<div></div>" [] []
-    20: MD_NEWLINE@161..162
-      0: NEWLINE@161..162 "\n" [] []
-  3: EOF@162..162 "" [] []
+    8: MD_PARAGRAPH@75..94
+      0: MD_INLINE_ITEM_LIST@75..94
+        0: MD_TEXTUAL@75..93
+          0: MD_TEXTUAL_LITERAL@75..93 "before tilde fence" [] []
+        1: MD_TEXTUAL@93..94
+          0: MD_TEXTUAL_LITERAL@93..94 "\n" [] []
+    9: MD_FENCED_CODE_BLOCK@94..107
+      0: MD_INDENT_TOKEN_LIST@94..94
+      1: TRIPLE_TILDE@94..97 "~~~" [] []
+      2: MD_CODE_NAME_LIST@97..97
+      3: MD_INLINE_ITEM_LIST@97..104
+        0: MD_CODE_CONTENT@97..104
+          0: MD_CODE_LITERAL@97..104 "\nfence\n" [] []
+      4: MD_INDENT_TOKEN_LIST@104..104
+      5: TRIPLE_TILDE@104..107 "~~~" [] []
+    10: MD_NEWLINE@107..108
+      0: NEWLINE@107..108 "\n" [] []
+    11: MD_NEWLINE@108..109
+      0: NEWLINE@108..109 "\n" [] []
+    12: MD_PARAGRAPH@109..122
+      0: MD_INLINE_ITEM_LIST@109..122
+        0: MD_TEXTUAL@109..121
+          0: MD_TEXTUAL_LITERAL@109..121 "before quote" [] []
+        1: MD_TEXTUAL@121..122
+          0: MD_TEXTUAL_LITERAL@121..122 "\n" [] []
+    13: MD_QUOTE@122..130
+      0: MD_QUOTE_PREFIX@122..124
+        0: MD_QUOTE_INDENT_LIST@122..122
+        1: R_ANGLE@122..123 ">" [] []
+        2: MD_QUOTE_POST_MARKER_SPACE@123..124 " " [] []
+      1: MD_BLOCK_LIST@124..130
+        0: MD_PARAGRAPH@124..130
+          0: MD_INLINE_ITEM_LIST@124..130
+            0: MD_TEXTUAL@124..129
+              0: MD_TEXTUAL_LITERAL@124..129 "quote" [] []
+            1: MD_TEXTUAL@129..130
+              0: MD_TEXTUAL_LITERAL@129..130 "\n" [] []
+    14: MD_NEWLINE@130..131
+      0: NEWLINE@130..131 "\n" [] []
+    15: MD_PARAGRAPH@131..147
+      0: MD_INLINE_ITEM_LIST@131..147
+        0: MD_TEXTUAL@131..146
+          0: MD_TEXTUAL_LITERAL@131..146 "before thematic" [] []
+        1: MD_TEXTUAL@146..147
+          0: MD_TEXTUAL_LITERAL@146..147 "\n" [] []
+    16: MD_THEMATIC_BREAK_BLOCK@147..150
+      0: MD_THEMATIC_BREAK_PART_LIST@147..150
+        0: MD_THEMATIC_BREAK_CHAR@147..148
+          0: STAR@147..148 "*" [] []
+        1: MD_THEMATIC_BREAK_CHAR@148..149
+          0: STAR@148..149 "*" [] []
+        2: MD_THEMATIC_BREAK_CHAR@149..150
+          0: STAR@149..150 "*" [] []
+    17: MD_NEWLINE@150..151
+      0: NEWLINE@150..151 "\n" [] []
+    18: MD_NEWLINE@151..152
+      0: NEWLINE@151..152 "\n" [] []
+    19: MD_PARAGRAPH@152..179
+      0: MD_INLINE_ITEM_LIST@152..179
+        0: MD_TEXTUAL@152..178
+          0: MD_TEXTUAL_LITERAL@152..178 "before underscore thematic" [] []
+        1: MD_TEXTUAL@178..179
+          0: MD_TEXTUAL_LITERAL@178..179 "\n" [] []
+    20: MD_THEMATIC_BREAK_BLOCK@179..182
+      0: MD_THEMATIC_BREAK_PART_LIST@179..182
+        0: MD_THEMATIC_BREAK_CHAR@179..180
+          0: UNDERSCORE@179..180 "_" [] []
+        1: MD_THEMATIC_BREAK_CHAR@180..181
+          0: UNDERSCORE@180..181 "_" [] []
+        2: MD_THEMATIC_BREAK_CHAR@181..182
+          0: UNDERSCORE@181..182 "_" [] []
+    21: MD_NEWLINE@182..183
+      0: NEWLINE@182..183 "\n" [] []
+    22: MD_NEWLINE@183..184
+      0: NEWLINE@183..184 "\n" [] []
+    23: MD_PARAGRAPH@184..196
+      0: MD_INLINE_ITEM_LIST@184..196
+        0: MD_TEXTUAL@184..195
+          0: MD_TEXTUAL_LITERAL@184..195 "before list" [] []
+        1: MD_TEXTUAL@195..196
+          0: MD_TEXTUAL_LITERAL@195..196 "\n" [] []
+    24: MD_BULLET_LIST_ITEM@196..203
+      0: MD_BULLET_LIST@196..203
+        0: MD_BULLET@196..203
+          0: MD_LIST_MARKER_PREFIX@196..198
+            0: MD_INDENT_TOKEN_LIST@196..196
+            1: MINUS@196..197 "-" [] []
+            2: MD_LIST_POST_MARKER_SPACE@197..198 " " [] []
+            3: MD_INDENT_TOKEN_LIST@198..198
+          1: MD_BLOCK_LIST@198..203
+            0: MD_PARAGRAPH@198..203
+              0: MD_INLINE_ITEM_LIST@198..203
+                0: MD_TEXTUAL@198..202
+                  0: MD_TEXTUAL_LITERAL@198..202 "item" [] []
+                1: MD_TEXTUAL@202..203
+                  0: MD_TEXTUAL_LITERAL@202..203 "\n" [] []
+    25: MD_NEWLINE@203..204
+      0: NEWLINE@203..204 "\n" [] []
+    26: MD_PARAGRAPH@204..221
+      0: MD_INLINE_ITEM_LIST@204..221
+        0: MD_TEXTUAL@204..220
+          0: MD_TEXTUAL_LITERAL@204..220 "before plus list" [] []
+        1: MD_TEXTUAL@220..221
+          0: MD_TEXTUAL_LITERAL@220..221 "\n" [] []
+    27: MD_BULLET_LIST_ITEM@221..228
+      0: MD_BULLET_LIST@221..228
+        0: MD_BULLET@221..228
+          0: MD_LIST_MARKER_PREFIX@221..223
+            0: MD_INDENT_TOKEN_LIST@221..221
+            1: PLUS@221..222 "+" [] []
+            2: MD_LIST_POST_MARKER_SPACE@222..223 " " [] []
+            3: MD_INDENT_TOKEN_LIST@223..223
+          1: MD_BLOCK_LIST@223..228
+            0: MD_PARAGRAPH@223..228
+              0: MD_INLINE_ITEM_LIST@223..228
+                0: MD_TEXTUAL@223..227
+                  0: MD_TEXTUAL_LITERAL@223..227 "item" [] []
+                1: MD_TEXTUAL@227..228
+                  0: MD_TEXTUAL_LITERAL@227..228 "\n" [] []
+    28: MD_NEWLINE@228..229
+      0: NEWLINE@228..229 "\n" [] []
+    29: MD_PARAGRAPH@229..241
+      0: MD_INLINE_ITEM_LIST@229..241
+        0: MD_TEXTUAL@229..240
+          0: MD_TEXTUAL_LITERAL@229..240 "before HTML" [] []
+        1: MD_TEXTUAL@240..241
+          0: MD_TEXTUAL_LITERAL@240..241 "\n" [] []
+    30: MD_HTML_BLOCK@241..252
+      0: MD_INDENT_TOKEN_LIST@241..241
+      1: MD_HTML_CONTENT@241..252
+        0: MD_HTML_LITERAL@241..252 "<div></div>" [] []
+    31: MD_NEWLINE@252..253
+      0: NEWLINE@252..253 "\n" [] []
+  3: EOF@253..253 "" [] []
 
 ```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/byte_dispatched_block_starts.md
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/byte_dispatched_block_starts.md
@@ -12,6 +12,8 @@ top tilde fence
 
 ***
 
+___
+
 - top bullet
 
 + top plus bullet
@@ -36,8 +38,12 @@ top tilde fence
 
 - ---
 
+- ___
+
 - - nested bullet
 
 - 1. nested ordered
 
 - plain text
+
+plain paragraph

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/byte_dispatched_block_starts.md
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/byte_dispatched_block_starts.md
@@ -1,0 +1,43 @@
+# top heading
+
+```text
+top fence
+```
+
+~~~text
+top tilde fence
+~~~
+
+> top quote
+
+***
+
+- top bullet
+
++ top plus bullet
+
+1. top ordered
+
+<div>top html</div>
+
+[top]: /top
+
+- # list heading
+
+- > list quote
+
+- ```text
+  list fence
+  ```
+
+- <div>list html</div>
+
+- [list]: /list
+
+- ---
+
+- - nested bullet
+
+- 1. nested ordered
+
+- plain text

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/byte_dispatched_block_starts.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/byte_dispatched_block_starts.md.snap
@@ -1,0 +1,949 @@
+---
+source: crates/biome_markdown_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```
+# top heading
+
+```text
+top fence
+```
+
+~~~text
+top tilde fence
+~~~
+
+> top quote
+
+***
+
+- top bullet
+
++ top plus bullet
+
+1. top ordered
+
+<div>top html</div>
+
+[top]: /top
+
+- # list heading
+
+- > list quote
+
+- ```text
+  list fence
+  ```
+
+- <div>list html</div>
+
+- [list]: /list
+
+- ---
+
+- - nested bullet
+
+- 1. nested ordered
+
+- plain text
+
+```
+
+
+## AST
+
+```
+MdRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    value: MdBlockList [
+        MdHeader {
+            indent: MdIndentTokenList [],
+            before: MdHashList [
+                MdHash {
+                    hash_token: HASH@0..1 "#" [] [],
+                },
+            ],
+            content: MdParagraph {
+                list: MdInlineItemList [
+                    MdTextual {
+                        value_token: MD_TEXTUAL_LITERAL@1..13 " top heading" [] [],
+                    },
+                ],
+            },
+            after: MdHashList [],
+        },
+        MdNewline {
+            value_token: NEWLINE@13..14 "\n" [] [],
+        },
+        MdNewline {
+            value_token: NEWLINE@14..15 "\n" [] [],
+        },
+        MdFencedCodeBlock {
+            indent: MdIndentTokenList [],
+            l_fence: TRIPLE_BACKTICK@15..18 "```" [] [],
+            code_list: MdCodeNameList [
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@18..22 "text" [] [],
+                },
+            ],
+            content: MdInlineItemList [
+                MdCodeContent {
+                    value_token: MD_CODE_LITERAL@22..33 "\ntop fence\n" [] [],
+                },
+            ],
+            r_fence_indent: MdIndentTokenList [],
+            r_fence: TRIPLE_BACKTICK@33..36 "```" [] [],
+        },
+        MdNewline {
+            value_token: NEWLINE@36..37 "\n" [] [],
+        },
+        MdNewline {
+            value_token: NEWLINE@37..38 "\n" [] [],
+        },
+        MdFencedCodeBlock {
+            indent: MdIndentTokenList [],
+            l_fence: TRIPLE_TILDE@38..41 "~~~" [] [],
+            code_list: MdCodeNameList [
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@41..45 "text" [] [],
+                },
+            ],
+            content: MdInlineItemList [
+                MdCodeContent {
+                    value_token: MD_CODE_LITERAL@45..62 "\ntop tilde fence\n" [] [],
+                },
+            ],
+            r_fence_indent: MdIndentTokenList [],
+            r_fence: TRIPLE_TILDE@62..65 "~~~" [] [],
+        },
+        MdNewline {
+            value_token: NEWLINE@65..66 "\n" [] [],
+        },
+        MdNewline {
+            value_token: NEWLINE@66..67 "\n" [] [],
+        },
+        MdQuote {
+            prefix: MdQuotePrefix {
+                pre_marker_indent: MdQuoteIndentList [],
+                marker_token: R_ANGLE@67..68 ">" [] [],
+                post_marker_space_token: MD_QUOTE_POST_MARKER_SPACE@68..69 " " [] [],
+            },
+            content: MdBlockList [
+                MdParagraph {
+                    list: MdInlineItemList [
+                        MdTextual {
+                            value_token: MD_TEXTUAL_LITERAL@69..78 "top quote" [] [],
+                        },
+                        MdTextual {
+                            value_token: MD_TEXTUAL_LITERAL@78..79 "\n" [] [],
+                        },
+                    ],
+                },
+            ],
+        },
+        MdNewline {
+            value_token: NEWLINE@79..80 "\n" [] [],
+        },
+        MdThematicBreakBlock {
+            parts: MdThematicBreakPartList [
+                MdThematicBreakChar {
+                    value: STAR@80..81 "*" [] [],
+                },
+                MdThematicBreakChar {
+                    value: STAR@81..82 "*" [] [],
+                },
+                MdThematicBreakChar {
+                    value: STAR@82..83 "*" [] [],
+                },
+            ],
+        },
+        MdNewline {
+            value_token: NEWLINE@83..84 "\n" [] [],
+        },
+        MdNewline {
+            value_token: NEWLINE@84..85 "\n" [] [],
+        },
+        MdBulletListItem {
+            md_bullet_list: MdBulletList [
+                MdBullet {
+                    prefix: MdListMarkerPrefix {
+                        pre_marker_indent: MdIndentTokenList [],
+                        marker: MINUS@85..86 "-" [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@86..87 " " [] [],
+                        content_indent: MdIndentTokenList [],
+                    },
+                    content: MdBlockList [
+                        MdParagraph {
+                            list: MdInlineItemList [
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@87..97 "top bullet" [] [],
+                                },
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@97..98 "\n" [] [],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+        MdNewline {
+            value_token: NEWLINE@98..99 "\n" [] [],
+        },
+        MdBulletListItem {
+            md_bullet_list: MdBulletList [
+                MdBullet {
+                    prefix: MdListMarkerPrefix {
+                        pre_marker_indent: MdIndentTokenList [],
+                        marker: PLUS@99..100 "+" [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@100..101 " " [] [],
+                        content_indent: MdIndentTokenList [],
+                    },
+                    content: MdBlockList [
+                        MdParagraph {
+                            list: MdInlineItemList [
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@101..116 "top plus bullet" [] [],
+                                },
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@116..117 "\n" [] [],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+        MdNewline {
+            value_token: NEWLINE@117..118 "\n" [] [],
+        },
+        MdOrderedListItem {
+            md_bullet_list: MdBulletList [
+                MdBullet {
+                    prefix: MdListMarkerPrefix {
+                        pre_marker_indent: MdIndentTokenList [],
+                        marker: MD_ORDERED_LIST_MARKER@118..120 "1." [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@120..121 " " [] [],
+                        content_indent: MdIndentTokenList [],
+                    },
+                    content: MdBlockList [
+                        MdParagraph {
+                            list: MdInlineItemList [
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@121..132 "top ordered" [] [],
+                                },
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@132..133 "\n" [] [],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+        MdNewline {
+            value_token: NEWLINE@133..134 "\n" [] [],
+        },
+        MdHtmlBlock {
+            indent: MdIndentTokenList [],
+            content: MdHtmlContent {
+                value_token: MD_HTML_LITERAL@134..153 "<div>top html</div>" [] [],
+            },
+        },
+        MdNewline {
+            value_token: NEWLINE@153..154 "\n" [] [],
+        },
+        MdNewline {
+            value_token: NEWLINE@154..155 "\n" [] [],
+        },
+        MdLinkReferenceDefinition {
+            indent: MdIndentTokenList [],
+            l_brack_token: L_BRACK@155..156 "[" [] [],
+            label: MdLinkLabel {
+                content: MdInlineItemList [
+                    MdTextual {
+                        value_token: MD_TEXTUAL_LITERAL@156..159 "top" [] [],
+                    },
+                ],
+            },
+            r_brack_token: R_BRACK@159..160 "]" [] [],
+            colon_token: COLON@160..161 ":" [] [],
+            destination: MdLinkDestination {
+                content: MdInlineItemList [
+                    MdTextual {
+                        value_token: MD_TEXTUAL_LITERAL@161..162 " " [] [],
+                    },
+                    MdTextual {
+                        value_token: MD_TEXTUAL_LITERAL@162..166 "/top" [] [],
+                    },
+                ],
+            },
+            title: missing (optional),
+        },
+        MdNewline {
+            value_token: NEWLINE@166..167 "\n" [] [],
+        },
+        MdNewline {
+            value_token: NEWLINE@167..168 "\n" [] [],
+        },
+        MdBulletListItem {
+            md_bullet_list: MdBulletList [
+                MdBullet {
+                    prefix: MdListMarkerPrefix {
+                        pre_marker_indent: MdIndentTokenList [],
+                        marker: MINUS@168..169 "-" [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@169..170 " " [] [],
+                        content_indent: MdIndentTokenList [],
+                    },
+                    content: MdBlockList [
+                        MdHeader {
+                            indent: MdIndentTokenList [],
+                            before: MdHashList [
+                                MdHash {
+                                    hash_token: HASH@170..171 "#" [] [],
+                                },
+                            ],
+                            content: MdParagraph {
+                                list: MdInlineItemList [
+                                    MdTextual {
+                                        value_token: MD_TEXTUAL_LITERAL@171..184 " list heading" [] [],
+                                    },
+                                ],
+                            },
+                            after: MdHashList [],
+                        },
+                        MdNewline {
+                            value_token: NEWLINE@184..185 "\n" [] [],
+                        },
+                        MdNewline {
+                            value_token: NEWLINE@185..186 "\n" [] [],
+                        },
+                    ],
+                },
+                MdBullet {
+                    prefix: MdListMarkerPrefix {
+                        pre_marker_indent: MdIndentTokenList [],
+                        marker: MINUS@186..187 "-" [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@187..188 " " [] [],
+                        content_indent: MdIndentTokenList [],
+                    },
+                    content: MdBlockList [
+                        MdQuote {
+                            prefix: MdQuotePrefix {
+                                pre_marker_indent: MdQuoteIndentList [],
+                                marker_token: R_ANGLE@188..189 ">" [] [],
+                                post_marker_space_token: missing (optional),
+                            },
+                            content: MdBlockList [
+                                MdParagraph {
+                                    list: MdInlineItemList [
+                                        MdTextual {
+                                            value_token: MD_TEXTUAL_LITERAL@189..200 " list quote" [] [],
+                                        },
+                                        MdTextual {
+                                            value_token: MD_TEXTUAL_LITERAL@200..201 "\n" [] [],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                        MdNewline {
+                            value_token: NEWLINE@201..202 "\n" [] [],
+                        },
+                    ],
+                },
+                MdBullet {
+                    prefix: MdListMarkerPrefix {
+                        pre_marker_indent: MdIndentTokenList [],
+                        marker: MINUS@202..203 "-" [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@203..204 " " [] [],
+                        content_indent: MdIndentTokenList [],
+                    },
+                    content: MdBlockList [
+                        MdFencedCodeBlock {
+                            indent: MdIndentTokenList [],
+                            l_fence: TRIPLE_BACKTICK@204..207 "```" [] [],
+                            code_list: MdCodeNameList [
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@207..211 "text" [] [],
+                                },
+                            ],
+                            content: MdInlineItemList [
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@211..212 "\n" [] [],
+                                },
+                                MdIndentToken {
+                                    md_indent_char_token: MD_INDENT_CHAR@212..214 "  " [] [],
+                                },
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@214..224 "list fence" [] [],
+                                },
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@224..225 "\n" [] [],
+                                },
+                            ],
+                            r_fence_indent: MdIndentTokenList [
+                                MdIndentToken {
+                                    md_indent_char_token: MD_INDENT_CHAR@225..227 "  " [] [],
+                                },
+                            ],
+                            r_fence: TRIPLE_BACKTICK@227..230 "```" [] [],
+                        },
+                        MdNewline {
+                            value_token: NEWLINE@230..231 "\n" [] [],
+                        },
+                        MdNewline {
+                            value_token: NEWLINE@231..232 "\n" [] [],
+                        },
+                    ],
+                },
+                MdBullet {
+                    prefix: MdListMarkerPrefix {
+                        pre_marker_indent: MdIndentTokenList [],
+                        marker: MINUS@232..233 "-" [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@233..234 " " [] [],
+                        content_indent: MdIndentTokenList [],
+                    },
+                    content: MdBlockList [
+                        MdHtmlBlock {
+                            indent: MdIndentTokenList [],
+                            content: MdHtmlContent {
+                                value_token: MD_HTML_LITERAL@234..254 "<div>list html</div>" [] [],
+                            },
+                        },
+                        MdNewline {
+                            value_token: NEWLINE@254..255 "\n" [] [],
+                        },
+                        MdNewline {
+                            value_token: NEWLINE@255..256 "\n" [] [],
+                        },
+                    ],
+                },
+                MdBullet {
+                    prefix: MdListMarkerPrefix {
+                        pre_marker_indent: MdIndentTokenList [],
+                        marker: MINUS@256..257 "-" [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@257..258 " " [] [],
+                        content_indent: MdIndentTokenList [],
+                    },
+                    content: MdBlockList [
+                        MdLinkReferenceDefinition {
+                            indent: MdIndentTokenList [],
+                            l_brack_token: L_BRACK@258..259 "[" [] [],
+                            label: MdLinkLabel {
+                                content: MdInlineItemList [
+                                    MdTextual {
+                                        value_token: MD_TEXTUAL_LITERAL@259..263 "list" [] [],
+                                    },
+                                ],
+                            },
+                            r_brack_token: R_BRACK@263..264 "]" [] [],
+                            colon_token: COLON@264..265 ":" [] [],
+                            destination: MdLinkDestination {
+                                content: MdInlineItemList [
+                                    MdTextual {
+                                        value_token: MD_TEXTUAL_LITERAL@265..266 " " [] [],
+                                    },
+                                    MdTextual {
+                                        value_token: MD_TEXTUAL_LITERAL@266..271 "/list" [] [],
+                                    },
+                                ],
+                            },
+                            title: missing (optional),
+                        },
+                    ],
+                },
+            ],
+        },
+        MdNewline {
+            value_token: NEWLINE@271..272 "\n" [] [],
+        },
+        MdNewline {
+            value_token: NEWLINE@272..273 "\n" [] [],
+        },
+        MdThematicBreakBlock {
+            parts: MdThematicBreakPartList [
+                MdThematicBreakChar {
+                    value: MINUS@273..274 "-" [] [],
+                },
+                MdIndentToken {
+                    md_indent_char_token: MD_INDENT_CHAR@274..275 " " [] [],
+                },
+                MdThematicBreakChar {
+                    value: MINUS@275..276 "-" [] [],
+                },
+                MdThematicBreakChar {
+                    value: MINUS@276..277 "-" [] [],
+                },
+                MdThematicBreakChar {
+                    value: MINUS@277..278 "-" [] [],
+                },
+            ],
+        },
+        MdNewline {
+            value_token: NEWLINE@278..279 "\n" [] [],
+        },
+        MdNewline {
+            value_token: NEWLINE@279..280 "\n" [] [],
+        },
+        MdBulletListItem {
+            md_bullet_list: MdBulletList [
+                MdBullet {
+                    prefix: MdListMarkerPrefix {
+                        pre_marker_indent: MdIndentTokenList [],
+                        marker: MINUS@280..281 "-" [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@281..282 " " [] [],
+                        content_indent: MdIndentTokenList [],
+                    },
+                    content: MdBlockList [
+                        MdBulletListItem {
+                            md_bullet_list: MdBulletList [
+                                MdBullet {
+                                    prefix: MdListMarkerPrefix {
+                                        pre_marker_indent: MdIndentTokenList [],
+                                        marker: MINUS@282..283 "-" [] [],
+                                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@283..284 " " [] [],
+                                        content_indent: MdIndentTokenList [],
+                                    },
+                                    content: MdBlockList [
+                                        MdParagraph {
+                                            list: MdInlineItemList [
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@284..297 "nested bullet" [] [],
+                                                },
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@297..298 "\n" [] [],
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                        MdNewline {
+                            value_token: NEWLINE@298..299 "\n" [] [],
+                        },
+                    ],
+                },
+                MdBullet {
+                    prefix: MdListMarkerPrefix {
+                        pre_marker_indent: MdIndentTokenList [],
+                        marker: MINUS@299..300 "-" [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@300..301 " " [] [],
+                        content_indent: MdIndentTokenList [],
+                    },
+                    content: MdBlockList [
+                        MdOrderedListItem {
+                            md_bullet_list: MdBulletList [
+                                MdBullet {
+                                    prefix: MdListMarkerPrefix {
+                                        pre_marker_indent: MdIndentTokenList [],
+                                        marker: MD_ORDERED_LIST_MARKER@301..303 "1." [] [],
+                                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@303..304 " " [] [],
+                                        content_indent: MdIndentTokenList [],
+                                    },
+                                    content: MdBlockList [
+                                        MdParagraph {
+                                            list: MdInlineItemList [
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@304..318 "nested ordered" [] [],
+                                                },
+                                                MdTextual {
+                                                    value_token: MD_TEXTUAL_LITERAL@318..319 "\n" [] [],
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                        MdNewline {
+                            value_token: NEWLINE@319..320 "\n" [] [],
+                        },
+                    ],
+                },
+                MdBullet {
+                    prefix: MdListMarkerPrefix {
+                        pre_marker_indent: MdIndentTokenList [],
+                        marker: MINUS@320..321 "-" [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@321..322 " " [] [],
+                        content_indent: MdIndentTokenList [],
+                    },
+                    content: MdBlockList [
+                        MdParagraph {
+                            list: MdInlineItemList [
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@322..332 "plain text" [] [],
+                                },
+                                MdTextual {
+                                    value_token: MD_TEXTUAL_LITERAL@332..333 "\n" [] [],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+    eof_token: EOF@333..333 "" [] [],
+}
+```
+
+## CST
+
+```
+0: MD_ROOT@0..333
+  0: (empty)
+  1: (empty)
+  2: MD_BLOCK_LIST@0..333
+    0: MD_HEADER@0..13
+      0: MD_INDENT_TOKEN_LIST@0..0
+      1: MD_HASH_LIST@0..1
+        0: MD_HASH@0..1
+          0: HASH@0..1 "#" [] []
+      2: MD_PARAGRAPH@1..13
+        0: MD_INLINE_ITEM_LIST@1..13
+          0: MD_TEXTUAL@1..13
+            0: MD_TEXTUAL_LITERAL@1..13 " top heading" [] []
+      3: MD_HASH_LIST@13..13
+    1: MD_NEWLINE@13..14
+      0: NEWLINE@13..14 "\n" [] []
+    2: MD_NEWLINE@14..15
+      0: NEWLINE@14..15 "\n" [] []
+    3: MD_FENCED_CODE_BLOCK@15..36
+      0: MD_INDENT_TOKEN_LIST@15..15
+      1: TRIPLE_BACKTICK@15..18 "```" [] []
+      2: MD_CODE_NAME_LIST@18..22
+        0: MD_TEXTUAL@18..22
+          0: MD_TEXTUAL_LITERAL@18..22 "text" [] []
+      3: MD_INLINE_ITEM_LIST@22..33
+        0: MD_CODE_CONTENT@22..33
+          0: MD_CODE_LITERAL@22..33 "\ntop fence\n" [] []
+      4: MD_INDENT_TOKEN_LIST@33..33
+      5: TRIPLE_BACKTICK@33..36 "```" [] []
+    4: MD_NEWLINE@36..37
+      0: NEWLINE@36..37 "\n" [] []
+    5: MD_NEWLINE@37..38
+      0: NEWLINE@37..38 "\n" [] []
+    6: MD_FENCED_CODE_BLOCK@38..65
+      0: MD_INDENT_TOKEN_LIST@38..38
+      1: TRIPLE_TILDE@38..41 "~~~" [] []
+      2: MD_CODE_NAME_LIST@41..45
+        0: MD_TEXTUAL@41..45
+          0: MD_TEXTUAL_LITERAL@41..45 "text" [] []
+      3: MD_INLINE_ITEM_LIST@45..62
+        0: MD_CODE_CONTENT@45..62
+          0: MD_CODE_LITERAL@45..62 "\ntop tilde fence\n" [] []
+      4: MD_INDENT_TOKEN_LIST@62..62
+      5: TRIPLE_TILDE@62..65 "~~~" [] []
+    7: MD_NEWLINE@65..66
+      0: NEWLINE@65..66 "\n" [] []
+    8: MD_NEWLINE@66..67
+      0: NEWLINE@66..67 "\n" [] []
+    9: MD_QUOTE@67..79
+      0: MD_QUOTE_PREFIX@67..69
+        0: MD_QUOTE_INDENT_LIST@67..67
+        1: R_ANGLE@67..68 ">" [] []
+        2: MD_QUOTE_POST_MARKER_SPACE@68..69 " " [] []
+      1: MD_BLOCK_LIST@69..79
+        0: MD_PARAGRAPH@69..79
+          0: MD_INLINE_ITEM_LIST@69..79
+            0: MD_TEXTUAL@69..78
+              0: MD_TEXTUAL_LITERAL@69..78 "top quote" [] []
+            1: MD_TEXTUAL@78..79
+              0: MD_TEXTUAL_LITERAL@78..79 "\n" [] []
+    10: MD_NEWLINE@79..80
+      0: NEWLINE@79..80 "\n" [] []
+    11: MD_THEMATIC_BREAK_BLOCK@80..83
+      0: MD_THEMATIC_BREAK_PART_LIST@80..83
+        0: MD_THEMATIC_BREAK_CHAR@80..81
+          0: STAR@80..81 "*" [] []
+        1: MD_THEMATIC_BREAK_CHAR@81..82
+          0: STAR@81..82 "*" [] []
+        2: MD_THEMATIC_BREAK_CHAR@82..83
+          0: STAR@82..83 "*" [] []
+    12: MD_NEWLINE@83..84
+      0: NEWLINE@83..84 "\n" [] []
+    13: MD_NEWLINE@84..85
+      0: NEWLINE@84..85 "\n" [] []
+    14: MD_BULLET_LIST_ITEM@85..98
+      0: MD_BULLET_LIST@85..98
+        0: MD_BULLET@85..98
+          0: MD_LIST_MARKER_PREFIX@85..87
+            0: MD_INDENT_TOKEN_LIST@85..85
+            1: MINUS@85..86 "-" [] []
+            2: MD_LIST_POST_MARKER_SPACE@86..87 " " [] []
+            3: MD_INDENT_TOKEN_LIST@87..87
+          1: MD_BLOCK_LIST@87..98
+            0: MD_PARAGRAPH@87..98
+              0: MD_INLINE_ITEM_LIST@87..98
+                0: MD_TEXTUAL@87..97
+                  0: MD_TEXTUAL_LITERAL@87..97 "top bullet" [] []
+                1: MD_TEXTUAL@97..98
+                  0: MD_TEXTUAL_LITERAL@97..98 "\n" [] []
+    15: MD_NEWLINE@98..99
+      0: NEWLINE@98..99 "\n" [] []
+    16: MD_BULLET_LIST_ITEM@99..117
+      0: MD_BULLET_LIST@99..117
+        0: MD_BULLET@99..117
+          0: MD_LIST_MARKER_PREFIX@99..101
+            0: MD_INDENT_TOKEN_LIST@99..99
+            1: PLUS@99..100 "+" [] []
+            2: MD_LIST_POST_MARKER_SPACE@100..101 " " [] []
+            3: MD_INDENT_TOKEN_LIST@101..101
+          1: MD_BLOCK_LIST@101..117
+            0: MD_PARAGRAPH@101..117
+              0: MD_INLINE_ITEM_LIST@101..117
+                0: MD_TEXTUAL@101..116
+                  0: MD_TEXTUAL_LITERAL@101..116 "top plus bullet" [] []
+                1: MD_TEXTUAL@116..117
+                  0: MD_TEXTUAL_LITERAL@116..117 "\n" [] []
+    17: MD_NEWLINE@117..118
+      0: NEWLINE@117..118 "\n" [] []
+    18: MD_ORDERED_LIST_ITEM@118..133
+      0: MD_BULLET_LIST@118..133
+        0: MD_BULLET@118..133
+          0: MD_LIST_MARKER_PREFIX@118..121
+            0: MD_INDENT_TOKEN_LIST@118..118
+            1: MD_ORDERED_LIST_MARKER@118..120 "1." [] []
+            2: MD_LIST_POST_MARKER_SPACE@120..121 " " [] []
+            3: MD_INDENT_TOKEN_LIST@121..121
+          1: MD_BLOCK_LIST@121..133
+            0: MD_PARAGRAPH@121..133
+              0: MD_INLINE_ITEM_LIST@121..133
+                0: MD_TEXTUAL@121..132
+                  0: MD_TEXTUAL_LITERAL@121..132 "top ordered" [] []
+                1: MD_TEXTUAL@132..133
+                  0: MD_TEXTUAL_LITERAL@132..133 "\n" [] []
+    19: MD_NEWLINE@133..134
+      0: NEWLINE@133..134 "\n" [] []
+    20: MD_HTML_BLOCK@134..153
+      0: MD_INDENT_TOKEN_LIST@134..134
+      1: MD_HTML_CONTENT@134..153
+        0: MD_HTML_LITERAL@134..153 "<div>top html</div>" [] []
+    21: MD_NEWLINE@153..154
+      0: NEWLINE@153..154 "\n" [] []
+    22: MD_NEWLINE@154..155
+      0: NEWLINE@154..155 "\n" [] []
+    23: MD_LINK_REFERENCE_DEFINITION@155..166
+      0: MD_INDENT_TOKEN_LIST@155..155
+      1: L_BRACK@155..156 "[" [] []
+      2: MD_LINK_LABEL@156..159
+        0: MD_INLINE_ITEM_LIST@156..159
+          0: MD_TEXTUAL@156..159
+            0: MD_TEXTUAL_LITERAL@156..159 "top" [] []
+      3: R_BRACK@159..160 "]" [] []
+      4: COLON@160..161 ":" [] []
+      5: MD_LINK_DESTINATION@161..166
+        0: MD_INLINE_ITEM_LIST@161..166
+          0: MD_TEXTUAL@161..162
+            0: MD_TEXTUAL_LITERAL@161..162 " " [] []
+          1: MD_TEXTUAL@162..166
+            0: MD_TEXTUAL_LITERAL@162..166 "/top" [] []
+      6: (empty)
+    24: MD_NEWLINE@166..167
+      0: NEWLINE@166..167 "\n" [] []
+    25: MD_NEWLINE@167..168
+      0: NEWLINE@167..168 "\n" [] []
+    26: MD_BULLET_LIST_ITEM@168..271
+      0: MD_BULLET_LIST@168..271
+        0: MD_BULLET@168..186
+          0: MD_LIST_MARKER_PREFIX@168..170
+            0: MD_INDENT_TOKEN_LIST@168..168
+            1: MINUS@168..169 "-" [] []
+            2: MD_LIST_POST_MARKER_SPACE@169..170 " " [] []
+            3: MD_INDENT_TOKEN_LIST@170..170
+          1: MD_BLOCK_LIST@170..186
+            0: MD_HEADER@170..184
+              0: MD_INDENT_TOKEN_LIST@170..170
+              1: MD_HASH_LIST@170..171
+                0: MD_HASH@170..171
+                  0: HASH@170..171 "#" [] []
+              2: MD_PARAGRAPH@171..184
+                0: MD_INLINE_ITEM_LIST@171..184
+                  0: MD_TEXTUAL@171..184
+                    0: MD_TEXTUAL_LITERAL@171..184 " list heading" [] []
+              3: MD_HASH_LIST@184..184
+            1: MD_NEWLINE@184..185
+              0: NEWLINE@184..185 "\n" [] []
+            2: MD_NEWLINE@185..186
+              0: NEWLINE@185..186 "\n" [] []
+        1: MD_BULLET@186..202
+          0: MD_LIST_MARKER_PREFIX@186..188
+            0: MD_INDENT_TOKEN_LIST@186..186
+            1: MINUS@186..187 "-" [] []
+            2: MD_LIST_POST_MARKER_SPACE@187..188 " " [] []
+            3: MD_INDENT_TOKEN_LIST@188..188
+          1: MD_BLOCK_LIST@188..202
+            0: MD_QUOTE@188..201
+              0: MD_QUOTE_PREFIX@188..189
+                0: MD_QUOTE_INDENT_LIST@188..188
+                1: R_ANGLE@188..189 ">" [] []
+                2: (empty)
+              1: MD_BLOCK_LIST@189..201
+                0: MD_PARAGRAPH@189..201
+                  0: MD_INLINE_ITEM_LIST@189..201
+                    0: MD_TEXTUAL@189..200
+                      0: MD_TEXTUAL_LITERAL@189..200 " list quote" [] []
+                    1: MD_TEXTUAL@200..201
+                      0: MD_TEXTUAL_LITERAL@200..201 "\n" [] []
+            1: MD_NEWLINE@201..202
+              0: NEWLINE@201..202 "\n" [] []
+        2: MD_BULLET@202..232
+          0: MD_LIST_MARKER_PREFIX@202..204
+            0: MD_INDENT_TOKEN_LIST@202..202
+            1: MINUS@202..203 "-" [] []
+            2: MD_LIST_POST_MARKER_SPACE@203..204 " " [] []
+            3: MD_INDENT_TOKEN_LIST@204..204
+          1: MD_BLOCK_LIST@204..232
+            0: MD_FENCED_CODE_BLOCK@204..230
+              0: MD_INDENT_TOKEN_LIST@204..204
+              1: TRIPLE_BACKTICK@204..207 "```" [] []
+              2: MD_CODE_NAME_LIST@207..211
+                0: MD_TEXTUAL@207..211
+                  0: MD_TEXTUAL_LITERAL@207..211 "text" [] []
+              3: MD_INLINE_ITEM_LIST@211..225
+                0: MD_TEXTUAL@211..212
+                  0: MD_TEXTUAL_LITERAL@211..212 "\n" [] []
+                1: MD_INDENT_TOKEN@212..214
+                  0: MD_INDENT_CHAR@212..214 "  " [] []
+                2: MD_TEXTUAL@214..224
+                  0: MD_TEXTUAL_LITERAL@214..224 "list fence" [] []
+                3: MD_TEXTUAL@224..225
+                  0: MD_TEXTUAL_LITERAL@224..225 "\n" [] []
+              4: MD_INDENT_TOKEN_LIST@225..227
+                0: MD_INDENT_TOKEN@225..227
+                  0: MD_INDENT_CHAR@225..227 "  " [] []
+              5: TRIPLE_BACKTICK@227..230 "```" [] []
+            1: MD_NEWLINE@230..231
+              0: NEWLINE@230..231 "\n" [] []
+            2: MD_NEWLINE@231..232
+              0: NEWLINE@231..232 "\n" [] []
+        3: MD_BULLET@232..256
+          0: MD_LIST_MARKER_PREFIX@232..234
+            0: MD_INDENT_TOKEN_LIST@232..232
+            1: MINUS@232..233 "-" [] []
+            2: MD_LIST_POST_MARKER_SPACE@233..234 " " [] []
+            3: MD_INDENT_TOKEN_LIST@234..234
+          1: MD_BLOCK_LIST@234..256
+            0: MD_HTML_BLOCK@234..254
+              0: MD_INDENT_TOKEN_LIST@234..234
+              1: MD_HTML_CONTENT@234..254
+                0: MD_HTML_LITERAL@234..254 "<div>list html</div>" [] []
+            1: MD_NEWLINE@254..255
+              0: NEWLINE@254..255 "\n" [] []
+            2: MD_NEWLINE@255..256
+              0: NEWLINE@255..256 "\n" [] []
+        4: MD_BULLET@256..271
+          0: MD_LIST_MARKER_PREFIX@256..258
+            0: MD_INDENT_TOKEN_LIST@256..256
+            1: MINUS@256..257 "-" [] []
+            2: MD_LIST_POST_MARKER_SPACE@257..258 " " [] []
+            3: MD_INDENT_TOKEN_LIST@258..258
+          1: MD_BLOCK_LIST@258..271
+            0: MD_LINK_REFERENCE_DEFINITION@258..271
+              0: MD_INDENT_TOKEN_LIST@258..258
+              1: L_BRACK@258..259 "[" [] []
+              2: MD_LINK_LABEL@259..263
+                0: MD_INLINE_ITEM_LIST@259..263
+                  0: MD_TEXTUAL@259..263
+                    0: MD_TEXTUAL_LITERAL@259..263 "list" [] []
+              3: R_BRACK@263..264 "]" [] []
+              4: COLON@264..265 ":" [] []
+              5: MD_LINK_DESTINATION@265..271
+                0: MD_INLINE_ITEM_LIST@265..271
+                  0: MD_TEXTUAL@265..266
+                    0: MD_TEXTUAL_LITERAL@265..266 " " [] []
+                  1: MD_TEXTUAL@266..271
+                    0: MD_TEXTUAL_LITERAL@266..271 "/list" [] []
+              6: (empty)
+    27: MD_NEWLINE@271..272
+      0: NEWLINE@271..272 "\n" [] []
+    28: MD_NEWLINE@272..273
+      0: NEWLINE@272..273 "\n" [] []
+    29: MD_THEMATIC_BREAK_BLOCK@273..278
+      0: MD_THEMATIC_BREAK_PART_LIST@273..278
+        0: MD_THEMATIC_BREAK_CHAR@273..274
+          0: MINUS@273..274 "-" [] []
+        1: MD_INDENT_TOKEN@274..275
+          0: MD_INDENT_CHAR@274..275 " " [] []
+        2: MD_THEMATIC_BREAK_CHAR@275..276
+          0: MINUS@275..276 "-" [] []
+        3: MD_THEMATIC_BREAK_CHAR@276..277
+          0: MINUS@276..277 "-" [] []
+        4: MD_THEMATIC_BREAK_CHAR@277..278
+          0: MINUS@277..278 "-" [] []
+    30: MD_NEWLINE@278..279
+      0: NEWLINE@278..279 "\n" [] []
+    31: MD_NEWLINE@279..280
+      0: NEWLINE@279..280 "\n" [] []
+    32: MD_BULLET_LIST_ITEM@280..333
+      0: MD_BULLET_LIST@280..333
+        0: MD_BULLET@280..299
+          0: MD_LIST_MARKER_PREFIX@280..282
+            0: MD_INDENT_TOKEN_LIST@280..280
+            1: MINUS@280..281 "-" [] []
+            2: MD_LIST_POST_MARKER_SPACE@281..282 " " [] []
+            3: MD_INDENT_TOKEN_LIST@282..282
+          1: MD_BLOCK_LIST@282..299
+            0: MD_BULLET_LIST_ITEM@282..298
+              0: MD_BULLET_LIST@282..298
+                0: MD_BULLET@282..298
+                  0: MD_LIST_MARKER_PREFIX@282..284
+                    0: MD_INDENT_TOKEN_LIST@282..282
+                    1: MINUS@282..283 "-" [] []
+                    2: MD_LIST_POST_MARKER_SPACE@283..284 " " [] []
+                    3: MD_INDENT_TOKEN_LIST@284..284
+                  1: MD_BLOCK_LIST@284..298
+                    0: MD_PARAGRAPH@284..298
+                      0: MD_INLINE_ITEM_LIST@284..298
+                        0: MD_TEXTUAL@284..297
+                          0: MD_TEXTUAL_LITERAL@284..297 "nested bullet" [] []
+                        1: MD_TEXTUAL@297..298
+                          0: MD_TEXTUAL_LITERAL@297..298 "\n" [] []
+            1: MD_NEWLINE@298..299
+              0: NEWLINE@298..299 "\n" [] []
+        1: MD_BULLET@299..320
+          0: MD_LIST_MARKER_PREFIX@299..301
+            0: MD_INDENT_TOKEN_LIST@299..299
+            1: MINUS@299..300 "-" [] []
+            2: MD_LIST_POST_MARKER_SPACE@300..301 " " [] []
+            3: MD_INDENT_TOKEN_LIST@301..301
+          1: MD_BLOCK_LIST@301..320
+            0: MD_ORDERED_LIST_ITEM@301..319
+              0: MD_BULLET_LIST@301..319
+                0: MD_BULLET@301..319
+                  0: MD_LIST_MARKER_PREFIX@301..304
+                    0: MD_INDENT_TOKEN_LIST@301..301
+                    1: MD_ORDERED_LIST_MARKER@301..303 "1." [] []
+                    2: MD_LIST_POST_MARKER_SPACE@303..304 " " [] []
+                    3: MD_INDENT_TOKEN_LIST@304..304
+                  1: MD_BLOCK_LIST@304..319
+                    0: MD_PARAGRAPH@304..319
+                      0: MD_INLINE_ITEM_LIST@304..319
+                        0: MD_TEXTUAL@304..318
+                          0: MD_TEXTUAL_LITERAL@304..318 "nested ordered" [] []
+                        1: MD_TEXTUAL@318..319
+                          0: MD_TEXTUAL_LITERAL@318..319 "\n" [] []
+            1: MD_NEWLINE@319..320
+              0: NEWLINE@319..320 "\n" [] []
+        2: MD_BULLET@320..333
+          0: MD_LIST_MARKER_PREFIX@320..322
+            0: MD_INDENT_TOKEN_LIST@320..320
+            1: MINUS@320..321 "-" [] []
+            2: MD_LIST_POST_MARKER_SPACE@321..322 " " [] []
+            3: MD_INDENT_TOKEN_LIST@322..322
+          1: MD_BLOCK_LIST@322..333
+            0: MD_PARAGRAPH@322..333
+              0: MD_INLINE_ITEM_LIST@322..333
+                0: MD_TEXTUAL@322..332
+                  0: MD_TEXTUAL_LITERAL@322..332 "plain text" [] []
+                1: MD_TEXTUAL@332..333
+                  0: MD_TEXTUAL_LITERAL@332..333 "\n" [] []
+  3: EOF@333..333 "" [] []
+
+```

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/byte_dispatched_block_starts.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/byte_dispatched_block_starts.md.snap
@@ -20,6 +20,8 @@ top tilde fence
 
 ***
 
+___
+
 - top bullet
 
 + top plus bullet
@@ -44,11 +46,15 @@ top tilde fence
 
 - ---
 
+- ___
+
 - - nested bullet
 
 - 1. nested ordered
 
 - plain text
+
+plain paragraph
 
 ```
 
@@ -167,23 +173,42 @@ MdRoot {
         MdNewline {
             value_token: NEWLINE@84..85 "\n" [] [],
         },
+        MdThematicBreakBlock {
+            parts: MdThematicBreakPartList [
+                MdThematicBreakChar {
+                    value: UNDERSCORE@85..86 "_" [] [],
+                },
+                MdThematicBreakChar {
+                    value: UNDERSCORE@86..87 "_" [] [],
+                },
+                MdThematicBreakChar {
+                    value: UNDERSCORE@87..88 "_" [] [],
+                },
+            ],
+        },
+        MdNewline {
+            value_token: NEWLINE@88..89 "\n" [] [],
+        },
+        MdNewline {
+            value_token: NEWLINE@89..90 "\n" [] [],
+        },
         MdBulletListItem {
             md_bullet_list: MdBulletList [
                 MdBullet {
                     prefix: MdListMarkerPrefix {
                         pre_marker_indent: MdIndentTokenList [],
-                        marker: MINUS@85..86 "-" [] [],
-                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@86..87 " " [] [],
+                        marker: MINUS@90..91 "-" [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@91..92 " " [] [],
                         content_indent: MdIndentTokenList [],
                     },
                     content: MdBlockList [
                         MdParagraph {
                             list: MdInlineItemList [
                                 MdTextual {
-                                    value_token: MD_TEXTUAL_LITERAL@87..97 "top bullet" [] [],
+                                    value_token: MD_TEXTUAL_LITERAL@92..102 "top bullet" [] [],
                                 },
                                 MdTextual {
-                                    value_token: MD_TEXTUAL_LITERAL@97..98 "\n" [] [],
+                                    value_token: MD_TEXTUAL_LITERAL@102..103 "\n" [] [],
                                 },
                             ],
                         },
@@ -192,25 +217,25 @@ MdRoot {
             ],
         },
         MdNewline {
-            value_token: NEWLINE@98..99 "\n" [] [],
+            value_token: NEWLINE@103..104 "\n" [] [],
         },
         MdBulletListItem {
             md_bullet_list: MdBulletList [
                 MdBullet {
                     prefix: MdListMarkerPrefix {
                         pre_marker_indent: MdIndentTokenList [],
-                        marker: PLUS@99..100 "+" [] [],
-                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@100..101 " " [] [],
+                        marker: PLUS@104..105 "+" [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@105..106 " " [] [],
                         content_indent: MdIndentTokenList [],
                     },
                     content: MdBlockList [
                         MdParagraph {
                             list: MdInlineItemList [
                                 MdTextual {
-                                    value_token: MD_TEXTUAL_LITERAL@101..116 "top plus bullet" [] [],
+                                    value_token: MD_TEXTUAL_LITERAL@106..121 "top plus bullet" [] [],
                                 },
                                 MdTextual {
-                                    value_token: MD_TEXTUAL_LITERAL@116..117 "\n" [] [],
+                                    value_token: MD_TEXTUAL_LITERAL@121..122 "\n" [] [],
                                 },
                             ],
                         },
@@ -219,25 +244,25 @@ MdRoot {
             ],
         },
         MdNewline {
-            value_token: NEWLINE@117..118 "\n" [] [],
+            value_token: NEWLINE@122..123 "\n" [] [],
         },
         MdOrderedListItem {
             md_bullet_list: MdBulletList [
                 MdBullet {
                     prefix: MdListMarkerPrefix {
                         pre_marker_indent: MdIndentTokenList [],
-                        marker: MD_ORDERED_LIST_MARKER@118..120 "1." [] [],
-                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@120..121 " " [] [],
+                        marker: MD_ORDERED_LIST_MARKER@123..125 "1." [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@125..126 " " [] [],
                         content_indent: MdIndentTokenList [],
                     },
                     content: MdBlockList [
                         MdParagraph {
                             list: MdInlineItemList [
                                 MdTextual {
-                                    value_token: MD_TEXTUAL_LITERAL@121..132 "top ordered" [] [],
+                                    value_token: MD_TEXTUAL_LITERAL@126..137 "top ordered" [] [],
                                 },
                                 MdTextual {
-                                    value_token: MD_TEXTUAL_LITERAL@132..133 "\n" [] [],
+                                    value_token: MD_TEXTUAL_LITERAL@137..138 "\n" [] [],
                                 },
                             ],
                         },
@@ -246,57 +271,57 @@ MdRoot {
             ],
         },
         MdNewline {
-            value_token: NEWLINE@133..134 "\n" [] [],
+            value_token: NEWLINE@138..139 "\n" [] [],
         },
         MdHtmlBlock {
             indent: MdIndentTokenList [],
             content: MdHtmlContent {
-                value_token: MD_HTML_LITERAL@134..153 "<div>top html</div>" [] [],
+                value_token: MD_HTML_LITERAL@139..158 "<div>top html</div>" [] [],
             },
         },
         MdNewline {
-            value_token: NEWLINE@153..154 "\n" [] [],
+            value_token: NEWLINE@158..159 "\n" [] [],
         },
         MdNewline {
-            value_token: NEWLINE@154..155 "\n" [] [],
+            value_token: NEWLINE@159..160 "\n" [] [],
         },
         MdLinkReferenceDefinition {
             indent: MdIndentTokenList [],
-            l_brack_token: L_BRACK@155..156 "[" [] [],
+            l_brack_token: L_BRACK@160..161 "[" [] [],
             label: MdLinkLabel {
                 content: MdInlineItemList [
                     MdTextual {
-                        value_token: MD_TEXTUAL_LITERAL@156..159 "top" [] [],
+                        value_token: MD_TEXTUAL_LITERAL@161..164 "top" [] [],
                     },
                 ],
             },
-            r_brack_token: R_BRACK@159..160 "]" [] [],
-            colon_token: COLON@160..161 ":" [] [],
+            r_brack_token: R_BRACK@164..165 "]" [] [],
+            colon_token: COLON@165..166 ":" [] [],
             destination: MdLinkDestination {
                 content: MdInlineItemList [
                     MdTextual {
-                        value_token: MD_TEXTUAL_LITERAL@161..162 " " [] [],
+                        value_token: MD_TEXTUAL_LITERAL@166..167 " " [] [],
                     },
                     MdTextual {
-                        value_token: MD_TEXTUAL_LITERAL@162..166 "/top" [] [],
+                        value_token: MD_TEXTUAL_LITERAL@167..171 "/top" [] [],
                     },
                 ],
             },
             title: missing (optional),
         },
         MdNewline {
-            value_token: NEWLINE@166..167 "\n" [] [],
+            value_token: NEWLINE@171..172 "\n" [] [],
         },
         MdNewline {
-            value_token: NEWLINE@167..168 "\n" [] [],
+            value_token: NEWLINE@172..173 "\n" [] [],
         },
         MdBulletListItem {
             md_bullet_list: MdBulletList [
                 MdBullet {
                     prefix: MdListMarkerPrefix {
                         pre_marker_indent: MdIndentTokenList [],
-                        marker: MINUS@168..169 "-" [] [],
-                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@169..170 " " [] [],
+                        marker: MINUS@173..174 "-" [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@174..175 " " [] [],
                         content_indent: MdIndentTokenList [],
                     },
                     content: MdBlockList [
@@ -304,152 +329,152 @@ MdRoot {
                             indent: MdIndentTokenList [],
                             before: MdHashList [
                                 MdHash {
-                                    hash_token: HASH@170..171 "#" [] [],
+                                    hash_token: HASH@175..176 "#" [] [],
                                 },
                             ],
                             content: MdParagraph {
                                 list: MdInlineItemList [
                                     MdTextual {
-                                        value_token: MD_TEXTUAL_LITERAL@171..184 " list heading" [] [],
+                                        value_token: MD_TEXTUAL_LITERAL@176..189 " list heading" [] [],
                                     },
                                 ],
                             },
                             after: MdHashList [],
                         },
                         MdNewline {
-                            value_token: NEWLINE@184..185 "\n" [] [],
+                            value_token: NEWLINE@189..190 "\n" [] [],
                         },
                         MdNewline {
-                            value_token: NEWLINE@185..186 "\n" [] [],
+                            value_token: NEWLINE@190..191 "\n" [] [],
                         },
                     ],
                 },
                 MdBullet {
                     prefix: MdListMarkerPrefix {
                         pre_marker_indent: MdIndentTokenList [],
-                        marker: MINUS@186..187 "-" [] [],
-                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@187..188 " " [] [],
+                        marker: MINUS@191..192 "-" [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@192..193 " " [] [],
                         content_indent: MdIndentTokenList [],
                     },
                     content: MdBlockList [
                         MdQuote {
                             prefix: MdQuotePrefix {
                                 pre_marker_indent: MdQuoteIndentList [],
-                                marker_token: R_ANGLE@188..189 ">" [] [],
+                                marker_token: R_ANGLE@193..194 ">" [] [],
                                 post_marker_space_token: missing (optional),
                             },
                             content: MdBlockList [
                                 MdParagraph {
                                     list: MdInlineItemList [
                                         MdTextual {
-                                            value_token: MD_TEXTUAL_LITERAL@189..200 " list quote" [] [],
+                                            value_token: MD_TEXTUAL_LITERAL@194..205 " list quote" [] [],
                                         },
                                         MdTextual {
-                                            value_token: MD_TEXTUAL_LITERAL@200..201 "\n" [] [],
+                                            value_token: MD_TEXTUAL_LITERAL@205..206 "\n" [] [],
                                         },
                                     ],
                                 },
                             ],
                         },
                         MdNewline {
-                            value_token: NEWLINE@201..202 "\n" [] [],
+                            value_token: NEWLINE@206..207 "\n" [] [],
                         },
                     ],
                 },
                 MdBullet {
                     prefix: MdListMarkerPrefix {
                         pre_marker_indent: MdIndentTokenList [],
-                        marker: MINUS@202..203 "-" [] [],
-                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@203..204 " " [] [],
+                        marker: MINUS@207..208 "-" [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@208..209 " " [] [],
                         content_indent: MdIndentTokenList [],
                     },
                     content: MdBlockList [
                         MdFencedCodeBlock {
                             indent: MdIndentTokenList [],
-                            l_fence: TRIPLE_BACKTICK@204..207 "```" [] [],
+                            l_fence: TRIPLE_BACKTICK@209..212 "```" [] [],
                             code_list: MdCodeNameList [
                                 MdTextual {
-                                    value_token: MD_TEXTUAL_LITERAL@207..211 "text" [] [],
+                                    value_token: MD_TEXTUAL_LITERAL@212..216 "text" [] [],
                                 },
                             ],
                             content: MdInlineItemList [
                                 MdTextual {
-                                    value_token: MD_TEXTUAL_LITERAL@211..212 "\n" [] [],
+                                    value_token: MD_TEXTUAL_LITERAL@216..217 "\n" [] [],
                                 },
                                 MdIndentToken {
-                                    md_indent_char_token: MD_INDENT_CHAR@212..214 "  " [] [],
+                                    md_indent_char_token: MD_INDENT_CHAR@217..219 "  " [] [],
                                 },
                                 MdTextual {
-                                    value_token: MD_TEXTUAL_LITERAL@214..224 "list fence" [] [],
+                                    value_token: MD_TEXTUAL_LITERAL@219..229 "list fence" [] [],
                                 },
                                 MdTextual {
-                                    value_token: MD_TEXTUAL_LITERAL@224..225 "\n" [] [],
+                                    value_token: MD_TEXTUAL_LITERAL@229..230 "\n" [] [],
                                 },
                             ],
                             r_fence_indent: MdIndentTokenList [
                                 MdIndentToken {
-                                    md_indent_char_token: MD_INDENT_CHAR@225..227 "  " [] [],
+                                    md_indent_char_token: MD_INDENT_CHAR@230..232 "  " [] [],
                                 },
                             ],
-                            r_fence: TRIPLE_BACKTICK@227..230 "```" [] [],
+                            r_fence: TRIPLE_BACKTICK@232..235 "```" [] [],
                         },
                         MdNewline {
-                            value_token: NEWLINE@230..231 "\n" [] [],
+                            value_token: NEWLINE@235..236 "\n" [] [],
                         },
                         MdNewline {
-                            value_token: NEWLINE@231..232 "\n" [] [],
+                            value_token: NEWLINE@236..237 "\n" [] [],
                         },
                     ],
                 },
                 MdBullet {
                     prefix: MdListMarkerPrefix {
                         pre_marker_indent: MdIndentTokenList [],
-                        marker: MINUS@232..233 "-" [] [],
-                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@233..234 " " [] [],
+                        marker: MINUS@237..238 "-" [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@238..239 " " [] [],
                         content_indent: MdIndentTokenList [],
                     },
                     content: MdBlockList [
                         MdHtmlBlock {
                             indent: MdIndentTokenList [],
                             content: MdHtmlContent {
-                                value_token: MD_HTML_LITERAL@234..254 "<div>list html</div>" [] [],
+                                value_token: MD_HTML_LITERAL@239..259 "<div>list html</div>" [] [],
                             },
                         },
                         MdNewline {
-                            value_token: NEWLINE@254..255 "\n" [] [],
+                            value_token: NEWLINE@259..260 "\n" [] [],
                         },
                         MdNewline {
-                            value_token: NEWLINE@255..256 "\n" [] [],
+                            value_token: NEWLINE@260..261 "\n" [] [],
                         },
                     ],
                 },
                 MdBullet {
                     prefix: MdListMarkerPrefix {
                         pre_marker_indent: MdIndentTokenList [],
-                        marker: MINUS@256..257 "-" [] [],
-                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@257..258 " " [] [],
+                        marker: MINUS@261..262 "-" [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@262..263 " " [] [],
                         content_indent: MdIndentTokenList [],
                     },
                     content: MdBlockList [
                         MdLinkReferenceDefinition {
                             indent: MdIndentTokenList [],
-                            l_brack_token: L_BRACK@258..259 "[" [] [],
+                            l_brack_token: L_BRACK@263..264 "[" [] [],
                             label: MdLinkLabel {
                                 content: MdInlineItemList [
                                     MdTextual {
-                                        value_token: MD_TEXTUAL_LITERAL@259..263 "list" [] [],
+                                        value_token: MD_TEXTUAL_LITERAL@264..268 "list" [] [],
                                     },
                                 ],
                             },
-                            r_brack_token: R_BRACK@263..264 "]" [] [],
-                            colon_token: COLON@264..265 ":" [] [],
+                            r_brack_token: R_BRACK@268..269 "]" [] [],
+                            colon_token: COLON@269..270 ":" [] [],
                             destination: MdLinkDestination {
                                 content: MdInlineItemList [
                                     MdTextual {
-                                        value_token: MD_TEXTUAL_LITERAL@265..266 " " [] [],
+                                        value_token: MD_TEXTUAL_LITERAL@270..271 " " [] [],
                                     },
                                     MdTextual {
-                                        value_token: MD_TEXTUAL_LITERAL@266..271 "/list" [] [],
+                                        value_token: MD_TEXTUAL_LITERAL@271..276 "/list" [] [],
                                     },
                                 ],
                             },
@@ -460,43 +485,72 @@ MdRoot {
             ],
         },
         MdNewline {
-            value_token: NEWLINE@271..272 "\n" [] [],
+            value_token: NEWLINE@276..277 "\n" [] [],
         },
         MdNewline {
-            value_token: NEWLINE@272..273 "\n" [] [],
+            value_token: NEWLINE@277..278 "\n" [] [],
         },
         MdThematicBreakBlock {
             parts: MdThematicBreakPartList [
                 MdThematicBreakChar {
-                    value: MINUS@273..274 "-" [] [],
+                    value: MINUS@278..279 "-" [] [],
                 },
                 MdIndentToken {
-                    md_indent_char_token: MD_INDENT_CHAR@274..275 " " [] [],
+                    md_indent_char_token: MD_INDENT_CHAR@279..280 " " [] [],
                 },
                 MdThematicBreakChar {
-                    value: MINUS@275..276 "-" [] [],
+                    value: MINUS@280..281 "-" [] [],
                 },
                 MdThematicBreakChar {
-                    value: MINUS@276..277 "-" [] [],
+                    value: MINUS@281..282 "-" [] [],
                 },
                 MdThematicBreakChar {
-                    value: MINUS@277..278 "-" [] [],
+                    value: MINUS@282..283 "-" [] [],
                 },
             ],
         },
         MdNewline {
-            value_token: NEWLINE@278..279 "\n" [] [],
+            value_token: NEWLINE@283..284 "\n" [] [],
         },
         MdNewline {
-            value_token: NEWLINE@279..280 "\n" [] [],
+            value_token: NEWLINE@284..285 "\n" [] [],
         },
         MdBulletListItem {
             md_bullet_list: MdBulletList [
                 MdBullet {
                     prefix: MdListMarkerPrefix {
                         pre_marker_indent: MdIndentTokenList [],
-                        marker: MINUS@280..281 "-" [] [],
-                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@281..282 " " [] [],
+                        marker: MINUS@285..286 "-" [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@286..287 " " [] [],
+                        content_indent: MdIndentTokenList [],
+                    },
+                    content: MdBlockList [
+                        MdThematicBreakBlock {
+                            parts: MdThematicBreakPartList [
+                                MdThematicBreakChar {
+                                    value: UNDERSCORE@287..288 "_" [] [],
+                                },
+                                MdThematicBreakChar {
+                                    value: UNDERSCORE@288..289 "_" [] [],
+                                },
+                                MdThematicBreakChar {
+                                    value: UNDERSCORE@289..290 "_" [] [],
+                                },
+                            ],
+                        },
+                        MdNewline {
+                            value_token: NEWLINE@290..291 "\n" [] [],
+                        },
+                        MdNewline {
+                            value_token: NEWLINE@291..292 "\n" [] [],
+                        },
+                    ],
+                },
+                MdBullet {
+                    prefix: MdListMarkerPrefix {
+                        pre_marker_indent: MdIndentTokenList [],
+                        marker: MINUS@292..293 "-" [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@293..294 " " [] [],
                         content_indent: MdIndentTokenList [],
                     },
                     content: MdBlockList [
@@ -505,18 +559,18 @@ MdRoot {
                                 MdBullet {
                                     prefix: MdListMarkerPrefix {
                                         pre_marker_indent: MdIndentTokenList [],
-                                        marker: MINUS@282..283 "-" [] [],
-                                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@283..284 " " [] [],
+                                        marker: MINUS@294..295 "-" [] [],
+                                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@295..296 " " [] [],
                                         content_indent: MdIndentTokenList [],
                                     },
                                     content: MdBlockList [
                                         MdParagraph {
                                             list: MdInlineItemList [
                                                 MdTextual {
-                                                    value_token: MD_TEXTUAL_LITERAL@284..297 "nested bullet" [] [],
+                                                    value_token: MD_TEXTUAL_LITERAL@296..309 "nested bullet" [] [],
                                                 },
                                                 MdTextual {
-                                                    value_token: MD_TEXTUAL_LITERAL@297..298 "\n" [] [],
+                                                    value_token: MD_TEXTUAL_LITERAL@309..310 "\n" [] [],
                                                 },
                                             ],
                                         },
@@ -525,15 +579,15 @@ MdRoot {
                             ],
                         },
                         MdNewline {
-                            value_token: NEWLINE@298..299 "\n" [] [],
+                            value_token: NEWLINE@310..311 "\n" [] [],
                         },
                     ],
                 },
                 MdBullet {
                     prefix: MdListMarkerPrefix {
                         pre_marker_indent: MdIndentTokenList [],
-                        marker: MINUS@299..300 "-" [] [],
-                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@300..301 " " [] [],
+                        marker: MINUS@311..312 "-" [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@312..313 " " [] [],
                         content_indent: MdIndentTokenList [],
                     },
                     content: MdBlockList [
@@ -542,18 +596,18 @@ MdRoot {
                                 MdBullet {
                                     prefix: MdListMarkerPrefix {
                                         pre_marker_indent: MdIndentTokenList [],
-                                        marker: MD_ORDERED_LIST_MARKER@301..303 "1." [] [],
-                                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@303..304 " " [] [],
+                                        marker: MD_ORDERED_LIST_MARKER@313..315 "1." [] [],
+                                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@315..316 " " [] [],
                                         content_indent: MdIndentTokenList [],
                                     },
                                     content: MdBlockList [
                                         MdParagraph {
                                             list: MdInlineItemList [
                                                 MdTextual {
-                                                    value_token: MD_TEXTUAL_LITERAL@304..318 "nested ordered" [] [],
+                                                    value_token: MD_TEXTUAL_LITERAL@316..330 "nested ordered" [] [],
                                                 },
                                                 MdTextual {
-                                                    value_token: MD_TEXTUAL_LITERAL@318..319 "\n" [] [],
+                                                    value_token: MD_TEXTUAL_LITERAL@330..331 "\n" [] [],
                                                 },
                                             ],
                                         },
@@ -562,25 +616,25 @@ MdRoot {
                             ],
                         },
                         MdNewline {
-                            value_token: NEWLINE@319..320 "\n" [] [],
+                            value_token: NEWLINE@331..332 "\n" [] [],
                         },
                     ],
                 },
                 MdBullet {
                     prefix: MdListMarkerPrefix {
                         pre_marker_indent: MdIndentTokenList [],
-                        marker: MINUS@320..321 "-" [] [],
-                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@321..322 " " [] [],
+                        marker: MINUS@332..333 "-" [] [],
+                        post_marker_space_token: MD_LIST_POST_MARKER_SPACE@333..334 " " [] [],
                         content_indent: MdIndentTokenList [],
                     },
                     content: MdBlockList [
                         MdParagraph {
                             list: MdInlineItemList [
                                 MdTextual {
-                                    value_token: MD_TEXTUAL_LITERAL@322..332 "plain text" [] [],
+                                    value_token: MD_TEXTUAL_LITERAL@334..344 "plain text" [] [],
                                 },
                                 MdTextual {
-                                    value_token: MD_TEXTUAL_LITERAL@332..333 "\n" [] [],
+                                    value_token: MD_TEXTUAL_LITERAL@344..345 "\n" [] [],
                                 },
                             ],
                         },
@@ -588,18 +642,31 @@ MdRoot {
                 },
             ],
         },
+        MdNewline {
+            value_token: NEWLINE@345..346 "\n" [] [],
+        },
+        MdParagraph {
+            list: MdInlineItemList [
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@346..361 "plain paragraph" [] [],
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@361..362 "\n" [] [],
+                },
+            ],
+        },
     ],
-    eof_token: EOF@333..333 "" [] [],
+    eof_token: EOF@362..362 "" [] [],
 }
 ```
 
 ## CST
 
 ```
-0: MD_ROOT@0..333
+0: MD_ROOT@0..362
   0: (empty)
   1: (empty)
-  2: MD_BLOCK_LIST@0..333
+  2: MD_BLOCK_LIST@0..362
     0: MD_HEADER@0..13
       0: MD_INDENT_TOKEN_LIST@0..0
       1: MD_HASH_LIST@0..1
@@ -670,280 +737,319 @@ MdRoot {
       0: NEWLINE@83..84 "\n" [] []
     13: MD_NEWLINE@84..85
       0: NEWLINE@84..85 "\n" [] []
-    14: MD_BULLET_LIST_ITEM@85..98
-      0: MD_BULLET_LIST@85..98
-        0: MD_BULLET@85..98
-          0: MD_LIST_MARKER_PREFIX@85..87
-            0: MD_INDENT_TOKEN_LIST@85..85
-            1: MINUS@85..86 "-" [] []
-            2: MD_LIST_POST_MARKER_SPACE@86..87 " " [] []
-            3: MD_INDENT_TOKEN_LIST@87..87
-          1: MD_BLOCK_LIST@87..98
-            0: MD_PARAGRAPH@87..98
-              0: MD_INLINE_ITEM_LIST@87..98
-                0: MD_TEXTUAL@87..97
-                  0: MD_TEXTUAL_LITERAL@87..97 "top bullet" [] []
-                1: MD_TEXTUAL@97..98
-                  0: MD_TEXTUAL_LITERAL@97..98 "\n" [] []
-    15: MD_NEWLINE@98..99
-      0: NEWLINE@98..99 "\n" [] []
-    16: MD_BULLET_LIST_ITEM@99..117
-      0: MD_BULLET_LIST@99..117
-        0: MD_BULLET@99..117
-          0: MD_LIST_MARKER_PREFIX@99..101
-            0: MD_INDENT_TOKEN_LIST@99..99
-            1: PLUS@99..100 "+" [] []
-            2: MD_LIST_POST_MARKER_SPACE@100..101 " " [] []
-            3: MD_INDENT_TOKEN_LIST@101..101
-          1: MD_BLOCK_LIST@101..117
-            0: MD_PARAGRAPH@101..117
-              0: MD_INLINE_ITEM_LIST@101..117
-                0: MD_TEXTUAL@101..116
-                  0: MD_TEXTUAL_LITERAL@101..116 "top plus bullet" [] []
-                1: MD_TEXTUAL@116..117
-                  0: MD_TEXTUAL_LITERAL@116..117 "\n" [] []
-    17: MD_NEWLINE@117..118
-      0: NEWLINE@117..118 "\n" [] []
-    18: MD_ORDERED_LIST_ITEM@118..133
-      0: MD_BULLET_LIST@118..133
-        0: MD_BULLET@118..133
-          0: MD_LIST_MARKER_PREFIX@118..121
-            0: MD_INDENT_TOKEN_LIST@118..118
-            1: MD_ORDERED_LIST_MARKER@118..120 "1." [] []
-            2: MD_LIST_POST_MARKER_SPACE@120..121 " " [] []
-            3: MD_INDENT_TOKEN_LIST@121..121
-          1: MD_BLOCK_LIST@121..133
-            0: MD_PARAGRAPH@121..133
-              0: MD_INLINE_ITEM_LIST@121..133
-                0: MD_TEXTUAL@121..132
-                  0: MD_TEXTUAL_LITERAL@121..132 "top ordered" [] []
-                1: MD_TEXTUAL@132..133
-                  0: MD_TEXTUAL_LITERAL@132..133 "\n" [] []
-    19: MD_NEWLINE@133..134
-      0: NEWLINE@133..134 "\n" [] []
-    20: MD_HTML_BLOCK@134..153
-      0: MD_INDENT_TOKEN_LIST@134..134
-      1: MD_HTML_CONTENT@134..153
-        0: MD_HTML_LITERAL@134..153 "<div>top html</div>" [] []
-    21: MD_NEWLINE@153..154
-      0: NEWLINE@153..154 "\n" [] []
-    22: MD_NEWLINE@154..155
-      0: NEWLINE@154..155 "\n" [] []
-    23: MD_LINK_REFERENCE_DEFINITION@155..166
-      0: MD_INDENT_TOKEN_LIST@155..155
-      1: L_BRACK@155..156 "[" [] []
-      2: MD_LINK_LABEL@156..159
-        0: MD_INLINE_ITEM_LIST@156..159
-          0: MD_TEXTUAL@156..159
-            0: MD_TEXTUAL_LITERAL@156..159 "top" [] []
-      3: R_BRACK@159..160 "]" [] []
-      4: COLON@160..161 ":" [] []
-      5: MD_LINK_DESTINATION@161..166
-        0: MD_INLINE_ITEM_LIST@161..166
-          0: MD_TEXTUAL@161..162
-            0: MD_TEXTUAL_LITERAL@161..162 " " [] []
-          1: MD_TEXTUAL@162..166
-            0: MD_TEXTUAL_LITERAL@162..166 "/top" [] []
+    14: MD_THEMATIC_BREAK_BLOCK@85..88
+      0: MD_THEMATIC_BREAK_PART_LIST@85..88
+        0: MD_THEMATIC_BREAK_CHAR@85..86
+          0: UNDERSCORE@85..86 "_" [] []
+        1: MD_THEMATIC_BREAK_CHAR@86..87
+          0: UNDERSCORE@86..87 "_" [] []
+        2: MD_THEMATIC_BREAK_CHAR@87..88
+          0: UNDERSCORE@87..88 "_" [] []
+    15: MD_NEWLINE@88..89
+      0: NEWLINE@88..89 "\n" [] []
+    16: MD_NEWLINE@89..90
+      0: NEWLINE@89..90 "\n" [] []
+    17: MD_BULLET_LIST_ITEM@90..103
+      0: MD_BULLET_LIST@90..103
+        0: MD_BULLET@90..103
+          0: MD_LIST_MARKER_PREFIX@90..92
+            0: MD_INDENT_TOKEN_LIST@90..90
+            1: MINUS@90..91 "-" [] []
+            2: MD_LIST_POST_MARKER_SPACE@91..92 " " [] []
+            3: MD_INDENT_TOKEN_LIST@92..92
+          1: MD_BLOCK_LIST@92..103
+            0: MD_PARAGRAPH@92..103
+              0: MD_INLINE_ITEM_LIST@92..103
+                0: MD_TEXTUAL@92..102
+                  0: MD_TEXTUAL_LITERAL@92..102 "top bullet" [] []
+                1: MD_TEXTUAL@102..103
+                  0: MD_TEXTUAL_LITERAL@102..103 "\n" [] []
+    18: MD_NEWLINE@103..104
+      0: NEWLINE@103..104 "\n" [] []
+    19: MD_BULLET_LIST_ITEM@104..122
+      0: MD_BULLET_LIST@104..122
+        0: MD_BULLET@104..122
+          0: MD_LIST_MARKER_PREFIX@104..106
+            0: MD_INDENT_TOKEN_LIST@104..104
+            1: PLUS@104..105 "+" [] []
+            2: MD_LIST_POST_MARKER_SPACE@105..106 " " [] []
+            3: MD_INDENT_TOKEN_LIST@106..106
+          1: MD_BLOCK_LIST@106..122
+            0: MD_PARAGRAPH@106..122
+              0: MD_INLINE_ITEM_LIST@106..122
+                0: MD_TEXTUAL@106..121
+                  0: MD_TEXTUAL_LITERAL@106..121 "top plus bullet" [] []
+                1: MD_TEXTUAL@121..122
+                  0: MD_TEXTUAL_LITERAL@121..122 "\n" [] []
+    20: MD_NEWLINE@122..123
+      0: NEWLINE@122..123 "\n" [] []
+    21: MD_ORDERED_LIST_ITEM@123..138
+      0: MD_BULLET_LIST@123..138
+        0: MD_BULLET@123..138
+          0: MD_LIST_MARKER_PREFIX@123..126
+            0: MD_INDENT_TOKEN_LIST@123..123
+            1: MD_ORDERED_LIST_MARKER@123..125 "1." [] []
+            2: MD_LIST_POST_MARKER_SPACE@125..126 " " [] []
+            3: MD_INDENT_TOKEN_LIST@126..126
+          1: MD_BLOCK_LIST@126..138
+            0: MD_PARAGRAPH@126..138
+              0: MD_INLINE_ITEM_LIST@126..138
+                0: MD_TEXTUAL@126..137
+                  0: MD_TEXTUAL_LITERAL@126..137 "top ordered" [] []
+                1: MD_TEXTUAL@137..138
+                  0: MD_TEXTUAL_LITERAL@137..138 "\n" [] []
+    22: MD_NEWLINE@138..139
+      0: NEWLINE@138..139 "\n" [] []
+    23: MD_HTML_BLOCK@139..158
+      0: MD_INDENT_TOKEN_LIST@139..139
+      1: MD_HTML_CONTENT@139..158
+        0: MD_HTML_LITERAL@139..158 "<div>top html</div>" [] []
+    24: MD_NEWLINE@158..159
+      0: NEWLINE@158..159 "\n" [] []
+    25: MD_NEWLINE@159..160
+      0: NEWLINE@159..160 "\n" [] []
+    26: MD_LINK_REFERENCE_DEFINITION@160..171
+      0: MD_INDENT_TOKEN_LIST@160..160
+      1: L_BRACK@160..161 "[" [] []
+      2: MD_LINK_LABEL@161..164
+        0: MD_INLINE_ITEM_LIST@161..164
+          0: MD_TEXTUAL@161..164
+            0: MD_TEXTUAL_LITERAL@161..164 "top" [] []
+      3: R_BRACK@164..165 "]" [] []
+      4: COLON@165..166 ":" [] []
+      5: MD_LINK_DESTINATION@166..171
+        0: MD_INLINE_ITEM_LIST@166..171
+          0: MD_TEXTUAL@166..167
+            0: MD_TEXTUAL_LITERAL@166..167 " " [] []
+          1: MD_TEXTUAL@167..171
+            0: MD_TEXTUAL_LITERAL@167..171 "/top" [] []
       6: (empty)
-    24: MD_NEWLINE@166..167
-      0: NEWLINE@166..167 "\n" [] []
-    25: MD_NEWLINE@167..168
-      0: NEWLINE@167..168 "\n" [] []
-    26: MD_BULLET_LIST_ITEM@168..271
-      0: MD_BULLET_LIST@168..271
-        0: MD_BULLET@168..186
-          0: MD_LIST_MARKER_PREFIX@168..170
-            0: MD_INDENT_TOKEN_LIST@168..168
-            1: MINUS@168..169 "-" [] []
-            2: MD_LIST_POST_MARKER_SPACE@169..170 " " [] []
-            3: MD_INDENT_TOKEN_LIST@170..170
-          1: MD_BLOCK_LIST@170..186
-            0: MD_HEADER@170..184
-              0: MD_INDENT_TOKEN_LIST@170..170
-              1: MD_HASH_LIST@170..171
-                0: MD_HASH@170..171
-                  0: HASH@170..171 "#" [] []
-              2: MD_PARAGRAPH@171..184
-                0: MD_INLINE_ITEM_LIST@171..184
-                  0: MD_TEXTUAL@171..184
-                    0: MD_TEXTUAL_LITERAL@171..184 " list heading" [] []
-              3: MD_HASH_LIST@184..184
-            1: MD_NEWLINE@184..185
-              0: NEWLINE@184..185 "\n" [] []
-            2: MD_NEWLINE@185..186
-              0: NEWLINE@185..186 "\n" [] []
-        1: MD_BULLET@186..202
-          0: MD_LIST_MARKER_PREFIX@186..188
-            0: MD_INDENT_TOKEN_LIST@186..186
-            1: MINUS@186..187 "-" [] []
-            2: MD_LIST_POST_MARKER_SPACE@187..188 " " [] []
-            3: MD_INDENT_TOKEN_LIST@188..188
-          1: MD_BLOCK_LIST@188..202
-            0: MD_QUOTE@188..201
-              0: MD_QUOTE_PREFIX@188..189
-                0: MD_QUOTE_INDENT_LIST@188..188
-                1: R_ANGLE@188..189 ">" [] []
+    27: MD_NEWLINE@171..172
+      0: NEWLINE@171..172 "\n" [] []
+    28: MD_NEWLINE@172..173
+      0: NEWLINE@172..173 "\n" [] []
+    29: MD_BULLET_LIST_ITEM@173..276
+      0: MD_BULLET_LIST@173..276
+        0: MD_BULLET@173..191
+          0: MD_LIST_MARKER_PREFIX@173..175
+            0: MD_INDENT_TOKEN_LIST@173..173
+            1: MINUS@173..174 "-" [] []
+            2: MD_LIST_POST_MARKER_SPACE@174..175 " " [] []
+            3: MD_INDENT_TOKEN_LIST@175..175
+          1: MD_BLOCK_LIST@175..191
+            0: MD_HEADER@175..189
+              0: MD_INDENT_TOKEN_LIST@175..175
+              1: MD_HASH_LIST@175..176
+                0: MD_HASH@175..176
+                  0: HASH@175..176 "#" [] []
+              2: MD_PARAGRAPH@176..189
+                0: MD_INLINE_ITEM_LIST@176..189
+                  0: MD_TEXTUAL@176..189
+                    0: MD_TEXTUAL_LITERAL@176..189 " list heading" [] []
+              3: MD_HASH_LIST@189..189
+            1: MD_NEWLINE@189..190
+              0: NEWLINE@189..190 "\n" [] []
+            2: MD_NEWLINE@190..191
+              0: NEWLINE@190..191 "\n" [] []
+        1: MD_BULLET@191..207
+          0: MD_LIST_MARKER_PREFIX@191..193
+            0: MD_INDENT_TOKEN_LIST@191..191
+            1: MINUS@191..192 "-" [] []
+            2: MD_LIST_POST_MARKER_SPACE@192..193 " " [] []
+            3: MD_INDENT_TOKEN_LIST@193..193
+          1: MD_BLOCK_LIST@193..207
+            0: MD_QUOTE@193..206
+              0: MD_QUOTE_PREFIX@193..194
+                0: MD_QUOTE_INDENT_LIST@193..193
+                1: R_ANGLE@193..194 ">" [] []
                 2: (empty)
-              1: MD_BLOCK_LIST@189..201
-                0: MD_PARAGRAPH@189..201
-                  0: MD_INLINE_ITEM_LIST@189..201
-                    0: MD_TEXTUAL@189..200
-                      0: MD_TEXTUAL_LITERAL@189..200 " list quote" [] []
-                    1: MD_TEXTUAL@200..201
-                      0: MD_TEXTUAL_LITERAL@200..201 "\n" [] []
-            1: MD_NEWLINE@201..202
-              0: NEWLINE@201..202 "\n" [] []
-        2: MD_BULLET@202..232
-          0: MD_LIST_MARKER_PREFIX@202..204
-            0: MD_INDENT_TOKEN_LIST@202..202
-            1: MINUS@202..203 "-" [] []
-            2: MD_LIST_POST_MARKER_SPACE@203..204 " " [] []
-            3: MD_INDENT_TOKEN_LIST@204..204
-          1: MD_BLOCK_LIST@204..232
-            0: MD_FENCED_CODE_BLOCK@204..230
-              0: MD_INDENT_TOKEN_LIST@204..204
-              1: TRIPLE_BACKTICK@204..207 "```" [] []
-              2: MD_CODE_NAME_LIST@207..211
-                0: MD_TEXTUAL@207..211
-                  0: MD_TEXTUAL_LITERAL@207..211 "text" [] []
-              3: MD_INLINE_ITEM_LIST@211..225
-                0: MD_TEXTUAL@211..212
-                  0: MD_TEXTUAL_LITERAL@211..212 "\n" [] []
-                1: MD_INDENT_TOKEN@212..214
-                  0: MD_INDENT_CHAR@212..214 "  " [] []
-                2: MD_TEXTUAL@214..224
-                  0: MD_TEXTUAL_LITERAL@214..224 "list fence" [] []
-                3: MD_TEXTUAL@224..225
-                  0: MD_TEXTUAL_LITERAL@224..225 "\n" [] []
-              4: MD_INDENT_TOKEN_LIST@225..227
-                0: MD_INDENT_TOKEN@225..227
-                  0: MD_INDENT_CHAR@225..227 "  " [] []
-              5: TRIPLE_BACKTICK@227..230 "```" [] []
-            1: MD_NEWLINE@230..231
-              0: NEWLINE@230..231 "\n" [] []
-            2: MD_NEWLINE@231..232
-              0: NEWLINE@231..232 "\n" [] []
-        3: MD_BULLET@232..256
-          0: MD_LIST_MARKER_PREFIX@232..234
-            0: MD_INDENT_TOKEN_LIST@232..232
-            1: MINUS@232..233 "-" [] []
-            2: MD_LIST_POST_MARKER_SPACE@233..234 " " [] []
-            3: MD_INDENT_TOKEN_LIST@234..234
-          1: MD_BLOCK_LIST@234..256
-            0: MD_HTML_BLOCK@234..254
-              0: MD_INDENT_TOKEN_LIST@234..234
-              1: MD_HTML_CONTENT@234..254
-                0: MD_HTML_LITERAL@234..254 "<div>list html</div>" [] []
-            1: MD_NEWLINE@254..255
-              0: NEWLINE@254..255 "\n" [] []
-            2: MD_NEWLINE@255..256
-              0: NEWLINE@255..256 "\n" [] []
-        4: MD_BULLET@256..271
-          0: MD_LIST_MARKER_PREFIX@256..258
-            0: MD_INDENT_TOKEN_LIST@256..256
-            1: MINUS@256..257 "-" [] []
-            2: MD_LIST_POST_MARKER_SPACE@257..258 " " [] []
-            3: MD_INDENT_TOKEN_LIST@258..258
-          1: MD_BLOCK_LIST@258..271
-            0: MD_LINK_REFERENCE_DEFINITION@258..271
-              0: MD_INDENT_TOKEN_LIST@258..258
-              1: L_BRACK@258..259 "[" [] []
-              2: MD_LINK_LABEL@259..263
-                0: MD_INLINE_ITEM_LIST@259..263
-                  0: MD_TEXTUAL@259..263
-                    0: MD_TEXTUAL_LITERAL@259..263 "list" [] []
-              3: R_BRACK@263..264 "]" [] []
-              4: COLON@264..265 ":" [] []
-              5: MD_LINK_DESTINATION@265..271
-                0: MD_INLINE_ITEM_LIST@265..271
-                  0: MD_TEXTUAL@265..266
-                    0: MD_TEXTUAL_LITERAL@265..266 " " [] []
-                  1: MD_TEXTUAL@266..271
-                    0: MD_TEXTUAL_LITERAL@266..271 "/list" [] []
+              1: MD_BLOCK_LIST@194..206
+                0: MD_PARAGRAPH@194..206
+                  0: MD_INLINE_ITEM_LIST@194..206
+                    0: MD_TEXTUAL@194..205
+                      0: MD_TEXTUAL_LITERAL@194..205 " list quote" [] []
+                    1: MD_TEXTUAL@205..206
+                      0: MD_TEXTUAL_LITERAL@205..206 "\n" [] []
+            1: MD_NEWLINE@206..207
+              0: NEWLINE@206..207 "\n" [] []
+        2: MD_BULLET@207..237
+          0: MD_LIST_MARKER_PREFIX@207..209
+            0: MD_INDENT_TOKEN_LIST@207..207
+            1: MINUS@207..208 "-" [] []
+            2: MD_LIST_POST_MARKER_SPACE@208..209 " " [] []
+            3: MD_INDENT_TOKEN_LIST@209..209
+          1: MD_BLOCK_LIST@209..237
+            0: MD_FENCED_CODE_BLOCK@209..235
+              0: MD_INDENT_TOKEN_LIST@209..209
+              1: TRIPLE_BACKTICK@209..212 "```" [] []
+              2: MD_CODE_NAME_LIST@212..216
+                0: MD_TEXTUAL@212..216
+                  0: MD_TEXTUAL_LITERAL@212..216 "text" [] []
+              3: MD_INLINE_ITEM_LIST@216..230
+                0: MD_TEXTUAL@216..217
+                  0: MD_TEXTUAL_LITERAL@216..217 "\n" [] []
+                1: MD_INDENT_TOKEN@217..219
+                  0: MD_INDENT_CHAR@217..219 "  " [] []
+                2: MD_TEXTUAL@219..229
+                  0: MD_TEXTUAL_LITERAL@219..229 "list fence" [] []
+                3: MD_TEXTUAL@229..230
+                  0: MD_TEXTUAL_LITERAL@229..230 "\n" [] []
+              4: MD_INDENT_TOKEN_LIST@230..232
+                0: MD_INDENT_TOKEN@230..232
+                  0: MD_INDENT_CHAR@230..232 "  " [] []
+              5: TRIPLE_BACKTICK@232..235 "```" [] []
+            1: MD_NEWLINE@235..236
+              0: NEWLINE@235..236 "\n" [] []
+            2: MD_NEWLINE@236..237
+              0: NEWLINE@236..237 "\n" [] []
+        3: MD_BULLET@237..261
+          0: MD_LIST_MARKER_PREFIX@237..239
+            0: MD_INDENT_TOKEN_LIST@237..237
+            1: MINUS@237..238 "-" [] []
+            2: MD_LIST_POST_MARKER_SPACE@238..239 " " [] []
+            3: MD_INDENT_TOKEN_LIST@239..239
+          1: MD_BLOCK_LIST@239..261
+            0: MD_HTML_BLOCK@239..259
+              0: MD_INDENT_TOKEN_LIST@239..239
+              1: MD_HTML_CONTENT@239..259
+                0: MD_HTML_LITERAL@239..259 "<div>list html</div>" [] []
+            1: MD_NEWLINE@259..260
+              0: NEWLINE@259..260 "\n" [] []
+            2: MD_NEWLINE@260..261
+              0: NEWLINE@260..261 "\n" [] []
+        4: MD_BULLET@261..276
+          0: MD_LIST_MARKER_PREFIX@261..263
+            0: MD_INDENT_TOKEN_LIST@261..261
+            1: MINUS@261..262 "-" [] []
+            2: MD_LIST_POST_MARKER_SPACE@262..263 " " [] []
+            3: MD_INDENT_TOKEN_LIST@263..263
+          1: MD_BLOCK_LIST@263..276
+            0: MD_LINK_REFERENCE_DEFINITION@263..276
+              0: MD_INDENT_TOKEN_LIST@263..263
+              1: L_BRACK@263..264 "[" [] []
+              2: MD_LINK_LABEL@264..268
+                0: MD_INLINE_ITEM_LIST@264..268
+                  0: MD_TEXTUAL@264..268
+                    0: MD_TEXTUAL_LITERAL@264..268 "list" [] []
+              3: R_BRACK@268..269 "]" [] []
+              4: COLON@269..270 ":" [] []
+              5: MD_LINK_DESTINATION@270..276
+                0: MD_INLINE_ITEM_LIST@270..276
+                  0: MD_TEXTUAL@270..271
+                    0: MD_TEXTUAL_LITERAL@270..271 " " [] []
+                  1: MD_TEXTUAL@271..276
+                    0: MD_TEXTUAL_LITERAL@271..276 "/list" [] []
               6: (empty)
-    27: MD_NEWLINE@271..272
-      0: NEWLINE@271..272 "\n" [] []
-    28: MD_NEWLINE@272..273
-      0: NEWLINE@272..273 "\n" [] []
-    29: MD_THEMATIC_BREAK_BLOCK@273..278
-      0: MD_THEMATIC_BREAK_PART_LIST@273..278
-        0: MD_THEMATIC_BREAK_CHAR@273..274
-          0: MINUS@273..274 "-" [] []
-        1: MD_INDENT_TOKEN@274..275
-          0: MD_INDENT_CHAR@274..275 " " [] []
-        2: MD_THEMATIC_BREAK_CHAR@275..276
-          0: MINUS@275..276 "-" [] []
-        3: MD_THEMATIC_BREAK_CHAR@276..277
-          0: MINUS@276..277 "-" [] []
-        4: MD_THEMATIC_BREAK_CHAR@277..278
-          0: MINUS@277..278 "-" [] []
-    30: MD_NEWLINE@278..279
-      0: NEWLINE@278..279 "\n" [] []
-    31: MD_NEWLINE@279..280
-      0: NEWLINE@279..280 "\n" [] []
-    32: MD_BULLET_LIST_ITEM@280..333
-      0: MD_BULLET_LIST@280..333
-        0: MD_BULLET@280..299
-          0: MD_LIST_MARKER_PREFIX@280..282
-            0: MD_INDENT_TOKEN_LIST@280..280
-            1: MINUS@280..281 "-" [] []
-            2: MD_LIST_POST_MARKER_SPACE@281..282 " " [] []
-            3: MD_INDENT_TOKEN_LIST@282..282
-          1: MD_BLOCK_LIST@282..299
-            0: MD_BULLET_LIST_ITEM@282..298
-              0: MD_BULLET_LIST@282..298
-                0: MD_BULLET@282..298
-                  0: MD_LIST_MARKER_PREFIX@282..284
-                    0: MD_INDENT_TOKEN_LIST@282..282
-                    1: MINUS@282..283 "-" [] []
-                    2: MD_LIST_POST_MARKER_SPACE@283..284 " " [] []
-                    3: MD_INDENT_TOKEN_LIST@284..284
-                  1: MD_BLOCK_LIST@284..298
-                    0: MD_PARAGRAPH@284..298
-                      0: MD_INLINE_ITEM_LIST@284..298
-                        0: MD_TEXTUAL@284..297
-                          0: MD_TEXTUAL_LITERAL@284..297 "nested bullet" [] []
-                        1: MD_TEXTUAL@297..298
-                          0: MD_TEXTUAL_LITERAL@297..298 "\n" [] []
-            1: MD_NEWLINE@298..299
-              0: NEWLINE@298..299 "\n" [] []
-        1: MD_BULLET@299..320
-          0: MD_LIST_MARKER_PREFIX@299..301
-            0: MD_INDENT_TOKEN_LIST@299..299
-            1: MINUS@299..300 "-" [] []
-            2: MD_LIST_POST_MARKER_SPACE@300..301 " " [] []
-            3: MD_INDENT_TOKEN_LIST@301..301
-          1: MD_BLOCK_LIST@301..320
-            0: MD_ORDERED_LIST_ITEM@301..319
-              0: MD_BULLET_LIST@301..319
-                0: MD_BULLET@301..319
-                  0: MD_LIST_MARKER_PREFIX@301..304
-                    0: MD_INDENT_TOKEN_LIST@301..301
-                    1: MD_ORDERED_LIST_MARKER@301..303 "1." [] []
-                    2: MD_LIST_POST_MARKER_SPACE@303..304 " " [] []
-                    3: MD_INDENT_TOKEN_LIST@304..304
-                  1: MD_BLOCK_LIST@304..319
-                    0: MD_PARAGRAPH@304..319
-                      0: MD_INLINE_ITEM_LIST@304..319
-                        0: MD_TEXTUAL@304..318
-                          0: MD_TEXTUAL_LITERAL@304..318 "nested ordered" [] []
-                        1: MD_TEXTUAL@318..319
-                          0: MD_TEXTUAL_LITERAL@318..319 "\n" [] []
-            1: MD_NEWLINE@319..320
-              0: NEWLINE@319..320 "\n" [] []
-        2: MD_BULLET@320..333
-          0: MD_LIST_MARKER_PREFIX@320..322
-            0: MD_INDENT_TOKEN_LIST@320..320
-            1: MINUS@320..321 "-" [] []
-            2: MD_LIST_POST_MARKER_SPACE@321..322 " " [] []
-            3: MD_INDENT_TOKEN_LIST@322..322
-          1: MD_BLOCK_LIST@322..333
-            0: MD_PARAGRAPH@322..333
-              0: MD_INLINE_ITEM_LIST@322..333
-                0: MD_TEXTUAL@322..332
-                  0: MD_TEXTUAL_LITERAL@322..332 "plain text" [] []
-                1: MD_TEXTUAL@332..333
-                  0: MD_TEXTUAL_LITERAL@332..333 "\n" [] []
-  3: EOF@333..333 "" [] []
+    30: MD_NEWLINE@276..277
+      0: NEWLINE@276..277 "\n" [] []
+    31: MD_NEWLINE@277..278
+      0: NEWLINE@277..278 "\n" [] []
+    32: MD_THEMATIC_BREAK_BLOCK@278..283
+      0: MD_THEMATIC_BREAK_PART_LIST@278..283
+        0: MD_THEMATIC_BREAK_CHAR@278..279
+          0: MINUS@278..279 "-" [] []
+        1: MD_INDENT_TOKEN@279..280
+          0: MD_INDENT_CHAR@279..280 " " [] []
+        2: MD_THEMATIC_BREAK_CHAR@280..281
+          0: MINUS@280..281 "-" [] []
+        3: MD_THEMATIC_BREAK_CHAR@281..282
+          0: MINUS@281..282 "-" [] []
+        4: MD_THEMATIC_BREAK_CHAR@282..283
+          0: MINUS@282..283 "-" [] []
+    33: MD_NEWLINE@283..284
+      0: NEWLINE@283..284 "\n" [] []
+    34: MD_NEWLINE@284..285
+      0: NEWLINE@284..285 "\n" [] []
+    35: MD_BULLET_LIST_ITEM@285..345
+      0: MD_BULLET_LIST@285..345
+        0: MD_BULLET@285..292
+          0: MD_LIST_MARKER_PREFIX@285..287
+            0: MD_INDENT_TOKEN_LIST@285..285
+            1: MINUS@285..286 "-" [] []
+            2: MD_LIST_POST_MARKER_SPACE@286..287 " " [] []
+            3: MD_INDENT_TOKEN_LIST@287..287
+          1: MD_BLOCK_LIST@287..292
+            0: MD_THEMATIC_BREAK_BLOCK@287..290
+              0: MD_THEMATIC_BREAK_PART_LIST@287..290
+                0: MD_THEMATIC_BREAK_CHAR@287..288
+                  0: UNDERSCORE@287..288 "_" [] []
+                1: MD_THEMATIC_BREAK_CHAR@288..289
+                  0: UNDERSCORE@288..289 "_" [] []
+                2: MD_THEMATIC_BREAK_CHAR@289..290
+                  0: UNDERSCORE@289..290 "_" [] []
+            1: MD_NEWLINE@290..291
+              0: NEWLINE@290..291 "\n" [] []
+            2: MD_NEWLINE@291..292
+              0: NEWLINE@291..292 "\n" [] []
+        1: MD_BULLET@292..311
+          0: MD_LIST_MARKER_PREFIX@292..294
+            0: MD_INDENT_TOKEN_LIST@292..292
+            1: MINUS@292..293 "-" [] []
+            2: MD_LIST_POST_MARKER_SPACE@293..294 " " [] []
+            3: MD_INDENT_TOKEN_LIST@294..294
+          1: MD_BLOCK_LIST@294..311
+            0: MD_BULLET_LIST_ITEM@294..310
+              0: MD_BULLET_LIST@294..310
+                0: MD_BULLET@294..310
+                  0: MD_LIST_MARKER_PREFIX@294..296
+                    0: MD_INDENT_TOKEN_LIST@294..294
+                    1: MINUS@294..295 "-" [] []
+                    2: MD_LIST_POST_MARKER_SPACE@295..296 " " [] []
+                    3: MD_INDENT_TOKEN_LIST@296..296
+                  1: MD_BLOCK_LIST@296..310
+                    0: MD_PARAGRAPH@296..310
+                      0: MD_INLINE_ITEM_LIST@296..310
+                        0: MD_TEXTUAL@296..309
+                          0: MD_TEXTUAL_LITERAL@296..309 "nested bullet" [] []
+                        1: MD_TEXTUAL@309..310
+                          0: MD_TEXTUAL_LITERAL@309..310 "\n" [] []
+            1: MD_NEWLINE@310..311
+              0: NEWLINE@310..311 "\n" [] []
+        2: MD_BULLET@311..332
+          0: MD_LIST_MARKER_PREFIX@311..313
+            0: MD_INDENT_TOKEN_LIST@311..311
+            1: MINUS@311..312 "-" [] []
+            2: MD_LIST_POST_MARKER_SPACE@312..313 " " [] []
+            3: MD_INDENT_TOKEN_LIST@313..313
+          1: MD_BLOCK_LIST@313..332
+            0: MD_ORDERED_LIST_ITEM@313..331
+              0: MD_BULLET_LIST@313..331
+                0: MD_BULLET@313..331
+                  0: MD_LIST_MARKER_PREFIX@313..316
+                    0: MD_INDENT_TOKEN_LIST@313..313
+                    1: MD_ORDERED_LIST_MARKER@313..315 "1." [] []
+                    2: MD_LIST_POST_MARKER_SPACE@315..316 " " [] []
+                    3: MD_INDENT_TOKEN_LIST@316..316
+                  1: MD_BLOCK_LIST@316..331
+                    0: MD_PARAGRAPH@316..331
+                      0: MD_INLINE_ITEM_LIST@316..331
+                        0: MD_TEXTUAL@316..330
+                          0: MD_TEXTUAL_LITERAL@316..330 "nested ordered" [] []
+                        1: MD_TEXTUAL@330..331
+                          0: MD_TEXTUAL_LITERAL@330..331 "\n" [] []
+            1: MD_NEWLINE@331..332
+              0: NEWLINE@331..332 "\n" [] []
+        3: MD_BULLET@332..345
+          0: MD_LIST_MARKER_PREFIX@332..334
+            0: MD_INDENT_TOKEN_LIST@332..332
+            1: MINUS@332..333 "-" [] []
+            2: MD_LIST_POST_MARKER_SPACE@333..334 " " [] []
+            3: MD_INDENT_TOKEN_LIST@334..334
+          1: MD_BLOCK_LIST@334..345
+            0: MD_PARAGRAPH@334..345
+              0: MD_INLINE_ITEM_LIST@334..345
+                0: MD_TEXTUAL@334..344
+                  0: MD_TEXTUAL_LITERAL@334..344 "plain text" [] []
+                1: MD_TEXTUAL@344..345
+                  0: MD_TEXTUAL_LITERAL@344..345 "\n" [] []
+    36: MD_NEWLINE@345..346
+      0: NEWLINE@345..346 "\n" [] []
+    37: MD_PARAGRAPH@346..362
+      0: MD_INLINE_ITEM_LIST@346..362
+        0: MD_TEXTUAL@346..361
+          0: MD_TEXTUAL_LITERAL@346..361 "plain paragraph" [] []
+        1: MD_TEXTUAL@361..362
+          0: MD_TEXTUAL_LITERAL@361..362 "\n" [] []
+  3: EOF@362..362 "" [] []
 
 ```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

> [!NOTE]
> Implemented via AI

This PR reduces the cost of `at_block_interrupt` by using simpler checks. It also uses the dispatch lookup table to avoid the cost of checking characters. Also the use of `lookahed` has been reduced. 



<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

New tests were added to ensure a specific series of characters doesn't change the parser's semantics.

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
