### PR TITLE
perf(type_inference): collect declaration only class methods as class members

### DIFF
--- a/.changeset/few-buckets-jump.md
+++ b/.changeset/few-buckets-jump.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11390](https://github.com/biomejs/biome/issues/11390), where `noFloatingPromises` performed expensive full type inference for calls to non-Promise methods declared on third-party TypeScript classes. The rule now classifies those calls using targeted type information.

--- a/crates/biome_js_type_info/src/local_inference.rs
+++ b/crates/biome_js_type_info/src/local_inference.rs
@@ -31,6 +31,7 @@ use biome_js_syntax::{
     TsTypeParameters, TsTypeofType, inner_string_text, unescape_js_string,
 };
 use biome_rowan::{AstNode, SyntaxResult, Text, TextRange, TokenText};
+use rustc_hash::FxHashMap;
 
 use crate::globals::{
     GLOBAL_GLOBAL_ID, GLOBAL_INSTANCEOF_PROMISE_ID, GLOBAL_NUMBER_ID, GLOBAL_STRING_ID,
@@ -356,13 +357,8 @@ impl TypeData {
                             )
                         })
                         .unwrap_or_default(),
-                    members: decl
-                        .members()
-                        .into_iter()
-                        .filter_map(|member| {
-                            TypeMember::from_any_js_class_member(collector, scope_id, &member)
-                        })
-                        .collect(),
+                    members: TypeMember::collect_class_members(collector, scope_id, decl.members())
+                        .into_boxed_slice(),
                 }))
             }
             AnyJsExportDefaultDeclaration::JsFunctionExportDefaultDeclaration(decl) => {
@@ -1970,6 +1966,46 @@ impl TypeMember {
                     .any(|modifier| modifier.as_js_static_modifier().is_some());
                 Self::from_class_member_info(collector, scope_id, name, ty.into(), is_static, false)
             }),
