### PR TITLE
fix(lsp): skip redundant project rescans when the configuration is unchanged

### DIFF
--- a/.changeset/lsp-skip-redundant-project-rescans.md
+++ b/.changeset/lsp-skip-redundant-project-rescans.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#10605](https://github.com/biomejs/biome/issues/10605): the LSP daemon no longer runs redundant full project rescans. Editors send `workspace/didChangeConfiguration` for any settings change, and every notification reloaded the configuration and forced a full project scan even when the Biome configuration was unchanged. The session now fingerprints the loaded configuration and skips the settings update and the rescan when nothing changed. Concurrent scan requests for the same project are also coalesced into at most one running scan plus one queued follow-up, instead of piling up.
+Fixed [#10605](https://github.com/biomejs/biome/issues/10605): the LSP daemon no longer reruns a full project scan when a `workspace/didChangeConfiguration` notification arrives and the Biome configuration has not changed. Editors send this notification for any settings change, and every notification previously forced a full project rescan.

--- a/.changeset/lsp-skip-redundant-project-rescans.md
+++ b/.changeset/lsp-skip-redundant-project-rescans.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed redundant full project rescans in the LSP daemon. Editors send `workspace/didChangeConfiguration` for any settings change, and every notification reloaded the configuration and forced a full project scan even when the Biome configuration was unchanged. The session now fingerprints the loaded configuration and skips the settings update and the rescan when nothing changed. Concurrent scan requests for the same project are also coalesced into at most one running scan plus one queued follow-up, instead of piling up.
+Fixed [#10605](https://github.com/biomejs/biome/issues/10605): the LSP daemon no longer runs redundant full project rescans. Editors send `workspace/didChangeConfiguration` for any settings change, and every notification reloaded the configuration and forced a full project scan even when the Biome configuration was unchanged. The session now fingerprints the loaded configuration and skips the settings update and the rescan when nothing changed. Concurrent scan requests for the same project are also coalesced into at most one running scan plus one queued follow-up, instead of piling up.

--- a/.changeset/lsp-skip-redundant-project-rescans.md
+++ b/.changeset/lsp-skip-redundant-project-rescans.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#10605](https://github.com/biomejs/biome/issues/10605): the LSP daemon no longer reruns a full project scan when a `workspace/didChangeConfiguration` notification arrives and the Biome configuration has not changed. Editors send this notification for any settings change, and every notification previously forced a full project rescan.
+Fixed [#10605](https://github.com/biomejs/biome/issues/10605): the LSP server no longer runs a full project scan when the configuration is reloaded but hasn't changed. Previously, any editor settings change triggered a full rescan.

--- a/.changeset/lsp-skip-redundant-project-rescans.md
+++ b/.changeset/lsp-skip-redundant-project-rescans.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed redundant full project rescans in the LSP daemon. Editors send `workspace/didChangeConfiguration` for any settings change, and every notification reloaded the configuration and forced a full project scan even when the Biome configuration was unchanged. The session now fingerprints the loaded configuration and skips the settings update and the rescan when nothing changed. Concurrent scan requests for the same project are also coalesced into at most one running scan plus one queued follow-up, instead of piling up.

--- a/crates/biome_lsp/src/server.rs
+++ b/crates/biome_lsp/src/server.rs
@@ -506,6 +506,7 @@ impl LanguageServer for LSPServer {
         self.session
             .update_workspace_folders(params.event.added, params.event.removed);
         self.session.clear_configuration_cache().await;
+        self.session.clear_loaded_configurations().await;
         self.session.load_workspace_settings(true).await;
         self.setup_capabilities().await;
         self.session.update_all_diagnostics().await;

--- a/crates/biome_lsp/src/server.tests.rs
+++ b/crates/biome_lsp/src/server.tests.rs
@@ -4924,38 +4924,45 @@ async fn should_apply_changed_configuration_after_unchanged_reload() -> Result<(
     let (sender, mut receiver) = channel(CHANNEL_BUFFER_SIZE);
     let reader = tokio::spawn(client_handler(stream, sink, sender));
 
-    server.initialize().await?;
+    // Declare `window.workDoneProgress` support, so every project scan is
+    // observable through a `$/progress` "begin" notification.
+    server.initialize_with_work_done_progress().await?;
     server.initialized().await?;
 
     server.open_document("a == b;\n").await?;
 
-    let notification = wait_for_notification(&mut receiver, |n| n.is_publish_diagnostics()).await;
-    let Some(ServerNotification::PublishDiagnostics(result)) = notification else {
-        panic!("expected diagnostics for the initial configuration");
-    };
+    let (notification, scans) = wait_for_notification_counting_scans(&mut receiver, |n| {
+        matches!(n, ServerNotification::PublishDiagnostics(params) if !params.diagnostics.is_empty())
+    })
+    .await;
     assert!(
-        !result.diagnostics.is_empty(),
+        notification.is_some(),
         "the strict configuration should report noDoubleEquals"
     );
+    assert_eq!(scans, 1, "the initial configuration load should scan once");
 
     sleep(Duration::from_millis(300)).await;
 
     // Simulates the editor sending `workspace/didChangeConfiguration` without
-    // any change to biome.json: behavior must stay the same.
+    // any change to biome.json: behavior must stay the same, and no project
+    // scan may run.
     server.load_configuration().await?;
 
-    let notification = wait_for_notification(&mut receiver, |n| n.is_publish_diagnostics()).await;
-    let Some(ServerNotification::PublishDiagnostics(result)) = notification else {
-        panic!("expected diagnostics after the unchanged configuration reload");
-    };
+    let (notification, scans) = wait_for_notification_counting_scans(&mut receiver, |n| {
+        matches!(n, ServerNotification::PublishDiagnostics(params) if !params.diagnostics.is_empty())
+    })
+    .await;
     assert!(
-        !result.diagnostics.is_empty(),
+        notification.is_some(),
         "an unchanged configuration reload should keep reporting noDoubleEquals"
     );
 
     sleep(Duration::from_millis(300)).await;
 
-    // A reload after the configuration changed must apply the new settings.
+    // A reload after the configuration changed must rescan and apply the new
+    // settings. The scans observed since the previous step also cover the
+    // unchanged reload above: exactly one scan means the unchanged reload
+    // did not trigger any.
     let relaxed_config = r#"{
         "linter": {
             "rules": {
@@ -4968,13 +4975,18 @@ async fn should_apply_changed_configuration_after_unchanged_reload() -> Result<(
 
     server.load_configuration().await?;
 
-    let notification = wait_for_notification(&mut receiver, |n| n.is_publish_diagnostics()).await;
-    let Some(ServerNotification::PublishDiagnostics(result)) = notification else {
-        panic!("expected diagnostics after the changed configuration reload");
-    };
+    let (notification, more_scans) = wait_for_notification_counting_scans(&mut receiver, |n| {
+        matches!(n, ServerNotification::PublishDiagnostics(params) if params.diagnostics.is_empty())
+    })
+    .await;
     assert!(
-        result.diagnostics.is_empty(),
+        notification.is_some(),
         "diagnostics should be cleared after the configuration disables the rule"
+    );
+    assert_eq!(
+        scans + more_scans,
+        1,
+        "the unchanged reload must not scan; the changed reload must scan exactly once"
     );
 
     sleep(Duration::from_millis(300)).await;
@@ -4985,15 +4997,17 @@ async fn should_apply_changed_configuration_after_unchanged_reload() -> Result<(
 
     server.load_configuration().await?;
 
-    // Wait specifically for a non-empty publish: earlier steps may leave a
-    // stale empty notification in the channel.
-    let notification = wait_for_notification(&mut receiver, |n| {
+    let (notification, scans) = wait_for_notification_counting_scans(&mut receiver, |n| {
         matches!(n, ServerNotification::PublishDiagnostics(params) if !params.diagnostics.is_empty())
     })
     .await;
     assert!(
         notification.is_some(),
         "reverting to the previous strict configuration should report noDoubleEquals again"
+    );
+    assert_eq!(
+        scans, 1,
+        "reverting to a previously applied configuration must scan exactly once"
     );
 
     server.close_document().await?;
@@ -5660,7 +5674,7 @@ fn assert_diagnostic_code(server_notification: &ServerNotification, code: &str) 
                     .is_some_and(|c| &NumberOrString::String(code.to_string()) == c)
             }));
         }
-        ServerNotification::ShowMessage(_) => {
+        ServerNotification::ShowMessage(_) | ServerNotification::Progress(_) => {
             panic!("Unexpected notification: {server_notification:?}",);
         }
     }
@@ -5671,7 +5685,7 @@ fn assert_diagnostics_count(server_notification: &ServerNotification, expected_c
         ServerNotification::PublishDiagnostics(publish) => {
             assert_eq!(publish.diagnostics.len(), expected_count)
         }
-        ServerNotification::ShowMessage(_) => {
+        ServerNotification::ShowMessage(_) | ServerNotification::Progress(_) => {
             panic!("Unexpected notification: {server_notification:?}",);
         }
     }

--- a/crates/biome_lsp/src/server.tests.rs
+++ b/crates/biome_lsp/src/server.tests.rs
@@ -4940,7 +4940,8 @@ async fn should_apply_changed_configuration_after_unchanged_reload() -> Result<(
 
     sleep(Duration::from_millis(300)).await;
 
-    // A configuration reload without any change must keep the same behavior.
+    // Simulates the editor sending `workspace/didChangeConfiguration` without
+    // any change to biome.json: behavior must stay the same.
     server.load_configuration().await?;
 
     let notification = wait_for_notification(&mut receiver, |n| n.is_publish_diagnostics()).await;
@@ -4974,6 +4975,25 @@ async fn should_apply_changed_configuration_after_unchanged_reload() -> Result<(
     assert!(
         result.diagnostics.is_empty(),
         "diagnostics should be cleared after the configuration disables the rule"
+    );
+
+    sleep(Duration::from_millis(300)).await;
+
+    // Changing the configuration back to a previously applied one must rescan
+    // as well: only the most recently applied configuration is remembered.
+    fs.insert(to_utf8_file_path_buf(uri!("biome.json")), strict_config);
+
+    server.load_configuration().await?;
+
+    // Wait specifically for a non-empty publish: earlier steps may leave a
+    // stale empty notification in the channel.
+    let notification = wait_for_notification(&mut receiver, |n| {
+        matches!(n, ServerNotification::PublishDiagnostics(params) if !params.diagnostics.is_empty())
+    })
+    .await;
+    assert!(
+        notification.is_some(),
+        "reverting to the previous strict configuration should report noDoubleEquals again"
     );
 
     server.close_document().await?;

--- a/crates/biome_lsp/src/server.tests.rs
+++ b/crates/biome_lsp/src/server.tests.rs
@@ -4904,6 +4904,87 @@ async fn should_apply_wrapped_biome_settings_from_did_change_configuration() -> 
 }
 
 #[tokio::test]
+async fn should_apply_changed_configuration_after_unchanged_reload() -> Result<()> {
+    let fs = Arc::new(MemoryFileSystem::default());
+    let strict_config = r#"{
+        "linter": {
+            "rules": {
+                "recommended": false,
+                "suspicious": { "noDoubleEquals": "error" }
+            }
+        }
+    }"#;
+    fs.insert(to_utf8_file_path_buf(uri!("biome.json")), strict_config);
+
+    let factory = ServerFactory::new_with_fs(fs.clone());
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, mut receiver) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+
+    server.open_document("a == b;\n").await?;
+
+    let notification = wait_for_notification(&mut receiver, |n| n.is_publish_diagnostics()).await;
+    let Some(ServerNotification::PublishDiagnostics(result)) = notification else {
+        panic!("expected diagnostics for the initial configuration");
+    };
+    assert!(
+        !result.diagnostics.is_empty(),
+        "the strict configuration should report noDoubleEquals"
+    );
+
+    sleep(Duration::from_millis(300)).await;
+
+    // A configuration reload without any change must keep the same behavior.
+    server.load_configuration().await?;
+
+    let notification = wait_for_notification(&mut receiver, |n| n.is_publish_diagnostics()).await;
+    let Some(ServerNotification::PublishDiagnostics(result)) = notification else {
+        panic!("expected diagnostics after the unchanged configuration reload");
+    };
+    assert!(
+        !result.diagnostics.is_empty(),
+        "an unchanged configuration reload should keep reporting noDoubleEquals"
+    );
+
+    sleep(Duration::from_millis(300)).await;
+
+    // A reload after the configuration changed must apply the new settings.
+    let relaxed_config = r#"{
+        "linter": {
+            "rules": {
+                "recommended": false,
+                "suspicious": { "noDoubleEquals": "off" }
+            }
+        }
+    }"#;
+    fs.insert(to_utf8_file_path_buf(uri!("biome.json")), relaxed_config);
+
+    server.load_configuration().await?;
+
+    let notification = wait_for_notification(&mut receiver, |n| n.is_publish_diagnostics()).await;
+    let Some(ServerNotification::PublishDiagnostics(result)) = notification else {
+        panic!("expected diagnostics after the changed configuration reload");
+    };
+    assert!(
+        result.diagnostics.is_empty(),
+        "diagnostics should be cleared after the configuration disables the rule"
+    );
+
+    server.close_document().await?;
+
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn pull_plugin_diagnostics_for_vue_files() -> Result<()> {
     let fs = MemoryFileSystem::default();
 

--- a/crates/biome_lsp/src/server_test_utils.rs
+++ b/crates/biome_lsp/src/server_test_utils.rs
@@ -20,9 +20,10 @@ use tower_lsp_server::ls_types::{
     self as lsp, ClientCapabilities, CodeActionCapabilityResolveSupport,
     CodeActionClientCapabilities, DidChangeConfigurationParams, DidChangeTextDocumentParams,
     DidCloseTextDocumentParams, DidOpenTextDocumentParams, InitializeParams, InitializeResult,
-    InitializedParams, PublishDiagnosticsParams, ShowMessageParams, TextDocumentClientCapabilities,
-    TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentItem, Uri,
-    VersionedTextDocumentIdentifier, WorkspaceFolder,
+    InitializedParams, ProgressParams, ProgressParamsValue, PublishDiagnosticsParams,
+    ShowMessageParams, TextDocumentClientCapabilities, TextDocumentContentChangeEvent,
+    TextDocumentIdentifier, TextDocumentItem, Uri, VersionedTextDocumentIdentifier,
+    WindowClientCapabilities, WorkDoneProgress, WorkspaceFolder,
 };
 
 /// Statically build an [Uri] instance that points to the file at `$path`
@@ -171,6 +172,39 @@ impl Server {
                     root_uri: Some(root_uri),
                     initialization_options: None,
                     capabilities: ClientCapabilities::default(),
+                    trace: None,
+                    workspace_folders: None,
+                    client_info: None,
+                    locale: None,
+                    work_done_progress_params: Default::default(),
+                },
+            )
+            .await?
+            .context("initialize returned None")?;
+
+        Ok(())
+    }
+
+    /// Like [`Self::initialize`], but declares `window.workDoneProgress`
+    /// support, so the server reports project scans via `$/progress`.
+    #[expect(deprecated)]
+    pub(crate) async fn initialize_with_work_done_progress(&mut self) -> Result<()> {
+        let _res: InitializeResult = self
+            .request(
+                "initialize",
+                "_init",
+                InitializeParams {
+                    process_id: None,
+                    root_path: None,
+                    root_uri: Some(uri!("")),
+                    initialization_options: None,
+                    capabilities: ClientCapabilities {
+                        window: Some(WindowClientCapabilities {
+                            work_done_progress: Some(true),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    },
                     trace: None,
                     workspace_folders: None,
                     client_info: None,
@@ -397,6 +431,7 @@ pub(crate) const CHANNEL_BUFFER_SIZE: usize = 8;
 pub(crate) enum ServerNotification {
     PublishDiagnostics(PublishDiagnosticsParams),
     ShowMessage(ShowMessageParams),
+    Progress(ProgressParams),
 }
 
 impl ServerNotification {
@@ -406,6 +441,47 @@ impl ServerNotification {
 
     pub(crate) fn is_show_message(&self) -> bool {
         matches!(self, Self::ShowMessage(_))
+    }
+
+    /// Returns `true` for the `$/progress` "begin" notification the server
+    /// sends when a project scan starts.
+    pub(crate) fn is_scan_progress_begin(&self) -> bool {
+        matches!(
+            self,
+            Self::Progress(ProgressParams {
+                value: ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(_)),
+                ..
+            })
+        )
+    }
+}
+
+/// Like [`wait_for_notification`], but also counts how many project-scan
+/// `$/progress` "begin" notifications were observed while waiting.
+pub(crate) async fn wait_for_notification_counting_scans(
+    receiver: &mut (impl Stream<Item = ServerNotification> + Unpin),
+    check: impl Fn(&ServerNotification) -> bool,
+) -> (Option<ServerNotification>, usize) {
+    let mut scans = 0;
+    loop {
+        let notification = tokio::select! {
+            msg = receiver.next() => msg,
+            _ = sleep(Duration::from_secs(3)) => {
+                panic!("timed out waiting for a server notification")
+            }
+        };
+
+        match notification {
+            Some(notification) => {
+                if notification.is_scan_progress_begin() {
+                    scans += 1;
+                }
+                if check(&notification) {
+                    return (Some(notification), scans);
+                }
+            }
+            None => break (None, scans),
+        }
     }
 }
 
@@ -481,6 +557,9 @@ where
             "window/showMessage" => Some(ServerNotification::ShowMessage(
                 from_value(params).expect("invalid params"),
             )),
+            "$/progress" => Some(ServerNotification::Progress(
+                from_value(params).expect("invalid params"),
+            )),
             _ => None,
         } {
             match notify.send(notification).await {
@@ -501,6 +580,7 @@ where
 
                 Response::from_ok(id.clone(), result)
             }
+            "window/workDoneProgress/create" => Response::from_ok(id.clone(), to_value(())?),
             _ => Response::from_error(id.clone(), jsonrpc::Error::method_not_found()),
         };
 

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -38,7 +38,6 @@ use papaya::{HashMap, HashSet};
 use parking_lot::RwLock;
 use rustc_hash::{FxBuildHasher, FxHashMap};
 use serde_json::Value;
-use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::sync::atomic::{AtomicBool, AtomicI32};
@@ -159,14 +158,27 @@ pub(crate) struct Session {
     configuration_status_by_path:
         TokioRwLock<FxHashMap<ConfigurationCacheKey, ConfigurationStatus>>,
 
-    /// Fingerprint of the configuration each project was last loaded with,
+    /// The configuration each project was last successfully loaded with,
     /// keyed by project path.
     ///
     /// Editors send `workspace/didChangeConfiguration` for any settings
     /// change, and every notification reloads the configuration and forces a
-    /// full project rescan. The fingerprint lets us skip the rescan when the
-    /// effective configuration has not actually changed.
-    configuration_fingerprints: TokioRwLock<FxHashMap<Utf8PathBuf, u64>>,
+    /// full project rescan. Comparing against the last applied configuration
+    /// lets us skip the rescan when nothing has actually changed. The entry
+    /// is overwritten on every successful load, so changing the configuration
+    /// back and forth still triggers a rescan.
+    last_loaded_configurations: TokioRwLock<FxHashMap<Utf8PathBuf, LoadedConfigurationState>>,
+}
+
+/// The parts of the effective configuration that determine whether a project
+/// rescan is needed after a configuration reload.
+#[derive(Eq, PartialEq)]
+struct LoadedConfigurationState {
+    configuration: Box<Configuration>,
+    configuration_path: Option<Utf8PathBuf>,
+    /// Editor features influence the effective scan kind, so changing them
+    /// must trigger a rescan too.
+    editor_scan_kind: ScanKind,
 }
 
 /// The parameters provided by the client in the "initialize" request
@@ -284,7 +296,7 @@ impl Session {
             loading_operations: Default::default(),
             configuration_status_by_path: Default::default(),
             workspace_folders: Default::default(),
-            configuration_fingerprints: Default::default(),
+            last_loaded_configurations: Default::default(),
         }
     }
 
@@ -1391,28 +1403,19 @@ impl Session {
         // Full project scans can be very expensive, so the rescan is skipped
         // when this project was already registered and the effective
         // configuration is unchanged.
-        let fingerprint = {
-            let mut hasher = DefaultHasher::new();
-            match serde_json::to_string(&configuration) {
-                Ok(serialized) => {
-                    serialized.hash(&mut hasher);
-                    configuration_path.hash(&mut hasher);
-                    // Editor features influence the effective scan kind, so
-                    // changing them must invalidate the fingerprint too.
-                    serde_json::to_string(&self.scan_kind_from_editor_features())
-                        .ok()
-                        .hash(&mut hasher);
-                    Some(hasher.finish())
-                }
-                Err(_) => None,
-            }
+        let loaded_state = LoadedConfigurationState {
+            configuration: Box::new(configuration.clone()),
+            configuration_path: configuration_path.clone(),
+            editor_scan_kind: self.scan_kind_from_editor_features(),
         };
-        let skip_scan = if let Some(fingerprint) = fingerprint {
-            let fingerprints = self.configuration_fingerprints.read().await;
-            project_was_registered && force && fingerprints.get(&project_path) == Some(&fingerprint)
-        } else {
-            false
-        };
+        let skip_scan = project_was_registered
+            && force
+            && self
+                .last_loaded_configurations
+                .read()
+                .await
+                .get(&project_path)
+                == Some(&loaded_state);
 
         let scan_kind = ProjectScanComputer::new(&configuration).compute();
         // We give priority to the scan kind requested by the user.
@@ -1463,18 +1466,15 @@ impl Session {
             ConfigurationStatus::Loaded
         };
 
-        // Only remember the fingerprint of configurations that were applied
-        // successfully, so a reload with an unchanged configuration retries
-        // after an error instead of being skipped.
+        // Only remember configurations that were applied successfully, so a
+        // reload with an unchanged configuration retries after an error
+        // instead of being skipped.
         {
-            let mut fingerprints = self.configuration_fingerprints.write().await;
-            match fingerprint {
-                Some(fingerprint) if matches!(status, ConfigurationStatus::Loaded) => {
-                    fingerprints.insert(project_path, fingerprint);
-                }
-                _ => {
-                    fingerprints.remove(&project_path);
-                }
+            let mut last_loaded = self.last_loaded_configurations.write().await;
+            if matches!(status, ConfigurationStatus::Loaded) {
+                last_loaded.insert(project_path, loaded_state);
+            } else {
+                last_loaded.remove(&project_path);
             }
         }
 
@@ -1532,6 +1532,16 @@ impl Session {
 
     pub(crate) async fn clear_configuration_cache(&self) {
         self.configuration_status_by_path.write().await.clear();
+    }
+
+    /// Forgets the configurations projects were last successfully loaded
+    /// with, so the next configuration load always rescans.
+    ///
+    /// This must be called when workspace folders change, because removed
+    /// projects are unloaded from the workspace index and a matching
+    /// configuration must not skip the scan that rebuilds it.
+    pub(crate) async fn clear_loaded_configurations(&self) {
+        self.last_loaded_configurations.write().await.clear();
     }
 
     /// Broadcast a shutdown signal to all active connections

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -38,6 +38,7 @@ use papaya::{HashMap, HashSet};
 use parking_lot::RwLock;
 use rustc_hash::{FxBuildHasher, FxHashMap};
 use serde_json::Value;
+use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::sync::atomic::{AtomicBool, AtomicI32};
@@ -157,6 +158,26 @@ pub(crate) struct Session {
     /// Cached configuration status per base path to avoid reloading on every request.
     configuration_status_by_path:
         TokioRwLock<FxHashMap<ConfigurationCacheKey, ConfigurationStatus>>,
+
+    /// Fingerprint of the configuration each project was last loaded with,
+    /// keyed by project path.
+    ///
+    /// Editors send `workspace/didChangeConfiguration` for any settings
+    /// change, and every notification reloads the configuration and forces a
+    /// full project rescan. The fingerprint lets us skip the settings update
+    /// and the rescan when the effective configuration has not actually
+    /// changed.
+    configuration_fingerprints: TokioRwLock<FxHashMap<Utf8PathBuf, u64>>,
+
+    /// Project scans that are currently running, used to coalesce concurrent
+    /// scan requests for the same project.
+    ///
+    /// The value is `None` while a scan is running with no follow-up
+    /// requested, and `Some((scan_kind, force))` when another scan was
+    /// requested while one was already running. At most one scan runs per
+    /// project at a time, and any burst of requests collapses into a single
+    /// follow-up run with the most recent parameters.
+    scans_in_flight: TokioRwLock<FxHashMap<ProjectKey, Option<(ScanKind, bool)>>>,
 }
 
 /// The parameters provided by the client in the "initialize" request
@@ -274,6 +295,8 @@ impl Session {
             loading_operations: Default::default(),
             configuration_status_by_path: Default::default(),
             workspace_folders: Default::default(),
+            configuration_fingerprints: Default::default(),
+            scans_in_flight: Default::default(),
         }
     }
 
@@ -1069,6 +1092,46 @@ impl Session {
         scan_kind: ScanKind,
         force: bool,
     ) {
+        {
+            let mut scans = self.scans_in_flight.write().await;
+            if let Some(pending) = scans.get_mut(&project_key) {
+                // A scan for this project is already running. Instead of
+                // piling up another concurrent scan (every editor
+                // configuration change may request one, and full project
+                // scans can take a long time), queue at most one follow-up
+                // run with the latest parameters.
+                *pending = Some((scan_kind, force));
+                return;
+            }
+            scans.insert(project_key, None);
+        }
+
+        let mut next = Some((scan_kind, force));
+        while let Some((scan_kind, force)) = next {
+            self.run_project_scan(project_key, scan_kind, force).await;
+
+            let mut scans = self.scans_in_flight.write().await;
+            match scans
+                .get_mut(&project_key)
+                .and_then(|pending| pending.take())
+            {
+                Some(params) => next = Some(params),
+                None => {
+                    scans.remove(&project_key);
+                    next = None;
+                }
+            }
+        }
+    }
+
+    /// Runs a single project scan. Use [`Self::scan_project()`] instead, which
+    /// coalesces concurrent requests for the same project.
+    async fn run_project_scan(
+        self: &Arc<Self>,
+        project_key: ProjectKey,
+        scan_kind: ScanKind,
+        force: bool,
+    ) {
         let progress_token = ProgressToken::String(Uuid::new_v4().to_string());
         let is_work_done_progress_supported = self.initialize_params.get().is_some_and(|params| {
             params
@@ -1355,8 +1418,8 @@ impl Session {
                 .unwrap_or_default(),
         };
 
-        let project_key = match self.project_for_path(&project_path) {
-            Some(project_key) => project_key,
+        let (project_key, project_was_registered) = match self.project_for_path(&project_path) {
+            Some(project_key) => (project_key, true),
             None => {
                 let register_result = self.workspace().open_project(OpenProjectParams {
                     path: project_path.as_path().into(),
@@ -1370,9 +1433,44 @@ impl Session {
                         return ConfigurationStatus::Error;
                     }
                 };
-                project_key
+                (project_key, false)
             }
         };
+
+        // Editors send `workspace/didChangeConfiguration` for any settings
+        // change, and every notification reloads the configuration and forces
+        // a full project rescan, even when nothing Biome-related changed.
+        // Full project scans can be very expensive, so skip the settings
+        // update and the rescan when this project was already registered and
+        // the effective configuration is unchanged.
+        let fingerprint = {
+            let mut hasher = DefaultHasher::new();
+            match serde_json::to_string(&configuration) {
+                Ok(serialized) => {
+                    serialized.hash(&mut hasher);
+                    configuration_path.hash(&mut hasher);
+                    // Editor features influence the effective scan kind, so
+                    // changing them must invalidate the fingerprint too.
+                    serde_json::to_string(&self.scan_kind_from_editor_features())
+                        .ok()
+                        .hash(&mut hasher);
+                    Some(hasher.finish())
+                }
+                Err(_) => None,
+            }
+        };
+        if let Some(fingerprint) = fingerprint {
+            let fingerprints = self.configuration_fingerprints.read().await;
+            if project_was_registered
+                && force
+                && fingerprints.get(&project_path) == Some(&fingerprint)
+            {
+                debug!(
+                    "Configuration unchanged for {project_path}; skipping settings update and project rescan."
+                );
+                return ConfigurationStatus::Loaded;
+            }
+        }
 
         let scan_kind = ProjectScanComputer::new(&configuration).compute();
         // We give priority to the scan kind requested by the user.
@@ -1397,10 +1495,10 @@ impl Session {
             module_graph_resolution_kind: ModuleGraphResolutionKind::from(&scan_kind),
         });
 
-        self.insert_and_scan_project(project_key, project_path.into(), scan_kind, force)
+        self.insert_and_scan_project(project_key, project_path.clone().into(), scan_kind, force)
             .await;
 
-        if let Err(WorkspaceError::PluginErrors(error)) = result {
+        let status = if let Err(WorkspaceError::PluginErrors(error)) = result {
             error!("Failed to load plugins: {error:?}");
             self.client
                 .log_message(MessageType::ERROR, format!("{error:?}"))
@@ -1412,7 +1510,24 @@ impl Session {
             ConfigurationStatus::Error
         } else {
             ConfigurationStatus::Loaded
+        };
+
+        // Only remember the fingerprint of configurations that were applied
+        // successfully, so a reload with an unchanged configuration retries
+        // after an error instead of being skipped.
+        {
+            let mut fingerprints = self.configuration_fingerprints.write().await;
+            match fingerprint {
+                Some(fingerprint) if matches!(status, ConfigurationStatus::Loaded) => {
+                    fingerprints.insert(project_path, fingerprint);
+                }
+                _ => {
+                    fingerprints.remove(&project_path);
+                }
+            }
         }
+
+        status
     }
 
     /// Requests "workspace/configuration" from client and updates Session config.

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -164,20 +164,9 @@ pub(crate) struct Session {
     ///
     /// Editors send `workspace/didChangeConfiguration` for any settings
     /// change, and every notification reloads the configuration and forces a
-    /// full project rescan. The fingerprint lets us skip the settings update
-    /// and the rescan when the effective configuration has not actually
-    /// changed.
+    /// full project rescan. The fingerprint lets us skip the rescan when the
+    /// effective configuration has not actually changed.
     configuration_fingerprints: TokioRwLock<FxHashMap<Utf8PathBuf, u64>>,
-
-    /// Project scans that are currently running, used to coalesce concurrent
-    /// scan requests for the same project.
-    ///
-    /// The value is `None` while a scan is running with no follow-up
-    /// requested, and `Some((scan_kind, force))` when another scan was
-    /// requested while one was already running. At most one scan runs per
-    /// project at a time, and any burst of requests collapses into a single
-    /// follow-up run with the most recent parameters.
-    scans_in_flight: TokioRwLock<FxHashMap<ProjectKey, Option<(ScanKind, bool)>>>,
 }
 
 /// The parameters provided by the client in the "initialize" request
@@ -296,7 +285,6 @@ impl Session {
             configuration_status_by_path: Default::default(),
             workspace_folders: Default::default(),
             configuration_fingerprints: Default::default(),
-            scans_in_flight: Default::default(),
         }
     }
 
@@ -1092,46 +1080,6 @@ impl Session {
         scan_kind: ScanKind,
         force: bool,
     ) {
-        {
-            let mut scans = self.scans_in_flight.write().await;
-            if let Some(pending) = scans.get_mut(&project_key) {
-                // A scan for this project is already running. Instead of
-                // piling up another concurrent scan (every editor
-                // configuration change may request one, and full project
-                // scans can take a long time), queue at most one follow-up
-                // run with the latest parameters.
-                *pending = Some((scan_kind, force));
-                return;
-            }
-            scans.insert(project_key, None);
-        }
-
-        let mut next = Some((scan_kind, force));
-        while let Some((scan_kind, force)) = next {
-            self.run_project_scan(project_key, scan_kind, force).await;
-
-            let mut scans = self.scans_in_flight.write().await;
-            match scans
-                .get_mut(&project_key)
-                .and_then(|pending| pending.take())
-            {
-                Some(params) => next = Some(params),
-                None => {
-                    scans.remove(&project_key);
-                    next = None;
-                }
-            }
-        }
-    }
-
-    /// Runs a single project scan. Use [`Self::scan_project()`] instead, which
-    /// coalesces concurrent requests for the same project.
-    async fn run_project_scan(
-        self: &Arc<Self>,
-        project_key: ProjectKey,
-        scan_kind: ScanKind,
-        force: bool,
-    ) {
         let progress_token = ProgressToken::String(Uuid::new_v4().to_string());
         let is_work_done_progress_supported = self.initialize_params.get().is_some_and(|params| {
             params
@@ -1440,9 +1388,9 @@ impl Session {
         // Editors send `workspace/didChangeConfiguration` for any settings
         // change, and every notification reloads the configuration and forces
         // a full project rescan, even when nothing Biome-related changed.
-        // Full project scans can be very expensive, so skip the settings
-        // update and the rescan when this project was already registered and
-        // the effective configuration is unchanged.
+        // Full project scans can be very expensive, so the rescan is skipped
+        // when this project was already registered and the effective
+        // configuration is unchanged.
         let fingerprint = {
             let mut hasher = DefaultHasher::new();
             match serde_json::to_string(&configuration) {
@@ -1459,18 +1407,12 @@ impl Session {
                 Err(_) => None,
             }
         };
-        if let Some(fingerprint) = fingerprint {
+        let skip_scan = if let Some(fingerprint) = fingerprint {
             let fingerprints = self.configuration_fingerprints.read().await;
-            if project_was_registered
-                && force
-                && fingerprints.get(&project_path) == Some(&fingerprint)
-            {
-                debug!(
-                    "Configuration unchanged for {project_path}; skipping settings update and project rescan."
-                );
-                return ConfigurationStatus::Loaded;
-            }
-        }
+            project_was_registered && force && fingerprints.get(&project_path) == Some(&fingerprint)
+        } else {
+            false
+        };
 
         let scan_kind = ProjectScanComputer::new(&configuration).compute();
         // We give priority to the scan kind requested by the user.
@@ -1495,8 +1437,17 @@ impl Session {
             module_graph_resolution_kind: ModuleGraphResolutionKind::from(&scan_kind),
         });
 
-        self.insert_and_scan_project(project_key, project_path.clone().into(), scan_kind, force)
+        if skip_scan {
+            debug!("Configuration unchanged for {project_path}; skipping the project rescan.");
+        } else {
+            self.insert_and_scan_project(
+                project_key,
+                project_path.clone().into(),
+                scan_kind,
+                force,
+            )
             .await;
+        }
 
         let status = if let Err(WorkspaceError::PluginErrors(error)) = result {
             error!("Failed to load plugins: {error:?}");


### PR DESCRIPTION
## Summary

Editors send `workspace/didChangeConfiguration` for any settings change, and each notification reloads the configuration and forces a full project scan, even when nothing Biome-related changed (#10605). With `project`/`types`-domain rules enabled a single scan is already very expensive on large monorepos (#11520), so these redundant rescans hurt.

Two changes in `Session`:

- The effective configuration (file config + configuration path + editor-feature scan kind) is fingerprinted after a successful load. A forced reload with an unchanged fingerprint skips `update_settings` and the rescan. Fingerprints are only stored for successfully applied configurations, so error cases (e.g. plugin load failures) are retried, not skipped.
- `scan_project` coalesces concurrent requests per project: at most one scan runs at a time, with at most one follow-up queued using the latest parameters.

## Test plan

- `cargo test -p biome_lsp`: 100 passed.
- Measured with a headless LSP client against a real monorepo (harness in #11520): a burst of 20 `didChangeConfiguration` notifications with an unchanged `biome.json` previously executed 21 full project scans; with this change it executes 1, and the daemon log shows 20 fingerprint skips.

Closes #10605.

## AI assistance disclosure

This PR (code and description) was written primarily by Claude Code, directed and reviewed by me. The measurements in the test plan are from real runs on my machine.
