### PR TITLE
refactor(noVueRefAsOperand): overhaul rule, and make it faster

### DIFF
--- a/.changeset/deep-streets-pump.md
+++ b/.changeset/deep-streets-pump.md
@@ -1,0 +1,7 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [`noVueRefAsOperand`](https://biomejs.dev/linter/rules/no-vue-ref-as-operand/) to track Vue refs through declaration aliases and `toRefs()` properties, and to recognize `useTemplateRef()` results. The rule no longer reports false positives such as plain ref transfers, plain `toRefs()` property access, `defineModel()` modifiers, or the supported `.effect` member as operands.
+
+The refactor enabling these fixes also improves the performance of the rule.

--- a/crates/biome_js_analyze/src/lint/nursery/no_vue_ref_as_operand.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_vue_ref_as_operand.rs
@@ -3,16 +3,20 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_js_semantic::SemanticModel;
+use biome_js_semantic::{ReferencesExtensions, SemanticModel};
 use biome_js_syntax::binding_ext::AnyJsIdentifierBinding;
 use biome_js_syntax::{
-    AnyJsExpression, AnyJsName, JsCallArgumentList, JsCallExpression, JsConditionalExpression,
-    JsIdentifierAssignment, JsIdentifierBinding, JsIdentifierExpression, JsLogicalExpression,
-    JsMethodObjectMember, JsStaticMemberAssignment, JsStaticMemberExpression, JsSyntaxKind,
-    JsTemplateElement, JsTemplateExpression, JsVariableDeclaration, JsVariableDeclarator,
+    AnyJsBindingPattern, AnyJsExpression, AnyJsIdentifierReference, AnyJsName,
+    AnyJsObjectBindingPatternMember, JsAssignmentExpression, JsAssignmentOperator,
+    JsCallArgumentList, JsCallExpression, JsComputedMemberAssignment, JsComputedMemberExpression,
+    JsConditionalExpression, JsIdentifierBinding, JsIdentifierExpression, JsInitializerClause,
+    JsLogicalExpression, JsMethodObjectMember, JsStaticMemberAssignment, JsStaticMemberExpression,
+    JsSyntaxKind, JsTemplateElement, JsTemplateExpression, JsVariableDeclaration,
+    JsVariableDeclarator, is_transparent_expression_wrapper,
 };
-use biome_rowan::{AstNode, SyntaxNodeCast, TextRange, declare_node_union};
+use biome_rowan::{AstNode, AstSeparatedList, SyntaxNodeCast, TextRange, declare_node_union};
 use biome_rule_options::no_vue_ref_as_operand::NoVueRefAsOperandOptions;
+use smallvec::{SmallVec, smallvec};
 
 use crate::frameworks::vue::vue_call::is_vue_compiler_macro_call;
 use crate::{frameworks::vue::vue_call::is_vue_api_reference, services::semantic::Semantic};
@@ -101,20 +105,37 @@ declare_lint_rule! {
     }
 }
 
-declare_node_union! {
-    pub NoVueRefAsOperandQuery = JsIdentifierExpression | JsIdentifierAssignment
-}
-
 impl Rule for NoVueRefAsOperand {
-    type Query = Semantic<NoVueRefAsOperandQuery>;
+    type Query = Semantic<JsVariableDeclarator>;
     type State = TextRange;
-    type Signals = Option<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = NoVueRefAsOperandOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
-        let expr = ctx.query();
+        let declarator = ctx.query();
         let model = ctx.model();
-        check_expression(expr, model)
+        let Some(producer) = ref_producer(declarator, model) else {
+            return Vec::new().into_boxed_slice();
+        };
+        let Ok(pattern) = declarator.id() else {
+            return Vec::new().into_boxed_slice();
+        };
+
+        let mut pending = seed_bindings(&pattern, &producer);
+        let mut violations = Vec::new();
+
+        while let Some(tracked) = pending.pop() {
+            match tracked {
+                TrackedBinding::Ref(binding) => {
+                    track_ref_references(&binding, model, &mut pending, &mut violations)
+                }
+                TrackedBinding::ToRefsObject(binding) => {
+                    track_to_refs_references(&binding, model, &mut pending, &mut violations)
+                }
+            }
+        }
+
+        violations.into_boxed_slice()
     }
 
     fn diagnostic(_ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
@@ -136,236 +157,427 @@ impl Rule for NoVueRefAsOperand {
     }
 }
 