+            AnyJsClassMember::TsMethodSignatureClassMember(member) => {
+                member.name().ok().and_then(|name| {
+                    let is_async = member.async_token().is_some();
+                    let function = Function {
+                        is_async,
+                        type_parameters: generic_params_from_ts_type_params(
+                            collector,
+                            scope_id,
+                            member.type_parameters(),
+                        ),
+                        name: name.name().map(text_from_class_member_name),
+                        parameters: function_params_from_js_params(
+                            collector,
+                            scope_id,
+                            member.parameters(),
+                        ),
+                        return_type: function_return_type(
+                            collector,
+                            scope_id,
+                            is_async,
+                            member.return_type_annotation(),
+                            None,
+                        ),
+                    };
+                    let ty = collector.register_and_resolve(function.into());
+                    let is_static = member
+                        .modifiers()
+                        .into_iter()
+                        .any(|modifier| modifier.as_js_static_modifier().is_some());
+                    let is_optional = member.question_mark_token().is_some();
+                    Self::from_class_member_info(
+                        collector,
+                        scope_id,
+                        name,
+                        ty.into(),
+                        is_static,
+                        is_optional,
+                    )
+                })
+            }
             AnyJsClassMember::JsPropertyClassMember(member) => {
                 member.name().ok().and_then(|name| {
                     let ty = match member
@@ -2416,10 +2452,7 @@ impl TypeMember {
         scope_id: ScopeId,
         member_list: JsClassMemberList,
     ) -> Box<[Self]> {
-        let mut members: Vec<_> = member_list
-            .into_iter()
-            .filter_map(|member| Self::from_any_js_class_member(collector, scope_id, &member))
-            .collect();
+        let mut members = Self::collect_class_members(collector, scope_id, member_list);
 
         // Extend members with those from constructor definitions:
         let num_members = members.len();
@@ -2448,6 +2481,95 @@ impl TypeMember {
         }
 
         members.into()
+    }
+
+    fn collect_class_members(
+        collector: &mut dyn RawTypeCollector,
+        scope_id: ScopeId,
+        member_list: JsClassMemberList,
+    ) -> Vec<Self> {
+        enum CollectedMember {
+            Direct(TypeMember),
+            MethodOverload {
+                member: TypeMember,
+                signatures: Vec<TypeReference>,
+            },
+        }
+
+        let mut collected = Vec::new();
+        let mut overloads_by_name = FxHashMap::default();
+        for syntax_member in member_list {
+            let is_method_signature = matches!(
+                &syntax_member,
+                AnyJsClassMember::TsMethodSignatureClassMember(_)
+            );
+            let is_method_implementation =
+                matches!(&syntax_member, AnyJsClassMember::JsMethodClassMember(_));
+            let Some(member) = Self::from_any_js_class_member(collector, scope_id, &syntax_member)
+            else {
+                continue;
+            };
+            if !is_method_signature && (!is_method_implementation || overloads_by_name.is_empty()) {
+                collected.push(CollectedMember::Direct(member));
+                continue;
+            }
+
+            let Some(name) = member.kind.name() else {
+                collected.push(CollectedMember::Direct(member));
+                continue;
+            };
+            let key = (name, member.is_static());
+
+            if is_method_signature {
+                if let Some(index) = overloads_by_name.get(&key).copied()
+                    && let CollectedMember::MethodOverload { signatures, .. } =
+                        &mut collected[index]
+                {
+                    signatures.push(member.ty);
+                } else {
+                    overloads_by_name.insert(key, collected.len());
+                    collected.push(CollectedMember::MethodOverload {
+                        signatures: vec![member.ty.clone()],
+                        member,
+                    });
+                }
+            } else if is_method_implementation
+                && let Some(index) = overloads_by_name.get(&key).copied()
+                && let CollectedMember::MethodOverload {
+                    member: representative,
+                    ..
+                } = &mut collected[index]
+            {
+                *representative = member;
+            } else {
+                collected.push(CollectedMember::Direct(member));
+            }
+        }
+
+        collected
+            .into_iter()
+            .map(|collected| match collected {
+                CollectedMember::Direct(member) => member,
+                CollectedMember::MethodOverload {
+                    mut member,
+                    signatures,
+                } => {
+                    member.ty = match signatures.as_slice() {
+                        [signature] => signature.clone(),
+                        _ => collector.reference_to_owned_data(TypeData::object_with_members(
+                            signatures
+                                .into_iter()
+                                .map(|ty| Self {
+                                    kind: TypeMemberKind::CallSignature,
+                                    ty,
+                                })
+                                .collect(),
+                        )),
+                    };
+                    member
+                }
+            })
+            .collect()
     }
 }
 

--- a/crates/biome_module_graph/src/db/type_inference/promise_classification.rs
+++ b/crates/biome_module_graph/src/db/type_inference/promise_classification.rs
@@ -25,7 +25,6 @@ use crate::db::queries::{
 use crate::js_module_info::TsBindingReferenceExt;
 use crate::module_graph::{ModuleInfo, ModuleInfoKind};
 use crate::{JsExport, JsModuleInfo, JsOwnExport, ModuleDb, ResolvedPath, SymbolFromModuleInfo};
-use biome_js_syntax::{AnyJsClass, AnyJsClassMember};
 use biome_js_type_info::{
     GlobalTypeId, ImportSymbol, Literal, RawTypeData, RawTypeId, ScopeId, TypeId, TypeMember,
     TypeReference, TypeReferenceQualifier, TypeResolverLevel, TypeofExpression, global_types,
@@ -33,7 +32,7 @@ use biome_js_type_info::{
         ReturnType, TypeData as InferredTypeData, TypeSubstitution, TypeTransformResult,
     },
 };
-use biome_rowan::{AstNode, Text, TextRange};
+use biome_rowan::Text;
 use rustc_hash::FxHashSet;
 
 const MAX_PROMISE_CLASSIFICATION_STATES: usize = 1024;
@@ -61,40 +60,14 @@ enum MemberLookupMode {
     /// Selects instance members when the target is a class.
     Instance,
     /// Selects a constructed instance after consuming its value-side members.
-    Constructed {
-        remaining: usize,
-        binding_range: Option<TextRange>,
-    },
+    Constructed { remaining: usize },
 }
 
 impl MemberLookupMode {
     fn prepend_constructed_members(self, count: usize) -> Self {
         match self {
-            Self::Constructed { remaining, .. } => Self::Constructed {
+            Self::Constructed { remaining } => Self::Constructed {
                 remaining: remaining.saturating_add(count),
-                binding_range: None,
-            },
-            mode @ (Self::Value | Self::Instance) => mode,
-        }
-    }
-
-    fn with_class_binding(self, binding_range: TextRange) -> Self {
-        match self {
-            Self::Constructed { remaining: 0, .. } => Self::Constructed {
-                remaining: 0,
-                binding_range: Some(binding_range),
-            },
-            mode @ (Self::Value | Self::Instance | Self::Constructed { remaining: 1.., .. }) => {
-                mode
-            }
-        }
-    }
-
-    fn without_class_binding(self) -> Self {
-        match self {
-            Self::Constructed { remaining, .. } => Self::Constructed {
-                remaining,
-                binding_range: None,
             },
             mode @ (Self::Value | Self::Instance) => mode,
         }
@@ -102,20 +75,18 @@ impl MemberLookupMode {
 
     fn after_member(self) -> Self {
         match self {
-            Self::Value | Self::Instance | Self::Constructed { remaining: 0, .. } => Self::Value,
-            Self::Constructed { remaining, .. } => Self::Constructed {
+            Self::Value | Self::Instance | Self::Constructed { remaining: 0 } => Self::Value,
+            Self::Constructed { remaining } => Self::Constructed {
                 remaining: remaining - 1,
-                binding_range: None,
             },
         }
     }
 
     fn after_namespace_member(self) -> Option<Self> {
         match self {
-            Self::Constructed { remaining: 0, .. } => None,
-            Self::Constructed { remaining, .. } => Some(Self::Constructed {
+            Self::Constructed { remaining: 0 } => None,
+            Self::Constructed { remaining } => Some(Self::Constructed {
                 remaining: remaining - 1,
-                binding_range: None,
             }),
             mode @ (Self::Value | Self::Instance) => Some(mode),
         }
@@ -381,7 +352,7 @@ fn classify_expression(
                                         resolved_path: import.resolved_path.clone(),
                                         symbol: import.symbol.clone(),
                                     },
-                                    mode: mode.without_class_binding(),
+                                    mode,
                                     members: members.clone(),
                                     projection: state.projection,
                                 };
@@ -394,7 +365,7 @@ fn classify_expression(
                             break ClassificationState {
                                 module: state.module,
                                 target: ClassificationTarget::Reference(reference.clone()),
-                                mode: mode.with_class_binding(binding_range),
+                                mode,
                                 members: members.clone(),
                                 projection: state.projection,
                             };
@@ -499,7 +470,7 @@ fn classify_expression(
                         resolved_path: import.resolved_path.clone(),
                         symbol: import.symbol.clone(),
                     },
-                    mode: state.mode.without_class_binding(),
+                    mode: state.mode,
                     members: state.members,
                     projection: state.projection,
                 },
@@ -511,24 +482,23 @@ fn classify_expression(
                 let Some(raw) = js_info.raw_types.get(type_id.index()) else {
                     return Indeterminate;
                 };
-                if matches!(
-                    state.mode,
-                    MemberLookupMode::Constructed { remaining: 0, .. }
-                ) && !(matches!(
-                    raw,
-                    RawTypeData::Class(_)
-                        | RawTypeData::Reference(_)
-                        | RawTypeData::TypeofType(_)
-                        | RawTypeData::TypeofValue(_)
-                ) || matches!(
-                    raw,
-                    RawTypeData::TypeofExpression(expression)
-                        if matches!(
-                            expression.as_ref(),
-                            TypeofExpression::StaticMember(_)
-                                | TypeofExpression::OptionalChainStaticMember(_)
-                        )
-                )) {
+                if matches!(state.mode, MemberLookupMode::Constructed { remaining: 0 })
+                    && !(matches!(
+                        raw,
+                        RawTypeData::Class(_)
+                            | RawTypeData::Reference(_)
+                            | RawTypeData::TypeofType(_)
+                            | RawTypeData::TypeofValue(_)
+                    ) || matches!(
+                        raw,
+                        RawTypeData::TypeofExpression(expression)
+                            if matches!(
+                                expression.as_ref(),
+                                TypeofExpression::StaticMember(_)
+                                    | TypeofExpression::OptionalChainStaticMember(_)
+                            )
+                    ))
+                {
                     return Indeterminate;
                 }
 
@@ -740,10 +710,7 @@ fn classify_expression(
                             ClassificationState {
                                 module: state.module,
                                 target: ClassificationTarget::Reference(expression.callee.clone()),
-                                mode: MemberLookupMode::Constructed {
-                                    remaining: 0,
-                                    binding_range: None,
-                                },
+                                mode: MemberLookupMode::Constructed { remaining: 0 },
                                 members: state.members,
                                 projection: state.projection,
                             }
@@ -858,10 +825,8 @@ fn classify_expression(
                         if matches!(state.projection, Projection::PromiseTarget) {
                             return DoesNotReturnPromise;
                         }
-                        if matches!(
-                            state.mode,
-                            MemberLookupMode::Constructed { remaining: 0, .. }
-                        ) && !class.type_parameters.is_empty()
+                        if matches!(state.mode, MemberLookupMode::Constructed { remaining: 0 })
+                            && !class.type_parameters.is_empty()
                         {
                             return Indeterminate;
                         }
@@ -874,36 +839,6 @@ fn classify_expression(
                         };
                         if member.is_getter() {
                             return Indeterminate;
-                        }
-                        if let MemberLookupMode::Constructed {
-                            remaining: 0,
-                            binding_range,
-                        } = state.mode
-                        {
-                            if class
-                                .members
-                                .iter()
-                                .filter(|candidate| {
-                                    candidate.has_name(name.text())
-                                        && candidate.is_static() == member.is_static()
-                                })
-                                .nth(1)
-                                .is_some()
-                            {
-                                return Indeterminate;
-                            }
-                            let Some(binding_range) = binding_range else {
-                                return Indeterminate;
-                            };
-                            let Some(false) = class_member_has_overload_signature(
-                                &js_info,
-                                type_id,
-                                binding_range,
-                                name,
-                                member.is_static(),
-                            ) else {
-                                return Indeterminate;
-                            };
                         }
                         ClassificationState {
                             module: state.module,
@@ -1153,7 +1088,7 @@ fn classify_expression(
                         ClassificationState {
                             module,
                             target: ClassificationTarget::Reference(reference.clone()),
-                            mode: state.mode.with_class_binding(*range),
+                            mode: state.mode,
                             members: state.members,
                             projection: state.projection,
                         }
@@ -1163,7 +1098,7 @@ fn classify_expression(
                         target: ClassificationTarget::Reference(TypeReference::Resolved(
                             RawTypeId::Local(*resolved),
                         )),
-                        mode: state.mode.without_class_binding(),
+                        mode: state.mode,
                         members: state.members,
                         projection: state.projection,
                     },
@@ -1173,7 +1108,7 @@ fn classify_expression(
                             resolved_path: reexport.import.resolved_path.clone(),
                             symbol: reexport.import.symbol.clone(),
                         },
-                        mode: state.mode.without_class_binding(),
+                        mode: state.mode,
                         members: state.members,
                         projection: state.projection,
                     },
@@ -1197,52 +1132,14 @@ fn find_own_member<'a>(
     members.iter().find(|member| {
         member.has_name(name.text())
             && mode.is_none_or(|mode| match mode {
-                MemberLookupMode::Value | MemberLookupMode::Constructed { remaining: 1.., .. } => {
+                MemberLookupMode::Value | MemberLookupMode::Constructed { remaining: 1.. } => {
                     member.is_static()
                 }
-                MemberLookupMode::Instance | MemberLookupMode::Constructed { remaining: 0, .. } => {
+                MemberLookupMode::Instance | MemberLookupMode::Constructed { remaining: 0 } => {
                     !member.is_static()
                 }
             })
     })
-}
-
-fn class_member_has_overload_signature(
-    js_info: &JsModuleInfo,
-    type_id: TypeId,
-    binding_range: TextRange,
-    name: &Text,
-    is_static: bool,
-) -> Option<bool> {
-    let binding = js_info.semantic_model.as_binding_by_range(binding_range)?;
-    let TypeReference::Resolved(resolved) = js_info.raw_binding_types.get(&binding_range)? else {
-        return None;
-    };
-    if resolved.level() != TypeResolverLevel::Thin || resolved.id().index() != type_id.index() {
-        return None;
-    }
-    let class = binding
-        .syntax()
-        .ancestors()
-        .skip(1)
-        .find_map(AnyJsClass::cast)?;
-
-    for candidate in class.members() {
-        let AnyJsClassMember::TsMethodSignatureClassMember(signature) = &candidate else {
-            continue;
-        };
-        let signature_is_static = signature
-            .modifiers()
-            .into_iter()
-            .any(|modifier| modifier.as_js_static_modifier().is_some());
-        let candidate_name = signature.name().ok()?;
-        if signature_is_static == is_static
-            && candidate_name.class_member_name_matches(name.text())?
-        {
-            return Some(true);
-        }
-    }
-    Some(false)
 }
 
 fn sole_call_signature(members: &[TypeMember]) -> Result<Option<&TypeMember>, ()> {

--- a/crates/biome_module_graph/tests/spec_tests/requests.test.rs
+++ b/crates/biome_module_graph/tests/spec_tests/requests.test.rs
@@ -350,6 +350,138 @@ fn classification_requests_preserve_conclusive_and_indeterminate_results() {
 }
 
 #[test]
+fn declaration_class_method_classification_is_conclusive() {
+    const DECLARATION_SOURCE: &str = r#"
+        export declare class Tracer {
+            putAnnotation(key: string, value: string | number | boolean): void;
+            overloaded(value: string): "sync";
+            overloaded(value: number): Promise<void>;
+            static staticOverloaded(value: string): "sync";
+            static staticOverloaded(value: number): Promise<void>;
+        }
+    "#;
+    const SOURCE: &str = r#"
+        import { Tracer } from "./tracer.d.ts";
+        const tracer = new Tracer();
+        declare const typedTracer: Tracer;
+        tracer.putAnnotation("Category", "value");
+        tracer.overloaded("value");
+        typedTracer.overloaded("value");
+        Tracer.staticOverloaded("value");
+    "#;
+    let fs = MemoryFileSystem::default();
+    fs.insert("/src/tracer.d.ts".into(), DECLARATION_SOURCE);
+    fs.insert("/src/index.ts".into(), SOURCE);
+
+    let db = build_js_test_module_db(&fs, &["/src/tracer.d.ts", "/src/index.ts"], true);
+    let declaration_module = db
+        .module_for_path(Utf8Path::new("/src/tracer.d.ts"))
+        .expect("declaration module must exist");
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let caller = TypeInferenceCaller::new("test", "declarationClassMethod");
+    let put_annotation = expression_range_by_source(
+        &db,
+        module,
+        SOURCE,
+        r#"tracer.putAnnotation("Category", "value")"#,
+    );
+    let overloaded =
+        expression_range_by_source(&db, module, SOURCE, r#"tracer.overloaded("value")"#);
+    let typed_overloaded =
+        expression_range_by_source(&db, module, SOURCE, r#"typedTracer.overloaded("value")"#);
+    let static_overloaded =
+        expression_range_by_source(&db, module, SOURCE, r#"Tracer.staticOverloaded("value")"#);
+
+    db.clear_salsa_events();
+    for classification in [
+        execute_type_inference_request(
+            &db,
+            caller,
+            PromiseClassificationRequest::new(module, put_annotation),
+        ),
+        execute_type_inference_request(
+            &db,
+            caller,
+            ArrayOfPromisesClassificationRequest::new(module, put_annotation),
+        ),
+    ] {
+        assert_eq!(classification, TypeInferenceClassification::NoMatch);
+    }
+    for expression in [overloaded, typed_overloaded, static_overloaded] {
+        for classification in [
+            execute_type_inference_request(
+                &db,
+                caller,
+                PromiseClassificationRequest::new(module, expression),
+            ),
+            execute_type_inference_request(
+                &db,
+                caller,
+                ArrayOfPromisesClassificationRequest::new(module, expression),
+            ),
+        ] {
+            assert_eq!(classification, TypeInferenceClassification::Indeterminate);
+        }
+    }
+    for expression in [overloaded, typed_overloaded, static_overloaded] {
+        let ty = execute_type_inference_request(
+            &db,
+            caller,
+            NormalizedExpressionTypeRequest::new(module, expression),
+        )
+        .expect("expression type must be inferred");
+        assert!(is_inferred_string(&db, ty));
+    }
+    let events = db.take_salsa_events();
+    assert_function_query_was_not_run(&db, infer_module_types, module, &events);
+    assert_function_query_was_not_run(&db, infer_module_types, declaration_module, &events);
+}
+
+#[test]
+fn class_method_overloads_preserve_member_lookup() {
+    const SOURCE: &str = r#"
+        class Handler {
+            run(value: string): "sync";
+            run(value: number): Promise<void>;
+            run(value: string | number): "sync" | Promise<void> {
+                return value === "sync" ? "sync" : Promise.resolve();
+            }
+
+            static staticRun(value: string): "sync";
+            static staticRun(value: number): Promise<void>;
+            static staticRun(value: string | number): "sync" | Promise<void> {
+                return value === "sync" ? "sync" : Promise.resolve();
+            }
+        }
+
+        const handler = new Handler();
+        handler.run("sync");
+        Handler.staticRun("sync");
+    "#;
+    let fs = MemoryFileSystem::default();
+    fs.insert("/src/index.ts".into(), SOURCE);
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let caller = TypeInferenceCaller::new("test", "classMethodOverloads");
+
+    for expression in [r#"handler.run("sync")"#, r#"Handler.staticRun("sync")"#] {
+        let expression = expression_range_by_source(&db, module, SOURCE, expression);
+        let ty = execute_type_inference_request(
+            &db,
+            caller,
+            NormalizedExpressionTypeRequest::new(module, expression),
+        )
+        .expect("expression type must be inferred");
+        assert!(is_inferred_string(&db, ty));
+    }
+}
+
+#[test]
 fn classification_and_return_type_requests_stay_selective() {
     let source = r#"
         const promise = Promise.resolve(1);


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
My clanker explains the root cause as:

> Root cause: TypeScript declaration-only class methods weren’t collected as class members. `noFloatingPromises` therefore fell back to full call inference, recursively exploring the large Zod/AWS type graph.

implemented by gpt 5.6 sol

I'm still not as comfortable in this area of the code, so I'm not quite sure this implementation is correct.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
closes #11390 

cc @ematipico, since you were assigned to the issue

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
no snapshot changes

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
