### PR TITLE
perf(md): reduce checks for link lookahead

### DIFF
--- a/crates/biome_markdown_parser/src/inline_phase.rs
+++ b/crates/biome_markdown_parser/src/inline_phase.rs
@@ -130,9 +130,14 @@ fn should_reparse_deferred_inline(
         return Some(false);
     }
 
+    if !deferred.has_unresolved_reference_lookup() {
+        return Some(false);
+    }
+
     let range = deferred.source_range();
-    let source = source.get(usize::from(range.start())..usize::from(range.end()))?;
-    Some(source.as_bytes().contains(&b'['))
+    source
+        .get(usize::from(range.start())..usize::from(range.end()))
+        .map(|_| true)
 }
 
 fn validate_deferred_inlines(source: &str, output: &MarkdownParserOutput) -> bool {
@@ -359,7 +364,43 @@ mod tests {
             DeferredInlineFlavor::Paragraph,
             context(),
             0,
+            false,
         )
+    }
+
+    fn deferred_with_unresolved_reference_lookup(
+        event_range: Range<usize>,
+        source_range: TextRange,
+    ) -> DeferredInline {
+        DeferredInline::for_test(
+            event_range,
+            source_range,
+            DeferredInlineFlavor::Paragraph,
+            context(),
+            0,
+            true,
+        )
+    }
+
+    #[test]
+    fn reparses_only_after_an_unresolved_reference_lookup() {
+        let source = "[link](/url)";
+        let range = TextRange::new(0.into(), TextSize::from(source.len() as u32));
+        let no_lookup = deferred(0..3, range);
+        let unresolved_lookup = deferred_with_unresolved_reference_lookup(0..3, range);
+
+        assert_eq!(
+            should_reparse_deferred_inline(source, &no_lookup, 1),
+            Some(false)
+        );
+        assert_eq!(
+            should_reparse_deferred_inline(source, &unresolved_lookup, 0),
+            Some(false)
+        );
+        assert_eq!(
+            should_reparse_deferred_inline(source, &unresolved_lookup, 1),
+            Some(true)
+        );
     }
 
     #[test]

