### PR TITLE
LSP scan perf test

### DIFF
--- a/.changeset/fifty-nights-wish.md
+++ b/.changeset/fifty-nights-wish.md
@@ -1,0 +1,6 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed a project scan that could take extremely long in monorepos with densely-linked module graphs, such as GraphQL schemas or barrel files. During dependency scanning Biome now opens each file at most once instead of re-opening it for every incoming import, which previously caused the same file to be indexed thousands of times.
+

--- a/crates/biome_service/src/scanner.rs
+++ b/crates/biome_service/src/scanner.rs
@@ -562,10 +562,16 @@ fn scan_dependencies<W: WorkspaceScannerBridge>(
         folders.into_iter().map(Utf8Path::to_path_buf).collect()
     };
 
+    // Tracks paths already scheduled for indexing so densely-linked module
+    // graphs (e.g. GraphQL schemas or barrel files) are not re-opened once per
+    // incoming dependency edge, which would blow up combinatorially.
+    let visited: HashSet<Utf8PathBuf> = HashSet::default();
+
     rayon::scope(|s| {
         fn index_dependency<'a, W: WorkspaceScannerBridge>(
             s: &Scope<'a>,
             ctx: &'a ScanContext<'a, W>,
+            visited: &'a HashSet<Utf8PathBuf>,
             dependency_path: Utf8PathBuf,
         ) {
             let dependencies = open_file(ctx, BiomePath::new(dependency_path), ctx.trigger);
@@ -585,8 +591,8 @@ fn scan_dependencies<W: WorkspaceScannerBridge>(
                         None,
                     )
                     .unwrap_or(true);
-                if !is_ignored {
-                    s.spawn(move |s| index_dependency(s, ctx, dependency_path));
+                if !is_ignored && visited.pin().insert(dependency_path.clone()) {
+                    s.spawn(move |s| index_dependency(s, ctx, visited, dependency_path));
                 }
             }
         }
@@ -602,8 +608,8 @@ fn scan_dependencies<W: WorkspaceScannerBridge>(
                     None,
                 )
                 .unwrap_or(true);
-            if !is_ignored {
-                s.spawn(|s| index_dependency(s, ctx, dependency_path));
+            if !is_ignored && visited.pin().insert(dependency_path.clone()) {
+                s.spawn(|s| index_dependency(s, ctx, &visited, dependency_path));
             }
         }
     });


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

idk if this even makes sense, ran the clanker over the server-logs of my project, the biome config of my project and biome's source code.

```
On a ~13.7 k-file GraphQL monorepo, a single LSP startup project scan opened files 11,549,389 times (avg 844× per file, worst file 133,338×)

Evidence (from --log-level=trace daemon log, Biome 2.5.9)
- open_file_internal calls: 11,549,389 (reason=Index = 11,549,389, ClientRequest = 120)
- Distinct paths: 13,690 → ~844× average re-open
- Worst: modules/content/src/schema/flex-page/components/content-fp-marketing-carousel.graphql opened 133,338×
- By extension: graphql 5.7M, ts 4.8M, json 0.95M, yaml 0.11M
- update_module_graph_internal / infer_types: 838,680 each
- salsa::Cancelled / retry: ~10 k / ~2 k (not significant)
```

Quite interesting how a single graphql file is opened 133,338 times

Not sure why these graphql files are even re-opened (they are not imported by js or ts)

All code stuff is also generated by the clanker

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