-fn check_expression(expr: &NoVueRefAsOperandQuery, model: &SemanticModel) -> Option<TextRange> {
-    match expr {
-        NoVueRefAsOperandQuery::JsIdentifierExpression(ident_expr) => {
-            let reference = ident_expr.name().ok()?;
-            let binding = model.binding(&reference)?.tree();
-            let declaration = binding.declaration()?;
-            let declaration = declaration
-                .parent_binding_pattern_declaration()
-                .unwrap_or(declaration);
-            let declarator = JsVariableDeclarator::cast(declaration.into_syntax())?;
-            let init_clause = declarator.initializer()?;
-            let init_expr = init_clause.expression().ok()?;
-            let call_expr = init_expr.as_js_call_expression()?;
+/// The shape returned by a Vue API that creates refs.
+enum RefProducer {
+    /// The call returns a ref directly.
+    ///
+    /// ```js
+    /// const count = ref(0)
+    /// const doubled = computed(() => count.value * 2)
+    /// const property = toRef(state, "property")
+    /// const custom = customRef(factory)
+    /// const shallow = shallowRef({ value: 0 })
+    /// const element = useTemplateRef("element")
+    /// ```
+    Ref,
+    /// The call returns a plain object whose properties are refs.
+    ///
+    /// ```js
+    /// const refs = toRefs(state)
+    /// refs.count // Ref<number>
+    /// refs // { count: Ref<number> }
+    /// ```
+    ToRefs,
+    /// The macro returns a ref directly or as the first element of a tuple.
+    /// The second tuple element contains the model modifiers and is not a ref.
+    ///
+    /// ```js
+    /// const model = defineModel()
+    /// const [modelValue, modifiers] = defineModel()
+    /// ```
+    DefineModel,
+}
 
-            let ident_binding =
-                if let AnyJsIdentifierBinding::JsIdentifierBinding(binding) = &binding {
-                    binding
-                } else {
-                    return None;
-                };
+/// Distinguishes a ref binding from a binding that contains multiple refs.
+///
+/// These states require different member-access semantics. A member such as
+/// `count.other` uses a [`TrackedBinding::Ref`] as an operand, while
+/// `refs.count` selects a ref from a [`TrackedBinding::ToRefsObject`].
+///
+/// ```js
+/// const count = ref(0)
+/// count.value++
+///
+/// const refs = toRefs(state)
+/// const refsAlias = refs // ToRefsObject
+/// const countAlias = refsAlias.count // Ref
+/// countAlias.value++
+/// ```
+enum TrackedBinding {
+    /// A binding whose value is a ref, including aliases and `toRefs()` properties.
+    Ref(JsIdentifierBinding),
+    /// A binding whose value is the plain object returned by `toRefs()`.
+    ToRefsObject(JsIdentifierBinding),
+}
 
-            if !is_calling_a_ref(call_expr, ident_binding, model) {
-                return None;
+fn ref_producer(declarator: &JsVariableDeclarator, model: &SemanticModel) -> Option<RefProducer> {
+    let initializer = declarator
+        .initializer()?
+        .expression()
+        .ok()?
+        .inner_expression()?;
+    let call = initializer.as_js_call_expression()?;
+    let callee = call.callee().ok()?;
+
+    if is_vue_api_reference(&callee, model, "toRefs") {
+        return Some(RefProducer::ToRefs);
+    }
+    if REF_VALUE_APIS
+        .iter()
+        .any(|ref_name| is_vue_api_reference(&callee, model, ref_name))
+    {
+        return Some(RefProducer::Ref);
+    }
+    if is_vue_compiler_macro_call(call, model, "defineModel") {
+        return Some(RefProducer::DefineModel);
+    }
+    None
+}
+
+/// Collect the initial set of bindings that produce Vue refs.
+fn seed_bindings(
+    pattern: &AnyJsBindingPattern,
+    producer: &RefProducer,
+) -> SmallVec<[TrackedBinding; 1]> {
+    match producer {
+        RefProducer::Ref => identifier_binding(pattern)
+            .map(TrackedBinding::Ref)
+            .into_iter()
+            .collect(),
+        RefProducer::ToRefs => {
+            if let Some(binding) = identifier_binding(pattern) {
+                // ```
+                // const foo = toRefs();
+                //       ^^^
+                // ```
+                smallvec![TrackedBinding::ToRefsObject(binding)]
+            } else if pattern.as_js_object_binding_pattern().is_some() {
+                object_pattern_bindings(pattern)
+            } else {
+                SmallVec::new()
             }
-
-            if let Some(parent) = ident_expr.syntax().parent() {
-                match parent.kind() {
-                    // if (refValue)
-                    JsSyntaxKind::JS_IF_STATEMENT |
-                    // switch (refValue)
-                    JsSyntaxKind::JS_SWITCH_STATEMENT |
-                    // -refValue, +refValue, !refValue, ~refValue, typeof refValue
-                    JsSyntaxKind::JS_UNARY_EXPRESSION |
-                    // refValue+1, refValue-1
-                    JsSyntaxKind::JS_BINARY_EXPRESSION |
-                    // bar+=refValue, bar-=refValue
-                    JsSyntaxKind::JS_ASSIGNMENT_EXPRESSION => {
-                        return Some(ident_expr.range())
-                    }
-                    // refValue || other, refValue && other. ignore: other || refValue
-                    JsSyntaxKind::JS_LOGICAL_EXPRESSION => {
-                        // Report only left
-                        if let Some(logical_expr) = parent.cast::<JsLogicalExpression>()
-                        && let Ok(left)= logical_expr.left()
-                        && let Some(left) = left.as_js_identifier_expression()
-                        && left != ident_expr {
-                            return None
-                        }
-
-                        // Report only refs which are constants
-                        if let Some(declaration) = declarator.syntax().ancestors().skip(1).find_map(JsVariableDeclaration::cast)
-                        && (declaration.is_const()) {
-                            return Some(ident_expr.range())
-                        }
-                    }
-                    // refValue ? x : y
-                    JsSyntaxKind::JS_CONDITIONAL_EXPRESSION => {
-                        // Report only test
-                        if let Some(conditional_expr) = parent.cast::<JsConditionalExpression>()
-                        && let Ok(test)= conditional_expr.test()
-                        && let Some(expr) = test.as_js_identifier_expression()
-                        && expr != ident_expr {
-                            return None
-                        }
-
-                        return Some(ident_expr.range())
-                    }
-                    // `${refValue}`
-                    JsSyntaxKind::JS_TEMPLATE_ELEMENT => {
-                        // Ignore tagged template
-                        if let Some(template_ele) = parent.cast::<JsTemplateElement>()
-                        && let Some(grand_parent) = template_ele.syntax().grand_parent()
-                        && let Some(template_expr) = grand_parent.cast::<JsTemplateExpression>()
-                        && template_expr.tag().is_some() {
-                            return None
-                        }
-
-                        return Some(ident_expr.range())
-                    }
-                    // refValue.x
-                    JsSyntaxKind::JS_STATIC_MEMBER_ASSIGNMENT | JsSyntaxKind::JS_STATIC_MEMBER_EXPRESSION => {
-                        if let Some(static_member_expr) = parent.cast::<AnyJsStaticMemberLike>() {
-                            return check_static_member_access(ident_expr, ident_binding, &static_member_expr, call_expr)
-                        }
-                    }
-                    // refValue in emit() in setup contexts: emit('event', refValue) or context.emit('event', refValue)
-                    // refValue in emit() with defineEmits
-                    JsSyntaxKind::JS_CALL_ARGUMENT_LIST => {
-                        if let Some(call_argument_list) = parent.cast::<JsCallArgumentList>()
-                            && let Some(grand_parent) = call_argument_list.syntax().grand_parent()
-                            && let Some(call_expr) = grand_parent.cast::<JsCallExpression>()
-                            && let Ok(callee) = call_expr.callee()
-                            && (is_emit_call_in_setup(&callee, model) || is_emit_call_by_macro(&callee, model))
-                        {
-                            return Some(ident_expr.range());
-                        }
-                    }
-                    _ => {}
-                }
-            }
-
-            None
         }
-        NoVueRefAsOperandQuery::JsIdentifierAssignment(ident_assignment) => {
-            let binding = model.binding(ident_assignment)?.tree();
-            let declaration = binding.declaration()?;
-            let declaration = declaration
-                .parent_binding_pattern_declaration()
-                .unwrap_or(declaration);
-            let declarator = JsVariableDeclarator::cast(declaration.into_syntax())?;
-            let init_clause = declarator.initializer()?;
-            let init_expr = init_clause.expression().ok()?;
-            let call_expr = init_expr.as_js_call_expression()?;
-            let ident_binding =
-                if let AnyJsIdentifierBinding::JsIdentifierBinding(binding) = &binding {
-                    binding
-                } else {
-                    return None;
-                };
-
-            if !is_calling_a_ref(call_expr, ident_binding, model) {
-                return None;
-            }
-
-            Some(ident_assignment.range())
+        RefProducer::DefineModel => {
+            let binding = identifier_binding(pattern).or_else(|| {
+                let array = pattern.as_js_array_binding_pattern()?;
+                let first = array.elements().first()?.ok()?;
+                let element = first.as_js_array_binding_pattern_element()?;
+                identifier_binding(&element.pattern().ok()?)
+            });
+            binding.map(TrackedBinding::Ref).into_iter().collect()
         }
     }
+}
+
+#[inline]
+fn identifier_binding(pattern: &AnyJsBindingPattern) -> Option<JsIdentifierBinding> {
+    pattern
+        .as_any_js_binding()?
+        .as_js_identifier_binding()
+        .cloned()
+}
+
+fn object_pattern_bindings(pattern: &AnyJsBindingPattern) -> SmallVec<[TrackedBinding; 1]> {
+    let Some(pattern) = pattern.as_js_object_binding_pattern() else {
+        return SmallVec::new();
+    };
+    pattern
+        .properties()
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter_map(|member| match member {
+            AnyJsObjectBindingPatternMember::JsObjectBindingPatternProperty(property) => {
+                identifier_binding(&property.pattern().ok()?).map(TrackedBinding::Ref)
+            }
+            AnyJsObjectBindingPatternMember::JsObjectBindingPatternRest(rest) => rest
+                .binding()
+                .ok()?
+                .as_js_identifier_binding()
+                .cloned()
+                .map(TrackedBinding::ToRefsObject),
+            AnyJsObjectBindingPatternMember::JsObjectBindingPatternShorthandProperty(property) => {
+                // For destructured assignments, treat each created binding as a produced ref.
+                // ```
+                // const { foo, bar } = toRefs();
+                //         ^^^  ^^^
+                // ```
+                property
+                    .identifier()
+                    .ok()?
+                    .as_js_identifier_binding()
+                    .cloned()
+                    .map(TrackedBinding::Ref)
+            }
+            AnyJsObjectBindingPatternMember::JsBogusBinding(_)
+            | AnyJsObjectBindingPatternMember::JsMetavariable(_) => None,
+        })
+        .collect()
+}
+
+fn track_ref_references(
+    binding: &JsIdentifierBinding,
+    model: &SemanticModel,
+    pending: &mut SmallVec<[TrackedBinding; 1]>,
+    violations: &mut Vec<TextRange>,
+) {
+    for reference in binding.all_references(model) {
+        let Some(reference) = AnyJsIdentifierReference::cast(reference.syntax()) else {
+            continue;
+        };
+        match reference {
+            AnyJsIdentifierReference::JsReferenceIdentifier(reference) => {
+                let Some(expression) = reference.parent::<JsIdentifierExpression>() else {
+                    continue;
+                };
+                if let Some(alias) = identifier_initializer_binding(&expression) {
+                    pending.push(TrackedBinding::Ref(alias));
+                } else if let Some(range) =
+                    check_ref_expression(&expression.clone().into(), binding, model)
+                {
+                    violations.push(range);
+                }
+            }
+            AnyJsIdentifierReference::JsIdentifierAssignment(assignment) => {
+                violations.push(assignment.range());
+            }
+            AnyJsIdentifierReference::JsxReferenceIdentifier(_) => {}
+        }
+    }
+}
+
+fn track_to_refs_references(
+    binding: &JsIdentifierBinding,
+    model: &SemanticModel,
+    pending: &mut SmallVec<[TrackedBinding; 1]>,
+    violations: &mut Vec<TextRange>,
+) {
+    for reference in binding.all_references(model) {
+        let Some(reference) = AnyJsIdentifierReference::cast(reference.syntax()) else {
+            continue;
+        };
+        let expression: AnyJsExpression = match reference {
+            AnyJsIdentifierReference::JsReferenceIdentifier(reference) => {
+                let Some(expression) = reference.parent::<JsIdentifierExpression>() else {
+                    continue;
+                };
+                expression.into()
+            }
+            AnyJsIdentifierReference::JsIdentifierAssignment(_) => continue,
+            AnyJsIdentifierReference::JsxReferenceIdentifier(_) => continue,
+        };
+
+        if let Some(pattern) = initializer_pattern(&expression) {
+            if let Some(alias) = identifier_binding(&pattern) {
+                pending.push(TrackedBinding::ToRefsObject(alias));
+            } else if pattern.as_js_object_binding_pattern().is_some() {
+                pending.extend(object_pattern_bindings(&pattern));
+            }
+            continue;
+        }
+
+        let object_expression = outermost_transparent_expression(&expression);
+        let Some(member) = object_expression
+            .syntax()
+            .parent()
+            .and_then(AnyJsRefMember::cast)
+        else {
+            continue;
+        };
+        let Ok(object) = member.object() else {
+            continue;
+        };
+        if object != object_expression {
+            continue;
+        }
+        if let Some(member_expression) = member.expression() {
+            if let Some(pattern) = initializer_pattern(&member_expression)
+                && let Some(alias) = identifier_binding(&pattern)
+            {
+                pending.push(TrackedBinding::Ref(alias));
+                continue;
+            }
+            if let Some(range) = check_ref_expression(&member_expression, binding, model) {
+                violations.push(range);
+            }
+        } else {
+            violations.push(member.range());
+        }
+    }
+}
+
+fn identifier_initializer_binding(expression: &JsIdentifierExpression) -> Option<JsIdentifierBinding> {
+    identifier_binding(&initializer_pattern(&expression.clone().into())?)
+}
+
+fn initializer_pattern(expression: &AnyJsExpression) -> Option<AnyJsBindingPattern> {
+    let expression = outermost_transparent_expression(expression);
+    let initializer = expression
+        .syntax()
+        .parent()
+        .and_then(JsInitializerClause::cast)?;
+    if initializer.expression().ok()? != expression {
+        return None;
+    }
+    initializer.parent::<JsVariableDeclarator>()?.id().ok()
+}
+
+fn outermost_transparent_expression(expression: &AnyJsExpression) -> AnyJsExpression {
+    let innermost = expression.clone();
+    let mut expression = expression.clone();
+    while let Some(parent) = expression
+        .syntax()
+        .parent()
+        .and_then(AnyJsExpression::cast)
+    {
+        if !is_transparent_expression_wrapper(parent.syntax()) {
+            break;
+        }
+        if !parent
+            .inner_expression()
+            .is_some_and(|inner| inner == innermost)
+        {
+            break;
+        }
+        expression = parent;
+    }
+    expression
+}
+
+fn is_plain_assignment_right(expression: &AnyJsExpression) -> bool {
+    let expression = outermost_transparent_expression(expression);
+    let Some(assignment) = expression
+        .syntax()
+        .parent()
+        .and_then(JsAssignmentExpression::cast)
+    else {
+        return false;
+    };
+    assignment.operator().ok() == Some(JsAssignmentOperator::Assign)
+        && assignment.right().is_ok_and(|right| right == expression)
+}
+
+fn check_ref_expression(
+    expression: &AnyJsExpression,
+    binding: &JsIdentifierBinding,
+    model: &SemanticModel,
+) -> Option<TextRange> {
+    if is_plain_assignment_right(expression) {
+        return None;
+    }
+    let operand = outermost_transparent_expression(expression);
+    let parent = operand.syntax().parent()?;
+    match parent.kind() {
+        JsSyntaxKind::JS_IF_STATEMENT
+        | JsSyntaxKind::JS_SWITCH_STATEMENT
+        | JsSyntaxKind::JS_UNARY_EXPRESSION
+        | JsSyntaxKind::JS_BINARY_EXPRESSION
+        | JsSyntaxKind::JS_ASSIGNMENT_EXPRESSION => Some(expression.range()),
+        JsSyntaxKind::JS_LOGICAL_EXPRESSION => {
+            let logical_expr = parent.cast::<JsLogicalExpression>()?;
+            let left = logical_expr.left().ok()?;
+            if left == operand && is_const_binding(binding) {
+                Some(expression.range())
+            } else {
+                None
+            }
+        }
+        JsSyntaxKind::JS_CONDITIONAL_EXPRESSION => {
+            let conditional_expr = parent.cast::<JsConditionalExpression>()?;
+            (conditional_expr.test().ok()? == operand).then_some(expression.range())
+        }
+        JsSyntaxKind::JS_TEMPLATE_ELEMENT => {
+            let template_element = parent.cast::<JsTemplateElement>()?;
+            let template = template_element
+                .syntax()
+                .grand_parent()
+                .and_then(JsTemplateExpression::cast)?;
+            template.tag().is_none().then_some(expression.range())
+        }
+        JsSyntaxKind::JS_STATIC_MEMBER_ASSIGNMENT | JsSyntaxKind::JS_STATIC_MEMBER_EXPRESSION => {
+            let static_member = parent.cast::<AnyJsStaticMemberLike>()?;
+            check_static_member_access(expression, &static_member)
+        }
+        JsSyntaxKind::JS_CALL_ARGUMENT_LIST => {
+            let call_argument_list = parent.cast::<JsCallArgumentList>()?;
+            let call_expr = call_argument_list
+                .syntax()
+                .grand_parent()
+                .and_then(JsCallExpression::cast)?;
+            let callee = call_expr.callee().ok()?;
+            (is_emit_call_in_setup(&callee, model) || is_emit_call_by_macro(&callee, model))
+                .then_some(expression.range())
+        }
+        _ => None,
+    }
+}
+
+fn is_const_binding(binding: &JsIdentifierBinding) -> bool {
+    binding
+        .syntax()
+        .ancestors()
+        .skip(1)
+        .find_map(JsVariableDeclaration::cast)
+        .is_some_and(|declaration| declaration.is_const())
 }
 
 declare_node_union! {
     pub AnyJsStaticMemberLike = JsStaticMemberExpression | JsStaticMemberAssignment
 }
 
+declare_node_union! {
+    pub AnyJsRefMember = JsStaticMemberExpression | JsComputedMemberExpression | JsStaticMemberAssignment | JsComputedMemberAssignment
+}
+
+impl AnyJsRefMember {
+    fn object(&self) -> biome_rowan::SyntaxResult<AnyJsExpression> {
+        match self {
+            Self::JsStaticMemberExpression(member) => member.object(),
+            Self::JsComputedMemberExpression(member) => member.object(),
+            Self::JsStaticMemberAssignment(member) => member.object(),
+            Self::JsComputedMemberAssignment(member) => member.object(),
+        }
+    }
+
+    fn expression(&self) -> Option<AnyJsExpression> {
+        match self {
+            Self::JsStaticMemberExpression(member) => Some(member.clone().into()),
+            Self::JsComputedMemberExpression(member) => Some(member.clone().into()),
+            Self::JsStaticMemberAssignment(_) | Self::JsComputedMemberAssignment(_) => None,
+        }
+    }
+}
+
+/// Vue APIs that return a `Ref<T>` of some kind
 const REF_VALUE_APIS: &[&str] = &[
     "ref",
     "computed",
     "toRef",
     "customRef",
     "shallowRef",
-    "toRefs",
+    "useTemplateRef",
 ];
 
-fn is_calling_a_ref(
-    call_expr: &JsCallExpression,
-    ident_binding: &JsIdentifierBinding,
-    model: &SemanticModel,
-) -> bool {
-    if let Ok(callee) = call_expr.callee() {
-        if ident_binding
-            .is_under_object_pattern_binding()
-            .is_some_and(|v| v)
-        {
-            return is_valid_destructured_ref(&callee, call_expr, model);
-        }
-
-        REF_VALUE_APIS
-            .iter()
-            .any(|ref_name| is_vue_api_reference(&callee, model, ref_name))
-            || is_vue_compiler_macro_call(call_expr, model, "defineModel")
-    } else {
-        false
-    }
-}
-
-/// Check if a destructured binding is a valid ref.
-/// Object destructuring may lose reactivity, but there are some cases allowed:
-/// 1. Reactive objects wrapped by toRefs()
-/// 2. Model destructured with defineModel()
-fn is_valid_destructured_ref(
-    callee: &AnyJsExpression,
-    call_expr: &JsCallExpression,
-    model: &SemanticModel,
-) -> bool {
-    is_vue_api_reference(callee, model, "toRefs")
-        || is_vue_compiler_macro_call(call_expr, model, "defineModel")
-}
-
-/// Check if a static member access on a ref is valid
 fn check_static_member_access(
-    ident_expr: &JsIdentifierExpression,
-    ident_binding: &JsIdentifierBinding,
+    expression: &AnyJsExpression,
     static_member_expr: &AnyJsStaticMemberLike,
-    ref_call_expr: &JsCallExpression,
 ) -> Option<TextRange> {
     let member = match static_member_expr {
         AnyJsStaticMemberLike::JsStaticMemberExpression(expr) => expr.member().ok()?,
         AnyJsStaticMemberLike::JsStaticMemberAssignment(assignment) => assignment.member().ok()?,
     };
 
-    let ref_callee_expr = ref_call_expr.callee().ok()?;
-    let ref_callee_name = ref_callee_expr.get_callee_member_name()?;
-    if ref_callee_name.text() == "toRefs" {
-        if is_valid_static_member_wrapped_in_to_refs(ident_binding, &member) {
-            return None;
-        }
-        return Some(static_member_expr.range());
-    }
-
-    if !is_value_static_member(&member) {
-        return Some(ident_expr.range());
+    if !is_allowed_ref_member(&member) {
+        return Some(expression.range());
     }
 
     None
 }
 
-/// Check if a static member is `.value`
-fn is_value_static_member(member: &AnyJsName) -> bool {
+fn is_allowed_ref_member(member: &AnyJsName) -> bool {
     member
         .as_js_name()
         .and_then(|m| m.value_token().ok())
-        .is_some_and(|m| m.text_trimmed() == "value")
-}
-
-/// Check if a static member is accessing a valid property on a ref created by `toRefs()`.
-fn is_valid_static_member_wrapped_in_to_refs(
-    ident_binding: &JsIdentifierBinding,
-    member: &AnyJsName,
-) -> bool {
-    // Destructured refs: `const { foo } = toRefs(obj); foo.value`
-    if ident_binding.is_under_pattern_binding().is_some_and(|v| v) {
-        return is_value_static_member(member);
-    }
-
-    // Direct refs: `const refs = toRefs(obj); refs.foo.value`
-    member
-        .syntax()
-        .grand_parent()
-        .and_then(|grand_parent| grand_parent.cast::<JsStaticMemberExpression>())
-        .and_then(|grand_parent_expr| grand_parent_expr.member().ok())
-        .is_some_and(|m| is_value_static_member(&m))
+        .is_some_and(|name| matches!(name.text_trimmed(), "value" | "effect"))
 }
 
 /// Check if emit is used in setup context

--- a/crates/biome_js_analyze/tests/specs/nursery/noVueRefAsOperand/invalid-multiple-ref-types.vue.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noVueRefAsOperand/invalid-multiple-ref-types.vue.snap
@@ -91,27 +91,6 @@ invalid-multiple-ref-types.vue:9:1 lint/nursery/noVueRefAsOperand ━━━━�
 ```
 
 ```
-invalid-multiple-ref-types.vue:21:13 lint/nursery/noVueRefAsOperand ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Ref value is accessed without `.value`.
-  
-    19 │ });
-    20 │ const refs = toRefs(state2)
-  > 21 │ console.log(refs.foo2)
-       │             ^^^^^^^^^
-    22 │ const { foo2 } = toRefs(state2)
-    23 │ console.log(`${foo2}`)
-  
-  i Without `.value`, Vue cannot track changes to the ref, which may break reactivity.
-  
-  i Use `.value` to access ref value.
-  
-  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
-  
-
-```
-
-```
 invalid-multiple-ref-types.vue:23:16 lint/nursery/noVueRefAsOperand ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Ref value is accessed without `.value`.

--- a/crates/biome_js_analyze/tests/specs/nursery/noVueRefAsOperand/invalid-ref-aliases.vue
+++ b/crates/biome_js_analyze/tests/specs/nursery/noVueRefAsOperand/invalid-ref-aliases.vue
@@ -1,0 +1,49 @@
+<!-- should generate diagnostics -->
+<script lang="ts">
+import { type Ref, ref, toRefs, useTemplateRef } from 'vue'
+
+const count = ref(0)
+const countAlias = count
+const nestedAlias = countAlias
+const parenthesizedAlias = (count)
+countAlias++
+if (nestedAlias) {}
+parenthesizedAlias++
+if ((countAlias)) {}
+
+const assertedProducer = ref(0) as Ref<number>
+assertedProducer++
+const satisfiesProducer = ref(0) satisfies Ref<number>
+satisfiesProducer++
+const typeAssertedProducer = <Ref<number>>ref(0)
+typeAssertedProducer++
+
+const assertedAlias = count as Ref<number>
+assertedAlias++
+const nonNullAlias = count!
+nonNullAlias++
+if (count as unknown) {}
+
+const templateRef = useTemplateRef('element')
+if (templateRef) {}
+
+const [defaultedModel = null, modelModifiers] = defineModel()
+if (defaultedModel) {}
+
+const refs = toRefs({ value: 0 })
+refs.value++
+refs['value']++
+((refs)).value++
+`${refs.value}`
+const valueRef = refs.value
+valueRef++
+const parenthesizedValueRef = (refs).value
+parenthesizedValueRef++
+
+const refsAlias = refs
+const { value: destructuredRef } = refsAlias
+destructuredRef++
+
+const { ...restRefs } = refs
+restRefs.value++
+</script>

--- a/crates/biome_js_analyze/tests/specs/nursery/noVueRefAsOperand/invalid-ref-aliases.vue.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noVueRefAsOperand/invalid-ref-aliases.vue.snap
@@ -1,0 +1,472 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid-ref-aliases.vue
+---
+# Input
+```vue
+<!-- should generate diagnostics -->
+<script lang="ts">
+import { type Ref, ref, toRefs, useTemplateRef } from 'vue'
+
+const count = ref(0)
+const countAlias = count
+const nestedAlias = countAlias
+const parenthesizedAlias = (count)
+countAlias++
+if (nestedAlias) {}
+parenthesizedAlias++
+if ((countAlias)) {}
+
+const assertedProducer = ref(0) as Ref<number>
+assertedProducer++
+const satisfiesProducer = ref(0) satisfies Ref<number>
+satisfiesProducer++
+const typeAssertedProducer = <Ref<number>>ref(0)
+typeAssertedProducer++
+
+const assertedAlias = count as Ref<number>
+assertedAlias++
+const nonNullAlias = count!
+nonNullAlias++
+if (count as unknown) {}
+
+const templateRef = useTemplateRef('element')
+if (templateRef) {}
+
+const [defaultedModel = null, modelModifiers] = defineModel()
+if (defaultedModel) {}
+
+const refs = toRefs({ value: 0 })
+refs.value++
+refs['value']++
+((refs)).value++
+`${refs.value}`
+const valueRef = refs.value
+valueRef++
+const parenthesizedValueRef = (refs).value
+parenthesizedValueRef++
+
+const refsAlias = refs
+const { value: destructuredRef } = refsAlias
+destructuredRef++
+
+const { ...restRefs } = refs
+restRefs.value++
+</script>
+
+```
+
+# Diagnostics
+```
+invalid-ref-aliases.vue:9:1 lint/nursery/noVueRefAsOperand ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Ref value is accessed without `.value`.
+  
+     7 │ const nestedAlias = countAlias
+     8 │ const parenthesizedAlias = (count)
+   > 9 │ countAlias++
+       │ ^^^^^^^^^^
+    10 │ if (nestedAlias) {}
+    11 │ parenthesizedAlias++
+  
+  i Without `.value`, Vue cannot track changes to the ref, which may break reactivity.
+  
+  i Use `.value` to access ref value.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid-ref-aliases.vue:10:5 lint/nursery/noVueRefAsOperand ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Ref value is accessed without `.value`.
+  
+     8 │ const parenthesizedAlias = (count)
+     9 │ countAlias++
+  > 10 │ if (nestedAlias) {}
+       │     ^^^^^^^^^^^
+    11 │ parenthesizedAlias++
+    12 │ if ((countAlias)) {}
+  
+  i Without `.value`, Vue cannot track changes to the ref, which may break reactivity.
+  
+  i Use `.value` to access ref value.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid-ref-aliases.vue:11:1 lint/nursery/noVueRefAsOperand ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Ref value is accessed without `.value`.
+  
+     9 │ countAlias++
+    10 │ if (nestedAlias) {}
+  > 11 │ parenthesizedAlias++
+       │ ^^^^^^^^^^^^^^^^^^
+    12 │ if ((countAlias)) {}
+    13 │ 
+  
+  i Without `.value`, Vue cannot track changes to the ref, which may break reactivity.
+  
+  i Use `.value` to access ref value.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid-ref-aliases.vue:12:6 lint/nursery/noVueRefAsOperand ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Ref value is accessed without `.value`.
+  
+    10 │ if (nestedAlias) {}
+    11 │ parenthesizedAlias++
+  > 12 │ if ((countAlias)) {}
+       │      ^^^^^^^^^^
+    13 │ 
+    14 │ const assertedProducer = ref(0) as Ref<number>
+  
+  i Without `.value`, Vue cannot track changes to the ref, which may break reactivity.
+  
+  i Use `.value` to access ref value.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid-ref-aliases.vue:22:1 lint/nursery/noVueRefAsOperand ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Ref value is accessed without `.value`.
+  
+    21 │ const assertedAlias = count as Ref<number>
+  > 22 │ assertedAlias++
+       │ ^^^^^^^^^^^^^
+    23 │ const nonNullAlias = count!
+    24 │ nonNullAlias++
+  
+  i Without `.value`, Vue cannot track changes to the ref, which may break reactivity.
+  
+  i Use `.value` to access ref value.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid-ref-aliases.vue:24:1 lint/nursery/noVueRefAsOperand ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Ref value is accessed without `.value`.
+  
+    22 │ assertedAlias++
+    23 │ const nonNullAlias = count!
+  > 24 │ nonNullAlias++
+       │ ^^^^^^^^^^^^
+    25 │ if (count as unknown) {}
+    26 │ 
+  
+  i Without `.value`, Vue cannot track changes to the ref, which may break reactivity.
+  
+  i Use `.value` to access ref value.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid-ref-aliases.vue:25:5 lint/nursery/noVueRefAsOperand ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Ref value is accessed without `.value`.
+  
+    23 │ const nonNullAlias = count!
+    24 │ nonNullAlias++
+  > 25 │ if (count as unknown) {}
+       │     ^^^^^
+    26 │ 
+    27 │ const templateRef = useTemplateRef('element')
+  
+  i Without `.value`, Vue cannot track changes to the ref, which may break reactivity.
+  
+  i Use `.value` to access ref value.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid-ref-aliases.vue:15:1 lint/nursery/noVueRefAsOperand ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Ref value is accessed without `.value`.
+  
+    14 │ const assertedProducer = ref(0) as Ref<number>
+  > 15 │ assertedProducer++
+       │ ^^^^^^^^^^^^^^^^
+    16 │ const satisfiesProducer = ref(0) satisfies Ref<number>
+    17 │ satisfiesProducer++
+  
+  i Without `.value`, Vue cannot track changes to the ref, which may break reactivity.
+  
+  i Use `.value` to access ref value.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid-ref-aliases.vue:17:1 lint/nursery/noVueRefAsOperand ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Ref value is accessed without `.value`.
+  
+    15 │ assertedProducer++
+    16 │ const satisfiesProducer = ref(0) satisfies Ref<number>
+  > 17 │ satisfiesProducer++
+       │ ^^^^^^^^^^^^^^^^^
+    18 │ const typeAssertedProducer = <Ref<number>>ref(0)
+    19 │ typeAssertedProducer++
+  
+  i Without `.value`, Vue cannot track changes to the ref, which may break reactivity.
+  
+  i Use `.value` to access ref value.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid-ref-aliases.vue:19:1 lint/nursery/noVueRefAsOperand ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Ref value is accessed without `.value`.
+  
+    17 │ satisfiesProducer++
+    18 │ const typeAssertedProducer = <Ref<number>>ref(0)
+  > 19 │ typeAssertedProducer++
+       │ ^^^^^^^^^^^^^^^^^^^^
+    20 │ 
+    21 │ const assertedAlias = count as Ref<number>
+  
+  i Without `.value`, Vue cannot track changes to the ref, which may break reactivity.
+  
+  i Use `.value` to access ref value.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid-ref-aliases.vue:28:5 lint/nursery/noVueRefAsOperand ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Ref value is accessed without `.value`.
+  
+    27 │ const templateRef = useTemplateRef('element')
+  > 28 │ if (templateRef) {}
+       │     ^^^^^^^^^^^
+    29 │ 
+    30 │ const [defaultedModel = null, modelModifiers] = defineModel()
+  
+  i Without `.value`, Vue cannot track changes to the ref, which may break reactivity.
+  
+  i Use `.value` to access ref value.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid-ref-aliases.vue:31:5 lint/nursery/noVueRefAsOperand ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Ref value is accessed without `.value`.
+  
+    30 │ const [defaultedModel = null, modelModifiers] = defineModel()
+  > 31 │ if (defaultedModel) {}
+       │     ^^^^^^^^^^^^^^
+    32 │ 
+    33 │ const refs = toRefs({ value: 0 })
+  
+  i Without `.value`, Vue cannot track changes to the ref, which may break reactivity.
+  
+  i Use `.value` to access ref value.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid-ref-aliases.vue:34:1 lint/nursery/noVueRefAsOperand ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Ref value is accessed without `.value`.
+  
+    33 │ const refs = toRefs({ value: 0 })
+  > 34 │ refs.value++
+       │ ^^^^^^^^^^
+    35 │ refs['value']++
+    36 │ ((refs)).value++
+  
+  i Without `.value`, Vue cannot track changes to the ref, which may break reactivity.
+  
+  i Use `.value` to access ref value.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid-ref-aliases.vue:35:1 lint/nursery/noVueRefAsOperand ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Ref value is accessed without `.value`.
+  
+    33 │ const refs = toRefs({ value: 0 })
+    34 │ refs.value++
+  > 35 │ refs['value']++
+       │ ^^^^^^^^^^^^^
+    36 │ ((refs)).value++
+    37 │ `${refs.value}`
+  
+  i Without `.value`, Vue cannot track changes to the ref, which may break reactivity.
+  
+  i Use `.value` to access ref value.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid-ref-aliases.vue:36:1 lint/nursery/noVueRefAsOperand ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Ref value is accessed without `.value`.
+  
+    34 │ refs.value++
+    35 │ refs['value']++
+  > 36 │ ((refs)).value++
+       │ ^^^^^^^^^^^^^^
+    37 │ `${refs.value}`
+    38 │ const valueRef = refs.value
+  
+  i Without `.value`, Vue cannot track changes to the ref, which may break reactivity.
+  
+  i Use `.value` to access ref value.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid-ref-aliases.vue:37:4 lint/nursery/noVueRefAsOperand ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Ref value is accessed without `.value`.
+  
+    35 │ refs['value']++
+    36 │ ((refs)).value++
+  > 37 │ `${refs.value}`
+       │    ^^^^^^^^^^
+    38 │ const valueRef = refs.value
+    39 │ valueRef++
+  
+  i Without `.value`, Vue cannot track changes to the ref, which may break reactivity.
+  
+  i Use `.value` to access ref value.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid-ref-aliases.vue:39:1 lint/nursery/noVueRefAsOperand ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Ref value is accessed without `.value`.
+  
+    37 │ `${refs.value}`
+    38 │ const valueRef = refs.value
+  > 39 │ valueRef++
+       │ ^^^^^^^^
+    40 │ const parenthesizedValueRef = (refs).value
+    41 │ parenthesizedValueRef++
+  
+  i Without `.value`, Vue cannot track changes to the ref, which may break reactivity.
+  
+  i Use `.value` to access ref value.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid-ref-aliases.vue:41:1 lint/nursery/noVueRefAsOperand ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Ref value is accessed without `.value`.
+  
+    39 │ valueRef++
+    40 │ const parenthesizedValueRef = (refs).value
+  > 41 │ parenthesizedValueRef++
+       │ ^^^^^^^^^^^^^^^^^^^^^
+    42 │ 
+    43 │ const refsAlias = refs
+  
+  i Without `.value`, Vue cannot track changes to the ref, which may break reactivity.
+  
+  i Use `.value` to access ref value.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid-ref-aliases.vue:45:1 lint/nursery/noVueRefAsOperand ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Ref value is accessed without `.value`.
+  
+    43 │ const refsAlias = refs
+    44 │ const { value: destructuredRef } = refsAlias
+  > 45 │ destructuredRef++
+       │ ^^^^^^^^^^^^^^^
+    46 │ 
+    47 │ const { ...restRefs } = refs
+  
+  i Without `.value`, Vue cannot track changes to the ref, which may break reactivity.
+  
+  i Use `.value` to access ref value.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid-ref-aliases.vue:48:1 lint/nursery/noVueRefAsOperand ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Ref value is accessed without `.value`.
+  
+    47 │ const { ...restRefs } = refs
+  > 48 │ restRefs.value++
+       │ ^^^^^^^^^^^^^^
+    49 │ </script>
+    50 │ 
+  
+  i Without `.value`, Vue cannot track changes to the ref, which may break reactivity.
+  
+  i Use `.value` to access ref value.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noVueRefAsOperand/valid-ref-transfers.vue
+++ b/crates/biome_js_analyze/tests/specs/nursery/noVueRefAsOperand/valid-ref-transfers.vue
@@ -1,0 +1,42 @@
+<!-- should not generate diagnostics -->
+<script setup lang="ts">
+import { type Ref, computed, ref, toRefs, useTemplateRef } from 'vue'
+
+const count = ref(0)
+let target
+target = count
+
+const assertedCount = ref(0) as Ref<number>
+assertedCount.value++
+const assertedAlias = count as Ref<number>
+consume(assertedAlias)
+if (count.value as unknown) {}
+
+const templateRef = useTemplateRef('element')
+consume(templateRef.value)
+
+const [defaultedModel = null, defaultedModifiers] = defineModel()
+consume(defaultedModel.value)
+if (defaultedModifiers) {}
+
+const countAlias = count
+consume(countAlias)
+
+const refs = toRefs({ value: 0 })
+const valueRef = refs.value
+consume(valueRef)
+target = (refs.value)
+
+const { ...restRefs } = refs
+restRefs.value.value++
+
+const { value: { value: nestedValue } } = refs
+nestedValue++
+
+const computedValue = computed(() => 1)
+consume(computedValue.effect)
+
+const [model, modifiers] = defineModel()
+if (modifiers) {}
+consume(model)
+</script>

--- a/crates/biome_js_analyze/tests/specs/nursery/noVueRefAsOperand/valid-ref-transfers.vue.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noVueRefAsOperand/valid-ref-transfers.vue.snap
@@ -1,0 +1,50 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid-ref-transfers.vue
+---
+# Input
+```vue
+<!-- should not generate diagnostics -->
+<script setup lang="ts">
+import { type Ref, computed, ref, toRefs, useTemplateRef } from 'vue'
+
+const count = ref(0)
+let target
+target = count
+
+const assertedCount = ref(0) as Ref<number>
+assertedCount.value++
+const assertedAlias = count as Ref<number>
+consume(assertedAlias)
+if (count.value as unknown) {}
+
+const templateRef = useTemplateRef('element')
+consume(templateRef.value)
+
+const [defaultedModel = null, defaultedModifiers] = defineModel()
+consume(defaultedModel.value)
+if (defaultedModifiers) {}
+
+const countAlias = count
+consume(countAlias)
+
+const refs = toRefs({ value: 0 })
+const valueRef = refs.value
+consume(valueRef)
+target = (refs.value)
+
+const { ...restRefs } = refs
+restRefs.value.value++
+
+const { value: { value: nestedValue } } = refs
+nestedValue++
+
+const computedValue = computed(() => 1)
+consume(computedValue.effect)
+
+const [model, modifiers] = defineModel()
+if (modifiers) {}
+consume(model)
+</script>
+
+```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This PR makes the rule trigger on variable declarations, checks if they make a vue ref, and then scans their usages. Previously, the rule effectively did the reverse: check all the usages, and then check if the binding was a vue ref (which caused the rule to do a bunch of extra work).

On my vue project, before:
```
  total       avg         min         max         count rule
    25.893ms     1.071µs    70.000ns     3.022ms  24171  nursery/noVueRefAsOperand
```
after:
```
  total       avg         min         max         count rule
     4.033ms     1.135µs    30.000ns    26.500µs   3553  nursery/noVueRefAsOperand
```

gpt 5.6 sol did the heavy lifting, but i designed the code

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
