### PR TITLE
feat(analyze/vue): track embedded references in v-bind css

### DIFF
--- a/.changeset/bumpy-emus-agree.md
+++ b/.changeset/bumpy-emus-agree.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11157](https://github.com/biomejs/biome/issues/11157): [`noUnusedVariables`](https://biomejs.dev/linter/rules/no-unused-variables/) no longer reports Vue `<script setup>` bindings used by CSS `v-bind()` as unused.

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/valid-vue-css-v-bind.vue
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/valid-vue-css-v-bind.vue
@@ -1,0 +1,18 @@
+<!-- should not generate diagnostics -->
+<script setup lang="ts">
+import { computed } from "vue";
+
+const size = computed(() => "1px");
+const theme = { buttonSize: "2px" };
+</script>
+
+<template>
+	<button>hello</button>
+</template>
+
+<style scoped>
+button {
+	height: v-bind(size);
+	width: v-bind("theme.buttonSize");
+}
+</style>

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/valid-vue-css-v-bind.vue.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/valid-vue-css-v-bind.vue.snap
@@ -1,0 +1,26 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid-vue-css-v-bind.vue
+---
+# Input
+```vue
+<!-- should not generate diagnostics -->
+<script setup lang="ts">
+import { computed } from "vue";
+
+const size = computed(() => "1px");
+const theme = { buttonSize: "2px" };
+</script>
+
+<template>
+	<button>hello</button>
+</template>
+
+<style scoped>
+button {
+	height: v-bind(size);
+	width: v-bind("theme.buttonSize");
+}
+</style>
+
+```

--- a/crates/biome_service/src/file_handlers/html/parse_embedded_nodes.rs
+++ b/crates/biome_service/src/file_handlers/html/parse_embedded_nodes.rs
@@ -6,7 +6,7 @@ use crate::embed::html::{
 use crate::file_handlers::html::{EmbedParseContext, ParsedEmbed, is_component_element};
 use crate::file_handlers::{DocumentFileSource, ParseEmbedResult, ParseEmbeddedParams};
 use biome_css_parser::{CssModulesKind, parse_css_with_offset_and_cache};
-use biome_css_syntax::{CssLanguage, TextSize};
+use biome_css_syntax::{AnyCssRoot, CssFunction, CssLanguage, CssString, TextSize};
 use biome_html_syntax::{
     AnyAstroDirective, AnySvelteBlock, AnySvelteBlockItem, AnySvelteDirective,
     AnySvelteDirectiveInitializerClause, AstroEmbeddedContent, HtmlAttribute,
@@ -171,15 +171,33 @@ pub(crate) fn parse_embedded_nodes(params: ParseEmbeddedParams) -> ParseEmbedRes
 
             // Pass 1: elements via registry, collecting JS file sources
             let mut embedded_file_source = JsFileSource::js_module();
+            let mut css_v_bind_candidates = vec![];
             for element in elements {
                 if let Some(candidate) = build_html_candidate(&element)
                     && let Some(parsed) = ctx.detect_and_parse(&candidate, &doc_file_source, None)
                 {
-                    if let Some(js_fs) = parsed.js_file_source {
+                    let ParsedEmbed {
+                        node: (parse, content, file_source),
+                        js_file_source,
+                    } = parsed;
+                    if let Some(js_fs) = js_file_source {
                         embedded_file_source = merge_js_file_source(embedded_file_source, js_fs);
                     }
-                    nodes.push(parsed.node);
+                    if file_source.to_css_file_source().is_some() {
+                        css_v_bind_candidates
+                            .extend(build_vue_css_v_bind_candidates(&parse, &content));
+                    }
+                    nodes.push((parse, content, file_source));
                 }
+            }
+
+            for candidate in css_v_bind_candidates {
+                ctx.parse_and_push(
+                    &candidate,
+                    &doc_file_source,
+                    Some(embedded_file_source),
+                    &mut nodes,
+                );
             }
 
             // Pass 2: text expressions via registry using merged embedded_file_source
@@ -876,6 +894,64 @@ fn build_html_candidate(element: &HtmlElement) -> Option<EmbedCandidate> {
             // The parser needs text and offset to be consistent.
             text: value_token.token_text(),
         },
+    })
+}
+
+fn build_vue_css_v_bind_candidates(
+    parse: &AnyParse,
+    style_content: &EmbedContent,
+) -> Vec<EmbedCandidate> {
+    let root: AnyCssRoot = parse.tree();
+    root.syntax()
+        .descendants()
+        .skip(1)
+        .filter_map(CssFunction::cast)
+        .filter_map(|function| build_vue_css_v_bind_candidate(&function, style_content))
+        .collect()
+}
+
+fn build_vue_css_v_bind_candidate(
+    function: &CssFunction,
+    style_content: &EmbedContent,
+) -> Option<EmbedCandidate> {
+    let name = function
+        .name()
+        .ok()?
+        .as_css_identifier()?
+        .value_token()
+        .ok()?;
+    if name.text_trimmed() != "v-bind" {
+        return None;
+    }
+
+    let items = function.items();
+    let string = items
+        .syntax()
+        .descendants()
+        .skip(1)
+        .find_map(CssString::cast)
+        .filter(|string| string.range() == items.range());
+    let (relative_range, text) = if let Some(string) = string {
+        let value_token = string.value_token().ok()?;
+        let text = string.inner_string_text().ok()?;
+        (text.source_range(value_token.text_range()), text)
+    } else {
+        let range = items.syntax().text_trimmed_range();
+        (range, style_content.text.clone().slice(range))
+    };
+    if relative_range.is_empty() {
+        return None;
+    }
+
+    let content_range = relative_range + style_content.content_offset;
+    Some(EmbedCandidate::TextExpression {
+        content: EmbedContent {
+            element_range: content_range,
+            content_range,
+            content_offset: content_range.start(),
+            text,
+        },
+        block_kind: EmbedBlockKind::Neutral,
     })
 }
 


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Tracks binding usage in v-bind functions in vue files. These functions are only valid in .vue files.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
closes #11157

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
