### PR TITLE
fix(noUnusedVariables): a value merged with a used namespace is not unused 🤖🤖🤖

### DIFF
--- a/.changeset/shy-places-doubt.md
+++ b/.changeset/shy-places-doubt.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11519](https://github.com/biomejs/biome/issues/11519): [`noUnusedVariables`](https://biomejs.dev/linter/rules/no-unused-variables/) no longer reports a value as unused when it merges with a namespace of the same name that is used locally.

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_variables.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_variables.rs
@@ -698,7 +698,7 @@ fn is_namespace_merged_with_used_value(
     Some(false)
 }
 
-fn is_value_merged_with_exported_namespace(
+fn is_value_merged_with_used_namespace(
     model: &SemanticModel,
     binding: &AnyJsIdentifierBinding,
 ) -> Option<bool> {
@@ -723,7 +723,16 @@ fn is_value_merged_with_exported_namespace(
         return Some(false);
     }
 
-    Some(model.is_exported(&namespace))
+    // A reference to the shared name resolves to the namespace, since it is the
+    // later declaration, so the value keeps no references of its own. Merging
+    // makes them one entity: a used namespace means a used value.
+    //
+    // References are counted directly rather than by asking `is_unused` about the
+    // namespace. `is_unused` ends by consulting this very function through
+    // `is_declaration_merged_with_used`, so that would recurse: value asks about
+    // namespace, namespace asks about value. A namespace binding cannot be
+    // assigned to, so any reference to it is a read.
+    Some(model.is_exported(&namespace) || namespace.all_references(model).next().is_some())
 }
 
 fn is_declaration_merged_with_used(
@@ -736,7 +745,7 @@ fn is_declaration_merged_with_used(
             is_namespace_merged_with_used_value(model, binding)
         }
         _ if is_namespace_merge_value_declaration(&decl) => {
-            is_value_merged_with_exported_namespace(model, binding)
+            is_value_merged_with_used_namespace(model, binding)
         }
         _ => None,
     }

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceMergedValueUsedLocally.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceMergedValueUsedLocally.ts
@@ -1,0 +1,27 @@
+/* should not generate diagnostics */
+
+// The call resolves to the namespace binding, which is declared last, so the
+// function itself has no references of its own. Declaration merging makes them
+// one entity, so a use of the name is a use of the function.
+function F() {}
+namespace F {}
+
+F();
+
+// The same, with the namespace carrying a type and the value being a const
+// arrow function: used locally, never exported.
+const G = () => {};
+namespace G {
+    export type Props = { id: string };
+}
+
+G();
+
+// A class merged with a namespace, used only as a type annotation.
+class H {}
+namespace H {
+    export type Options = { deep: boolean };
+}
+
+const h: H = new H();
+console.log(h);

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceMergedValueUsedLocally.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceMergedValueUsedLocally.ts.snap
@@ -1,0 +1,35 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validNamespaceMergedValueUsedLocally.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+// The call resolves to the namespace binding, which is declared last, so the
+// function itself has no references of its own. Declaration merging makes them
+// one entity, so a use of the name is a use of the function.
+function F() {}
+namespace F {}
+
+F();
+
+// The same, with the namespace carrying a type and the value being a const
+// arrow function: used locally, never exported.
+const G = () => {};
+namespace G {
+    export type Props = { id: string };
+}
+
+G();
+
+// A class merged with a namespace, used only as a type annotation.
+class H {}
+namespace H {
+    export type Options = { deep: boolean };
+}
+
+const h: H = new H();
+console.log(h);
+
+```


### PR DESCRIPTION
## Summary

Fixes #11519.

```ts
function F() {}
namespace F {}

F()
```

`F` is reported unused even though it is called. A reference to a name shared by a value and a namespace resolves to the namespace, because that is the later declaration, so the function keeps no references of its own. The rescue path for the value side only accepted an *exported* namespace, so a pair used locally was never rescued. The namespace side already accepted either an export or a use; this makes the value side match.

One thing worth flagging in review. The obvious symmetric fix — asking `is_unused` about the namespace — recurses: `is_unused` ends by calling `is_declaration_merged_with_used`, which routes straight back into this function, and the suite dies with a stack overflow. So references are counted directly on the namespace binding instead. A namespace cannot be assigned to, so any reference to it is a read.

## Test Plan

`validNamespaceMergedValueUsedLocally.ts` covers a function, a const arrow function, and a class, each merged with a namespace and used only locally. It fails on `main` with "This test should not generate diagnostics".

`cargo test -p biome_js_analyze` gives 2864 passed, 0 failed. No existing snapshot changed, so `invalidNamespaceUnused.ts` still reports the genuinely unused merged pairs. Reverting just the reference check fails exactly this one test. `cargo fmt --check`, clippy under `-D warnings`, and `rules_check` are clean, and `gen-rules` plus `gen-configuration` produce no diff.

## Docs

No change. The rule's existing note already describes declaration merging with "an exported or referenced value".

---

Disclosure: written with Claude Code. I reviewed the change before opening this PR and the commands above were run locally.
