### PR TITLE
fix(noFloatingPromises): various bugs

### DIFF
--- a/.changeset/full-icons-grin.md
+++ b/.changeset/full-icons-grin.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11528](https://github.com/biomejs/biome/issues/11528): [`noFloatingPromises`](https://biomejs.dev/linter/rules/no-floating-promises/) no longer reports statement-level `await` expressions that handle Promise values, including overloaded calls returning Promise aliases. Awaited values that resolve to arrays of Promises remain reported because their element Promises are not handled by `await`.

--- a/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
@@ -191,24 +191,42 @@ impl Rule for NoFloatingPromises {
         // Uncomment the following line for debugging convenience:
         //let printed = format!("type of {expression:?} = {ty:?}");
         let array_classification = ctx.classify_expression_as_array_of_promises(&expression);
-        if array_classification == TypeInferenceClassification::Match {
-            return Some(NoFloatingPromisesState::ArrayOfPromises);
+        let mut inferred_ty = None;
+        match array_classification {
+            TypeInferenceClassification::Match => {
+                return Some(NoFloatingPromisesState::ArrayOfPromises);
+            }
+            TypeInferenceClassification::NoMatch => {}
+            TypeInferenceClassification::Indeterminate => {
+                let ty = ctx.type_of_expression(&expression)?;
+                if ty.is_array_of_promise() == Some(true) {
+                    return Some(NoFloatingPromisesState::ArrayOfPromises);
+                }
+                inferred_ty = Some(ty);
+            }
+        }
+
+        // Expressions that are awaited can't produce a floating Promise. Arrays of
+        // Promises remain unhandled and are classified above.
+        if matches!(
+            expression.clone().omit_parentheses(),
+            AnyJsExpression::JsAwaitExpression(_)
+        ) {
+            return None;
         }
 
         let promise_classification = ctx.classify_expression_as_promise(&expression);
-        if promise_classification != TypeInferenceClassification::Match {
-            if array_classification == TypeInferenceClassification::NoMatch
-                && promise_classification == TypeInferenceClassification::NoMatch
-            {
-                return None;
-            }
-
-            let ty = ctx.type_of_expression(&expression)?;
-            if ty.is_array_of_promise() == Some(true) {
-                return Some(NoFloatingPromisesState::ArrayOfPromises);
-            }
-            if ty.is_promise_instance() != Some(true) {
-                return None;
+        match promise_classification {
+            TypeInferenceClassification::Match => {}
+            TypeInferenceClassification::NoMatch => return None,
+            TypeInferenceClassification::Indeterminate => {
+                let ty = match inferred_ty {
+                    Some(ty) => ty,
+                    None => ctx.type_of_expression(&expression)?,
+                };
+                if ty.is_promise_instance() != Some(true) {
+                    return None;
+                }
             }
         }
 

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/awaitedArrayOfPromisesInvalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/awaitedArrayOfPromisesInvalid.ts
@@ -6,8 +6,15 @@ function syncValues(): Promise<Array<Promise<void>>> {
 	return Promise.resolve([]);
 }
 declare const directValues: Promise<Array<Promise<void>>>;
+declare const values: Array<Promise<void>>;
+
+asyncValues();
+syncValues();
+directValues;
+values;
 
 await asyncValues();
 await syncValues();
 await directValues;
 await await asyncValues();
+await values;

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/awaitedArrayOfPromisesInvalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/awaitedArrayOfPromisesInvalid.ts.snap
@@ -12,46 +12,35 @@ function syncValues(): Promise<Array<Promise<void>>> {
 	return Promise.resolve([]);
 }
 declare const directValues: Promise<Array<Promise<void>>>;
+declare const values: Array<Promise<void>>;
+
+asyncValues();
+syncValues();
+directValues;
+values;
 
 await asyncValues();
 await syncValues();
 await directValues;
 await await asyncValues();
+await values;
 
 ```
 
 # Diagnostics
 ```
-awaitedArrayOfPromisesInvalid.ts:10:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i An array of Promises was found, meaning they are not properly handled and could lead to ignored errors or unexpected behavior.
-  
-     8 │ declare const directValues: Promise<Array<Promise<void>>>;
-     9 │ 
-  > 10 │ await asyncValues();
-       │ ^^^^^^^^^^^^^^^^^^^^
-    11 │ await syncValues();
-    12 │ await directValues;
-  
-  i This happens when an array of Promises is not wrapped with Promise.all() or a similar method, and is not explicitly ignored using the `void` operator.
-  
-  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
-  
-
-```
-
-```
 awaitedArrayOfPromisesInvalid.ts:11:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i An array of Promises was found, meaning they are not properly handled and could lead to ignored errors or unexpected behavior.
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    10 │ await asyncValues();
-  > 11 │ await syncValues();
-       │ ^^^^^^^^^^^^^^^^^^^
-    12 │ await directValues;
-    13 │ await await asyncValues();
+     9 │ declare const values: Array<Promise<void>>;
+    10 │ 
+  > 11 │ asyncValues();
+       │ ^^^^^^^^^^^^^^
+    12 │ syncValues();
+    13 │ directValues;
   
-  i This happens when an array of Promises is not wrapped with Promise.all() or a similar method, and is not explicitly ignored using the `void` operator.
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
@@ -61,16 +50,15 @@ awaitedArrayOfPromisesInvalid.ts:11:1 lint/nursery/noFloatingPromises ━━━�
 ```
 awaitedArrayOfPromisesInvalid.ts:12:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i An array of Promises was found, meaning they are not properly handled and could lead to ignored errors or unexpected behavior.
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    10 │ await asyncValues();
-    11 │ await syncValues();
-  > 12 │ await directValues;
-       │ ^^^^^^^^^^^^^^^^^^^
-    13 │ await await asyncValues();
-    14 │ 
+    11 │ asyncValues();
+  > 12 │ syncValues();
+       │ ^^^^^^^^^^^^^
+    13 │ directValues;
+    14 │ values;
   
-  i This happens when an array of Promises is not wrapped with Promise.all() or a similar method, and is not explicitly ignored using the `void` operator.
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   
@@ -80,13 +68,126 @@ awaitedArrayOfPromisesInvalid.ts:12:1 lint/nursery/noFloatingPromises ━━━�
 ```
 awaitedArrayOfPromisesInvalid.ts:13:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    11 │ asyncValues();
+    12 │ syncValues();
+  > 13 │ directValues;
+       │ ^^^^^^^^^^^^^
+    14 │ values;
+    15 │ 
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+awaitedArrayOfPromisesInvalid.ts:14:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
   i An array of Promises was found, meaning they are not properly handled and could lead to ignored errors or unexpected behavior.
   
-    11 │ await syncValues();
-    12 │ await directValues;
-  > 13 │ await await asyncValues();
+    12 │ syncValues();
+    13 │ directValues;
+  > 14 │ values;
+       │ ^^^^^^^
+    15 │ 
+    16 │ await asyncValues();
+  
+  i This happens when an array of Promises is not wrapped with Promise.all() or a similar method, and is not explicitly ignored using the `void` operator.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+awaitedArrayOfPromisesInvalid.ts:16:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i An array of Promises was found, meaning they are not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    14 │ values;
+    15 │ 
+  > 16 │ await asyncValues();
+       │ ^^^^^^^^^^^^^^^^^^^^
+    17 │ await syncValues();
+    18 │ await directValues;
+  
+  i This happens when an array of Promises is not wrapped with Promise.all() or a similar method, and is not explicitly ignored using the `void` operator.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+awaitedArrayOfPromisesInvalid.ts:17:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i An array of Promises was found, meaning they are not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    16 │ await asyncValues();
+  > 17 │ await syncValues();
+       │ ^^^^^^^^^^^^^^^^^^^
+    18 │ await directValues;
+    19 │ await await asyncValues();
+  
+  i This happens when an array of Promises is not wrapped with Promise.all() or a similar method, and is not explicitly ignored using the `void` operator.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+awaitedArrayOfPromisesInvalid.ts:18:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i An array of Promises was found, meaning they are not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    16 │ await asyncValues();
+    17 │ await syncValues();
+  > 18 │ await directValues;
+       │ ^^^^^^^^^^^^^^^^^^^
+    19 │ await await asyncValues();
+    20 │ await values;
+  
+  i This happens when an array of Promises is not wrapped with Promise.all() or a similar method, and is not explicitly ignored using the `void` operator.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+awaitedArrayOfPromisesInvalid.ts:19:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i An array of Promises was found, meaning they are not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    17 │ await syncValues();
+    18 │ await directValues;
+  > 19 │ await await asyncValues();
        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^
-    14 │ 
+    20 │ await values;
+    21 │ 
+  
+  i This happens when an array of Promises is not wrapped with Promise.all() or a similar method, and is not explicitly ignored using the `void` operator.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+awaitedArrayOfPromisesInvalid.ts:20:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i An array of Promises was found, meaning they are not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    18 │ await directValues;
+    19 │ await await asyncValues();
+  > 20 │ await values;
+       │ ^^^^^^^^^^^^^
+    21 │ 
   
   i This happens when an array of Promises is not wrapped with Promise.all() or a similar method, and is not explicitly ignored using the `void` operator.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue11528_valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue11528_valid.ts
@@ -1,0 +1,18 @@
+// should not generate diagnostics
+interface GaxiosResponse<T> {
+	data: T;
+}
+
+type GaxiosPromise<T> = Promise<GaxiosResponse<T>>;
+type BodyResponseCallback<T> = (response: GaxiosResponse<T>) => void;
+
+declare class OAuth2Client {
+	revokeToken(token: string): GaxiosPromise<string>;
+	revokeToken(token: string, callback: BodyResponseCallback<string>): void;
+}
+
+export async function revokeAccessToken(client: OAuth2Client, token: string) {
+	await client.revokeToken(token);
+	await (client.revokeToken(token));
+	(await client.revokeToken(token));
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue11528_valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue11528_valid.ts.snap
@@ -1,0 +1,26 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue11528_valid.ts
+---
+# Input
+```ts
+// should not generate diagnostics
+interface GaxiosResponse<T> {
+	data: T;
+}
+
+type GaxiosPromise<T> = Promise<GaxiosResponse<T>>;
+type BodyResponseCallback<T> = (response: GaxiosResponse<T>) => void;
+
+declare class OAuth2Client {
+	revokeToken(token: string): GaxiosPromise<string>;
+	revokeToken(token: string, callback: BodyResponseCallback<string>): void;
+}
+
+export async function revokeAccessToken(client: OAuth2Client, token: string) {
+	await client.revokeToken(token);
+	await (client.revokeToken(token));
+	(await client.revokeToken(token));
+}
+
+```

--- a/crates/biome_module_graph/src/db/type_inference/expressions.rs
+++ b/crates/biome_module_graph/src/db/type_inference/expressions.rs
@@ -873,9 +873,67 @@ impl<'db> ResolutionCtx<'db, '_> {
             }
 
             let InferredTypeData::InstanceOf(instance) = ty else {
-                continue;
+                return Some(ty);
             };
             let target = self.resolve_inferred_type(instance.ty(self.db));
+            // Generic type aliases are represented as nested instances. Apply
+            // their arguments to the aliased body, then discard the declaration
+            // wrapper so its parameters are not interpreted a second time.
+            if let InferredTypeData::InstanceOf(alias) = target {
+                let supplied_parameters = instance.type_parameters(self.db);
+                let declared_parameters = alias.type_parameters(self.db);
+                let has_generic_parameters = declared_parameters.iter().any(|parameter| {
+                    matches!(parameter, InferredTypeData::Generic(_))
+                        || matches!(
+                            parameter,
+                            InferredTypeData::InstanceOf(instance)
+                                if matches!(instance.ty(self.db), InferredTypeData::Generic(_))
+                        )
+                });
+                if !has_generic_parameters {
+                    pending.push(target);
+                    continue;
+                }
+
+                let mut type_parameters = Vec::with_capacity(declared_parameters.len());
+                for (index, declared) in declared_parameters.iter().enumerate() {
+                    let substitutions =
+                        substitutions_for_instance(self.db, target, &type_parameters, &[]);
+                    let supplied = supplied_parameters.get(index).copied();
+                    let parameter = supplied.unwrap_or(*declared);
+                    let parameter = apply_substitutions(self.db, parameter, &substitutions);
+                    let generic = if let InferredTypeData::Generic(generic) = declared {
+                        Some(*generic)
+                    } else if let InferredTypeData::InstanceOf(instance) = declared
+                        && let InferredTypeData::Generic(generic) = instance.ty(self.db)
+                    {
+                        Some(generic)
+                    } else {
+                        None
+                    };
+                    type_parameters.push(
+                        (supplied.is_none() || supplied == Some(*declared))
+                            .then_some(generic)
+                            .flatten()
+                            .and_then(|generic| generic.default(self.db))
+                            .map_or(parameter, |default| {
+                                apply_substitutions(self.db, default, &substitutions)
+                            }),
+                    );
+                }
+                let substitutions =
+                    substitutions_for_instance(self.db, target, &type_parameters, &[]);
+                if substitutions.is_empty() {
+                    pending.push(target);
+                } else {
+                    pending.push(apply_substitutions(
+                        self.db,
+                        alias.ty(self.db),
+                        &substitutions,
+                    ));
+                }
+                continue;
+            }
             if self.is_promise_like_target(target) {
                 return Some(
                     instance

--- a/crates/biome_module_graph/tests/spec_tests/promises.test.rs
+++ b/crates/biome_module_graph/tests/spec_tests/promises.test.rs
@@ -506,6 +506,275 @@ fn test_infer_module_types_evaluates_await_expressions_on_build() {
 }
 
 #[test]
+fn test_infer_module_types_evaluates_awaited_promise_aliases() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            interface Response<T> { data: T }
+            interface Pair<Left, Right> { left: Left; right: Right }
+            interface Box<T> { value: T }
+
+            type PromiseAlias<T> = Promise<T>;
+            type AliasChain<T> = PromiseAlias<T>;
+            type ConcreteAlias = Promise<number>;
+            type StructuredAlias<T> = Promise<Response<T>>;
+            type ReorderedAlias<First, Second> = Promise<Pair<Second, First>>;
+            type UnusedAlias<Unused, Value> = Promise<Box<Value>>;
+            type DefaultAlias<T = string> = Promise<T>;
+            type DependentDefaultAlias<T, U = T> = Promise<U>;
+
+            declare function structuredCall(value: string, callback: () => void): void;
+            declare function structuredCall(value: string): StructuredAlias<string>;
+
+            export async function consume(
+                generic: AliasChain<string>,
+                concrete: ConcreteAlias,
+                reordered: ReorderedAlias<string, number>,
+                unused: UnusedAlias<boolean, string>,
+                defaulted: DefaultAlias,
+                dependentDefault: DependentDefaultAlias<string>,
+            ) {
+                const awaitedGeneric = await generic;
+                const awaitedConcrete = await concrete;
+                const awaitedStructured = await structuredCall("value");
+                const awaitedReordered = await reordered;
+                const awaitedUnused = await unused;
+                const awaitedDefaulted = await defaulted;
+                const awaitedDependentDefault = await dependentDefault;
+                return {
+                    awaitedGeneric,
+                    awaitedConcrete,
+                    awaitedStructured,
+                    awaitedReordered,
+                    awaitedUnused,
+                    awaitedDefaulted,
+                    awaitedDependentDefault,
+                };
+            }
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let index_module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let inferred = infer_module_types(&db, index_module).expect("types must be inferred");
+
+    let awaited_generic =
+        inferred_binding_ty_by_name(&db, index_module, inferred, "awaitedGeneric")
+            .expect("awaitedGeneric binding type must be inferred");
+    assert!(
+        is_inferred_string(&db, inferred.resolve_type(&db, awaited_generic)),
+        "awaitedGeneric must be string"
+    );
+
+    let awaited_concrete =
+        inferred_binding_ty_by_name(&db, index_module, inferred, "awaitedConcrete")
+            .expect("awaitedConcrete binding type must be inferred");
+    let awaited_concrete = inferred.resolve_type(&db, awaited_concrete);
+    assert!(
+        is_inferred_number(&db, awaited_concrete),
+        "awaitedConcrete must be number, got {}",
+        format_inferred_type(&db, awaited_concrete)
+    );
+
+    let awaited_structured =
+        inferred_binding_ty_by_name(&db, index_module, inferred, "awaitedStructured")
+            .expect("awaitedStructured binding type must be inferred");
+    let structured_data = inferred
+        .find_member_type(&db, inferred.resolve_type(&db, awaited_structured), "data")
+        .expect("awaitedStructured.data must be inferred");
+    assert!(
+        is_inferred_string(&db, structured_data),
+        "awaitedStructured.data must be string"
+    );
+
+    let awaited_reordered =
+        inferred_binding_ty_by_name(&db, index_module, inferred, "awaitedReordered")
+            .expect("awaitedReordered binding type must be inferred");
+    let awaited_reordered = inferred.resolve_type(&db, awaited_reordered);
+    let reordered_left = inferred
+        .find_member_type(&db, awaited_reordered, "left")
+        .expect("awaitedReordered.left must be inferred");
+    let reordered_right = inferred
+        .find_member_type(&db, awaited_reordered, "right")
+        .expect("awaitedReordered.right must be inferred");
+    assert!(
+        is_inferred_number(&db, reordered_left),
+        "awaitedReordered.left must be number"
+    );
+    assert!(
+        is_inferred_string(&db, reordered_right),
+        "awaitedReordered.right must be string"
+    );
+
+    let awaited_unused = inferred_binding_ty_by_name(&db, index_module, inferred, "awaitedUnused")
+        .expect("awaitedUnused binding type must be inferred");
+    let unused_value = inferred
+        .find_member_type(&db, inferred.resolve_type(&db, awaited_unused), "value")
+        .expect("awaitedUnused.value must be inferred");
+    assert!(
+        is_inferred_string(&db, unused_value),
+        "awaitedUnused.value must be string"
+    );
+
+    let awaited_defaulted =
+        inferred_binding_ty_by_name(&db, index_module, inferred, "awaitedDefaulted")
+            .expect("awaitedDefaulted binding type must be inferred");
+    assert!(
+        is_inferred_string(&db, inferred.resolve_type(&db, awaited_defaulted)),
+        "awaitedDefaulted must be string"
+    );
+
+    let awaited_dependent_default =
+        inferred_binding_ty_by_name(&db, index_module, inferred, "awaitedDependentDefault")
+            .expect("awaitedDependentDefault binding type must be inferred");
+    let awaited_dependent_default = inferred.resolve_type(&db, awaited_dependent_default);
+    assert!(
+        is_inferred_string(&db, awaited_dependent_default),
+        "awaitedDependentDefault must be string, got {}",
+        format_inferred_type(&db, awaited_dependent_default)
+    );
+}
+
+#[test]
+fn test_infer_module_types_evaluates_awaited_promise_alias_edge_cases() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+            interface Box<T> { value: T }
+
+            type DefaultAlias<T = string> = Promise<T>;
+            type DependentDefaultAlias<T, U = T> = Promise<U>;
+            type ChainedDefaultAlias<T = string, U = T, V = Box<U>> = Promise<V>;
+            type DefaultAliasChain<T = boolean> = DefaultAlias<T>;
+            type NestedAlias<T> = Promise<Promise<T>>;
+            type UnionAlias<T> = Promise<T> | T;
+            type ValueAlias<T> = T;
+
+            declare function typedCall(value: number): void;
+            declare function typedCall(value: string): DefaultAlias<number>;
+
+            export async function consume<T = number>(
+                explicitDefault: DefaultAlias<boolean>,
+                overriddenDependent: DependentDefaultAlias<string, number>,
+                chainedDefault: ChainedDefaultAlias,
+                defaultChain: DefaultAliasChain,
+                nested: NestedAlias<string>,
+                union: UnionAlias<boolean>,
+                value: ValueAlias<string>,
+                outerGeneric: DefaultAlias<T>,
+            ) {
+                const awaitedExplicitDefault = await explicitDefault;
+                const awaitedOverriddenDependent = await overriddenDependent;
+                const awaitedChainedDefault = await chainedDefault;
+                const awaitedDefaultChain = await defaultChain;
+                const awaitedNested = await nested;
+                const awaitedUnion = await union;
+                const awaitedValue = await value;
+                const awaitedOuterGeneric = await outerGeneric;
+                const awaitedTypedOverload = await typedCall("value");
+                return {
+                    awaitedExplicitDefault,
+                    awaitedOverriddenDependent,
+                    awaitedChainedDefault,
+                    awaitedDefaultChain,
+                    awaitedNested,
+                    awaitedUnion,
+                    awaitedValue,
+                    awaitedOuterGeneric,
+                    awaitedTypedOverload,
+                };
+            }
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let index_module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let inferred = infer_module_types(&db, index_module).expect("types must be inferred");
+    let resolved_binding = |name| {
+        let ty = inferred_binding_ty_by_name(&db, index_module, inferred, name)
+            .unwrap_or_else(|| panic!("{name} binding type must be inferred"));
+        inferred.resolve_type(&db, ty)
+    };
+
+    let explicit_default = resolved_binding("awaitedExplicitDefault");
+    assert!(
+        is_inferred_boolean(&db, explicit_default),
+        "awaitedExplicitDefault must be boolean, got {}",
+        format_inferred_type(&db, explicit_default)
+    );
+
+    let overridden_dependent = resolved_binding("awaitedOverriddenDependent");
+    assert!(
+        is_inferred_number(&db, overridden_dependent),
+        "awaitedOverriddenDependent must be number, got {}",
+        format_inferred_type(&db, overridden_dependent)
+    );
+
+    let chained_default = resolved_binding("awaitedChainedDefault");
+    let chained_value = inferred
+        .find_member_type(&db, chained_default, "value")
+        .expect("awaitedChainedDefault.value must be inferred");
+    assert!(
+        is_inferred_string(&db, chained_value),
+        "awaitedChainedDefault.value must be string, got {}",
+        format_inferred_type(&db, chained_value)
+    );
+
+    let default_chain = resolved_binding("awaitedDefaultChain");
+    assert!(
+        is_inferred_boolean(&db, default_chain),
+        "awaitedDefaultChain must be boolean, got {}",
+        format_inferred_type(&db, default_chain)
+    );
+
+    let nested = resolved_binding("awaitedNested");
+    assert!(
+        is_inferred_string(&db, nested),
+        "awaitedNested must be string, got {}",
+        format_inferred_type(&db, nested)
+    );
+
+    let union = resolved_binding("awaitedUnion");
+    assert!(
+        is_inferred_boolean(&db, union),
+        "awaitedUnion must be boolean, got {}",
+        format_inferred_type(&db, union)
+    );
+
+    let value = resolved_binding("awaitedValue");
+    assert!(
+        is_inferred_string(&db, value),
+        "awaitedValue must be string, got {}",
+        format_inferred_type(&db, value)
+    );
+
+    let outer_generic = resolved_binding("awaitedOuterGeneric");
+    assert!(
+        matches!(outer_generic, InferredTypeData::Generic(_))
+            || matches!(
+                outer_generic,
+                InferredTypeData::InstanceOf(instance)
+                    if matches!(instance.ty(&db), InferredTypeData::Generic(_))
+            ),
+        "awaitedOuterGeneric must preserve T, got {}",
+        format_inferred_type(&db, outer_generic)
+    );
+
+    let typed_overload = resolved_binding("awaitedTypedOverload");
+    assert!(
+        is_inferred_number(&db, typed_overload),
+        "awaitedTypedOverload must be number, got {}",
+        format_inferred_type(&db, typed_overload)
+    );
+}
+
+#[test]
 fn test_infer_module_types_preserves_floating_promise_shapes() {
     let fs = MemoryFileSystem::default();
     fs.insert(


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
There were effectively 3 bugs that compounded on each other that resulted in #11528:

1. Uncertainty from array classification can override a conclusive Promise `NoMatch`.
2. Await inference fails to unwrap Promise aliases (`type FooPromise = Promise<Foo>`), despite it being trivial to infer.
3. The rule does not enforce the syntax-level invariant that `await ...` cannot enter the `UnhandledPromise` state.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #11528

implemented by gpt 5.6 sol
<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
tests and snapshots

I ran it through ecosystem CI, and it looks fine

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
