### PR TITLE
perf(analyzer): faster conditional type inference

### DIFF
--- a/.changeset/fast-conditions-run.md
+++ b/.changeset/fast-conditions-run.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+The [`noUnnecessaryConditions`](https://biomejs.dev/linter/rules/no-unnecessary-conditions/) rule now avoids resolving complete type tables when raw type information is sufficient, reducing unnecessary type-inference work during linting.

--- a/crates/biome_js_analyze/src/lint/suspicious/no_unnecessary_conditions.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_unnecessary_conditions.rs
@@ -12,6 +12,7 @@ use biome_js_syntax::{
     JsUnaryOperator, JsWhileStatement, inner_string_text,
 };
 use biome_js_type_info::InferredType;
+use biome_module_graph::type_inference::CaseLiteral as TypeInferenceCaseLiteral;
 use biome_rowan::{AstNode, TextRange, TokenText, declare_node_union};
 use biome_rule_options::no_unnecessary_conditions::NoUnnecessaryConditionsOptions;
 
@@ -172,6 +173,17 @@ enum CaseLiteral {
     Number(f64),
     Boolean(bool),
     Null,
+}
+
+fn to_type_inference_case_literal(literal: &CaseLiteral) -> TypeInferenceCaseLiteral {
+    match literal {
+        CaseLiteral::String(value) => {
+            TypeInferenceCaseLiteral::String(value.text().to_string().into())
+        }
+        CaseLiteral::Number(value) => TypeInferenceCaseLiteral::Number(value.to_bits()),
+        CaseLiteral::Boolean(value) => TypeInferenceCaseLiteral::Boolean(*value),
+        CaseLiteral::Null => TypeInferenceCaseLiteral::Null,
+    }
 }
 
 impl Rule for NoUnnecessaryConditions {
@@ -457,10 +469,10 @@ fn check_condition_necessity(
                 return Some(IssueKind::AlwaysFalsyCondition(expr.range()));
             }
 
-            let ty = ctx.type_of_expression(expr)?;
-            if ty.is_always_truthy() {
+            let conditional = ctx.conditional_type_of_expression(expr)?;
+            if conditional.is_truthy() {
                 return Some(IssueKind::AlwaysTruthyCondition(expr.range()));
-            } else if ty.is_always_falsy() {
+            } else if conditional.is_falsy() {
                 return Some(IssueKind::AlwaysFalsyCondition(expr.range()));
             }
         }
@@ -491,10 +503,10 @@ fn check_condition_necessity(
                 return None;
             }
 
-            let ty = ctx.type_of_expression(expr)?;
-            if ty.is_always_truthy() {
+            let conditional = ctx.conditional_type_of_expression(expr)?;
+            if conditional.is_truthy() {
                 return Some(IssueKind::AlwaysTruthyCondition(expr.range()));
-            } else if ty.is_always_falsy() {
+            } else if conditional.is_falsy() {
                 return Some(IssueKind::AlwaysFalsyCondition(expr.range()));
             }
         }
@@ -545,8 +557,8 @@ fn check_nullish_necessity(
     }
 
     // Type-aware path: report when the left-hand side is statically non-nullish.
-    let ty = ctx.type_of_expression(expr)?;
-    if ty.is_non_nullish() {
+    let conditional = ctx.conditional_type_of_expression(expr)?;
+    if conditional.is_non_nullish() {
         return Some(IssueKind::UnnecessaryCoalescing(
             expr.range(),
             optional_chain_range,
@@ -579,8 +591,8 @@ fn check_optional_chain_necessity(
     }
 
     // Type-aware path: report when the object is statically non-nullish.
-    let ty = ctx.type_of_expression(expr)?;
-    if ty.is_non_nullish() {
+    let conditional = ctx.conditional_type_of_expression(expr)?;
+    if conditional.is_non_nullish() {
         return Some(IssueKind::UnnecessaryOptionalChain(
             expr.range(),
             optional_chain_range,
@@ -738,12 +750,11 @@ fn check_comparison_necessity(
         _ => return None,
     };
 
-    let ty = ctx.type_of_expression(typed_side)?;
-
     // Is the non-null side known to be non-nullish? Then the comparison is unnecessary
     // for any equality operator: `x === null`, `x !== undefined`, `x == null` are
     // all statically false/true.
-    if ty.is_non_nullish() {
+    let conditional = ctx.conditional_type_of_expression(typed_side)?;
+    if conditional.is_non_nullish() {
         let range = TextRange::new(left.range().start(), right.range().end());
         return Some(IssueKind::UnnecessaryComparison(range));
     }
@@ -755,7 +766,7 @@ fn check_comparison_necessity(
     // literal, so skip those to avoid false positives.
     // Note: this narrow pass does not detect `void 0` because it's a unary
     // expression, not an identifier.
-    if ty.is_nullish()
+    if conditional.is_nullish()
         && matches!(
             operator,
             JsBinaryOperator::Equality | JsBinaryOperator::Inequality
@@ -829,8 +840,18 @@ fn check_case_clause_reachability(
         .find_map(JsSwitchStatement::cast)?;
     let discriminant = switch_stmt.discriminant().ok()?;
 
-    let discriminant_ty = ctx.type_of_expression(&discriminant)?;
-    if type_could_equal_literal(discriminant_ty, &case_literal) {
+    let could_equal = match ctx.could_equal_case_literal(
+        &discriminant,
+        to_type_inference_case_literal(&case_literal),
+    ) {
+        Some(could_equal) => could_equal,
+        None => {
+            let discriminant_ty = ctx.type_of_expression(&discriminant)?;
+            type_could_equal_literal(discriminant_ty, &case_literal)
+        }
+    };
+
+    if could_equal {
         None
     } else {
         Some(IssueKind::UnreachableCase(test.range()))

--- a/crates/biome_js_analyze/src/services/typed.rs
+++ b/crates/biome_js_analyze/src/services/typed.rs
@@ -8,31 +8,39 @@ use biome_js_syntax::{
     JsClassDeclaration, JsClassExpression, JsLanguage, JsObjectExpression, JsReferenceIdentifier,
     JsSyntaxNode,
 };
-use biome_js_type_info::InferredType;
+use biome_js_type_info::{InferredType, interned_types::ConditionalType};
 use biome_module_graph::{
     ModuleDb, ModuleInfo,
     type_inference::{
-        ArrayOfPromisesClassificationRequest, CallableMemberRequest,
-        ExpectedCallArgumentTypeRequest, ExpectedConstructorArgumentTypeRequest,
-        FunctionReturnTypeRequest, MemberReturnTypeRequest, NormalizedBindingTypeRequest,
-        NormalizedExpressionTypeRequest, PromiseClassificationRequest,
-        PromiseReturningFunctionClassificationRequest, TypeInferenceArgument, TypeInferenceCaller,
-        TypeInferenceClassification, TypeInferenceRequest, TypeInferenceSource,
-        execute_type_inference_request,
+        ArrayOfPromisesClassificationRequest, CallableMemberRequest, CaseLiteral,
+        CaseLiteralRequest, ConditionalTypeRequest, ExpectedCallArgumentTypeRequest,
+        ExpectedConstructorArgumentTypeRequest, FunctionReturnTypeRequest, MemberReturnTypeRequest,
+        NormalizedBindingTypeRequest, NormalizedExpressionTypeRequest,
+        PromiseClassificationRequest, PromiseReturningFunctionClassificationRequest,
+        TypeInferenceArgument, TypeInferenceCaller, TypeInferenceClassification,
+        TypeInferenceRequest, TypeInferenceSource, execute_type_inference_request,
     },
 };
 use biome_rowan::{AstNode, AstSeparatedList, TextRange};
-use std::rc::Rc;
+use rustc_hash::FxHashMap;
+use std::{cell::RefCell, rc::Rc};
 
 #[derive(Clone)]
 pub(crate) struct TypedModule {
     db: Rc<dyn ModuleDb>,
     module: ModuleInfo,
+    conditional_types: Rc<RefCell<FxHashMap<TextRange, Option<ConditionalType>>>>,
+    case_literals: Rc<RefCell<FxHashMap<(TextRange, CaseLiteral), Option<bool>>>>,
 }
 
 impl TypedModule {
     pub(crate) fn new(db: Rc<dyn ModuleDb>, module: ModuleInfo) -> Self {
-        Self { db, module }
+        Self {
+            db,
+            module,
+            conditional_types: Rc::default(),
+            case_literals: Rc::default(),
+        }
     }
 }
 
@@ -79,6 +87,58 @@ impl TypedService {
         )?;
 
         Some(InferredType::new(typed_module.db.as_ref(), ty))
+    }
+
+    pub fn conditional_type_of_expression(
+        &self,
+        expression: &AnyJsExpression,
+    ) -> Option<ConditionalType> {
+        let typed_module = self.module.as_ref()?;
+        let range = expression.range();
+
+        if let Some(conditional) = typed_module.conditional_types.borrow().get(&range) {
+            return *conditional;
+        }
+
+        let conditional = if let Some(conditional) = self.execute_request(
+            typed_module,
+            ConditionalTypeRequest::new(typed_module.module, range),
+        ) {
+            Some(conditional)
+        } else {
+            self.execute_request(
+                typed_module,
+                NormalizedExpressionTypeRequest::new(typed_module.module, range),
+            )
+            .map(|ty| InferredType::new(typed_module.db.as_ref(), ty).conditional_type())
+        };
+
+        typed_module
+            .conditional_types
+            .borrow_mut()
+            .insert(range, conditional);
+        conditional
+    }
+
+    pub fn could_equal_case_literal(
+        &self,
+        expression: &AnyJsExpression,
+        literal: CaseLiteral,
+    ) -> Option<bool> {
+        let typed_module = self.module.as_ref()?;
+        let range = expression.range();
+        let key = (range, literal.clone());
+
+        if let Some(result) = typed_module.case_literals.borrow().get(&key) {
+            return *result;
+        }
+
+        let result = self.execute_request(
+            typed_module,
+            CaseLiteralRequest::new(typed_module.module, range, literal),
+        );
+        typed_module.case_literals.borrow_mut().insert(key, result);
+        result
     }
 
     /// Classifies an expression as a Promise without resolving unrelated members.

--- a/crates/biome_js_type_info/src/inferred_type.rs
+++ b/crates/biome_js_type_info/src/inferred_type.rs
@@ -1210,7 +1210,7 @@ impl<'db> InferredType<'db> {
         }
     }
 
-    fn conditional_type(self) -> ConditionalType {
+    pub fn conditional_type(self) -> ConditionalType {
         let mut conditional = ConditionalType::Unknown;
         let mut seen = FxHashSet::default();
         let mut pending = vec![self.data];
@@ -1615,8 +1615,8 @@ where
 mod tests {
     use super::*;
     use crate::interned_types::{
-        InternedIntersection, InternedLiteral, InternedObject, InternedUnion, TypeMember,
-        TypeMemberKind,
+        ConditionalType, InternedIntersection, InternedLiteral, InternedObject, InternedUnion,
+        TypeMember, TypeMemberKind,
     };
 
     #[salsa::db]
@@ -1685,6 +1685,25 @@ mod tests {
 
         assert!(array.is_always_truthy());
         assert!(array.is_non_nullish());
+    }
+
+    #[test]
+    fn conditional_type_classifies_inferred_values() {
+        let db = TestDb::default();
+        let array = InferredType::new(
+            &db,
+            TypeData::array_instance(&db, Box::new([TypeData::String])),
+        );
+
+        assert!(matches!(array.conditional_type(), ConditionalType::Truthy));
+        assert!(matches!(
+            InferredType::new(&db, TypeData::String).conditional_type(),
+            ConditionalType::NonNullish
+        ));
+        assert!(matches!(
+            InferredType::new(&db, TypeData::Null).conditional_type(),
+            ConditionalType::Nullish
+        ));
     }
 
     #[test]

--- a/crates/biome_js_type_info/src/interned_types.rs
+++ b/crates/biome_js_type_info/src/interned_types.rs
@@ -171,7 +171,7 @@ impl ExactSizeIterator for UnionIterator<'_> {
 
 impl FusedIterator for UnionIterator<'_> {}
 
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Eq, PartialEq, salsa::Update)]
 pub enum ConditionalType {
     Anything,
     Falsy,

--- a/crates/biome_module_graph/src/db/queries/type_inference.rs
+++ b/crates/biome_module_graph/src/db/queries/type_inference.rs
@@ -26,6 +26,7 @@
 //! shapes produce `Unknown` or `None` instead of a TypeScript diagnostic.
 
 mod calls;
+mod conditional;
 mod exports;
 mod interned;
 mod lookups;
@@ -39,11 +40,12 @@ pub(in crate::db) use calls::{
 pub use calls::{
     infer_call_argument_type, infer_call_expression_type, infer_constructor_argument_type,
 };
+pub(crate) use conditional::{infer_expression_case_literal, infer_expression_conditional_type};
 pub use exports::infer_export_type;
 pub(crate) use exports::{namespace_export_names, resolved_export_origin};
 pub use interned::{
-    BindingTypeInput, CallArgumentTypeInput, CallExpressionTypeInput, ExpressionTypeInput,
-    LocalTypeInput, NormalizeTypeInput,
+    BindingTypeInput, CallArgumentTypeInput, CallExpressionTypeInput, ExpressionCaseLiteralInput,
+    ExpressionTypeInput, LocalTypeInput, NormalizeTypeInput,
 };
 pub(crate) use interned::{BindingTypeWithImportBudgetInput, LocalTypeWithImportBudgetInput};
 pub use lookups::{

--- a/crates/biome_module_graph/src/db/queries/type_inference/conditional.rs
+++ b/crates/biome_module_graph/src/db/queries/type_inference/conditional.rs
@@ -1,0 +1,78 @@
+use super::{ExpressionCaseLiteralInput, ExpressionTypeInput};
+use crate::ModuleDb;
+use crate::db::type_inference::{
+    classify_expression_case_literal, classify_expression_conditional,
+};
+use crate::module_graph::ModuleInfoKind;
+use crate::type_inference::profiling::{
+    TypeInferenceProfileOrigin, TypeInferenceQueryKind, execute_query,
+};
+use biome_js_type_info::interned_types::ConditionalType;
+
+/// Classifies an expression using only raw type information when the result is
+/// available without resolving complete local type tables.
+#[salsa::tracked(cycle_result = infer_expression_conditional_type_cycle_result)]
+pub fn infer_expression_conditional_type<'db>(
+    db: &'db dyn ModuleDb,
+    input: ExpressionTypeInput<'db>,
+) -> Option<ConditionalType> {
+    let module = input.module(db);
+    let expression = input.expression(db);
+    execute_query(
+        TypeInferenceQueryKind::Lookups,
+        TypeInferenceProfileOrigin::exact(module, expression),
+        "infer_expression_conditional_type",
+        || {
+            let ModuleInfoKind::Js(js_info) = module.kind(db) else {
+                return None;
+            };
+            if !js_info.infer_types {
+                return None;
+            }
+
+            classify_expression_conditional(db, module, expression)
+        },
+    )
+}
+
+fn infer_expression_conditional_type_cycle_result<'db>(
+    _db: &'db dyn ModuleDb,
+    _id: salsa::Id,
+    _input: ExpressionTypeInput<'db>,
+) -> Option<ConditionalType> {
+    None
+}
+
+/// Checks whether a raw expression type can equal a switch-case literal.
+#[salsa::tracked(cycle_result = infer_expression_case_literal_cycle_result)]
+pub fn infer_expression_case_literal<'db>(
+    db: &'db dyn ModuleDb,
+    input: ExpressionCaseLiteralInput<'db>,
+) -> Option<bool> {
+    let module = input.module(db);
+    let expression = input.expression(db);
+    let literal = input.literal(db).clone();
+    execute_query(
+        TypeInferenceQueryKind::Lookups,
+        TypeInferenceProfileOrigin::exact(module, expression),
+        "infer_expression_case_literal",
+        || {
+            let ModuleInfoKind::Js(js_info) = module.kind(db) else {
+                return None;
+            };
+            if !js_info.infer_types {
+                return None;
+            }
+
+            classify_expression_case_literal(db, module, expression, &literal)
+        },
+    )
+}
+
+fn infer_expression_case_literal_cycle_result<'db>(
+    _db: &'db dyn ModuleDb,
+    _id: salsa::Id,
+    _input: ExpressionCaseLiteralInput<'db>,
+) -> Option<bool> {
+    None
+}

--- a/crates/biome_module_graph/src/db/queries/type_inference/interned.rs
+++ b/crates/biome_module_graph/src/db/queries/type_inference/interned.rs
@@ -5,6 +5,7 @@
 //! cached by interning.
 
 use crate::ModuleInfo;
+use crate::type_inference::CaseLiteral;
 use biome_js_type_info::interned_types::{
     CallArgumentType as InferredCallArgumentType, LocalTypeId as InferredLocalTypeId,
     TypeData as InferredTypeData,
@@ -20,6 +21,17 @@ pub struct ExpressionTypeInput<'db> {
     pub module: ModuleInfo,
     /// Source location that identifies the expression in the module's raw table.
     pub expression: TextRange,
+}
+
+/// Interned input for switch-case compatibility queries.
+#[salsa::interned]
+#[derive(Debug)]
+pub struct ExpressionCaseLiteralInput<'db> {
+    pub module: ModuleInfo,
+    /// Source location that identifies the expression in the module's raw table.
+    pub expression: TextRange,
+    #[returns(ref)]
+    pub literal: CaseLiteral,
 }
 
 /// Interned input for [`super::infer_binding_type`].

--- a/crates/biome_module_graph/src/db/type_inference/conditional_classification.rs
+++ b/crates/biome_module_graph/src/db/type_inference/conditional_classification.rs
@@ -1,0 +1,916 @@
+//! Fast conditional classification for expressions whose raw type is enough
+//! to answer the question without resolving complete local type tables.
+
+use crate::ModuleDb;
+use crate::js_module_info::{JsExport, JsModuleInfo, JsOwnExport};
+use crate::module_graph::{ModuleInfo, ModuleInfoKind};
+use crate::type_inference::CaseLiteral;
+use biome_js_syntax::numbers::canonicalize_js_bigint_literal;
+use biome_js_type_info::interned_types::ConditionalType;
+use biome_js_type_info::{
+    GlobalTypeId, ImportSymbol, Literal, RawTypeData, RawTypeId, ScopeId, TypeId,
+    TypeImportQualifier, TypeMember, TypeReference, TypeReferenceQualifier, TypeofExpression,
+    global_types,
+};
+use biome_rowan::{Text, TextRange};
+use camino::Utf8PathBuf;
+use rustc_hash::FxHashSet;
+
+const MAX_CONDITIONAL_CLASSIFICATION_STEPS: usize = 1024;
+
+#[derive(Clone, Copy)]
+enum MemberMode {
+    Value,
+    Instance,
+}
+
+struct RawReference {
+    module: ModuleInfo,
+    js_info: JsModuleInfo,
+    reference: TypeReference,
+}
+
+struct ConditionalClassifier<'db> {
+    db: &'db dyn ModuleDb,
+    seen_local_types: FxHashSet<(Utf8PathBuf, TypeId)>,
+    seen_imports: FxHashSet<(Utf8PathBuf, ImportSymbol)>,
+    steps: usize,
+}
+
+pub(in crate::db) fn classify_expression_conditional(
+    db: &dyn ModuleDb,
+    module: ModuleInfo,
+    expression: TextRange,
+) -> Option<ConditionalType> {
+    let ModuleInfoKind::Js(js_info) = module.kind(db) else {
+        return None;
+    };
+    if !js_info.infer_types {
+        return None;
+    }
+
+    let reference = js_info.raw_expressions.get(&expression)?.clone();
+    let mut classifier = ConditionalClassifier {
+        db,
+        seen_local_types: FxHashSet::default(),
+        seen_imports: FxHashSet::default(),
+        steps: 0,
+    };
+    classifier.classify_reference(RawReference {
+        module,
+        js_info,
+        reference,
+    })
+}
+
+pub(in crate::db) fn classify_expression_case_literal(
+    db: &dyn ModuleDb,
+    module: ModuleInfo,
+    expression: TextRange,
+    literal: &CaseLiteral,
+) -> Option<bool> {
+    let ModuleInfoKind::Js(js_info) = module.kind(db) else {
+        return None;
+    };
+    if !js_info.infer_types {
+        return None;
+    }
+
+    let reference = js_info.raw_expressions.get(&expression)?.clone();
+    let mut classifier = ConditionalClassifier {
+        db,
+        seen_local_types: FxHashSet::default(),
+        seen_imports: FxHashSet::default(),
+        steps: 0,
+    };
+    classifier.could_equal_reference(
+        RawReference {
+            module,
+            js_info,
+            reference,
+        },
+        literal,
+    )
+}
+
+impl<'db> ConditionalClassifier<'db> {
+    fn classify_reference(&mut self, reference: RawReference) -> Option<ConditionalType> {
+        if !self.step() {
+            return None;
+        }
+
+        match &reference.reference {
+            TypeReference::Resolved(RawTypeId::Local(type_id)) => {
+                self.classify_local_type(&reference, *type_id)
+            }
+            TypeReference::Resolved(RawTypeId::Global(global_id)) => {
+                self.classify_global_type(*global_id)
+            }
+            TypeReference::Qualifier(qualifier) => {
+                let reference = self.resolve_qualifier(&reference, qualifier)?;
+                self.classify_reference(reference)
+            }
+            TypeReference::Import(import) => self.classify_import(import),
+        }
+    }
+
+    fn classify_local_type(
+        &mut self,
+        reference: &RawReference,
+        type_id: TypeId,
+    ) -> Option<ConditionalType> {
+        let key = (reference.module.path(self.db).clone(), type_id);
+        if !self.seen_local_types.insert(key.clone()) {
+            return None;
+        }
+
+        let result = reference
+            .js_info
+            .raw_types
+            .get(type_id.index())
+            .cloned()
+            .and_then(|raw| self.classify_raw_type(reference, &raw));
+
+        self.seen_local_types.remove(&key);
+        result
+    }
+
+    fn could_equal_reference(
+        &mut self,
+        reference: RawReference,
+        literal: &CaseLiteral,
+    ) -> Option<bool> {
+        if !self.step() {
+            return None;
+        }
+
+        match &reference.reference {
+            TypeReference::Resolved(RawTypeId::Local(type_id)) => {
+                let raw = reference.js_info.raw_types.get(type_id.index())?.clone();
+                self.could_equal_raw_type(&reference, &raw, literal)
+            }
+            TypeReference::Resolved(RawTypeId::Global(_)) => None,
+            TypeReference::Qualifier(qualifier) => {
+                let reference = self.resolve_qualifier(&reference, qualifier)?;
+                self.could_equal_reference(reference, literal)
+            }
+            TypeReference::Import(import) => {
+                if import.type_only {
+                    return None;
+                }
+                if matches!(&import.symbol, ImportSymbol::All) {
+                    return Some(false);
+                }
+                let reference = self.resolve_import_reference(import)?;
+                self.could_equal_reference(reference, literal)
+            }
+        }
+    }
+
+    fn could_equal_raw_type(
+        &mut self,
+        source: &RawReference,
+        raw: &RawTypeData,
+        literal: &CaseLiteral,
+    ) -> Option<bool> {
+        match raw {
+            RawTypeData::Unknown | RawTypeData::AnyKeyword | RawTypeData::UnknownKeyword => {
+                Some(true)
+            }
+            RawTypeData::NeverKeyword => Some(false),
+            RawTypeData::BigInt
+            | RawTypeData::Class(_)
+            | RawTypeData::Constructor(_)
+            | RawTypeData::Function(_)
+            | RawTypeData::Global
+            | RawTypeData::ImportNamespace(_)
+            | RawTypeData::Interface(_)
+            | RawTypeData::Module(_)
+            | RawTypeData::Namespace(_)
+            | RawTypeData::Object(_)
+            | RawTypeData::ObjectKeyword
+            | RawTypeData::Symbol
+            | RawTypeData::ThisKeyword
+            | RawTypeData::Tuple(_) => Some(false),
+            RawTypeData::Boolean => Some(matches!(literal, CaseLiteral::Boolean(_))),
+            RawTypeData::Number => Some(matches!(literal, CaseLiteral::Number(_))),
+            RawTypeData::String => Some(matches!(literal, CaseLiteral::String(_))),
+            RawTypeData::Null | RawTypeData::Undefined | RawTypeData::VoidKeyword => {
+                Some(matches!(literal, CaseLiteral::Null))
+            }
+            RawTypeData::Literal(value) => Some(raw_literal_could_equal(value, literal)),
+            RawTypeData::Reference(reference) => self.could_equal_reference(
+                RawReference {
+                    module: source.module,
+                    js_info: source.js_info.clone(),
+                    reference: reference.clone(),
+                },
+                literal,
+            ),
+            RawTypeData::TypeofType(reference) => self.could_equal_reference(
+                RawReference {
+                    module: source.module,
+                    js_info: source.js_info.clone(),
+                    reference: reference.as_ref().clone(),
+                },
+                literal,
+            ),
+            RawTypeData::TypeofValue(value) => {
+                let reference = if value.ty.is_unknown() {
+                    TypeReferenceQualifier::from_path(
+                        value.scope_id.unwrap_or(ScopeId::GLOBAL),
+                        value.identifier.clone(),
+                    )
+                    .into()
+                } else {
+                    value.ty.clone()
+                };
+                self.could_equal_reference(
+                    RawReference {
+                        module: source.module,
+                        js_info: source.js_info.clone(),
+                        reference,
+                    },
+                    literal,
+                )
+            }
+            RawTypeData::Generic(generic) => {
+                if generic.constraint.is_unknown() {
+                    Some(true)
+                } else {
+                    self.could_equal_reference(
+                        RawReference {
+                            module: source.module,
+                            js_info: source.js_info.clone(),
+                            reference: generic.constraint.clone(),
+                        },
+                        literal,
+                    )
+                }
+            }
+            RawTypeData::InstanceOf(instance) => self.could_equal_reference(
+                RawReference {
+                    module: source.module,
+                    js_info: source.js_info.clone(),
+                    reference: instance.ty.clone(),
+                },
+                literal,
+            ),
+            RawTypeData::Union(union) => {
+                self.could_equal_union(source, union.types().iter(), literal)
+            }
+            RawTypeData::Intersection(_) => Some(false),
+            RawTypeData::MergedReference(_)
+            | RawTypeData::Conditional
+            | RawTypeData::TypeOperator(_) => None,
+            RawTypeData::TypeofExpression(_) => Some(true),
+        }
+    }
+
+    fn could_equal_union<'a>(
+        &mut self,
+        source: &RawReference,
+        references: impl IntoIterator<Item = &'a TypeReference>,
+        literal: &CaseLiteral,
+    ) -> Option<bool> {
+        let mut could_equal = false;
+        for reference in references {
+            match self.could_equal_reference(
+                RawReference {
+                    module: source.module,
+                    js_info: source.js_info.clone(),
+                    reference: reference.clone(),
+                },
+                literal,
+            )? {
+                true => could_equal = true,
+                false => {}
+            }
+        }
+        Some(could_equal)
+    }
+
+    fn classify_global_type(&self, global_id: GlobalTypeId) -> Option<ConditionalType> {
+        global_types(self.db)
+            .get(global_id)
+            .conditional_type_shallow(self.db)
+    }
+
+    fn classify_raw_type(
+        &mut self,
+        source: &RawReference,
+        raw: &RawTypeData,
+    ) -> Option<ConditionalType> {
+        match raw {
+            RawTypeData::Unknown
+            | RawTypeData::AnyKeyword
+            | RawTypeData::Conditional
+            | RawTypeData::NeverKeyword
+            | RawTypeData::ThisKeyword
+            | RawTypeData::UnknownKeyword => Some(ConditionalType::Anything),
+            RawTypeData::BigInt
+            | RawTypeData::Boolean
+            | RawTypeData::Interface(_)
+            | RawTypeData::Number
+            | RawTypeData::String => Some(ConditionalType::NonNullish),
+            RawTypeData::Class(_)
+            | RawTypeData::Constructor(_)
+            | RawTypeData::Function(_)
+            | RawTypeData::Global
+            | RawTypeData::ImportNamespace(_)
+            | RawTypeData::Module(_)
+            | RawTypeData::Namespace(_)
+            | RawTypeData::Object(_)
+            | RawTypeData::ObjectKeyword
+            | RawTypeData::Symbol
+            | RawTypeData::Tuple(_) => Some(ConditionalType::Truthy),
+            RawTypeData::Null | RawTypeData::Undefined | RawTypeData::VoidKeyword => {
+                Some(ConditionalType::Nullish)
+            }
+            RawTypeData::Literal(literal) => Some(match literal.as_ref() {
+                Literal::BigInt(text) => match canonicalize_js_bigint_literal(text.text()) {
+                    Some(text) if text == "0n" => ConditionalType::FalsyButNotNullish,
+                    Some(_) => ConditionalType::Truthy,
+                    None => ConditionalType::Anything,
+                },
+                Literal::Boolean(boolean) => {
+                    if boolean.as_bool() {
+                        ConditionalType::Truthy
+                    } else {
+                        ConditionalType::FalsyButNotNullish
+                    }
+                }
+                Literal::Number(number) => match number.to_f64() {
+                    Some(number) if number == 0. || number.is_nan() => {
+                        ConditionalType::FalsyButNotNullish
+                    }
+                    Some(_) => ConditionalType::Truthy,
+                    None => ConditionalType::Anything,
+                },
+                Literal::Object(_) | Literal::RegExp(_) => ConditionalType::Truthy,
+                Literal::String(string) => {
+                    if string.as_str().is_empty() {
+                        ConditionalType::FalsyButNotNullish
+                    } else {
+                        ConditionalType::Truthy
+                    }
+                }
+                Literal::Template(_) => ConditionalType::Anything,
+            }),
+            RawTypeData::Reference(reference) => self.classify_reference(RawReference {
+                module: source.module,
+                js_info: source.js_info.clone(),
+                reference: reference.clone(),
+            }),
+            RawTypeData::TypeofType(reference) => self.classify_reference(RawReference {
+                module: source.module,
+                js_info: source.js_info.clone(),
+                reference: reference.as_ref().clone(),
+            }),
+            RawTypeData::TypeofValue(value) => {
+                if value.ty.is_unknown() {
+                    let qualifier = TypeReferenceQualifier::from_path(
+                        value.scope_id.unwrap_or(ScopeId::GLOBAL),
+                        value.identifier.clone(),
+                    );
+                    self.classify_reference(RawReference {
+                        module: source.module,
+                        js_info: source.js_info.clone(),
+                        reference: qualifier.into(),
+                    })
+                } else {
+                    self.classify_reference(RawReference {
+                        module: source.module,
+                        js_info: source.js_info.clone(),
+                        reference: value.ty.clone(),
+                    })
+                }
+            }
+            RawTypeData::Generic(generic) => (!generic.constraint.is_unknown())
+                .then(|| {
+                    self.classify_reference(RawReference {
+                        module: source.module,
+                        js_info: source.js_info.clone(),
+                        reference: generic.constraint.clone(),
+                    })
+                })
+                .flatten(),
+            RawTypeData::InstanceOf(instance) => self.classify_reference(RawReference {
+                module: source.module,
+                js_info: source.js_info.clone(),
+                reference: instance.ty.clone(),
+            }),
+            RawTypeData::MergedReference(reference) => self.merge_references(
+                source,
+                [
+                    reference.ty.as_ref(),
+                    reference.value_ty.as_ref(),
+                    reference.namespace_ty.as_ref(),
+                ]
+                .into_iter()
+                .flatten(),
+            ),
+            RawTypeData::Union(union) => self.merge_references(source, union.types().iter()),
+            RawTypeData::Intersection(intersection) => {
+                self.merge_references(source, intersection.types().iter())
+            }
+            RawTypeData::TypeOperator(_) => None,
+            RawTypeData::TypeofExpression(expression) => {
+                self.classify_expression_type(source, expression.as_ref())
+            }
+        }
+    }
+
+    fn classify_expression_type(
+        &mut self,
+        source: &RawReference,
+        expression: &TypeofExpression,
+    ) -> Option<ConditionalType> {
+        match expression {
+            TypeofExpression::Addition(_)
+            | TypeofExpression::BitwiseNot(_)
+            | TypeofExpression::UnaryMinus(_) => Some(ConditionalType::NonNullish),
+            TypeofExpression::New(_) | TypeofExpression::Typeof(_) => Some(ConditionalType::Truthy),
+            TypeofExpression::StaticMember(expression) => {
+                let member = self.member_reference(
+                    source,
+                    &expression.object,
+                    expression.member.text(),
+                    MemberMode::Value,
+                )?;
+                self.classify_reference(member)
+            }
+            TypeofExpression::OptionalChainStaticMember(_)
+            | TypeofExpression::Call(_)
+            | TypeofExpression::Await(_)
+            | TypeofExpression::Destructure(_)
+            | TypeofExpression::Index(_)
+            | TypeofExpression::OptionalChainIndex(_)
+            | TypeofExpression::IterableValueOf(_)
+            | TypeofExpression::Super(_)
+            | TypeofExpression::This(_) => None,
+            TypeofExpression::Conditional(expression) => {
+                let consequent = self.classify_reference(RawReference {
+                    module: source.module,
+                    js_info: source.js_info.clone(),
+                    reference: expression.consequent.clone(),
+                })?;
+                let alternate = self.classify_reference(RawReference {
+                    module: source.module,
+                    js_info: source.js_info.clone(),
+                    reference: expression.alternate.clone(),
+                })?;
+                let merged = consequent.merged_with(alternate);
+
+                if merged.is_truthy() || merged.is_falsy() || merged.is_non_nullish() {
+                    return Some(merged);
+                }
+
+                let test = self.classify_reference(RawReference {
+                    module: source.module,
+                    js_info: source.js_info.clone(),
+                    reference: expression.test.clone(),
+                })?;
+                if test.is_truthy() {
+                    Some(consequent)
+                } else if test.is_falsy() {
+                    Some(alternate)
+                } else {
+                    Some(merged)
+                }
+            }
+            TypeofExpression::LogicalAnd(expression) => {
+                let left = self.classify_reference(RawReference {
+                    module: source.module,
+                    js_info: source.js_info.clone(),
+                    reference: expression.left.clone(),
+                })?;
+                if left.is_truthy() {
+                    self.classify_reference(RawReference {
+                        module: source.module,
+                        js_info: source.js_info.clone(),
+                        reference: expression.right.clone(),
+                    })
+                } else if left.is_falsy() {
+                    Some(left)
+                } else {
+                    None
+                }
+            }
+            TypeofExpression::LogicalOr(expression) => {
+                let left = self.classify_reference(RawReference {
+                    module: source.module,
+                    js_info: source.js_info.clone(),
+                    reference: expression.left.clone(),
+                })?;
+                if left.is_truthy() {
+                    Some(left)
+                } else if left.is_falsy() {
+                    self.classify_reference(RawReference {
+                        module: source.module,
+                        js_info: source.js_info.clone(),
+                        reference: expression.right.clone(),
+                    })
+                } else {
+                    None
+                }
+            }
+            TypeofExpression::NullishCoalescing(expression) => {
+                let left = self.classify_reference(RawReference {
+                    module: source.module,
+                    js_info: source.js_info.clone(),
+                    reference: expression.left.clone(),
+                })?;
+                if left.is_non_nullish() {
+                    Some(left)
+                } else if left.is_nullish() {
+                    self.classify_reference(RawReference {
+                        module: source.module,
+                        js_info: source.js_info.clone(),
+                        reference: expression.right.clone(),
+                    })
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    fn merge_references<'a>(
+        &mut self,
+        source: &RawReference,
+        references: impl IntoIterator<Item = &'a TypeReference>,
+    ) -> Option<ConditionalType> {
+        let mut merged = ConditionalType::Unknown;
+        let mut found = false;
+
+        for reference in references {
+            let conditional = self.classify_reference(RawReference {
+                module: source.module,
+                js_info: source.js_info.clone(),
+                reference: reference.clone(),
+            })?;
+            merged = if found {
+                merged.merged_with(conditional)
+            } else {
+                conditional
+            };
+            found = true;
+        }
+
+        Some(if found {
+            merged
+        } else {
+            ConditionalType::Anything
+        })
+    }
+
+    fn resolve_qualifier(
+        &mut self,
+        source: &RawReference,
+        qualifier: &TypeReferenceQualifier,
+    ) -> Option<RawReference> {
+        if !qualifier.type_parameters.is_empty() {
+            return None;
+        }
+
+        let mut path = qualifier.path.iter();
+        let identifier = path.next()?;
+        let mut scope = source
+            .js_info
+            .semantic_model
+            .scope_from_id(qualifier.scope_id);
+        let binding = loop {
+            if let Some(binding) = scope.get_binding(identifier.text()) {
+                break binding;
+            }
+            scope = scope.parent()?;
+        };
+
+        let range = binding.syntax().text_trimmed_range();
+        let mut reference = RawReference {
+            module: source.module,
+            js_info: source.js_info.clone(),
+            reference: source.js_info.raw_binding_types.get(&range)?.clone(),
+        };
+        for member in path {
+            let raw_reference = reference.reference.clone();
+            reference = self.member_reference(
+                &reference,
+                &raw_reference,
+                member.text(),
+                MemberMode::Value,
+            )?;
+        }
+        Some(reference)
+    }
+
+    fn member_reference(
+        &mut self,
+        source: &RawReference,
+        reference: &TypeReference,
+        name: &str,
+        mode: MemberMode,
+    ) -> Option<RawReference> {
+        if let TypeReference::Import(import) = reference {
+            return self.import_member_reference(import, name, mode);
+        }
+
+        let raw = self.raw_type(source, reference)?;
+        match raw {
+            RawTypeData::Reference(reference) => {
+                self.member_reference(source, &reference, name, mode)
+            }
+            RawTypeData::TypeofType(reference) => {
+                self.member_reference(source, reference.as_ref(), name, mode)
+            }
+            RawTypeData::TypeofValue(value) => {
+                let reference = if value.ty.is_unknown() {
+                    TypeReferenceQualifier::from_path(
+                        value.scope_id.unwrap_or(ScopeId::GLOBAL),
+                        value.identifier,
+                    )
+                    .into()
+                } else {
+                    value.ty
+                };
+                self.member_reference(source, &reference, name, mode)
+            }
+            RawTypeData::TypeofExpression(expression) => {
+                let TypeofExpression::StaticMember(expression) = expression.as_ref() else {
+                    return None;
+                };
+                let member = self.member_reference(
+                    source,
+                    &expression.object,
+                    expression.member.text(),
+                    MemberMode::Value,
+                )?;
+                let member_reference = member.reference.clone();
+                self.member_reference(&member, &member_reference, name, mode)
+            }
+            RawTypeData::InstanceOf(instance) => {
+                self.member_reference(source, &instance.ty, name, MemberMode::Instance)
+            }
+            RawTypeData::Class(class) => {
+                find_member(&class.members, name, mode).map(|member| RawReference {
+                    module: source.module,
+                    js_info: source.js_info.clone(),
+                    reference: member.ty.clone(),
+                })
+            }
+            RawTypeData::Interface(interface) => {
+                find_member(&interface.members, name, MemberMode::Instance).map(|member| {
+                    RawReference {
+                        module: source.module,
+                        js_info: source.js_info.clone(),
+                        reference: member.ty.clone(),
+                    }
+                })
+            }
+            RawTypeData::Object(object) => find_member(&object.members, name, MemberMode::Instance)
+                .map(|member| RawReference {
+                    module: source.module,
+                    js_info: source.js_info.clone(),
+                    reference: member.ty.clone(),
+                }),
+            RawTypeData::Module(module) => find_member(&module.members, name, MemberMode::Value)
+                .map(|member| RawReference {
+                    module: source.module,
+                    js_info: source.js_info.clone(),
+                    reference: member.ty.clone(),
+                }),
+            RawTypeData::Namespace(namespace) => {
+                find_member(&namespace.members, name, MemberMode::Value).map(|member| {
+                    RawReference {
+                        module: source.module,
+                        js_info: source.js_info.clone(),
+                        reference: member.ty.clone(),
+                    }
+                })
+            }
+            RawTypeData::Literal(literal) => {
+                let Literal::Object(object) = literal.as_ref() else {
+                    return None;
+                };
+                find_member(object.members(), name, MemberMode::Instance).map(|member| {
+                    RawReference {
+                        module: source.module,
+                        js_info: source.js_info.clone(),
+                        reference: member.ty.clone(),
+                    }
+                })
+            }
+            RawTypeData::Union(_)
+            | RawTypeData::Intersection(_)
+            | RawTypeData::MergedReference(_) => None,
+            RawTypeData::Unknown
+            | RawTypeData::Global
+            | RawTypeData::BigInt
+            | RawTypeData::Boolean
+            | RawTypeData::Null
+            | RawTypeData::Number
+            | RawTypeData::String
+            | RawTypeData::Symbol
+            | RawTypeData::Undefined
+            | RawTypeData::Conditional
+            | RawTypeData::ImportNamespace(_)
+            | RawTypeData::Constructor(_)
+            | RawTypeData::Function(_)
+            | RawTypeData::Tuple(_)
+            | RawTypeData::Generic(_)
+            | RawTypeData::TypeOperator(_)
+            | RawTypeData::AnyKeyword
+            | RawTypeData::NeverKeyword
+            | RawTypeData::ObjectKeyword
+            | RawTypeData::ThisKeyword
+            | RawTypeData::UnknownKeyword
+            | RawTypeData::VoidKeyword => None,
+        }
+    }
+
+    fn raw_type(
+        &mut self,
+        source: &RawReference,
+        reference: &TypeReference,
+    ) -> Option<RawTypeData> {
+        if !self.step() {
+            return None;
+        }
+
+        match reference {
+            TypeReference::Resolved(RawTypeId::Local(type_id)) => {
+                source.js_info.raw_types.get(type_id.index()).cloned()
+            }
+            TypeReference::Resolved(RawTypeId::Global(_)) | TypeReference::Import(_) => None,
+            TypeReference::Qualifier(qualifier) => {
+                let reference = self.resolve_qualifier(source, qualifier)?;
+                let raw_reference = reference.reference.clone();
+                self.raw_type(&reference, &raw_reference)
+            }
+        }
+    }
+
+    fn classify_import(&mut self, import: &TypeImportQualifier) -> Option<ConditionalType> {
+        if import.type_only {
+            return None;
+        }
+
+        if matches!(&import.symbol, ImportSymbol::All) {
+            return Some(ConditionalType::Truthy);
+        }
+
+        let reference = self.resolve_import_reference(import)?;
+        self.classify_reference(reference)
+    }
+
+    fn resolve_import_reference(&mut self, import: &TypeImportQualifier) -> Option<RawReference> {
+        let (module, _) = self.module_for_import(import)?;
+        self.resolve_export_reference(module, &import.symbol)
+    }
+
+    fn import_member_reference(
+        &mut self,
+        import: &TypeImportQualifier,
+        name: &str,
+        mode: MemberMode,
+    ) -> Option<RawReference> {
+        if import.type_only {
+            return None;
+        }
+
+        let (module, _) = self.module_for_import(import)?;
+        if matches!(&import.symbol, ImportSymbol::All) {
+            return self.resolve_export_reference(
+                module,
+                &ImportSymbol::Named(Text::from(name.to_string())),
+            );
+        }
+
+        let reference = self.resolve_import_reference(import)?;
+        let raw_reference = reference.reference.clone();
+        self.member_reference(&reference, &raw_reference, name, mode)
+    }
+
+    fn module_for_import(
+        &self,
+        import: &TypeImportQualifier,
+    ) -> Option<(ModuleInfo, JsModuleInfo)> {
+        let path = import.resolved_path.as_path()?;
+        let module = self.db.module_for_path(path)?;
+        let ModuleInfoKind::Js(js_info) = module.kind(self.db) else {
+            return None;
+        };
+        Some((module, js_info))
+    }
+
+    fn resolve_export_reference(
+        &mut self,
+        module: ModuleInfo,
+        symbol: &ImportSymbol,
+    ) -> Option<RawReference> {
+        let name = match symbol {
+            ImportSymbol::Default => Text::from("default"),
+            ImportSymbol::Named(name) => name.clone(),
+            ImportSymbol::All => return None,
+        };
+        let key = (module.path(self.db).clone(), symbol.clone());
+        if !self.seen_imports.insert(key.clone()) {
+            return None;
+        }
+
+        let result = match module.kind(self.db) {
+            ModuleInfoKind::Js(js_info) => js_info
+                .exports
+                .get(&name)
+                .cloned()
+                .and_then(|export| self.raw_reference_for_export(module, &js_info, export)),
+            ModuleInfoKind::Css(_) | ModuleInfoKind::Html(_) => None,
+        };
+
+        self.seen_imports.remove(&key);
+        result
+    }
+
+    fn raw_reference_for_export(
+        &mut self,
+        module: ModuleInfo,
+        js_info: &JsModuleInfo,
+        export: JsExport,
+    ) -> Option<RawReference> {
+        match export {
+            JsExport::Own(own) => match own {
+                JsOwnExport::Binding(range) => {
+                    js_info
+                        .raw_binding_types
+                        .get(&range)
+                        .map(|reference| RawReference {
+                            module,
+                            js_info: js_info.clone(),
+                            reference: reference.clone(),
+                        })
+                }
+                JsOwnExport::Type(type_id) => Some(RawReference {
+                    module,
+                    js_info: js_info.clone(),
+                    reference: TypeReference::Resolved(RawTypeId::Local(type_id)),
+                }),
+                JsOwnExport::Namespace(reexport) => Some(RawReference {
+                    module,
+                    js_info: js_info.clone(),
+                    reference: TypeReference::from(TypeImportQualifier {
+                        symbol: ImportSymbol::All,
+                        resolved_path: reexport.import.resolved_path.clone(),
+                        type_only: false,
+                    }),
+                }),
+            },
+            JsExport::Reexport(reexport) => {
+                let (target, _) = self.module_for_import(&TypeImportQualifier {
+                    symbol: reexport.import.symbol.clone(),
+                    resolved_path: reexport.import.resolved_path.clone(),
+                    type_only: false,
+                })?;
+                self.resolve_export_reference(target, &reexport.import.symbol)
+            }
+            JsExport::OwnType(_) | JsExport::ReexportType(_) => None,
+        }
+    }
+
+    fn step(&mut self) -> bool {
+        self.steps += 1;
+        self.steps <= MAX_CONDITIONAL_CLASSIFICATION_STEPS
+    }
+}
+
+fn raw_literal_could_equal(value: &Literal, literal: &CaseLiteral) -> bool {
+    match (value, literal) {
+        (Literal::Boolean(value), CaseLiteral::Boolean(expected)) => value.as_bool() == *expected,
+        (Literal::Number(value), CaseLiteral::Number(expected)) => {
+            value.to_f64() == Some(f64::from_bits(*expected))
+        }
+        (Literal::String(value), CaseLiteral::String(expected)) => {
+            value.as_str() == expected.text()
+        }
+        (
+            Literal::Object(_) | Literal::RegExp(_) | Literal::Template(_) | Literal::BigInt(_),
+            _,
+        ) => false,
+        _ => false,
+    }
+}
+
+fn find_member<'a>(
+    members: &'a [TypeMember],
+    name: &str,
+    mode: MemberMode,
+) -> Option<&'a TypeMember> {
+    let member = members.iter().find(|member| {
+        member.has_name(name)
+            && match mode {
+                MemberMode::Value => member.is_static(),
+                MemberMode::Instance => !member.is_static(),
+            }
+    })?;
+    (!member.is_getter()).then_some(member)
+}

--- a/crates/biome_module_graph/src/db/type_inference/mod.rs
+++ b/crates/biome_module_graph/src/db/type_inference/mod.rs
@@ -9,6 +9,7 @@ use biome_js_type_info::interned_types::{
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 
+mod conditional_classification;
 mod expressions;
 mod globals;
 mod imports;
@@ -17,6 +18,9 @@ mod promise_classification;
 mod qualifiers;
 mod resolver;
 
+pub(in crate::db) use conditional_classification::{
+    classify_expression_case_literal, classify_expression_conditional,
+};
 pub(in crate::db) use imports::{
     ExportOriginResult, collect_namespace_export_names, find_export_origin,
     resolve_export_type_on_demand,

--- a/crates/biome_module_graph/src/type_inference/context.rs
+++ b/crates/biome_module_graph/src/type_inference/context.rs
@@ -5,13 +5,14 @@
 //! behavior consistent between requests.
 
 use biome_js_type_info::interned_types::{
-    CallArgumentType as InferredCallArgumentType, TypeData as InferredTypeData,
+    CallArgumentType as InferredCallArgumentType, ConditionalType, TypeData as InferredTypeData,
 };
 use biome_rowan::TextRange;
 
 use crate::db::queries::{
-    BindingTypeInput, ExpressionTypeInput, find_member_type, find_value_member_type,
-    infer_binding_type, infer_export_type, infer_expression_function_returns_promise,
+    BindingTypeInput, ExpressionCaseLiteralInput, ExpressionTypeInput, find_member_type,
+    find_value_member_type, infer_binding_type, infer_export_type, infer_expression_case_literal,
+    infer_expression_conditional_type, infer_expression_function_returns_promise,
     infer_expression_is_array_of_promises, infer_expression_is_promise, infer_expression_type,
     resolve_callable_type,
 };
@@ -20,7 +21,7 @@ use crate::{
     infer_call_argument_type, infer_constructor_argument_type, normalize_type,
 };
 
-use super::{TypeInferenceClassification, TypeInferenceRequestContext};
+use super::{CaseLiteral, TypeInferenceClassification, TypeInferenceRequestContext};
 
 impl<'db> TypeInferenceRequestContext<'db> {
     /// Resolves the collected type of an expression.
@@ -34,6 +35,28 @@ impl<'db> TypeInferenceRequestContext<'db> {
     ) -> Option<InferredTypeData<'db>> {
         let db = self.db();
         infer_expression_type(db, ExpressionTypeInput::new(db, module, range))
+    }
+
+    pub(crate) fn conditional_type(
+        &self,
+        module: ModuleInfo,
+        range: TextRange,
+    ) -> Option<ConditionalType> {
+        let db = self.db();
+        infer_expression_conditional_type(db, ExpressionTypeInput::new(db, module, range))
+    }
+
+    pub(crate) fn case_literal(
+        &self,
+        module: ModuleInfo,
+        range: TextRange,
+        literal: CaseLiteral,
+    ) -> Option<bool> {
+        let db = self.db();
+        infer_expression_case_literal(
+            db,
+            ExpressionCaseLiteralInput::new(db, module, range, literal),
+        )
     }
 
     pub(crate) fn classify_expression_as_promise(

--- a/crates/biome_module_graph/src/type_inference/mod.rs
+++ b/crates/biome_module_graph/src/type_inference/mod.rs
@@ -22,7 +22,8 @@ pub use request::{
     execute_type_inference_request,
 };
 pub use requests::{
-    ArrayOfPromisesClassificationRequest, CallableMemberRequest, ExpectedCallArgumentTypeRequest,
+    ArrayOfPromisesClassificationRequest, CallableMemberRequest, CaseLiteral, CaseLiteralRequest,
+    ConditionalTypeRequest, ExpectedCallArgumentTypeRequest,
     ExpectedConstructorArgumentTypeRequest, FunctionReturnTypeRequest, MemberReturnTypeRequest,
     NormalizedBindingTypeRequest, NormalizedExpressionTypeRequest, PromiseClassificationRequest,
     PromiseReturningFunctionClassificationRequest, TypeInferenceArgument, TypeInferenceSource,

--- a/crates/biome_module_graph/src/type_inference/requests/conditional.rs
+++ b/crates/biome_module_graph/src/type_inference/requests/conditional.rs
@@ -1,0 +1,95 @@
+use super::super::{
+    Sealed, TypeInferenceCodeReference, TypeInferenceRequest, TypeInferenceRequestContext,
+    TypeInferenceRequestMetadata, TypeInferenceRequestOrigin,
+};
+use biome_js_type_info::interned_types::ConditionalType;
+use biome_rowan::{Text, TextRange};
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, salsa::Update)]
+pub enum CaseLiteral {
+    String(Text),
+    Number(u64),
+    Boolean(bool),
+    Null,
+}
+
+/// Attempts to classify an expression without resolving complete local type
+/// tables. A missing result falls back to regular expression inference.
+pub struct ConditionalTypeRequest {
+    module: crate::ModuleInfo,
+    expression: TextRange,
+}
+
+impl ConditionalTypeRequest {
+    /// Uses `expression` as both the query input and profile origin.
+    pub const fn new(module: crate::ModuleInfo, expression: TextRange) -> Self {
+        Self { module, expression }
+    }
+}
+
+impl Sealed for ConditionalTypeRequest {}
+
+impl TypeInferenceRequestMetadata for ConditionalTypeRequest {
+    const ID: &'static str = "request.conditional-type";
+    const LABEL: &'static str = "Conditional expression type";
+}
+
+impl<'db> TypeInferenceRequest<'db> for ConditionalTypeRequest {
+    type Output = Option<ConditionalType>;
+
+    const IMPLEMENTATION: TypeInferenceCodeReference =
+        TypeInferenceCodeReference::new(file!(), line!(), "ConditionalTypeRequest::execute");
+
+    fn origin(&self) -> TypeInferenceRequestOrigin {
+        TypeInferenceRequestOrigin::new(self.module, self.expression)
+    }
+
+    fn execute(self, context: &TypeInferenceRequestContext<'db>) -> Self::Output {
+        context.conditional_type(self.module, self.expression)
+    }
+}
+
+/// Attempts to determine whether an expression can equal a literal used by a
+/// switch case without resolving complete local type tables.
+pub struct CaseLiteralRequest {
+    module: crate::ModuleInfo,
+    expression: TextRange,
+    literal: CaseLiteral,
+}
+
+impl CaseLiteralRequest {
+    /// Uses `expression` as both the query input and profile origin.
+    pub const fn new(
+        module: crate::ModuleInfo,
+        expression: TextRange,
+        literal: CaseLiteral,
+    ) -> Self {
+        Self {
+            module,
+            expression,
+            literal,
+        }
+    }
+}
+
+impl Sealed for CaseLiteralRequest {}
+
+impl TypeInferenceRequestMetadata for CaseLiteralRequest {
+    const ID: &'static str = "request.case-literal";
+    const LABEL: &'static str = "Case literal compatibility";
+}
+
+impl<'db> TypeInferenceRequest<'db> for CaseLiteralRequest {
+    type Output = Option<bool>;
+
+    const IMPLEMENTATION: TypeInferenceCodeReference =
+        TypeInferenceCodeReference::new(file!(), line!(), "CaseLiteralRequest::execute");
+
+    fn origin(&self) -> TypeInferenceRequestOrigin {
+        TypeInferenceRequestOrigin::new(self.module, self.expression)
+    }
+
+    fn execute(self, context: &TypeInferenceRequestContext<'db>) -> Self::Output {
+        context.case_literal(self.module, self.expression, self.literal)
+    }
+}

--- a/crates/biome_module_graph/src/type_inference/requests/mod.rs
+++ b/crates/biome_module_graph/src/type_inference/requests/mod.rs
@@ -1,6 +1,7 @@
 //! Type-inference requests available to analyzers.
 
 mod call;
+mod conditional;
 mod expression;
 mod member;
 mod promise;
@@ -9,6 +10,7 @@ mod return_type;
 pub use call::{
     ExpectedCallArgumentTypeRequest, ExpectedConstructorArgumentTypeRequest, TypeInferenceArgument,
 };
+pub use conditional::{CaseLiteral, CaseLiteralRequest, ConditionalTypeRequest};
 pub use expression::{NormalizedBindingTypeRequest, NormalizedExpressionTypeRequest};
 pub use member::CallableMemberRequest;
 pub use promise::{


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This reduces the inference time for conditional types, which affects `noUnnecessaryConditions`. It implements a new inference module specifically for expressions whose raw type is enough to answer the question without resolving complete local type tables.

Type-inference cost improved:
- Normalized inference: 64.9s → 47–52s
- Local inference: 20.4s → 14-15s

Total rule time remained variable and higher: 72–80s versus the original 65s.

Fixes https://github.com/biomejs/biome/issues/11376


## Test Plan

TODO

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->

This was implemented via an LLM given my instructions for the inference bottleneck for `noUnnecessaryConditions`. I submitted it as a draft so the effort is open-source and available for the subsequent work on this