### PR TITLE
fix(noDescendingSpecificity): compare against the highest specificity for a repeated tail selector 🤖🤖🤖

### DIFF
--- a/.changeset/open-comics-bow.md
+++ b/.changeset/open-comics-bow.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#11512](https://github.com/biomejs/biome/issues/11512): [`noDescendingSpecificity`](https://biomejs.dev/linter/rules/no-descending-specificity/) now compares a selector against the highest specificity seen among preceding selectors that share its tail selector, rather than only the first one seen. A descending pair is now reported when a lower-specificity selector follows a higher-specificity one that was not the first occurrence of that tail.
+Fixed [#11512](https://github.com/biomejs/biome/issues/11512): [`noDescendingSpecificity`](https://biomejs.dev/linter/rules/no-descending-specificity/) now correctly checks descending selectors that share the same trailing element.

--- a/.changeset/open-comics-bow.md
+++ b/.changeset/open-comics-bow.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11512](https://github.com/biomejs/biome/issues/11512): [`noDescendingSpecificity`](https://biomejs.dev/linter/rules/no-descending-specificity/) now compares a selector against the highest specificity seen among preceding selectors that share its tail selector, rather than only the first one seen. A descending pair is now reported when a lower-specificity selector follows a higher-specificity one that was not the first occurrence of that tail.

--- a/crates/biome_css_analyze/src/lint/style/no_descending_specificity.rs
+++ b/crates/biome_css_analyze/src/lint/style/no_descending_specificity.rs
@@ -172,8 +172,12 @@ fn find_tail_selector_str(selector: &AnyCssSelector) -> Option<String> {
 }
 
 /// This function traverses the CSS rules starting from the given rule and checks for selectors that have the same tail selector.
-/// For each selector, it compares its specificity with the previously encountered specificity of the same tail selector.
+/// For each selector, it compares its specificity against the highest specificity seen so far among preceding selectors sharing that tail.
 /// If a lower specificity selector is found after a higher specificity selector with the same tail selector, it records this as a descending selector.
+///
+/// `visited_selectors` therefore holds the running maximum per tail selector, not the first
+/// occurrence: a tail may appear any number of times, and only the highest preceding specificity
+/// can be overridden by a later one.
 fn find_descending_selector(
     root: &AnyCssRoot,
     rule: &CssSemanticRule,
@@ -195,13 +199,17 @@ fn find_descending_selector(
             continue;
         };
 
-        if let Some((last_text_range, last_specificity)) = visited_selectors.get(&tail_selector_str)
+        if let Some(&(last_text_range, last_specificity)) =
+            visited_selectors.get(&tail_selector_str)
         {
-            if last_specificity > &selector.specificity() {
+            let specificity = selector.specificity();
+            if last_specificity > specificity {
                 descending_selectors.push(DescendingSelector {
-                    high: (*last_text_range, *last_specificity),
-                    low: (selector.range(root), selector.specificity()),
+                    high: (last_text_range, last_specificity),
+                    low: (selector.range(root), specificity),
                 });
+            } else if specificity > last_specificity {
+                visited_selectors.insert(tail_selector_str, (selector.range(root), specificity));
             }
         } else {
             visited_selectors.insert(

--- a/crates/biome_css_analyze/src/lint/style/no_descending_specificity.rs
+++ b/crates/biome_css_analyze/src/lint/style/no_descending_specificity.rs
@@ -174,10 +174,6 @@ fn find_tail_selector_str(selector: &AnyCssSelector) -> Option<String> {
 /// This function traverses the CSS rules starting from the given rule and checks for selectors that have the same tail selector.
 /// For each selector, it compares its specificity against the highest specificity seen so far among preceding selectors sharing that tail.
 /// If a lower specificity selector is found after a higher specificity selector with the same tail selector, it records this as a descending selector.
-///
-/// `visited_selectors` therefore holds the running maximum per tail selector, not the first
-/// occurrence: a tail may appear any number of times, and only the highest preceding specificity
-/// can be overridden by a later one.
 fn find_descending_selector(
     root: &AnyCssRoot,
     rule: &CssSemanticRule,

--- a/crates/biome_css_analyze/src/lint/style/no_descending_specificity.rs
+++ b/crates/biome_css_analyze/src/lint/style/no_descending_specificity.rs
@@ -195,9 +195,11 @@ fn find_descending_selector(
             continue;
         };
 
-        if let Some(&(last_text_range, last_specificity)) =
-            visited_selectors.get(&tail_selector_str)
-        {
+        // `get_mut` rather than `get` + `insert`: the running maximum is
+        // updated in place, so a tail that keeps climbing is hashed once per
+        // selector instead of twice.
+        if let Some(seen) = visited_selectors.get_mut(&tail_selector_str) {
+            let (last_text_range, last_specificity) = *seen;
             let specificity = selector.specificity();
             if last_specificity > specificity {
                 descending_selectors.push(DescendingSelector {
@@ -205,7 +207,7 @@ fn find_descending_selector(
                     low: (selector.range(root), specificity),
                 });
             } else if specificity > last_specificity {
-                visited_selectors.insert(tail_selector_str, (selector.range(root), specificity));
+                *seen = (selector.range(root), specificity);
             }
         } else {
             visited_selectors.insert(

--- a/crates/biome_css_analyze/src/lint/style/no_descending_specificity.rs
+++ b/crates/biome_css_analyze/src/lint/style/no_descending_specificity.rs
@@ -195,9 +195,6 @@ fn find_descending_selector(
             continue;
         };
 
-        // `get_mut` rather than `get` + `insert`: the running maximum is
-        // updated in place, so a tail that keeps climbing is hashed once per
-        // selector instead of twice.
         if let Some(seen) = visited_selectors.get_mut(&tail_selector_str) {
             let (last_text_range, last_specificity) = *seen;
             let specificity = selector.specificity();

--- a/crates/biome_css_analyze/tests/specs/style/noDescendingSpecificity/invalid_issue_11512.css
+++ b/crates/biome_css_analyze/tests/specs/style/noDescendingSpecificity/invalid_issue_11512.css
@@ -1,0 +1,12 @@
+/* should generate diagnostics */
+.a th {
+    color: red;
+}
+
+.a .b .c th {
+    color: green;
+}
+
+.a .b th {
+    color: blue;
+}

--- a/crates/biome_css_analyze/tests/specs/style/noDescendingSpecificity/invalid_issue_11512.css.snap
+++ b/crates/biome_css_analyze/tests/specs/style/noDescendingSpecificity/invalid_issue_11512.css.snap
@@ -1,0 +1,47 @@
+---
+source: crates/biome_css_analyze/tests/spec_tests.rs
+expression: invalid_issue_11512.css
+---
+# Input
+```css
+/* should generate diagnostics */
+.a th {
+    color: red;
+}
+
+.a .b .c th {
+    color: green;
+}
+
+.a .b th {
+    color: blue;
+}
+
+```
+
+# Diagnostics
+```
+invalid_issue_11512.css:10:1 lint/style/noDescendingSpecificity ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Descending specificity selector found. This selector specificity is (0, 2, 1)
+  
+     8 │ }
+     9 │ 
+  > 10 │ .a .b th {
+       │ ^^^^^^^^
+    11 │     color: blue;
+    12 │ }
+  
+  i This selector specificity is (0, 3, 1)
+  
+    4 │ }
+    5 │ 
+  > 6 │ .a .b .c th {
+      │ ^^^^^^^^^^^
+    7 │     color: green;
+    8 │ }
+  
+  i Descending specificity selector may not be applied. Consider rearranging the order of the selectors. See MDN web docs for more details.
+  
+
+```


### PR DESCRIPTION
## Summary

Fixes #11512.

`visited_selectors` holds one entry per tail selector, and it only ever wrote that entry the first time it saw the tail. So when a higher specificity turned up later it never became the baseline, and the next lower-specificity selector got compared against the first entry instead of the highest one preceding it.

With the CSS from the issue, `.a .b th` (0, 2, 1) follows `.a .b .c th` (0, 3, 1) and was not reported at all.

The entry now holds the running maximum for that tail. I replace it only when the new specificity is strictly greater, so selectors of equal specificity still report against the earliest occurrence and none of the existing snapshots changed.

## Test Plan

Added `invalid_issue_11512.css` with the CSS from the issue. On `main` it fails with "This test should generate diagnostics". With the fix it reports one diagnostic on `.a .b th` pointing back at `.a .b .c th`, and does not report the ascending pair.

`cargo test -p biome_css_analyze` gives 187 passed, 0 failed. `rules_check`, `cargo fmt --check`, and clippy under `-D warnings` are clean. `gen-rules` and `gen-configuration` both produce no diff.

Changeset included at `patch`.

## Docs

Nothing to change. The rule's documented behaviour is the same; it just no longer misses this case.

---

Disclosure: this was written with Claude Code. I reviewed the change on GitHub before opening the PR, and the test and lint commands above were run locally.