--- a/crates/biome_markdown_parser/src/parser.rs
+++ b/crates/biome_markdown_parser/src/parser.rs
@@ -428,7 +428,7 @@ pub(crate) struct MarkdownParser<'source> {
     unresolved_reference_lookup_count: Cell<usize>,
 }
 
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Default)]
 pub(crate) struct LineIndent {
     pub(crate) token_count: usize,
     pub(crate) byte_count: usize,

--- a/crates/biome_markdown_parser/src/parser.rs
+++ b/crates/biome_markdown_parser/src/parser.rs
@@ -11,7 +11,7 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use std::ops::Range;
 use std::rc::Rc;
 
-use crate::lexer::{MarkdownLexContext, MarkdownReLexContext};
+use crate::lexer::{MarkdownLexContext, MarkdownLexer, MarkdownReLexContext};
 use crate::syntax::TAB_STOP_SPACES;
 use crate::syntax::inline::EmphasisContext;
 use crate::syntax::parse_error::DEFAULT_MAX_NESTING_DEPTH;
@@ -428,6 +428,12 @@ pub(crate) struct MarkdownParser<'source> {
     unresolved_reference_lookup_count: Cell<usize>,
 }
 
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct LineIndent {
+    pub(crate) token_count: usize,
+    pub(crate) byte_count: usize,
+}
+
 impl<'source> MarkdownParser<'source> {
     pub fn new(source: &'source str, options: MarkdownParserOptions) -> Self {
         Self {
@@ -806,7 +812,7 @@ impl<'source> MarkdownParser<'source> {
     ///
     /// Uses position-based check rather than trivia_len, so it works correctly
     /// when NEWLINE becomes an explicit token (not trivia).
-    pub fn at_start_of_input(&self) -> bool {
+    pub fn is_at_start_of_input(&self) -> bool {
         self.source.at_start_of_input()
     }
 
@@ -818,8 +824,9 @@ impl<'source> MarkdownParser<'source> {
     ///
     /// Used for detecting block-level constructs that must start at line beginning
     /// (e.g., headers, list items, thematic breaks).
-    pub fn at_line_start(&self) -> bool {
-        self.at_start_of_input()
+    #[inline]
+    pub fn is_at_line_start(&self) -> bool {
+        self.is_at_start_of_input()
             || self.has_preceding_line_break()
             || self.source.at_line_start_with_whitespace()
             || self.state.virtual_line_start == Some(self.cur_range().start())
@@ -831,11 +838,9 @@ impl<'source> MarkdownParser<'source> {
 
     /// Emit an MdIndentTokenList for optional block prefix indentation at line start.
     ///
-    /// Like `skip_line_indent()` but emits real CST nodes (`MdIndentToken` /
-    /// `MdIndentTokenList`) instead of skipped trivia. Use this for non-lookahead,
-    /// non-error-recovery paths where the indent tokens should be visible in the tree.
+    /// Emits real CST nodes (`MdIndentToken` / `MdIndentTokenList`) for indentation.
     pub fn emit_line_indent(&mut self, max_indent: usize) -> bool {
-        if !self.at_line_start() {
+        if !self.is_at_line_start() {
             let list_m = self.start();
             list_m.complete(self, MarkdownSyntaxKind::MD_INDENT_TOKEN_LIST);
             return false;
@@ -853,7 +858,7 @@ impl<'source> MarkdownParser<'source> {
     /// is already a valid child (via `AnyMdInline`). Unlike `emit_line_indent()`,
     /// this does NOT wrap tokens in an `MdIndentTokenList`.
     pub fn emit_indent_tokens(&mut self, max_indent: usize) -> bool {
-        if !self.at_line_start() {
+        if !self.is_at_line_start() {
             return false;
         }
 
@@ -903,41 +908,57 @@ impl<'source> MarkdownParser<'source> {
         true
     }
 
-    /// Consume optional indentation whitespace at line start, up to `max_indent`
-    /// columns. Each whitespace token is consumed as `Whitespace` trivia
-    /// (attached to the next real token).
-    ///
-    /// This avoids producing `Skipped` trivia, which should be reserved for
-    /// error-recovery paths.
-    pub fn skip_line_indent(&mut self, max_indent: usize) -> bool {
-        if !self.at_line_start() {
-            return false;
+    /// Returns the indentation tokens at the current line start that fit within
+    /// `max_indent` columns without consuming them.
+    pub(crate) fn peek_line_indent(&mut self, max_indent: usize) -> LineIndent {
+        if !self.is_at_line_start() {
+            return LineIndent::default();
         }
 
-        let mut consumed = 0usize;
-        let mut did_skip = false;
+        let mut indent = LineIndent::default();
+        let mut consumed_columns = 0usize;
 
-        while self.at(MarkdownSyntaxKind::MD_TEXTUAL_LITERAL) {
-            let text = self.cur_text();
-            if text.is_empty() || !text.chars().all(|c| c == ' ' || c == '\t') {
+        while self
+            .nth_at::<MarkdownLexer>(indent.token_count, MarkdownSyntaxKind::MD_TEXTUAL_LITERAL)
+        {
+            let Some(text) = self.nth_text(indent.token_count) else {
+                break;
+            };
+            if text.is_empty()
+                || text
+                    .as_bytes()
+                    .iter()
+                    .any(|byte| !matches!(byte, b' ' | b'\t'))
+            {
                 break;
             }
 
-            let indent = text
-                .chars()
-                .map(|c| if c == '\t' { TAB_STOP_SPACES } else { 1 })
+            let columns = text
+                .as_bytes()
+                .iter()
+                .map(|byte| if *byte == b'\t' { TAB_STOP_SPACES } else { 1 })
                 .sum::<usize>();
 
-            if consumed + indent > max_indent {
+            if consumed_columns + columns > max_indent {
                 break;
             }
 
-            consumed += indent;
-            did_skip = true;
+            indent.token_count += 1;
+            indent.byte_count += text.len();
+            consumed_columns += columns;
+        }
+
+        indent
+    }
+
+    /// Consumes optional indentation at line start as whitespace trivia.
+    pub(crate) fn consume_line_indent_as_whitespace_trivia(&mut self, max_indent: usize) -> bool {
+        let indent = self.peek_line_indent(max_indent);
+        for _ in 0..indent.token_count {
             self.consume_as_whitespace_trivia();
         }
 
-        did_skip
+        indent.token_count > 0
     }
 
     /// Consume the current token as `Whitespace` trivia (not `Skipped`).

--- a/crates/biome_markdown_parser/src/parser.rs
+++ b/crates/biome_markdown_parser/src/parser.rs
@@ -241,6 +241,10 @@ pub(crate) struct DeferredInline {
     /// A smaller value than the final definition count means later definitions
     /// may change reference and emphasis parsing in this subtree.
     definitions_len: usize,
+    /// Whether parsing this subtree encountered an unresolved reference lookup.
+    ///
+    /// Later definitions can change this subtree only when this is true.
+    has_unresolved_reference_lookup: bool,
 }
 
 pub(crate) struct DeferredInlineStart {
@@ -249,6 +253,7 @@ pub(crate) struct DeferredInlineStart {
     flavor: DeferredInlineFlavor,
     context: InlineContainerContext,
     definitions_len: usize,
+    unresolved_reference_lookup_count: usize,
 }
 
 impl DeferredInline {
@@ -272,6 +277,10 @@ impl DeferredInline {
         self.definitions_len
     }
 
+    pub(crate) fn has_unresolved_reference_lookup(&self) -> bool {
+        self.has_unresolved_reference_lookup
+    }
+
     #[cfg(test)]
     pub(crate) fn for_test(
         event_range: Range<usize>,
@@ -279,6 +288,7 @@ impl DeferredInline {
         flavor: DeferredInlineFlavor,
         context: InlineContainerContext,
         definitions_len: usize,
+        has_unresolved_reference_lookup: bool,
     ) -> Self {
         Self {
             event_range,
@@ -286,6 +296,7 @@ impl DeferredInline {
             flavor,
             context,
             definitions_len,
+            has_unresolved_reference_lookup,
         }
     }
 }
@@ -410,6 +421,11 @@ pub(crate) struct MarkdownParser<'source> {
     /// the parser does not advance, so caching the last computed pair avoids
     /// repeated O(line-length) scans for the preceding newline.
     abs_col_cache: Cell<Option<(u32, usize)>>,
+    /// Counts missed reference lookups across parser checkpoints.
+    ///
+    /// Rollbacks must not discard an inline range's dependency on definitions
+    /// that appear later in the document.
+    unresolved_reference_lookup_count: Cell<usize>,
 }
 
 impl<'source> MarkdownParser<'source> {
@@ -421,6 +437,7 @@ impl<'source> MarkdownParser<'source> {
             known_link_reference_definitions: None,
             state: MarkdownParserState::default(),
             abs_col_cache: Cell::new(None),
+            unresolved_reference_lookup_count: Cell::new(0),
         }
     }
 
@@ -449,6 +466,7 @@ impl<'source> MarkdownParser<'source> {
             known_link_reference_definitions: Some(definitions),
             state,
             abs_col_cache: Cell::new(None),
+            unresolved_reference_lookup_count: Cell::new(0),
         })
     }
 
@@ -518,12 +536,23 @@ impl<'source> MarkdownParser<'source> {
 
     /// Returns true if a normalized label has a link reference definition.
     pub(crate) fn has_link_reference_definition(&self, label: &str) -> bool {
-        self.known_link_reference_definitions
+        let is_defined = self
+            .known_link_reference_definitions
             .is_some_and(|definitions| definitions.contains(self.source.source_text(), label))
             || self
                 .state
                 .link_reference_definitions
-                .contains(self.source.source_text(), label)
+                .contains(self.source.source_text(), label);
+
+        if !is_defined {
+            self.unresolved_reference_lookup_count.set(
+                self.unresolved_reference_lookup_count
+                    .get()
+                    .saturating_add(1),
+            );
+        }
+
+        is_defined
     }
 
     pub(crate) fn inline_container_context(&self) -> InlineContainerContext {
@@ -548,6 +577,7 @@ impl<'source> MarkdownParser<'source> {
             flavor,
             context: self.inline_container_context(),
             definitions_len: self.link_reference_definitions_len(),
+            unresolved_reference_lookup_count: self.unresolved_reference_lookup_count(),
         }
     }
 
@@ -568,7 +598,13 @@ impl<'source> MarkdownParser<'source> {
             flavor: start.flavor,
             context: start.context,
             definitions_len: start.definitions_len,
+            has_unresolved_reference_lookup: self.unresolved_reference_lookup_count()
+                > start.unresolved_reference_lookup_count,
         });
+    }
+
+    fn unresolved_reference_lookup_count(&self) -> usize {
+        self.unresolved_reference_lookup_count.get()
     }
 
     pub(crate) fn link_reference_definitions_len(&self) -> usize {
@@ -945,7 +981,8 @@ impl<'source> MarkdownParser<'source> {
     /// When this returns true, the parser should NOT consume the NEWLINE.
     /// Instead, the block-level parser should handle the paragraph boundary.
     /// The NEWLINE at a blank line marks the end of the current block.
-    pub fn at_blank_line(&self) -> bool {
+    #[inline]
+    pub fn is_at_blank_line(&self) -> bool {
         if !self.at(MarkdownSyntaxKind::NEWLINE) {
             return false;
         }
@@ -1101,6 +1138,7 @@ pub struct MarkdownParserCheckpoint {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::syntax::parse_document;
 
     #[test]
     fn rewind_removes_only_speculative_link_definitions() {
@@ -1121,5 +1159,39 @@ mod tests {
             parser.state.link_reference_definitions.ranges_by_hash.len(),
             1
         );
+    }
+
+    #[test]
+    fn rewind_preserves_unresolved_reference_lookups() {
+        let mut parser = MarkdownParser::new("", MarkdownParserOptions::default());
+        let checkpoint = parser.checkpoint();
+
+        assert!(!parser.has_link_reference_definition("missing"));
+        parser.rewind(checkpoint);
+
+        assert_eq!(parser.unresolved_reference_lookup_count(), 1);
+    }
+
+    #[test]
+    fn deferred_inlines_track_unresolved_reference_lookups() {
+        let mut direct_link = MarkdownParser::new(
+            "[link](/url)\n\n[ref]: /url\n",
+            MarkdownParserOptions::default(),
+        );
+        parse_document(&mut direct_link);
+        let direct_output = direct_link.finish();
+
+        assert_eq!(direct_output.deferred_inlines.len(), 1);
+        assert!(!direct_output.deferred_inlines[0].has_unresolved_reference_lookup());
+
+        let mut forward_reference = MarkdownParser::new(
+            "[link][ref]\n\n[ref]: /url\n",
+            MarkdownParserOptions::default(),
+        );
+        parse_document(&mut forward_reference);
+        let forward_output = forward_reference.finish();
+
+        assert_eq!(forward_output.deferred_inlines.len(), 1);
+        assert!(forward_output.deferred_inlines[0].has_unresolved_reference_lookup());
     }
 }

--- a/crates/biome_markdown_parser/src/syntax/fenced_code_block.rs
+++ b/crates/biome_markdown_parser/src/syntax/fenced_code_block.rs
@@ -135,21 +135,15 @@ pub(crate) fn detect_fence(s: &str) -> Option<(char, usize)> {
 
 /// Check if we're at a fenced code block (``` or ~~~).
 pub(crate) fn at_fenced_code_block(p: &mut MarkdownParser) -> bool {
-    p.lookahead(|p| {
-        if !p.at_start_of_input() && !is_line_start_within_indent(p, MAX_BLOCK_PREFIX_INDENT) {
-            return false;
-        }
-        p.skip_line_indent(MAX_BLOCK_PREFIX_INDENT);
-
-        let rest = p.source_after_current();
-        let Some((fence_char, _)) = detect_fence(rest) else {
-            return false;
-        };
-        if fence_char == '`' && info_string_has_backtick(p) {
-            return false;
-        }
-        true
-    })
+    if !p.is_at_start_of_input() && !is_line_start_within_indent(p, MAX_BLOCK_PREFIX_INDENT) {
+        return false;
+    }
+    let indent = p.peek_line_indent(MAX_BLOCK_PREFIX_INDENT);
+    let rest = &p.source_after_current()[indent.byte_count..];
+    let Some((fence_char, fence_len)) = detect_fence(rest) else {
+        return false;
+    };
+    fence_char != '`' || !info_string_has_backtick(rest, fence_len)
 }
 
 /// Parse a fenced code block.
@@ -419,41 +413,16 @@ fn prepare_next_code_content_token(
 /// Consume all expected `>` quote prefixes for the current line inside a
 /// fenced code block.
 ///
-/// Uses a lookahead preflight to verify all `quote_depth` prefixes are
-/// present before consuming any. This prevents partial consumption from
-/// stealing outer blockquote markers when an inner prefix is missing
+/// Verifies all `quote_depth` prefixes in the source before consuming any.
+/// This prevents partial consumption from stealing outer blockquote markers
+/// when an inner prefix is missing
 /// (e.g., `> hello` inside a depth-2 blockquote would consume the outer
 /// `>` but fail on the missing inner `>`, corrupting outer parsing).
 ///
 /// Returns `true` if all prefixes were consumed successfully, `false` if
 /// any prefix is missing — the caller should break out of the content loop.
 fn consume_quote_prefixes_in_code_content(p: &mut MarkdownParser, quote_depth: usize) -> bool {
-    // Preflight: verify all prefixes exist before consuming any.
-    let all_present = p.lookahead(|p| {
-        p.skip_line_indent(MAX_BLOCK_PREFIX_INDENT);
-        for _ in 0..quote_depth {
-            if p.at(MD_TEXTUAL_LITERAL) && p.cur_text().starts_with('>') {
-                p.force_relex_regular();
-            }
-            if p.at(T![>]) {
-                p.bump(T![>]);
-            } else if p.at(MD_TEXTUAL_LITERAL) && p.cur_text() == ">" {
-                p.bump(MD_TEXTUAL_LITERAL);
-            } else {
-                return false;
-            }
-            // Skip optional post-marker space
-            if p.at(MD_TEXTUAL_LITERAL) {
-                let text = p.cur_text();
-                if text == " " || text == "\t" {
-                    p.bump(MD_TEXTUAL_LITERAL);
-                }
-            }
-        }
-        true
-    });
-
-    if !all_present {
+    if !has_code_content_quote_prefixes(p, quote_depth) {
         return false;
     }
 
@@ -487,7 +456,7 @@ fn consume_quote_prefix_in_code_content(p: &mut MarkdownParser) -> bool {
 
     let prefix_m = p.start();
 
-    // Empty pre-marker indent list (initial indent handled by skip_line_indent).
+    // The initial pre-marker indent is emitted before consuming the prefixes.
     let indent_list_m = p.start();
     indent_list_m.complete(p, MD_QUOTE_INDENT_LIST);
 
@@ -534,29 +503,31 @@ fn bump_code_textual(p: &mut MarkdownParser) {
     text_m.complete(p, MD_TEXTUAL);
 }
 
-pub(crate) fn info_string_has_backtick(p: &mut MarkdownParser) -> bool {
-    p.lookahead(|p| {
-        if p.at(TRIPLE_TILDE) {
+pub(crate) fn info_string_has_backtick(line: &str, fence_len: usize) -> bool {
+    line.get(fence_len..)
+        .and_then(|rest| rest.split(['\n', '\r']).next())
+        .is_some_and(|info| info.contains('`'))
+}
+
+fn has_code_content_quote_prefixes(p: &MarkdownParser, quote_depth: usize) -> bool {
+    let Some((start, source)) = get_source_context(p) else {
+        return false;
+    };
+    let bytes = source.as_bytes();
+    let Some(mut idx) = consume_indent(bytes, start, MAX_BLOCK_PREFIX_INDENT, false) else {
+        return false;
+    };
+
+    for _ in 0..quote_depth {
+        if bytes.get(idx) != Some(&b'>') {
             return false;
         }
-
-        if p.at(T!["```"]) {
-            p.bump(T!["```"]);
-        } else if p.at(BACKTICK) {
-            p.bump(BACKTICK);
-        } else {
-            return false;
+        idx += 1;
+        if matches!(bytes.get(idx), Some(b' ' | b'\t')) {
+            idx += 1;
         }
-
-        while !p.at_inline_end() {
-            if p.at(BACKTICK) || p.at(T!["```"]) {
-                return true;
-            }
-            p.bump(p.cur());
-        }
-
-        false
-    })
+    }
+    true
 }
 
 /// Skip up to `quote_depth` blockquote prefixes (`>` with optional 0-3 leading

--- a/crates/biome_markdown_parser/src/syntax/fenced_code_block.rs
+++ b/crates/biome_markdown_parser/src/syntax/fenced_code_block.rs
@@ -139,7 +139,9 @@ pub(crate) fn at_fenced_code_block(p: &mut MarkdownParser) -> bool {
         return false;
     }
     let indent = p.peek_line_indent(MAX_BLOCK_PREFIX_INDENT);
-    let rest = &p.source_after_current()[indent.byte_count..];
+    let Some(rest) = p.source_after_current().get(indent.byte_count..) else {
+        return false;
+    };
     let Some((fence_char, fence_len)) = detect_fence(rest) else {
         return false;
     };

--- a/crates/biome_markdown_parser/src/syntax/header.rs
+++ b/crates/biome_markdown_parser/src/syntax/header.rs
@@ -43,13 +43,11 @@ const MAX_HEADER_HASHES: usize = 6;
 /// Check if we might be at an ATX header.
 /// We only check if the current token is a HASH - full validation happens in parse_header.
 pub(crate) fn at_header(p: &mut MarkdownParser) -> bool {
-    p.lookahead(|p| {
-        if !p.at_line_start() && !p.at_start_of_input() {
-            return false;
-        }
-        p.skip_line_indent(MAX_BLOCK_PREFIX_INDENT);
-        p.at(T![#])
-    })
+    if !p.is_at_line_start() {
+        return false;
+    }
+    let indent = p.peek_line_indent(MAX_BLOCK_PREFIX_INDENT);
+    p.nth_at(indent.token_count, T![#])
 }
 
 /// Parse an ATX header.

--- a/crates/biome_markdown_parser/src/syntax/header.rs
+++ b/crates/biome_markdown_parser/src/syntax/header.rs
@@ -168,11 +168,11 @@ pub(crate) fn parse_header_content(p: &mut MarkdownParser) {
         return;
     }
 
-    // Set up emphasis context for header content (single line only)
-    let prev_context = set_header_emphasis_context(p);
-
     // Parse content as a paragraph containing inline items
     let deferred = p.start_deferred_inline(DeferredInlineFlavor::AtxParagraph);
+
+    // Set up emphasis context for header content (single line only)
+    let prev_context = set_header_emphasis_context(p);
     let m = p.start();
     let inline_m = p.start();
 

--- a/crates/biome_markdown_parser/src/syntax/html_block.rs
+++ b/crates/biome_markdown_parser/src/syntax/html_block.rs
@@ -335,7 +335,7 @@ fn advance_until_blank_line(p: &mut MarkdownParser) -> TextSize {
 
     while !p.at(EOF) {
         if p.at(NEWLINE) {
-            if p.at_blank_line() {
+            if p.is_at_blank_line() {
                 break;
             }
             // Consume the newline first, then check if the next line exits the container

--- a/crates/biome_markdown_parser/src/syntax/html_block.rs
+++ b/crates/biome_markdown_parser/src/syntax/html_block.rs
@@ -19,19 +19,11 @@ use biome_rowan::TextSize;
 
 /// Check if we're at an HTML block (line start, up to 3 spaces indent, then `<`).
 pub(crate) fn at_html_block(p: &mut MarkdownParser) -> bool {
-    p.lookahead(|p| {
-        if !p.at_line_start() && !p.at_start_of_input() {
-            return false;
-        }
+    if !p.is_at_line_start() || p.line_start_leading_indent() > MAX_BLOCK_PREFIX_INDENT {
+        return false;
+    }
 
-        if p.line_start_leading_indent() > MAX_BLOCK_PREFIX_INDENT {
-            return false;
-        }
-
-        p.skip_line_indent(MAX_BLOCK_PREFIX_INDENT);
-
-        p.at(L_ANGLE) && is_html_like_content(p)
-    })
+    is_html_like_content(p)
 }
 
 /// Check if content after `<` looks like HTML (tag, comment, declaration, etc.).
@@ -250,25 +242,23 @@ const BLOCK_TAGS: &[&str] = &[
 
 /// Only block-level HTML and special constructs interrupt paragraphs.
 pub(crate) fn at_html_block_interrupt(p: &mut MarkdownParser) -> bool {
-    p.lookahead(|p| {
-        if p.line_start_leading_indent() > MAX_BLOCK_PREFIX_INDENT {
-            return false;
-        }
+    if p.line_start_leading_indent() > MAX_BLOCK_PREFIX_INDENT {
+        return false;
+    }
 
-        let Some(kind) = html_block_kind(p) else {
-            return false;
-        };
+    let Some(kind) = html_block_kind(p) else {
+        return false;
+    };
 
-        matches!(
-            kind,
-            HtmlBlockKind::Type1 { .. }
-                | HtmlBlockKind::Type2
-                | HtmlBlockKind::Type3
-                | HtmlBlockKind::Type4
-                | HtmlBlockKind::Type5
-                | HtmlBlockKind::Type6
-        )
-    })
+    matches!(
+        kind,
+        HtmlBlockKind::Type1 { .. }
+            | HtmlBlockKind::Type2
+            | HtmlBlockKind::Type3
+            | HtmlBlockKind::Type4
+            | HtmlBlockKind::Type5
+            | HtmlBlockKind::Type6
+    )
 }
 
 /// Parse HTML block as raw text until blank line.
@@ -437,7 +427,7 @@ fn skip_container_prefixes(p: &mut MarkdownParser) {
 
 fn at_container_boundary(p: &mut MarkdownParser) -> bool {
     let quote_depth = p.state().block_quote_depth;
-    if quote_depth > 0 && p.at_line_start() && !has_quote_prefix(p, quote_depth) {
+    if quote_depth > 0 && p.is_at_line_start() && !has_quote_prefix(p, quote_depth) {
         // Skip if at virtual line start — the quote prefix was already consumed
         // by the container parser that set this virtual start position.
         if p.state()
@@ -449,7 +439,7 @@ fn at_container_boundary(p: &mut MarkdownParser) -> bool {
     }
 
     let required_indent = p.state().list_item_required_indent;
-    if required_indent > 0 && p.at_line_start() {
+    if required_indent > 0 && p.is_at_line_start() {
         // Skip if at virtual line start — the list indent was already
         // consumed by check_continuation_indent.
         if p.state()

--- a/crates/biome_markdown_parser/src/syntax/inline/code_span.rs
+++ b/crates/biome_markdown_parser/src/syntax/inline/code_span.rs
@@ -48,7 +48,7 @@ fn has_matching_code_span_closer(p: &mut MarkdownParser, opening_count: usize) -
             }
 
             // Blank line = paragraph boundary, terminates search
-            if p.at(NEWLINE) && p.at_blank_line() {
+            if p.at(NEWLINE) && p.is_at_blank_line() {
                 return false;
             }
 
@@ -206,7 +206,7 @@ pub(crate) fn parse_inline_code(p: &mut MarkdownParser) -> ParsedSyntax {
 
         // DESIGN PRINCIPLE #3: Terminate on blank line (paragraph boundary)
         if p.at(NEWLINE) {
-            if p.at_blank_line() {
+            if p.is_at_blank_line() {
                 break; // Paragraph boundary - stop
             }
             // Soft line break - consume NEWLINE as content and continue

--- a/crates/biome_markdown_parser/src/syntax/inline/emphasis.rs
+++ b/crates/biome_markdown_parser/src/syntax/inline/emphasis.rs
@@ -235,7 +235,7 @@ fn extract_label_text(source: &str, start: usize, close_pos: usize) -> &str {
     }
 }
 
-fn collect_delimiter_runs(source: &str, reference_checker: impl Fn(&str) -> bool) -> Vec<DelimRun> {
+fn collect_delimiters(source: &str, reference_checker: impl Fn(&str) -> bool) -> Vec<DelimRun> {
     let mut runs = Vec::new();
     let bytes = source.as_bytes();
     let mut i = 0;
@@ -486,7 +486,14 @@ impl EmphasisContext {
         base_offset: usize,
         reference_checker: impl Fn(&str) -> bool,
     ) -> Self {
-        let mut runs = collect_delimiter_runs(source, reference_checker);
+        if !source.bytes().any(|byte| matches!(byte, b'*' | b'_')) {
+            return Self {
+                matches: Vec::new(),
+                base_offset,
+            };
+        }
+
+        let mut runs = collect_delimiters(source, reference_checker);
         let matches = match_delimiters(&mut runs);
         Self {
             matches,
@@ -689,4 +696,18 @@ fn inline_list_source_len_until(p: &mut MarkdownParser, stop: MarkdownSyntaxKind
         let end: usize = p.cur_range().start().into();
         end.saturating_sub(start)
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EmphasisContext;
+
+    #[test]
+    fn skips_reference_lookups_without_emphasis_delimiters() {
+        let context = EmphasisContext::new("[shortcut]", 0, |_| {
+            panic!("reference lookup should be skipped")
+        });
+
+        assert!(context.matches.is_empty());
+    }
 }

--- a/crates/biome_markdown_parser/src/syntax/inline/links.rs
+++ b/crates/biome_markdown_parser/src/syntax/inline/links.rs
@@ -503,7 +503,7 @@ fn collect_label_text_simple(p: &mut MarkdownParser) -> Option<TextRange> {
         }
 
         // Blank lines terminate
-        if p.at(NEWLINE) && p.at_blank_line() {
+        if p.at(NEWLINE) && p.is_at_blank_line() {
             return None;
         }
 
@@ -531,7 +531,7 @@ fn collect_link_text(p: &mut MarkdownParser) -> Option<TextRange> {
         }
 
         // Per CommonMark, blank lines terminate link text
-        if p.at(NEWLINE) && p.at_blank_line() {
+        if p.at(NEWLINE) && p.is_at_blank_line() {
             return None;
         }
 
@@ -544,7 +544,7 @@ fn collect_link_text(p: &mut MarkdownParser) -> Option<TextRange> {
             // Find matching closing backticks
             let mut found_close = false;
             while !p.at(T![EOF]) && !p.at_inline_end() {
-                if p.at(NEWLINE) && p.at_blank_line() {
+                if p.at(NEWLINE) && p.is_at_blank_line() {
                     break; // Blank line terminates
                 }
                 if p.at(BACKTICK) && p.cur_text().len() == opening_count {
@@ -764,7 +764,7 @@ fn parse_inline_link_destination_tokens(p: &mut MarkdownParser) -> DestinationSc
         return DestinationScanResult::Invalid;
     }
     if p.at(NEWLINE) {
-        return if p.at_blank_line() {
+        return if p.is_at_blank_line() {
             DestinationScanResult::Invalid
         } else {
             DestinationScanResult::Valid
@@ -774,7 +774,7 @@ fn parse_inline_link_destination_tokens(p: &mut MarkdownParser) -> DestinationSc
 }
 
 fn is_title_separator_token(p: &MarkdownParser) -> bool {
-    is_space_or_tab_token(p) || (p.at(NEWLINE) && !p.at_blank_line())
+    is_space_or_tab_token(p) || (p.at(NEWLINE) && !p.is_at_blank_line())
 }
 
 fn bump_link_def_separator(p: &mut MarkdownParser) {
@@ -805,7 +805,7 @@ fn parse_title_content(p: &mut MarkdownParser, close_char: Option<char>) {
 
     loop {
         // Stop on EOF or blank line (titles cannot span blank lines per CommonMark)
-        if p.at(EOF) || p.at_blank_line() {
+        if p.at(EOF) || p.is_at_blank_line() {
             return;
         }
 

--- a/crates/biome_markdown_parser/src/syntax/inline/mod.rs
+++ b/crates/biome_markdown_parser/src/syntax/inline/mod.rs
@@ -76,7 +76,7 @@ fn parse_inline_item_list_until_impl(
         // Per CommonMark, link text can span lines, but blank lines end the link.
         // Check for blank line (NEWLINE followed by NEWLINE or EOF after optional whitespace)
         if p.at(NEWLINE) {
-            if p.at_blank_line() {
+            if p.is_at_blank_line() {
                 break; // Blank line ends link text
             }
             // Single newline inside link text - consume and continue

--- a/crates/biome_markdown_parser/src/syntax/link_block.rs
+++ b/crates/biome_markdown_parser/src/syntax/link_block.rs
@@ -45,26 +45,36 @@ const MAX_LABEL_LENGTH: usize = 999;
 /// where label doesn't contain unescaped `]` or `[`, and is followed by `:`.
 #[inline]
 pub(crate) fn at_link_block(p: &mut MarkdownParser) -> bool {
-    p.lookahead(|p| at_link_block_start_impl(p) && is_valid_link_definition_lookahead(p))
+    let Some(indent_tokens) = link_block_start_indent_tokens(p) else {
+        return false;
+    };
+
+    p.lookahead(|p| {
+        for _ in 0..indent_tokens {
+            p.bump(MD_TEXTUAL_LITERAL);
+        }
+        is_valid_link_definition_lookahead(p)
+    })
 }
 
 #[inline]
 pub(crate) fn at_link_block_start(p: &mut MarkdownParser) -> bool {
-    p.lookahead(at_link_block_start_impl)
+    link_block_start_indent_tokens(p).is_some()
 }
 
 #[inline]
-fn at_link_block_start_impl(p: &mut MarkdownParser) -> bool {
-    if !p.at_line_start() && !p.at_start_of_input() {
-        return false;
+fn link_block_start_indent_tokens(p: &mut MarkdownParser) -> Option<usize> {
+    if !p.is_at_line_start() {
+        return None;
     }
 
     if p.line_start_leading_indent() > MAX_BLOCK_PREFIX_INDENT {
-        return false;
+        return None;
     }
 
-    p.skip_line_indent(MAX_BLOCK_PREFIX_INDENT);
-    p.at(L_BRACK)
+    let indent = p.peek_line_indent(MAX_BLOCK_PREFIX_INDENT);
+    p.nth_at(indent.token_count, L_BRACK)
+        .then_some(indent.token_count)
 }
 
 /// Token-based lookahead to verify a link reference definition.

--- a/crates/biome_markdown_parser/src/syntax/link_block.rs
+++ b/crates/biome_markdown_parser/src/syntax/link_block.rs
@@ -69,9 +69,9 @@ fn at_link_block_start_impl(p: &mut MarkdownParser) -> bool {
 
 /// Token-based lookahead to verify a link reference definition.
 ///
-/// This advances tokens to check: `[label]: destination [title]?`
-/// Returns true if the pattern is valid, false otherwise.
-/// Does NOT build nodes - just validates the structure.
+/// This validates the label, destination, and any same-line title because
+/// trailing same-line content determines whether the line is a definition.
+/// A title on the following line is validated while parsing the definition.
 fn is_valid_link_definition_lookahead(p: &mut MarkdownParser) -> bool {
     // Expect [
     if !p.at(L_BRACK) {
@@ -86,7 +86,7 @@ fn is_valid_link_definition_lookahead(p: &mut MarkdownParser) -> bool {
         if p.at(EOF) {
             return false;
         }
-        if p.at(NEWLINE) && p.at_blank_line() {
+        if p.at(NEWLINE) && p.is_at_blank_line() {
             return false; // Blank line ends link definition
         }
         if p.at(R_BRACK) {
@@ -138,7 +138,7 @@ fn is_valid_link_definition_lookahead(p: &mut MarkdownParser) -> bool {
     // Per CommonMark §4.7, destination can be on the next line if there's a
     // single non-blank newline after the colon.
     if p.at(NEWLINE) {
-        if p.at_blank_line() {
+        if p.is_at_blank_line() {
             return false; // Blank line = no destination
         }
         // Single newline - allow destination on next line
@@ -147,7 +147,7 @@ fn is_valid_link_definition_lookahead(p: &mut MarkdownParser) -> bool {
     }
 
     // Destination is required (can be on same line or next line now)
-    if p.at(EOF) || p.at_blank_line() {
+    if p.at(EOF) || p.is_at_blank_line() {
         return false;
     }
 
@@ -164,18 +164,8 @@ fn is_valid_link_definition_lookahead(p: &mut MarkdownParser) -> bool {
     }
 
     if p.at(NEWLINE) {
-        // Check for title on next line (newline counts as separator)
-        p.bump_link_definition();
-        skip_whitespace_tokens(p);
-
-        if at_title_start(p) {
-            // If title looks valid, it's included in the definition.
-            // If title has trailing content, it's invalid - but the definition
-            // is still valid (destination-only). The invalid title line will
-            // be parsed as a paragraph. Per CommonMark §4.7.
-            let _ = skip_title_tokens(p); // Ignore result - definition is valid either way
-        }
-        // Destination-only is valid, or destination+valid_title is valid
+        // A definition can end at the destination. A following title is part
+        // of the definition only when the parser later confirms that it is valid.
         return true;
     }
 
@@ -366,7 +356,7 @@ fn skip_title_tokens(p: &mut MarkdownParser) -> bool {
         }
 
         // Titles can span lines, but blank line ends them
-        if p.at(NEWLINE) && p.at_blank_line() {
+        if p.at(NEWLINE) && p.is_at_blank_line() {
             return false;
         }
 
@@ -421,7 +411,7 @@ pub(crate) fn parse_link_block(p: &mut MarkdownParser) -> ParsedSyntax {
             while is_space_or_tab_token(p) {
                 p.bump_link_definition();
             }
-            if p.at(NEWLINE) && !p.at_blank_line() {
+            if p.at(NEWLINE) && !p.is_at_blank_line() {
                 // Check if there's a title starter on next line
                 if !title_on_next_line(p) {
                     return false;
@@ -456,7 +446,7 @@ fn parse_link_label(p: &mut MarkdownParser) {
     let list = p.start();
 
     while !p.at(R_BRACK) && !p.at(EOF) {
-        if p.at(NEWLINE) && p.at_blank_line() {
+        if p.at(NEWLINE) && p.is_at_blank_line() {
             break;
         }
         bump_textual(p);
@@ -485,7 +475,7 @@ fn parse_link_destination(p: &mut MarkdownParser) {
     }
 
     // Per CommonMark §4.7, destination can be on the next line
-    if p.at(NEWLINE) && !p.at_blank_line() {
+    if p.at(NEWLINE) && !p.is_at_blank_line() {
         bump_textual_link_def(p);
         while is_space_or_tab_token(p) {
             bump_textual_link_def(p);
@@ -546,7 +536,7 @@ fn consume_trailing_destination_whitespace(p: &mut MarkdownParser) {
         }
 
         if p.at(NEWLINE) {
-            if p.at_blank_line() {
+            if p.is_at_blank_line() {
                 return true;
             }
 
@@ -716,7 +706,7 @@ fn parse_title_content(p: &mut MarkdownParser, close_char: Option<char>) {
         }
 
         // Stop at blank line
-        if p.at_blank_line() {
+        if p.is_at_blank_line() {
             break;
         }
 

--- a/crates/biome_markdown_parser/src/syntax/list.rs
+++ b/crates/biome_markdown_parser/src/syntax/list.rs
@@ -151,7 +151,7 @@ fn list_marker_base_indent(p: &MarkdownParser) -> usize {
 }
 
 fn list_item_within_indent(p: &mut MarkdownParser, base_indent: usize) -> bool {
-    if !p.at_line_start() {
+    if !p.is_at_line_start() {
         return false;
     }
 
@@ -191,7 +191,7 @@ pub(crate) fn at_sibling_list_marker(p: &mut MarkdownParser) -> bool {
         return false;
     }
     p.lookahead(|p| {
-        if !p.at_line_start() {
+        if !p.is_at_line_start() {
             return false;
         }
         let indent = p.line_start_leading_indent();
@@ -391,17 +391,21 @@ fn at_bullet_list_item_with_base_indent(p: &mut MarkdownParser, base_indent: usi
 }
 
 pub(crate) fn marker_followed_by_whitespace_or_eol(p: &mut MarkdownParser) -> bool {
-    if p.at(NEWLINE) || p.at(T![EOF]) {
+    marker_followed_by_whitespace_or_eol_at(p, 0)
+}
+
+pub(crate) fn marker_followed_by_whitespace_or_eol_at(p: &mut MarkdownParser, n: usize) -> bool {
+    if p.nth_at(n, NEWLINE) || p.nth_at(n, T![EOF]) {
         return true;
     }
 
-    // MD_HARD_LINE_LITERAL is spaces+newline — counts as whitespace after marker.
-    if p.at(MD_HARD_LINE_LITERAL) {
+    if p.nth_at(n, MD_HARD_LINE_LITERAL) {
         return true;
     }
 
-    if p.at(MD_TEXTUAL_LITERAL) {
-        let text = p.cur_text();
+    if p.nth_at(n, MD_TEXTUAL_LITERAL)
+        && let Some(text) = p.nth_text(n)
+    {
         return text.starts_with(' ') || text.starts_with('\t');
     }
 
@@ -494,7 +498,7 @@ where
     let at_virtual_line_start = p.state().virtual_line_start == Some(p.cur_range().start());
     if quote_depth > 0
         && !at_virtual_line_start
-        && (p.at_line_start() || p.has_preceding_line_break())
+        && (p.is_at_line_start() || p.has_preceding_line_break())
         && !has_quote_prefix(p, quote_depth)
     {
         return true;
@@ -513,7 +517,7 @@ where
     // If at a blank line, look ahead to see if there's another list item.
     // Per CommonMark §5.3, blank lines between items make the list loose,
     // but don't end the list.
-    if p.at_line_start() && at_blank_line_start(p) {
+    if p.is_at_line_start() && at_blank_line_start(p) {
         return !has_item_after_blank_lines(p);
     }
 
@@ -587,7 +591,7 @@ impl ParseNodeList for BulletList {
 
         // Check blank line at line start with indent awareness BEFORE
         // delegating to is_at_list_end_common (which uses non-indent-aware check).
-        if p.at_line_start() && at_blank_line_start(p) {
+        if p.is_at_line_start() && at_blank_line_start(p) {
             let has_item = has_bullet_item_after_blank_lines_at_indent(p, marker_indent);
             if !has_item {
                 return true;
@@ -661,7 +665,7 @@ impl ParseNodeList for BulletList {
 
 fn current_bullet_marker(p: &mut MarkdownParser) -> Option<MarkdownSyntaxKind> {
     p.lookahead(|p| {
-        if !p.at_line_start() {
+        if !p.is_at_line_start() {
             return None;
         }
 
@@ -859,7 +863,7 @@ fn parse_bullet(p: &mut MarkdownParser) -> (ParsedSyntax, ListItemBlankInfo) {
 
     // Pre-marker indent: consume all whitespace before the marker.
     // The 0-3 column rule is enforced by at_bullet_list_item(); no cap needed here.
-    // In nested contexts, skip_line_indent() may leave more than 3 columns.
+    // Nested contexts may leave more than 3 columns before the marker.
     emit_indent_char_list(p, 0);
 
     // Bullet marker is 1 character (-, *, or +)
@@ -1042,7 +1046,7 @@ impl ParseNodeList for OrderedList {
         let marker_indent = self.marker_indent;
         let marker_delim = self.marker_delim;
 
-        if p.at_line_start() && at_blank_line_start(p) {
+        if p.is_at_line_start() && at_blank_line_start(p) {
             // Check if there's an ordered item after blank lines
             let has_item = has_ordered_item_after_blank_lines_at_indent(p, marker_indent);
             if has_item {
@@ -1117,7 +1121,7 @@ impl ParseNodeList for OrderedList {
 
 fn current_ordered_delim(p: &mut MarkdownParser) -> Option<char> {
     p.lookahead(|p| {
-        if !p.at_line_start() {
+        if !p.is_at_line_start() {
             return None;
         }
 
@@ -1202,7 +1206,7 @@ fn parse_ordered_bullet(p: &mut MarkdownParser) -> (ParsedSyntax, ListItemBlankI
 
     // Pre-marker indent: consume all whitespace before the marker.
     // The 0-3 column rule is enforced by at_order_list_item(); no cap needed here.
-    // In nested contexts, skip_line_indent() may leave more than 3 columns.
+    // Nested contexts may leave more than 3 columns before the marker.
     emit_indent_char_list(p, 0);
 
     // Ordered marker (variable width: "1." = 2, "10." = 3, etc.)
@@ -1645,7 +1649,7 @@ fn handle_blank_lines(p: &mut MarkdownParser, state: &mut ListItemLoopState) -> 
 
     let newline_has_quote_prefix = quote_depth > 0
         && p.at(NEWLINE)
-        && (((p.at_line_start() || p.has_preceding_line_break())
+        && (((p.is_at_line_start() || p.has_preceding_line_break())
             && has_quote_prefix(p, quote_depth))
             || (state.last_block_was_link_reference
                 && p.lookahead(|p| {
@@ -1660,7 +1664,7 @@ fn handle_blank_lines(p: &mut MarkdownParser, state: &mut ListItemLoopState) -> 
 
     // Phases 4-5 share a quote-prefix check.
     let line_has_quote_prefix = quote_depth > 0
-        && (p.at_line_start() || p.has_preceding_line_break())
+        && (p.is_at_line_start() || p.has_preceding_line_break())
         && (has_quote_prefix(p, quote_depth)
             || quote_only_line_indent_at_current(p, quote_depth).is_some());
 
@@ -1894,7 +1898,7 @@ fn blank_line_phase_after_prefix(
         return BlankLineOutcome::with_prefix(LoopAction::FallThrough, line_has_quote_prefix);
     }
 
-    if (p.at_line_start() || line_has_quote_prefix) && blank_line_after_prefix {
+    if (p.is_at_line_start() || line_has_quote_prefix) && blank_line_after_prefix {
         if line_has_quote_prefix
             && quote_only_line_indent_at_current(p, quote_depth).is_some()
             && let Some(next_indent) = next_quote_content_indent(p, quote_depth)
@@ -2051,7 +2055,7 @@ fn handle_first_line_marker_only(
         } else {
             p.bump(NEWLINE);
         }
-        if p.at_line_start() {
+        if p.is_at_line_start() {
             at_bullet_list_item_with_base_indent(p, state.marker_indent)
                 || at_order_list_item_with_base_indent(p, state.marker_indent)
         } else {
@@ -2653,7 +2657,7 @@ fn check_continuation_indent(
     line_started_with_quote_prefix: bool,
     prev_was_blank: bool,
 ) -> ContinuationResult {
-    if state.first_line || (!p.at_line_start() && !line_started_with_quote_prefix) {
+    if state.first_line || (!p.is_at_line_start() && !line_started_with_quote_prefix) {
         return ContinuationResult {
             action: LoopAction::FallThrough,
             restore: VirtualLineRestore::None,
@@ -3029,7 +3033,7 @@ fn parse_indent_code_block_in_list_first_line(p: &mut MarkdownParser) {
             continue;
         }
 
-        if p.at_line_start() && !at_indent_code_block(p) {
+        if p.is_at_line_start() && !at_indent_code_block(p) {
             if at_blank_line_start(p) {
                 if list_has_following_indented_code_line(p) {
                     consume_blank_line(p);
@@ -3051,7 +3055,7 @@ fn parse_indent_code_block_in_list_first_line(p: &mut MarkdownParser) {
 
 fn list_has_following_indented_code_line(p: &mut MarkdownParser) -> bool {
     p.lookahead(|p| {
-        while p.at_line_start() && at_blank_line_start(p) {
+        while p.is_at_line_start() && at_blank_line_start(p) {
             while p.at(MD_TEXTUAL_LITERAL) {
                 let text = p.cur_text();
                 if text == " " || text == "\t" {
@@ -3325,7 +3329,7 @@ fn classify_blank_line_in_quote(
 }
 
 fn at_blank_line_start(p: &mut MarkdownParser) -> bool {
-    if !p.at_line_start() {
+    if !p.is_at_line_start() {
         return false;
     }
 

--- a/crates/biome_markdown_parser/src/syntax/list.rs
+++ b/crates/biome_markdown_parser/src/syntax/list.rs
@@ -1806,7 +1806,7 @@ fn blank_line_phase_non_quote_classify(
     state: &mut ListItemLoopState,
     newline_has_quote_prefix: bool,
 ) -> Option<BlankLineOutcome> {
-    if state.first_line || !p.at(NEWLINE) || p.at_blank_line() || newline_has_quote_prefix {
+    if state.first_line || !p.at(NEWLINE) || p.is_at_blank_line() || newline_has_quote_prefix {
         return None;
     }
 
@@ -2289,7 +2289,7 @@ fn parse_first_line_blocks(
 }
 
 fn list_link_reference_before_dash_thematic_break(p: &mut MarkdownParser) -> bool {
-    if !p.at(NEWLINE) || p.at_blank_line() {
+    if !p.at(NEWLINE) || p.is_at_blank_line() {
         return false;
     }
 
@@ -2853,7 +2853,7 @@ fn parse_continuation_block(
     parse_mode: ContinuationParseMode,
     restore: VirtualLineRestore,
 ) {
-    let is_blank_line = p.at_blank_line();
+    let is_blank_line = p.is_at_blank_line();
     if is_blank_line {
         // Don't record as blank if the blank line is actually the boundary
         // before a different-marker list (CommonMark §5.3). The blank line
@@ -2866,7 +2866,7 @@ fn parse_continuation_block(
                 let mi = state.marker_indent;
                 p.lookahead(|p| {
                     // Skip blank lines (including whitespace-only tokens between newlines)
-                    while p.at_blank_line() {
+                    while p.is_at_blank_line() {
                         p.bump(NEWLINE);
                         while p.at(MD_TEXTUAL_LITERAL) && is_whitespace_only(p.cur_text()) {
                             p.bump(MD_TEXTUAL_LITERAL);
@@ -3335,7 +3335,7 @@ fn at_blank_line_start(p: &mut MarkdownParser) -> bool {
 fn at_blank_line_after_prefix(p: &mut MarkdownParser) -> bool {
     p.lookahead(|p| {
         if p.at(NEWLINE) {
-            return p.at_blank_line();
+            return p.is_at_blank_line();
         }
         if p.at(T![EOF]) {
             return true;

--- a/crates/biome_markdown_parser/src/syntax/mod.rs
+++ b/crates/biome_markdown_parser/src/syntax/mod.rs
@@ -1212,7 +1212,8 @@ fn break_for_list_interrupt_after_inline_newline(
         return line_starts_with_nonone_ordered_marker_after_indent(p);
     }
 
-    if indent <= required_indent.saturating_add(MAX_BLOCK_PREFIX_INDENT)
+    if p.state().block_quote_depth == 0
+        && indent <= required_indent.saturating_add(MAX_BLOCK_PREFIX_INDENT)
         && (source_line_starts_with_bullet_marker(p)
             || source_line_starts_with_nonempty_one_ordered_marker(p))
     {

--- a/crates/biome_markdown_parser/src/syntax/mod.rs
+++ b/crates/biome_markdown_parser/src/syntax/mod.rs
@@ -59,8 +59,8 @@ use inline::EmphasisContext;
 use link_block::{at_link_block_start, parse_link_block};
 use list::{
     at_bullet_list_item, at_order_list_item, at_sibling_list_marker,
-    marker_followed_by_whitespace_or_eol, parse_bullet_list_item, parse_order_list_item,
-    textual_starts_with_ordered_marker,
+    marker_followed_by_whitespace_or_eol, marker_followed_by_whitespace_or_eol_at,
+    parse_bullet_list_item, parse_order_list_item, textual_starts_with_ordered_marker,
 };
 use quote::{
     at_quote, consume_quote_prefix, consume_quote_prefix_without_virtual, has_quote_prefix,
@@ -500,7 +500,7 @@ enum QuoteBreakKind {
 /// Uses `line_start_leading_indent()` to correctly handle indentation when NEWLINE
 /// tokens are explicit (not trivia).
 pub(crate) fn at_indent_code_block(p: &mut MarkdownParser) -> bool {
-    if !p.at_line_start() {
+    if !p.is_at_line_start() {
         return false;
     }
 
@@ -555,7 +555,7 @@ pub(crate) fn parse_indent_code_block(p: &mut MarkdownParser) -> ParsedSyntax {
             continue;
         }
 
-        if p.at_line_start() {
+        if p.is_at_line_start() {
             if at_blank_line_start(p) {
                 if has_following_indented_code_line(p) {
                     consume_blank_line(p);
@@ -585,7 +585,7 @@ pub(crate) fn parse_indent_code_block(p: &mut MarkdownParser) -> ParsedSyntax {
 
 fn has_following_indented_code_line(p: &mut MarkdownParser) -> bool {
     p.lookahead(|p| {
-        while p.at_line_start() && at_blank_line_start(p) {
+        while p.is_at_line_start() && at_blank_line_start(p) {
             while p.at(MD_TEXTUAL_LITERAL) {
                 let text = p.cur_text();
                 if text == " " || text == "\t" {
@@ -651,7 +651,7 @@ fn consume_indent_prefix(p: &mut MarkdownParser, indent: usize) {
 
 /// Consume exactly `indent` columns of leading whitespace at line start.
 fn at_blank_line_start(p: &mut MarkdownParser) -> bool {
-    if !p.at_line_start() {
+    if !p.is_at_line_start() {
         return false;
     }
 
@@ -795,27 +795,34 @@ pub(crate) fn is_dash_only_thematic_break_text(text: &str) -> bool {
 /// whitespace, then checks for a setext underline token or a dash-only thematic
 /// break token. The returned byte count covers only the skipped whitespace.
 pub(crate) fn at_setext_underline_after_newline(p: &mut MarkdownParser) -> Option<usize> {
+    at_setext_underline_after_indent(p, 0)
+}
+
+fn at_setext_underline_after_indent(p: &mut MarkdownParser, mut n: usize) -> Option<usize> {
     let mut columns = 0;
     let mut bytes_consumed = 0;
     while columns < INDENT_CODE_BLOCK_SPACES
-        && p.at(MD_TEXTUAL_LITERAL)
-        && p.cur_text().chars().all(|c| c == ' ' || c == '\t')
+        && p.nth_at(n, MD_TEXTUAL_LITERAL)
+        && p.nth_text(n)
+            .is_some_and(|text| !text.as_bytes().iter().any(|b| !matches!(b, b' ' | b'\t')))
     {
-        for c in p.cur_text().chars() {
-            match c {
-                ' ' => columns += 1,
-                '\t' => columns += TAB_STOP_SPACES - (columns % TAB_STOP_SPACES),
+        let text = p.nth_text(n)?;
+        for byte in text.as_bytes() {
+            match byte {
+                b' ' => columns += 1,
+                b'\t' => columns += TAB_STOP_SPACES - (columns % TAB_STOP_SPACES),
                 _ => {}
             }
         }
-        bytes_consumed += p.cur_text().len();
-        p.bump(MD_TEXTUAL_LITERAL);
+        bytes_consumed += text.len();
+        n += 1;
     }
     if columns >= INDENT_CODE_BLOCK_SPACES {
         return None;
     }
-    let is_setext = p.at(MD_SETEXT_UNDERLINE_LITERAL)
-        || (p.at(MD_THEMATIC_BREAK_LITERAL) && is_dash_only_thematic_break_text(p.cur_text()));
+    let is_setext = p.nth_at(n, MD_SETEXT_UNDERLINE_LITERAL)
+        || (p.nth_at(n, MD_THEMATIC_BREAK_LITERAL)
+            && p.nth_text(n).is_some_and(is_dash_only_thematic_break_text));
     if is_setext {
         Some(bytes_consumed)
     } else {
@@ -1164,10 +1171,8 @@ fn break_for_setext_after_inline_newline(
         return false;
     }
 
-    let is_setext = p.lookahead(|p| {
-        p.skip_line_indent(required_indent);
-        at_setext_underline_after_newline(p).is_some()
-    });
+    let indent = p.peek_line_indent(required_indent);
+    let is_setext = at_setext_underline_after_indent(p, indent.token_count).is_some();
     if is_setext {
         p.emit_indent_tokens(required_indent);
         p.emit_indent_tokens(INDENT_CODE_BLOCK_SPACES);
@@ -1205,9 +1210,11 @@ fn break_for_list_interrupt_after_inline_newline(
         return line_starts_with_nonone_ordered_marker_after_indent(p, indent);
     }
 
-    let skip = indent.min(required_indent);
+    let skip = p.peek_line_indent(indent.min(required_indent)).token_count;
     p.lookahead(|p| {
-        p.skip_line_indent(skip);
+        for _ in 0..skip {
+            p.bump(MD_TEXTUAL_LITERAL);
+        }
         let prev_required = p.state().list_item_required_indent;
         with_virtual_line_start(p, p.cur_range().start(), |p| {
             p.state_mut().list_item_required_indent = 0;
@@ -1236,29 +1243,28 @@ fn line_starts_with_nonone_ordered_marker_after_indent(
     p: &mut MarkdownParser,
     indent: usize,
 ) -> bool {
-    p.lookahead(|p| {
-        p.skip_line_indent(indent);
-        if p.at(MD_ORDERED_LIST_MARKER) {
-            let text = p.cur_text();
-            if text == "1." || text == "1)" {
-                return false;
-            }
-            p.bump(MD_ORDERED_LIST_MARKER);
-            return marker_followed_by_whitespace_or_eol(p);
+    let n = p.peek_line_indent(indent).token_count;
+    if p.nth_at(n, MD_ORDERED_LIST_MARKER) {
+        if p.nth_text(n)
+            .is_some_and(|text| text == "1." || text == "1)")
+        {
+            return false;
         }
-        if p.at(MD_TEXTUAL_LITERAL) {
-            let text = p.cur_text();
-            if text
-                .strip_prefix("1.")
-                .or_else(|| text.strip_prefix("1)"))
-                .is_some_and(|rest| rest.is_empty() || rest.starts_with([' ', '\t', '\n', '\r']))
-            {
-                return false;
-            }
-            return textual_starts_with_ordered_marker(text);
+        return marker_followed_by_whitespace_or_eol_at(p, n + 1);
+    }
+    if p.nth_at(n, MD_TEXTUAL_LITERAL)
+        && let Some(text) = p.nth_text(n)
+    {
+        if text
+            .strip_prefix("1.")
+            .or_else(|| text.strip_prefix("1)"))
+            .is_some_and(|rest| rest.is_empty() || rest.starts_with([' ', '\t', '\n', '\r']))
+        {
+            return false;
         }
-        false
-    })
+        return textual_starts_with_ordered_marker(text);
+    }
+    false
 }
 
 /// Lookahead: after skipping `indent` columns of leading whitespace, is the next
@@ -1266,42 +1272,32 @@ fn line_starts_with_nonone_ordered_marker_after_indent(
 /// Handles raw marker tokens and markers still folded into `MD_TEXTUAL_LITERAL`
 /// / `MD_SETEXT_UNDERLINE_LITERAL`.
 fn line_starts_with_list_marker_after_indent(p: &mut MarkdownParser, indent: usize) -> bool {
-    p.lookahead(|p| {
-        p.skip_line_indent(indent);
-
-        if p.at(T![-]) || p.at(T![*]) || p.at(T![+]) {
-            p.bump(p.cur());
-            return marker_followed_by_whitespace_or_eol(p);
-        }
-
-        if p.at(MD_SETEXT_UNDERLINE_LITERAL) {
-            let trimmed = p.cur_text().trim_matches(|c| c == ' ' || c == '\t');
-            if trimmed != "-" {
-                return false;
-            }
-            p.bump_remap(T![-]);
-            return marker_followed_by_whitespace_or_eol(p);
-        }
-
-        if p.at(MD_ORDERED_LIST_MARKER) {
-            p.bump(MD_ORDERED_LIST_MARKER);
-            return marker_followed_by_whitespace_or_eol(p);
-        }
-
-        if !p.at(MD_TEXTUAL_LITERAL) {
+    let n = p.peek_line_indent(indent).token_count;
+    if p.nth_at(n, T![-]) || p.nth_at(n, T![*]) || p.nth_at(n, T![+]) {
+        return marker_followed_by_whitespace_or_eol_at(p, n + 1);
+    }
+    if p.nth_at(n, MD_SETEXT_UNDERLINE_LITERAL) {
+        if !p
+            .nth_text(n)
+            .is_some_and(|text| text.trim_matches(|c| c == ' ' || c == '\t') == "-")
+        {
             return false;
         }
-
-        let text = p.cur_text();
-        let marker_kind = match text {
-            "-" => T![-],
-            "*" => T![*],
-            "+" => T![+],
-            _ => return textual_starts_with_ordered_marker(text),
+        return marker_followed_by_whitespace_or_eol_at(p, n + 1);
+    }
+    if p.nth_at(n, MD_ORDERED_LIST_MARKER) {
+        return marker_followed_by_whitespace_or_eol_at(p, n + 1);
+    }
+    if p.nth_at(n, MD_TEXTUAL_LITERAL)
+        && let Some(text) = p.nth_text(n)
+    {
+        return if matches!(text, "-" | "*" | "+") {
+            marker_followed_by_whitespace_or_eol_at(p, n + 1)
+        } else {
+            textual_starts_with_ordered_marker(text)
         };
-        p.bump_remap(marker_kind);
-        marker_followed_by_whitespace_or_eol(p)
-    })
+    }
+    false
 }
 
 /// Per CommonMark §5.2, list-item continuations emit their required indent
@@ -1408,7 +1404,7 @@ pub(crate) fn parse_inline_item_list(p: &mut MarkdownParser) {
     let m = p.start();
     let prev_emphasis_context = set_inline_emphasis_context(p);
     let quote_depth = p.state().block_quote_depth;
-    if quote_depth > 0 && p.at_line_start() {
+    if quote_depth > 0 && p.is_at_line_start() {
         consume_quote_prefix(p, quote_depth);
     }
     let inline_start: usize = p.cur_range().start().into();
@@ -1776,24 +1772,19 @@ fn scan_list_indent(p: &mut MarkdownParser, required_indent: usize) {
 // #endregion
 
 fn line_starts_with_fence(p: &mut MarkdownParser) -> bool {
-    if !p.at_line_start() {
+    if !p.is_at_line_start() {
         return false;
     }
 
-    p.lookahead(|p| {
-        if p.line_start_leading_indent() > MAX_BLOCK_PREFIX_INDENT {
-            return false;
-        }
-        p.skip_line_indent(MAX_BLOCK_PREFIX_INDENT);
-        let rest = p.source_after_current();
-        let Some((fence_char, _len)) = fenced_code_block::detect_fence(rest) else {
-            return false;
-        };
-        if fence_char == '`' {
-            return !info_string_has_backtick(p);
-        }
-        true
-    })
+    if p.line_start_leading_indent() > MAX_BLOCK_PREFIX_INDENT {
+        return false;
+    }
+    let indent = p.peek_line_indent(MAX_BLOCK_PREFIX_INDENT);
+    let rest = &p.source_after_current()[indent.byte_count..];
+    let Some((fence_char, fence_len)) = fenced_code_block::detect_fence(rest) else {
+        return false;
+    };
+    fence_char != '`' || !info_string_has_backtick(rest, fence_len)
 }
 
 fn consume_partial_quote_prefix(p: &mut MarkdownParser, depth: usize) -> bool {
@@ -2095,7 +2086,7 @@ pub(crate) fn is_ordered_list_starts_with_one(p: &mut MarkdownParser) -> bool {
 /// not just at the current context's indent level.
 fn at_bullet_list_item_at_any_indent(p: &mut MarkdownParser) -> bool {
     p.lookahead(|p| {
-        if !p.at_line_start() {
+        if !p.is_at_line_start() {
             return false;
         }
 
@@ -2135,7 +2126,7 @@ fn at_bullet_list_item_at_any_indent(p: &mut MarkdownParser) -> bool {
 /// context (like a list item) but need to detect list markers at any level.
 fn at_order_list_item_at_any_indent(p: &mut MarkdownParser) -> bool {
     p.lookahead(|p| {
-        if !p.at_line_start() {
+        if !p.is_at_line_start() {
             return false;
         }
 
@@ -2157,7 +2148,7 @@ fn at_order_list_item_at_any_indent(p: &mut MarkdownParser) -> bool {
 
 fn at_order_list_item_textual(p: &mut MarkdownParser) -> bool {
     p.lookahead(|p| {
-        if !p.at_line_start() {
+        if !p.is_at_line_start() {
             return false;
         }
 
@@ -2286,26 +2277,20 @@ pub(crate) fn is_whitespace_only(text: &str) -> bool {
 /// Check if we're at a valid ATX heading start (1-6 `#` followed by space or EOL).
 /// Uses lookahead to verify without consuming tokens.
 fn is_valid_atx_heading_start(p: &mut MarkdownParser) -> bool {
-    p.lookahead(|p| {
-        p.skip_line_indent(MAX_BLOCK_PREFIX_INDENT);
-
-        let mut hash_count = 0;
-        while hash_count < MAX_ATX_HEADING_LEVEL && p.eat(T![#]) {
-            hash_count += 1;
-        }
-
-        if hash_count == 0 || p.at(T![#]) {
-            return false;
-        }
-
-        // Check if followed by space, tab, or EOL/EOF per CommonMark §4.2
-        // In Markdown, whitespace is significant and included in token text.
-        let text = p.cur_text();
-        p.at(T![EOF])
-            || p.has_preceding_line_break()
-            || text.starts_with(' ')
-            || text.starts_with('\t')
-    })
+    let indent = p.peek_line_indent(MAX_BLOCK_PREFIX_INDENT);
+    let mut n = indent.token_count;
+    let mut hash_count = 0;
+    while hash_count < MAX_ATX_HEADING_LEVEL && p.nth_at(n, T![#]) {
+        hash_count += 1;
+        n += 1;
+    }
+    if hash_count == 0 || p.nth_at(n, T![#]) {
+        return false;
+    }
+    p.nth_at(n, T![EOF])
+        || p.has_nth_preceding_line_break(n)
+        || p.nth_text(n)
+            .is_some_and(|text| text.starts_with(' ') || text.starts_with('\t'))
 }
 
 /// Parse any inline element.

--- a/crates/biome_markdown_parser/src/syntax/mod.rs
+++ b/crates/biome_markdown_parser/src/syntax/mod.rs
@@ -295,7 +295,7 @@ pub(crate) fn parse_any_block_with_indent_code_policy(
     // Handle standalone NEWLINE tokens as MdNewline nodes.
     // This prevents inter-block NEWLINEs from becoming "newline-only paragraphs".
     if p.at(NEWLINE) {
-        if p.at_blank_line() {
+        if p.is_at_blank_line() {
             p.state_mut().link_reference_definition_continuation = false;
         }
         let m = p.start();
@@ -749,7 +749,7 @@ pub(crate) fn parse_empty_paragraph(p: &mut MarkdownParser) -> CompletedMarker {
 }
 
 fn link_reference_definition_before_dash_thematic_break(p: &mut MarkdownParser) -> bool {
-    if !p.at(NEWLINE) || p.at_blank_line() {
+    if !p.at(NEWLINE) || p.is_at_blank_line() {
         return false;
     }
 
@@ -1320,7 +1320,7 @@ fn emit_inline_continuation_indent(p: &mut MarkdownParser, required_indent: usiz
 }
 
 fn handle_inline_newline(p: &mut MarkdownParser, has_content: bool) -> InlineNewlineAction {
-    if p.at_blank_line() {
+    if p.is_at_blank_line() {
         emit_inline_newline_as_text(p);
         return InlineNewlineAction::Break;
     }
@@ -1638,7 +1638,7 @@ fn inline_list_source_len(p: &mut MarkdownParser) -> usize {
 /// Returns `true` if the scan should stop (paragraph boundary reached),
 /// `false` if scanning should continue to the next line.
 fn scan_newline_in_inline_list(p: &mut MarkdownParser, has_content: bool) -> bool {
-    if p.at_blank_line() {
+    if p.is_at_blank_line() {
         p.bump(NEWLINE);
         return true;
     }

--- a/crates/biome_markdown_parser/src/syntax/mod.rs
+++ b/crates/biome_markdown_parser/src/syntax/mod.rs
@@ -59,8 +59,8 @@ use inline::EmphasisContext;
 use link_block::{at_link_block_start, parse_link_block};
 use list::{
     at_bullet_list_item, at_order_list_item, at_sibling_list_marker,
-    marker_followed_by_whitespace_or_eol, marker_followed_by_whitespace_or_eol_at,
-    parse_bullet_list_item, parse_order_list_item, textual_starts_with_ordered_marker,
+    marker_followed_by_whitespace_or_eol, parse_bullet_list_item, parse_order_list_item,
+    textual_starts_with_ordered_marker,
 };
 use quote::{
     at_quote, consume_quote_prefix, consume_quote_prefix_without_virtual, has_quote_prefix,
@@ -1170,6 +1170,9 @@ fn break_for_setext_after_inline_newline(
     if real_indent < required_indent {
         return false;
     }
+    if !source_line_is_setext_underline(p) {
+        return false;
+    }
 
     let indent = p.peek_line_indent(required_indent);
     let is_setext = at_setext_underline_after_indent(p, indent.token_count).is_some();
@@ -1199,15 +1202,21 @@ fn break_for_list_interrupt_after_inline_newline(
     }
 
     // Line sits at sibling/parent level. A list marker here ends the
-    // current paragraph (CommonMark §5.2). Tabs need the broad token-aware
-    // lookahead because `MD_TEXTUAL_LITERAL` can absorb the tab and any
-    // following marker; the non-tab path only needs to cover non-1 ordered
-    // siblings continuing an existing list.
+    // current paragraph (CommonMark §5.2). The tab path checks every marker
+    // kind because `MD_TEXTUAL_LITERAL` can absorb the tab and marker; the
+    // non-tab path only needs to cover non-1 ordered siblings.
     if indent < required_indent {
         if line_start_indent_contains_tab(p) {
-            return line_starts_with_list_marker_after_indent(p, indent);
+            return line_starts_with_list_marker_after_indent(p);
         }
-        return line_starts_with_nonone_ordered_marker_after_indent(p, indent);
+        return line_starts_with_nonone_ordered_marker_after_indent(p);
+    }
+
+    if indent <= required_indent.saturating_add(MAX_BLOCK_PREFIX_INDENT)
+        && (source_line_starts_with_bullet_marker(p)
+            || source_line_starts_with_nonempty_one_ordered_marker(p))
+    {
+        return true;
     }
 
     let skip = p.peek_line_indent(indent.min(required_indent)).token_count;
@@ -1234,70 +1243,69 @@ fn line_start_indent_contains_tab(p: &MarkdownParser) -> bool {
             .any(|c| c == '\t')
 }
 
-/// Lookahead: after skipping `indent` columns of leading whitespace, does
-/// the next token begin a non-1 ordered marker followed by whitespace/EOL?
+/// After leading whitespace, does the line begin a non-1 ordered marker
+/// followed by whitespace or EOL?
 /// Covers `parse_inline_item_list`'s blind spot (`textual_looks_like_list_marker`
 /// only matches `1.`/`1)` for ordered); `1.`/`1)` and bullets are left to the
 /// inline loop.
-fn line_starts_with_nonone_ordered_marker_after_indent(
-    p: &mut MarkdownParser,
-    indent: usize,
-) -> bool {
-    let n = p.peek_line_indent(indent).token_count;
-    if p.nth_at(n, MD_ORDERED_LIST_MARKER) {
-        if p.nth_text(n)
-            .is_some_and(|text| text == "1." || text == "1)")
-        {
-            return false;
-        }
-        return marker_followed_by_whitespace_or_eol_at(p, n + 1);
-    }
-    if p.nth_at(n, MD_TEXTUAL_LITERAL)
-        && let Some(text) = p.nth_text(n)
-    {
-        if text
+fn line_starts_with_nonone_ordered_marker_after_indent(p: &MarkdownParser) -> bool {
+    let source = source_after_indent(p);
+    textual_starts_with_ordered_marker(source)
+        && !source
             .strip_prefix("1.")
-            .or_else(|| text.strip_prefix("1)"))
-            .is_some_and(|rest| rest.is_empty() || rest.starts_with([' ', '\t', '\n', '\r']))
-        {
-            return false;
-        }
-        return textual_starts_with_ordered_marker(text);
-    }
-    false
+            .or_else(|| source.strip_prefix("1)"))
+            .is_some_and(|rest| rest.is_empty() || rest.starts_with([' ', '\t']))
 }
 
-/// Lookahead: after skipping `indent` columns of leading whitespace, is the next
-/// token a list marker (`-`, `*`, `+`, ordered) followed by whitespace or EOL?
-/// Handles raw marker tokens and markers still folded into `MD_TEXTUAL_LITERAL`
-/// / `MD_SETEXT_UNDERLINE_LITERAL`.
-fn line_starts_with_list_marker_after_indent(p: &mut MarkdownParser, indent: usize) -> bool {
-    let n = p.peek_line_indent(indent).token_count;
-    if p.nth_at(n, T![-]) || p.nth_at(n, T![*]) || p.nth_at(n, T![+]) {
-        return marker_followed_by_whitespace_or_eol_at(p, n + 1);
-    }
-    if p.nth_at(n, MD_SETEXT_UNDERLINE_LITERAL) {
-        if !p
-            .nth_text(n)
-            .is_some_and(|text| text.trim_matches(|c| c == ' ' || c == '\t') == "-")
-        {
-            return false;
+/// After leading whitespace, does the line begin a list marker followed by
+/// whitespace or EOL?
+fn line_starts_with_list_marker_after_indent(p: &MarkdownParser) -> bool {
+    source_line_starts_with_bullet_marker(p)
+        || textual_starts_with_ordered_marker(source_after_indent(p))
+}
+
+fn source_after_indent<'a>(p: &'a MarkdownParser<'_>) -> &'a str {
+    p.source_after_current().trim_start_matches([' ', '\t'])
+}
+
+fn source_line_starts_with_bullet_marker(p: &MarkdownParser) -> bool {
+    let source = source_after_indent(p);
+    matches!(source.as_bytes().first(), Some(b'-' | b'*' | b'+'))
+        && source
+            .as_bytes()
+            .get(1)
+            .is_none_or(|byte| matches!(byte, b' ' | b'\t' | b'\r' | b'\n'))
+}
+
+fn source_line_starts_with_nonempty_one_ordered_marker(p: &MarkdownParser) -> bool {
+    let source = source_after_indent(p);
+    source
+        .strip_prefix("1.")
+        .or_else(|| source.strip_prefix("1)"))
+        .is_some_and(|rest| {
+            rest.starts_with([' ', '\t'])
+                && rest
+                    .bytes()
+                    .find(|byte| !matches!(byte, b' ' | b'\t'))
+                    .is_some_and(|byte| !matches!(byte, b'\r' | b'\n'))
+        })
+}
+
+fn source_line_is_setext_underline(p: &MarkdownParser) -> bool {
+    let source = source_after_indent(p);
+    let Some(marker @ (b'=' | b'-')) = source.as_bytes().first() else {
+        return false;
+    };
+    let mut trailing_whitespace = false;
+    for byte in source.as_bytes().iter().skip(1) {
+        match byte {
+            b'\r' | b'\n' => break,
+            b' ' | b'\t' => trailing_whitespace = true,
+            _ if byte == marker && !trailing_whitespace => {}
+            _ => return false,
         }
-        return marker_followed_by_whitespace_or_eol_at(p, n + 1);
     }
-    if p.nth_at(n, MD_ORDERED_LIST_MARKER) {
-        return marker_followed_by_whitespace_or_eol_at(p, n + 1);
-    }
-    if p.nth_at(n, MD_TEXTUAL_LITERAL)
-        && let Some(text) = p.nth_text(n)
-    {
-        return if matches!(text, "-" | "*" | "+") {
-            marker_followed_by_whitespace_or_eol_at(p, n + 1)
-        } else {
-            textual_starts_with_ordered_marker(text)
-        };
-    }
-    false
+    true
 }
 
 /// Per CommonMark §5.2, list-item continuations emit their required indent
@@ -1780,7 +1788,9 @@ fn line_starts_with_fence(p: &mut MarkdownParser) -> bool {
         return false;
     }
     let indent = p.peek_line_indent(MAX_BLOCK_PREFIX_INDENT);
-    let rest = &p.source_after_current()[indent.byte_count..];
+    let Some(rest) = p.source_after_current().get(indent.byte_count..) else {
+        return false;
+    };
     let Some((fence_char, fence_len)) = fenced_code_block::detect_fence(rest) else {
         return false;
     };

--- a/crates/biome_markdown_parser/src/syntax/quote.rs
+++ b/crates/biome_markdown_parser/src/syntax/quote.rs
@@ -380,7 +380,7 @@ impl QuoteBlockList {
 
     /// Check if lazy continuation should stop.
     fn should_stop_lazy_continuation(&self, p: &MarkdownParser) -> bool {
-        (p.at_blank_line() || has_empty_line_before(p) || self.last_block_was_paragraph)
+        (p.is_at_blank_line() || has_empty_line_before(p) || self.last_block_was_paragraph)
             && !self.line_started_with_prefix
     }
 
@@ -422,7 +422,7 @@ impl QuoteBlockList {
 }
 
 fn quote_link_reference_before_dash_thematic_break(p: &mut MarkdownParser, depth: usize) -> bool {
-    if !p.at(NEWLINE) || p.at_blank_line() {
+    if !p.at(NEWLINE) || p.is_at_blank_line() {
         return false;
     }
 

--- a/crates/biome_markdown_parser/src/syntax/quote.rs
+++ b/crates/biome_markdown_parser/src/syntax/quote.rs
@@ -49,22 +49,19 @@ use crate::syntax::{
 
 /// Check if we're at the start of a block quote (`>`).
 pub(crate) fn at_quote(p: &mut MarkdownParser) -> bool {
-    p.lookahead(|p| {
-        let at_virtual_line_start = p.state().virtual_line_start == Some(p.cur_range().start());
-        if !p.at_line_start() && !p.at_start_of_input() && !at_virtual_line_start {
-            return false;
-        }
-        let mut indent = p.line_start_leading_indent();
-        if at_virtual_line_start && indent > 0 {
-            // Treat virtual line start as column 0.
-            indent = 0;
-        }
-        if indent > MAX_BLOCK_PREFIX_INDENT {
-            return false;
-        }
-        p.skip_line_indent(MAX_BLOCK_PREFIX_INDENT);
-        p.at(T![>])
-    })
+    let at_virtual_line_start = p.state().virtual_line_start == Some(p.cur_range().start());
+    if !p.is_at_line_start() && !at_virtual_line_start {
+        return false;
+    }
+    let mut leading_indent = p.line_start_leading_indent();
+    if at_virtual_line_start && leading_indent > 0 {
+        leading_indent = 0;
+    }
+    if leading_indent > MAX_BLOCK_PREFIX_INDENT {
+        return false;
+    }
+    let indent = p.peek_line_indent(MAX_BLOCK_PREFIX_INDENT);
+    p.nth_at(indent.token_count, T![>])
 }
 
 /// Parse a block quote.
@@ -87,7 +84,7 @@ pub(crate) fn parse_quote(p: &mut MarkdownParser) -> ParsedSyntax {
         // Wrap recovery tokens in MdBogusBlock (a valid AnyMdBlock child)
         // so they don't attach as Skipped trivia on normal content nodes.
         let bogus_m = p.start();
-        p.skip_line_indent(MAX_BLOCK_PREFIX_INDENT);
+        p.consume_line_indent_as_whitespace_trivia(MAX_BLOCK_PREFIX_INDENT);
         try_bump_quote_marker(p);
         let has_indented_code = at_quote_indented_code_start(p);
         emit_optional_marker_space(p, has_indented_code);
@@ -342,7 +339,9 @@ impl QuoteBlockList {
     fn handle_line_start_prefix(&mut self, p: &mut MarkdownParser) -> bool {
         self.line_started_with_prefix = self.first_line;
 
-        if !self.first_line && !p.at(NEWLINE) && (p.at_line_start() || p.has_preceding_line_break())
+        if !self.first_line
+            && !p.at(NEWLINE)
+            && (p.is_at_line_start() || p.has_preceding_line_break())
         {
             if consume_quote_prefix(p, self.depth) {
                 relex_after_quote_prefix_consumed(p);
@@ -755,7 +754,7 @@ fn consume_quote_prefix_impl(
     depth: usize,
     set_virtual_line_start: bool,
 ) -> bool {
-    if !p.at_line_start() && !p.at_start_of_input() && !p.has_preceding_line_break() {
+    if !p.is_at_line_start() && !p.has_preceding_line_break() {
         return false;
     }
 

--- a/crates/biome_markdown_parser/src/syntax/thematic_break_block.rs
+++ b/crates/biome_markdown_parser/src/syntax/thematic_break_block.rs
@@ -26,86 +26,87 @@ use biome_parser::{
 const THEMATIC_BREAK_MIN_CHARS: usize = 3;
 
 pub(crate) fn at_thematic_break_block(p: &mut MarkdownParser) -> bool {
-    p.lookahead(|p| {
-        if p.at_line_start() || p.at_start_of_input() {
-            if p.line_start_leading_indent() > MAX_BLOCK_PREFIX_INDENT {
-                return false;
-            }
-            p.skip_line_indent(MAX_BLOCK_PREFIX_INDENT);
-            return p.at(MD_THEMATIC_BREAK_LITERAL) || is_thematic_break_pattern(p);
+    if p.is_at_line_start() || p.is_at_start_of_input() {
+        if p.line_start_leading_indent() > MAX_BLOCK_PREFIX_INDENT {
+            return false;
         }
+        let indent = p.peek_line_indent(MAX_BLOCK_PREFIX_INDENT);
+        return p.nth_at(indent.token_count, MD_THEMATIC_BREAK_LITERAL)
+            || is_thematic_break_pattern(p, indent.token_count);
+    }
 
-        // Special case: we may not be at line start if a list marker was consumed
-        // (e.g., `- * * *` where `-` was consumed as a list marker).
-        // Check if the remaining content is a thematic break pattern.
-        is_thematic_break_pattern(p)
-    })
+    // A list marker may already be consumed for input such as `- * * *`.
+    is_thematic_break_pattern(p, 0)
 }
 
 /// Check if the remaining content forms a thematic break pattern.
 ///
 /// Per CommonMark §4.1, a thematic break is 3 or more matching characters
 /// (`*`, `-`, or `_`) on a line by itself, optionally with spaces between them.
-fn is_thematic_break_pattern(p: &mut MarkdownParser) -> bool {
-    // Skip leading whitespace
-    while p.at(MD_TEXTUAL_LITERAL) && p.cur_text().chars().all(|c| c == ' ' || c == '\t') {
-        p.bump(MD_TEXTUAL_LITERAL);
+fn is_thematic_break_pattern(p: &mut MarkdownParser, mut n: usize) -> bool {
+    while p.nth_at(n, MD_TEXTUAL_LITERAL)
+        && p.nth_text(n)
+            .is_some_and(|text| !text.as_bytes().iter().any(|b| !matches!(b, b' ' | b'\t')))
+    {
+        n += 1;
     }
 
-    // Check for lexer-produced thematic break token
-    if p.at(MD_THEMATIC_BREAK_LITERAL) {
+    if p.nth_at(n, MD_THEMATIC_BREAK_LITERAL) {
         return true;
     }
 
-    // If the entire line segment is a single textual literal, validate it directly.
-    if p.at(MD_TEXTUAL_LITERAL)
-        && p.cur_text()
-            .chars()
-            .all(|c| matches!(c, ' ' | '\t' | '\n' | '\r' | '*' | '-' | '_'))
-    {
+    let textual_break_count = p.nth_text(n).and_then(|text| {
+        if text
+            .as_bytes()
+            .iter()
+            .any(|b| !matches!(b, b' ' | b'\t' | b'\n' | b'\r' | b'*' | b'-' | b'_'))
+        {
+            return None;
+        }
         let mut break_char = None;
         let mut break_count = 0usize;
-
-        for c in p.cur_text().chars() {
-            if matches!(c, ' ' | '\t' | '\n' | '\r') {
-                continue;
+        for &byte in text
+            .as_bytes()
+            .iter()
+            .filter(|byte| !matches!(byte, b' ' | b'\t' | b'\n' | b'\r'))
+        {
+            if break_char.is_some_and(|existing| existing != byte) {
+                return Some(0);
             }
-            if let Some(existing) = break_char {
-                if existing != c {
-                    return false;
-                }
-            } else {
-                break_char = Some(c);
-            }
+            break_char = Some(byte);
             break_count += 1;
         }
-
-        let has_eol = p.lookahead(|p| {
-            p.bump(MD_TEXTUAL_LITERAL);
-            while p.at(MD_TEXTUAL_LITERAL) && p.cur_text().chars().all(|c| c == ' ' || c == '\t') {
-                p.bump(MD_TEXTUAL_LITERAL);
-            }
-            p.at(NEWLINE) || p.at(T![EOF])
-        });
-
+        Some(break_count)
+    });
+    if p.nth_at(n, MD_TEXTUAL_LITERAL)
+        && let Some(break_count) = textual_break_count
+    {
+        n += 1;
+        while p.nth_at(n, MD_TEXTUAL_LITERAL)
+            && p.nth_text(n)
+                .is_some_and(|text| !text.as_bytes().iter().any(|b| !matches!(b, b' ' | b'\t')))
+        {
+            n += 1;
+        }
+        let has_eol = p.nth_at(n, NEWLINE) || p.nth_at(n, T![EOF]);
         return break_count >= THEMATIC_BREAK_MIN_CHARS && has_eol;
     }
 
-    // Get the break character from the first non-whitespace token.
-    // DOUBLE_STAR / DOUBLE_UNDERSCORE count as 2 of the underlying char.
-    let break_char = if p.at(T![*]) || p.at(T![**]) {
-        '*'
-    } else if p.at(T![-]) {
-        '-'
-    } else if p.at(UNDERSCORE) || p.at(DOUBLE_UNDERSCORE) {
-        '_'
-    } else if p.at(MD_TEXTUAL_LITERAL) {
-        let text = p.cur_text();
+    let break_char = if p.nth_at(n, T![*]) || p.nth_at(n, T![**]) {
+        b'*'
+    } else if p.nth_at(n, T![-]) {
+        b'-'
+    } else if p.nth_at(n, UNDERSCORE) || p.nth_at(n, DOUBLE_UNDERSCORE) {
+        b'_'
+    } else if p.nth_at(n, MD_TEXTUAL_LITERAL) {
+        let Some(text) = p.nth_text(n) else {
+            return false;
+        };
         if text.len() == 1 {
-            match text.chars().next() {
-                Some('*') => '*',
-                Some('-') => '-',
-                Some('_') => '_',
+            match text.as_bytes().first() {
+                Some(b'*') => b'*',
+                Some(b'-') => b'-',
+                Some(b'_') => b'_',
                 _ => return false,
             }
         } else {
@@ -115,17 +116,25 @@ fn is_thematic_break_pattern(p: &mut MarkdownParser) -> bool {
         return false;
     };
 
-    // Count matching characters.
-    // DOUBLE_STAR / DOUBLE_UNDERSCORE contribute 2 to the count.
     let mut count = 0usize;
 
     loop {
         let (is_break, char_count) = match break_char {
-            '*' if p.at(T![**]) => (true, 2),
-            '*' if p.at(T![*]) || (p.at(MD_TEXTUAL_LITERAL) && p.cur_text() == "*") => (true, 1),
-            '-' if p.at(T![-]) || (p.at(MD_TEXTUAL_LITERAL) && p.cur_text() == "-") => (true, 1),
-            '_' if p.at(DOUBLE_UNDERSCORE) => (true, 2),
-            '_' if p.at(UNDERSCORE) || (p.at(MD_TEXTUAL_LITERAL) && p.cur_text() == "_") => {
+            b'*' if p.nth_at(n, T![**]) => (true, 2),
+            b'*' if p.nth_at(n, T![*])
+                || (p.nth_at(n, MD_TEXTUAL_LITERAL) && p.nth_text(n) == Some("*")) =>
+            {
+                (true, 1)
+            }
+            b'-' if p.nth_at(n, T![-])
+                || (p.nth_at(n, MD_TEXTUAL_LITERAL) && p.nth_text(n) == Some("-")) =>
+            {
+                (true, 1)
+            }
+            b'_' if p.nth_at(n, DOUBLE_UNDERSCORE) => (true, 2),
+            b'_' if p.nth_at(n, UNDERSCORE)
+                || (p.nth_at(n, MD_TEXTUAL_LITERAL) && p.nth_text(n) == Some("_")) =>
+            {
                 (true, 1)
             }
             _ => (false, 0),
@@ -133,25 +142,26 @@ fn is_thematic_break_pattern(p: &mut MarkdownParser) -> bool {
 
         if is_break {
             count += char_count;
-            p.bump_any();
+            n += 1;
             continue;
         }
 
-        // Skip whitespace between break characters
-        if p.at(MD_TEXTUAL_LITERAL) && p.cur_text().chars().all(|c| c == ' ' || c == '\t') {
-            p.bump(MD_TEXTUAL_LITERAL);
+        if p.nth_at(n, MD_TEXTUAL_LITERAL)
+            && p.nth_text(n)
+                .is_some_and(|text| !text.as_bytes().iter().any(|b| !matches!(b, b' ' | b'\t')))
+        {
+            n += 1;
             continue;
         }
-
-        // End of line or other content
         break;
     }
 
-    // Valid thematic break if 3+ characters followed by end of line
     count >= THEMATIC_BREAK_MIN_CHARS
-        && (p.at(NEWLINE)
-            || p.at(T![EOF])
-            || (p.at(MD_TEXTUAL_LITERAL) && matches!(p.cur_text(), "\n" | "\r\n" | "\r")))
+        && (p.nth_at(n, NEWLINE)
+            || p.nth_at(n, T![EOF])
+            || (p.nth_at(n, MD_TEXTUAL_LITERAL)
+                && p.nth_text(n)
+                    .is_some_and(|text| matches!(text, "\n" | "\r\n" | "\r"))))
 }
 
 pub(crate) fn parse_thematic_break_block(p: &mut MarkdownParser) -> ParsedSyntax {

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/link_definition_edge_cases.md
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/link_definition_edge_cases.md
@@ -31,3 +31,6 @@ Another paragraph
 [invalid-trailing]: /url invalid
 
 [angle-trailing]: </url> invalid
+
+[invalid-next-line-title]: /url
+  "title" trailing

--- a/crates/biome_markdown_parser/tests/md_test_suite/ok/link_definition_edge_cases.md.snap
+++ b/crates/biome_markdown_parser/tests/md_test_suite/ok/link_definition_edge_cases.md.snap
@@ -40,6 +40,9 @@ Another paragraph
 
 [angle-trailing]: </url> invalid
 
+[invalid-next-line-title]: /url
+  "title" trailing
+
 ```
 
 
@@ -566,18 +569,64 @@ MdRoot {
                 },
             ],
         },
+        MdNewline {
+            value_token: NEWLINE@531..532 "\n" [] [],
+        },
+        MdLinkReferenceDefinition {
+            indent: MdIndentTokenList [],
+            l_brack_token: L_BRACK@532..533 "[" [] [],
+            label: MdLinkLabel {
+                content: MdInlineItemList [
+                    MdTextual {
+                        value_token: MD_TEXTUAL_LITERAL@533..556 "invalid-next-line-title" [] [],
+                    },
+                ],
+            },
+            r_brack_token: R_BRACK@556..557 "]" [] [],
+            colon_token: COLON@557..558 ":" [] [],
+            destination: MdLinkDestination {
+                content: MdInlineItemList [
+                    MdTextual {
+                        value_token: MD_TEXTUAL_LITERAL@558..559 " " [] [],
+                    },
+                    MdTextual {
+                        value_token: MD_TEXTUAL_LITERAL@559..563 "/url" [] [],
+                    },
+                ],
+            },
+            title: missing (optional),
+        },
+        MdNewline {
+            value_token: NEWLINE@563..564 "\n" [] [],
+        },
+        MdParagraph {
+            list: MdInlineItemList [
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@564..565 " " [] [],
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@565..566 " " [] [],
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@566..582 "\"title\" trailing" [] [],
+                },
+                MdTextual {
+                    value_token: MD_TEXTUAL_LITERAL@582..583 "\n" [] [],
+                },
+            ],
+        },
     ],
-    eof_token: EOF@531..531 "" [] [],
+    eof_token: EOF@583..583 "" [] [],
 }
 ```
 
 ## CST
 
 ```
-0: MD_ROOT@0..531
+0: MD_ROOT@0..583
   0: (empty)
   1: (empty)
-  2: MD_BLOCK_LIST@0..531
+  2: MD_BLOCK_LIST@0..583
     0: MD_PARAGRAPH@0..31
       0: MD_INLINE_ITEM_LIST@0..31
         0: MD_TEXTUAL@0..30
@@ -914,6 +963,36 @@ MdRoot {
           0: MD_TEXTUAL_LITERAL@522..530 " invalid" [] []
         4: MD_TEXTUAL@530..531
           0: MD_TEXTUAL_LITERAL@530..531 "\n" [] []
-  3: EOF@531..531 "" [] []
+    42: MD_NEWLINE@531..532
+      0: NEWLINE@531..532 "\n" [] []
+    43: MD_LINK_REFERENCE_DEFINITION@532..563
+      0: MD_INDENT_TOKEN_LIST@532..532
+      1: L_BRACK@532..533 "[" [] []
+      2: MD_LINK_LABEL@533..556
+        0: MD_INLINE_ITEM_LIST@533..556
+          0: MD_TEXTUAL@533..556
+            0: MD_TEXTUAL_LITERAL@533..556 "invalid-next-line-title" [] []
+      3: R_BRACK@556..557 "]" [] []
+      4: COLON@557..558 ":" [] []
+      5: MD_LINK_DESTINATION@558..563
+        0: MD_INLINE_ITEM_LIST@558..563
+          0: MD_TEXTUAL@558..559
+            0: MD_TEXTUAL_LITERAL@558..559 " " [] []
+          1: MD_TEXTUAL@559..563
+            0: MD_TEXTUAL_LITERAL@559..563 "/url" [] []
+      6: (empty)
+    44: MD_NEWLINE@563..564
+      0: NEWLINE@563..564 "\n" [] []
+    45: MD_PARAGRAPH@564..583
+      0: MD_INLINE_ITEM_LIST@564..583
+        0: MD_TEXTUAL@564..565
+          0: MD_TEXTUAL_LITERAL@564..565 " " [] []
+        1: MD_TEXTUAL@565..566
+          0: MD_TEXTUAL_LITERAL@565..566 " " [] []
+        2: MD_TEXTUAL@566..582
+          0: MD_TEXTUAL_LITERAL@566..582 "\"title\" trailing" [] []
+        3: MD_TEXTUAL@582..583
+          0: MD_TEXTUAL_LITERAL@582..583 "\n" [] []
+  3: EOF@583..583 "" [] []
 
 ```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

- Reduces the use of the function `lookahead` to a minimum. The cause was the function `skip_line_indent`, which essentially advances the parser, and that's why many checks used lookahead. Instead, we now have a `peek_line_indent` which uses `nth_at` under the hood.
- Reduced the check for valid link references to a minimum. There, lookahead is valid, but it was also checking for *optional* fields. Optional fields don't count for the current shape of nodes.


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Current CI should pass

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
