### PR TITLE
fix(noUnresolvedImports): do not flag Bun built-in modules (bun: prefix)

### DIFF
--- a/crates/biome_js_analyze/src/lint/correctness/no_unresolved_imports.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unresolved_imports.rs
@@ -120,6 +120,12 @@ impl Rule for NoUnresolvedImports {
                     return Vec::new();
                 }
 
+                // Bun built-ins (e.g. `bun:test`, `bun:ffi`) are also valid
+                // imports that cannot be resolved to a file path.
+                if specifier.text().starts_with("bun:") {
+                    return Vec::new();
+                }
+
                 if Utf8Path::new(&specifier)
                     .extension()
                     .is_some_and(|extension| !SUPPORTED_EXTENSIONS.contains(&extension))

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnresolvedImports/valid.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnresolvedImports/valid.js
@@ -9,3 +9,9 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { EventEmitter } from "node:events";
 import * as crypto from "node:crypto";
+
+// Bun built-in modules with the `bun:` prefix must also never be flagged.
+// See: https://github.com/biomejs/biome/issues/11475
+import { test, expect } from "bun:test";
+import { dlopen, FFIType } from "bun:ffi";
+import { serve } from "bun:sqlite";

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnresolvedImports/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnresolvedImports/valid.js.snap
@@ -16,4 +16,10 @@ import { fileURLToPath } from "node:url";
 import { EventEmitter } from "node:events";
 import * as crypto from "node:crypto";
 
+// Bun built-in modules with the `bun:` prefix must also never be flagged.
+// See: https://github.com/biomejs/biome/issues/11475
+import { test, expect } from "bun:test";
+import { dlopen, FFIType } from "bun:ffi";
+import { serve } from "bun:sqlite";
+
 ```


### PR DESCRIPTION
## Summary

Fixes #11475.

`noUnresolvedImports` was incorrectly flagging Bun built-in modules like `bun:test`, `bun:ffi`, and `bun:sqlite` as unresolved imports.

**Root cause:** The resolver cannot resolve `bun:*` specifiers to a file path (they live inside the Bun runtime). Node.js built-ins produce `ResolveError::NodeBuiltIn` and already have an early return. Bun built-ins produce `ResolveError::NotFound` instead, so they fall through to the diagnostic.

**Fix:** Add an early return when the specifier starts with `"bun:"`, matching the pattern already used for `node:` built-ins:

```diff
 // Node.js built-ins (e.g. `node:fs`, `node:path`) are valid
 // imports — they simply cannot be resolved to a file path.
 if *resolve_error == ResolveError::NodeBuiltIn {
     return Vec::new();
 }

+// Bun built-ins (e.g. `bun:test`, `bun:ffi`) are also valid
+// imports that cannot be resolved to a file path.
+if specifier.text().starts_with("bun:") {
+    return Vec::new();
+}
```

**Test:** Added `bun:test`, `bun:ffi`, and `bun:sqlite` to the `valid.js` fixture and updated the snapshot.

## Checklist

- [x] I have read the [contributing guide](https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md)
- [x] I have described the changes in this PR
- [x] I have added tests for my changes
- [x] I have run `cargo test` locally (snapshot updated to match)