### PR TITLE
fix(workspace): scanner behaviour

### DIFF
--- a/.changeset/floppy-humans-grin.md
+++ b/.changeset/floppy-humans-grin.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11520](https://github.com/biomejs/biome/issues/11520), where the Biome scanner would start analysing dependencies multiple times, leading to long and unresponsive sessions.

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -289,8 +289,9 @@ impl Session {
     ///   again: dropping a `didChange` would leave our copy of the document
     ///   permanently out of sync with the editor.
     /// - **Background tasks** the server starts on its own, such as
-    ///   refreshing the diagnostics of the open documents, loading the
-    ///   configuration file, or scanning the project folder.
+    ///   refreshing the diagnostics of the open documents or loading the
+    ///   configuration file. Project scans handle interruptions at individual
+    ///   indexing boundaries instead of retrying the entire scan.
     ///
     /// LSP request handlers (formatting, code actions, ...) should use
     /// [Self::workspace_for_request] instead.

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -290,8 +290,8 @@ impl Session {
     ///   permanently out of sync with the editor.
     /// - **Background tasks** the server starts on its own, such as
     ///   refreshing the diagnostics of the open documents or loading the
-    ///   configuration file. Project scans handle interruptions at individual
-    ///   indexing boundaries instead of retrying the entire scan.
+    ///   configuration file. Project scans run inside an epoch that queues
+    ///   setter-based writes instead of retrying the traversal.
     ///
     /// LSP request handlers (formatting, code actions, ...) should use
     /// [Self::workspace_for_request] instead.

--- a/crates/biome_service/src/db/mod.rs
+++ b/crates/biome_service/src/db/mod.rs
@@ -315,6 +315,15 @@ impl WorkspaceDb {
         pending_setter.to(next);
     }
 
+    /// Advances the module graph generation without changing its entries.
+    ///
+    /// This publishes module changes already made through shared collections to
+    /// Salsa-tracked queries.
+    #[cfg(feature = "module_graph")]
+    pub(crate) fn invalidate_module_graph(&mut self) {
+        self.write_module_data(|_| {});
+    }
+
     /// Returns handles to the collections that this database shares with all
     /// its clones.
     pub fn data(&self) -> WorkspaceDbData {
@@ -763,6 +772,16 @@ pub struct SharedWorkspaceDb {
 
 impl Default for SharedWorkspaceDb {
     fn default() -> Self {
+        Self::from_workspace_db(WorkspaceDb::default())
+    }
+}
+
+impl SharedWorkspaceDb {
+    /// Converts `db` into handles for creating operation-local forks.
+    ///
+    /// The resulting forks share Salsa storage and workspace collections with
+    /// `db`, but each fork has fresh Salsa local state.
+    pub(crate) fn from_workspace_db(db: WorkspaceDb) -> Self {
         let WorkspaceDb {
             files,
             #[cfg(feature = "module_graph")]
@@ -771,7 +790,7 @@ impl Default for SharedWorkspaceDb {
             storage,
             projects,
             settings_queries,
-        } = WorkspaceDb::default();
+        } = db;
         Self {
             files,
             #[cfg(feature = "module_graph")]
@@ -782,9 +801,7 @@ impl Default for SharedWorkspaceDb {
             storage: storage.into_zalsa_handle(),
         }
     }
-}
 
-impl SharedWorkspaceDb {
     pub fn data(&self) -> WorkspaceDbData {
         WorkspaceDbData {
             files: self.files.clone(),

--- a/crates/biome_service/src/db/state.rs
+++ b/crates/biome_service/src/db/state.rs
@@ -181,23 +181,88 @@ use biome_db::{ParsedSnippet, ParsedSource};
 use biome_languages::DocumentFileSource;
 use biome_parser::AnyParse;
 use camino::{Utf8Path, Utf8PathBuf};
-use parking_lot::Mutex;
+use parking_lot::{Mutex, MutexGuard};
 use std::cell::Cell;
 use std::marker::PhantomData;
 use std::ops::Deref;
 use std::panic::resume_unwind;
-use std::sync::atomic::{AtomicUsize, Ordering};
+#[cfg(feature = "module_graph")]
+use std::sync::atomic::AtomicBool;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
 use tracing::error;
 
 /// Represents the state of the database in the workspace.
 pub struct DbState {
     storage: DbStorage,
-    pub(crate) path_info_cache: PathInfoCache,
+    pub(crate) path_info_cache: Arc<PathInfoCache>,
+    /// Records module-map changes made by a scanner epoch's shared view.
+    #[cfg(feature = "module_graph")]
+    scanner_module_graph_dirty: Option<Arc<AtomicBool>>,
 }
 
 enum DbStorage {
     Shared(SharedWorkspaceDb),
     Owned(OwnedDb),
+}
+
+/// Database view used for the duration of a project scan.
+///
+/// For owned storage, the epoch holds the setter gate and supplies a shared
+/// replacement-update view over the same Salsa storage and workspace
+/// collections. This keeps individual scanner updates from announcing pending
+/// Salsa writes. Dropping the epoch discards the view before publishing one
+/// module graph invalidation and releasing the setter gate.
+/// Shared storage needs no setter gate and reuses its existing update mode.
+pub(crate) struct ScannerDbEpoch<'a> {
+    // Struct fields drop in declaration order. The shared view must be gone
+    // before the finalizer invokes a setter on the canonical database.
+    view: DbState,
+    _finalizer: ScannerDbEpochFinalizer<'a>,
+}
+
+impl ScannerDbEpoch<'_> {
+    /// Returns the database state scanner operations must use during the epoch.
+    pub(crate) fn view(&self) -> &DbState {
+        &self.view
+    }
+}
+
+/// Publishes accumulated scanner changes before releasing the setter gate.
+enum ScannerDbEpochFinalizer<'a> {
+    Shared,
+    Owned {
+        #[cfg(feature = "module_graph")]
+        owner: &'a OwnedDb,
+        setter_guard: MutexGuard<'a, ()>,
+        #[cfg(feature = "module_graph")]
+        module_graph_dirty: Arc<AtomicBool>,
+    },
+}
+
+impl Drop for ScannerDbEpochFinalizer<'_> {
+    fn drop(&mut self) {
+        match self {
+            Self::Shared => {}
+            Self::Owned {
+                #[cfg(feature = "module_graph")]
+                owner,
+                setter_guard,
+                #[cfg(feature = "module_graph")]
+                module_graph_dirty,
+            } => {
+                #[cfg(feature = "module_graph")]
+                if module_graph_dirty.load(Ordering::Acquire) {
+                    owner.with_setter_gate_held(setter_guard, WorkspaceDb::invalidate_module_graph);
+                }
+
+                #[cfg(not(feature = "module_graph"))]
+                let _ = setter_guard;
+            }
+        }
+    }
 }
 
 // Counts database forks held by the current thread.
@@ -288,12 +353,27 @@ struct OwnedDb {
     /// The database instance itself. The lock is held only briefly to create
     /// a clone, and for the whole duration of a setter-based update.
     db: Mutex<WorkspaceDb>,
+    /// Serializes setter intent and keeps setters outside scanner epochs.
+    /// Queued setters do not announce pending writes while waiting here.
+    setter_lock: Mutex<()>,
     /// The collections shared between the database and all its clones. See
     /// [WorkspaceDbData].
     data: WorkspaceDbData,
-    /// How many threads are currently applying, or waiting to apply, a
-    /// setter-based update.
+    /// Whether a setter currently owns the setter gate and is applying, or
+    /// waiting to apply, an update.
     pending_setters: AtomicUsize,
+    /// Number of setter attempts observed before acquiring the setter gate.
+    #[cfg(test)]
+    setter_gate_attempts: AtomicUsize,
+}
+
+/// Clears the pending-setter signal when a setter completes or unwinds.
+struct PendingSetterGuard<'a>(&'a AtomicUsize);
+
+impl Drop for PendingSetterGuard<'_> {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::Release);
+    }
 }
 
 impl OwnedDb {
@@ -301,8 +381,11 @@ impl OwnedDb {
         let data = db.data();
         Self {
             db: Mutex::new(db),
+            setter_lock: Mutex::new(()),
             data,
             pending_setters: AtomicUsize::new(0),
+            #[cfg(test)]
+            setter_gate_attempts: AtomicUsize::new(0),
         }
     }
 
@@ -326,13 +409,6 @@ impl OwnedDb {
     }
 
     fn with_setter<R>(&self, f: impl FnOnce(&mut WorkspaceDb) -> R) -> R {
-        struct PendingSetterGuard<'a>(&'a AtomicUsize);
-        impl Drop for PendingSetterGuard<'_> {
-            fn drop(&mut self) {
-                self.0.fetch_sub(1, Ordering::Release);
-            }
-        }
-
         if LIVE_READS.with(|reads| reads.get()) != 0 {
             debug_assert!(
                 false,
@@ -344,6 +420,21 @@ impl OwnedDb {
             resume_unwind(Box::new(salsa::Cancelled::PendingWrite));
         }
 
+        #[cfg(test)]
+        self.setter_gate_attempts.fetch_add(1, Ordering::Release);
+        let setter_guard = self.setter_lock.lock();
+        self.with_setter_gate_held(&setter_guard, f)
+    }
+
+    /// Runs a setter after the caller has acquired this database's setter gate.
+    ///
+    /// The guard keeps queued setters from announcing a pending write until the
+    /// current operation has completed.
+    fn with_setter_gate_held<R>(
+        &self,
+        _setter_guard: &MutexGuard<'_, ()>,
+        f: impl FnOnce(&mut WorkspaceDb) -> R,
+    ) -> R {
         self.pending_setters.fetch_add(1, Ordering::Release);
         let _guard = PendingSetterGuard(&self.pending_setters);
         let mut db = self.db.lock();
@@ -355,7 +446,9 @@ impl Default for DbState {
     fn default() -> Self {
         Self {
             storage: DbStorage::Shared(SharedWorkspaceDb::default()),
-            path_info_cache: PathInfoCache::default(),
+            path_info_cache: Arc::default(),
+            #[cfg(feature = "module_graph")]
+            scanner_module_graph_dirty: None,
         }
     }
 }
@@ -364,7 +457,55 @@ impl DbState {
     pub fn lsp() -> Self {
         Self {
             storage: DbStorage::Owned(OwnedDb::new(WorkspaceDb::default())),
-            path_info_cache: PathInfoCache::default(),
+            path_info_cache: Arc::default(),
+            #[cfg(feature = "module_graph")]
+            scanner_module_graph_dirty: None,
+        }
+    }
+
+    /// Creates the database epoch used by one project scan.
+    ///
+    /// Owned storage waits for the setter gate without announcing a pending
+    /// Salsa write, then returns a replacement-update view. This leaves reads
+    /// available while preventing setter-based updates from overlapping the
+    /// scan. Shared storage returns an equivalent shared view without locking.
+    pub(crate) fn scanner_epoch(&self) -> ScannerDbEpoch<'_> {
+        #[cfg(feature = "module_graph")]
+        let module_graph_dirty = Arc::new(AtomicBool::new(false));
+
+        match &self.storage {
+            DbStorage::Shared(shared_db) => ScannerDbEpoch {
+                view: Self {
+                    storage: DbStorage::Shared(shared_db.clone()),
+                    path_info_cache: self.path_info_cache.clone(),
+                    #[cfg(feature = "module_graph")]
+                    scanner_module_graph_dirty: None,
+                },
+                _finalizer: ScannerDbEpochFinalizer::Shared,
+            },
+            DbStorage::Owned(owner) => {
+                let setter_guard = owner.setter_lock.lock();
+                let shared_db = {
+                    let db = owner.db.lock();
+                    SharedWorkspaceDb::from_workspace_db(db.clone())
+                };
+
+                ScannerDbEpoch {
+                    view: Self {
+                        storage: DbStorage::Shared(shared_db),
+                        path_info_cache: self.path_info_cache.clone(),
+                        #[cfg(feature = "module_graph")]
+                        scanner_module_graph_dirty: Some(module_graph_dirty.clone()),
+                    },
+                    _finalizer: ScannerDbEpochFinalizer::Owned {
+                        #[cfg(feature = "module_graph")]
+                        owner,
+                        setter_guard,
+                        #[cfg(feature = "module_graph")]
+                        module_graph_dirty,
+                    },
+                }
+            }
         }
     }
 
@@ -512,7 +653,11 @@ impl DbState {
 
     pub(crate) fn unload_path(&self, path: &Utf8Path) {
         match &self.storage {
-            DbStorage::Shared(shared_db) => shared_db.fork().data().unload_path(path),
+            DbStorage::Shared(shared_db) => {
+                shared_db.fork().data().unload_path(path);
+                #[cfg(feature = "module_graph")]
+                self.mark_module_graph_dirty();
+            }
             DbStorage::Owned(db) => db.with_setter(|db| db.unload_path(path)),
         }
     }
@@ -540,6 +685,7 @@ impl DbState {
                 let db = shared_db.fork();
                 let module = ModuleInfo::new(&db, path.clone(), kind);
                 db.data().insert_module(path, module);
+                self.mark_module_graph_dirty();
                 module
             }
             DbStorage::Owned(db) => db.with_setter(|db| db.update_or_insert_module(path, kind)),
@@ -549,8 +695,19 @@ impl DbState {
     #[cfg(feature = "module_graph")]
     pub(crate) fn remove_module(&self, path: &Utf8Path) {
         match &self.storage {
-            DbStorage::Shared(shared_db) => shared_db.fork().data().remove_module(path),
+            DbStorage::Shared(shared_db) => {
+                shared_db.fork().data().remove_module(path);
+                self.mark_module_graph_dirty();
+            }
             DbStorage::Owned(db) => db.with_setter(|db| db.remove_module(path)),
+        }
+    }
+
+    /// Records that a replacement update changed the external module map.
+    #[cfg(feature = "module_graph")]
+    fn mark_module_graph_dirty(&self) {
+        if let Some(dirty) = &self.scanner_module_graph_dirty {
+            dirty.store(true, Ordering::Release);
         }
     }
 
@@ -562,6 +719,15 @@ impl DbState {
         match &self.storage {
             DbStorage::Shared(_) => 0,
             DbStorage::Owned(db) => db.pending_setters.load(Ordering::Acquire),
+        }
+    }
+
+    /// Returns the number of setters that reached the setter gate.
+    #[cfg(test)]
+    pub(crate) fn setter_gate_attempts(&self) -> usize {
+        match &self.storage {
+            DbStorage::Shared(_) => 0,
+            DbStorage::Owned(db) => db.setter_gate_attempts.load(Ordering::Acquire),
         }
     }
 }
@@ -710,6 +876,59 @@ mod tests {
 
         drop(db);
         setter.join().unwrap();
+    }
+
+    /// A queued setter must not extend read cancellation while another setter
+    /// already owns the database. Only the setter that can make progress should
+    /// contribute to `pending_setters`.
+    #[test]
+    fn owned_storage_queues_only_one_pending_setter() {
+        let state = Arc::new(DbState::lsp());
+        let path = Utf8PathBuf::from("test.js");
+        state.update_parsed_file(&path, parse_js("let a = 1;"), 0, vec![]);
+
+        let db = state.fork();
+        let first_setter = {
+            let state = state.clone();
+            let path = path.clone();
+            thread::spawn(move || {
+                state.update_parsed_file(&path, parse_js("let b = 2;"), 0, vec![]);
+            })
+        };
+        wait_for_pending_setter(&state);
+
+        let second_start = Arc::new(Barrier::new(2));
+        let second_setter = {
+            let state = state.clone();
+            let path = path.clone();
+            let second_start = second_start.clone();
+            thread::spawn(move || {
+                let parsed = parse_js("let c = 3;");
+                second_start.wait();
+                state.update_parsed_file(&path, parsed, 0, vec![]);
+            })
+        };
+        second_start.wait();
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(1);
+        let second_was_pending = loop {
+            if state.pending_setters() > 1 {
+                break true;
+            }
+            if std::time::Instant::now() >= deadline {
+                break false;
+            }
+            thread::yield_now();
+        };
+
+        drop(db);
+        first_setter.join().unwrap();
+        second_setter.join().unwrap();
+
+        assert!(
+            !second_was_pending,
+            "a setter waiting behind another setter prolonged read cancellation"
+        );
     }
 
     /// Scanner bookkeeping must remain available while another thread is

--- a/crates/biome_service/src/scanner.rs
+++ b/crates/biome_service/src/scanner.rs
@@ -6,15 +6,19 @@
 //!
 //! ## Scanner behaviour
 //!
-//! The scanner must run as an epoch. The database setters must not
-//! interrupt an active scan with [`salsa::Cancelled::PendingWrite`].
+//! An initial project scan runs as an epoch. Database setters must not interrupt
+//! it with [`salsa::Cancelled::PendingWrite`].
 //!
-//! Before a scan starts, the workspace creates a dedicated database view with
-//! [`DbState::scanner_epoch`](crate::db::DbState::scanner_epoch). When the LSP
-//! owns the database, the scanner updates this view without invoking Salsa
+//! Before the scan starts, the workspace creates a dedicated database view
+//! with [`DbState::scanner_epoch`](crate::db::DbState::scanner_epoch). When the
+//! LSP owns the database, the scanner updates this view without invoking Salsa
 //! setters. Regular writes wait until the scan ends, while reads continue.
 //! After the scan, the temporary view is dropped, the database reports module
 //! graph changes to Salsa once, and waiting writes continue.
+//!
+//! Watcher-driven updates run outside the epoch. If a setter interrupts file
+//! indexing, the scanner retries that file instead of restarting a project
+//! scan.
 //!
 //! A file changed during traversal may leave the completed index temporarily
 //! stale. A subsequent watcher update indexes the latest file state. This is

--- a/crates/biome_service/src/scanner.rs
+++ b/crates/biome_service/src/scanner.rs
@@ -3,6 +3,26 @@
 //! In addition to scanning and indexing, the scanner also has a
 //! [`watcher`](watcher::Watcher) that can watch scanned folders to keep the
 //! index in sync with the filesystem.
+//!
+//! ## Scanner behaviour
+//!
+//! The scanner must run as an epoch. The database setters must not
+//! interrupt an active scan with [`salsa::Cancelled::PendingWrite`].
+//!
+//! Before a scan starts, the workspace creates a dedicated database view with
+//! [`DbState::scanner_epoch`](crate::db::DbState::scanner_epoch). When the LSP
+//! owns the database, the scanner updates this view without invoking Salsa
+//! setters. Regular writes wait until the scan ends, while reads continue.
+//! After the scan, the temporary view is dropped, the database reports module
+//! graph changes to Salsa once, and waiting writes continue.
+//!
+//! A file changed during traversal may leave the completed index temporarily
+//! stale. A subsequent watcher update indexes the latest file state. This is
+//! an intended limitation, because:
+//! - Dependencies rarely change during a scan phase
+//! - Files opened by the editor still fire `changeFile`, so they are indexed again.
+//!
+//! A possible desynchronization is negligible.
 
 mod watcher;
 mod workspace_bridges;

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -1878,13 +1878,15 @@ pub(crate) fn retry_on_pending_write<T>(op: impl Fn() -> T) -> T {
     }
 }
 
-/// Wraps another [Workspace] so that any call interrupted by a concurrent
-/// update to the workspace database is automatically retried.
+/// Wraps another [Workspace] so that short operations interrupted by a
+/// concurrent update to the workspace database are automatically retried.
 ///
 /// See [retry_on_pending_write] for what "interrupted" means. Callers that
 /// would rather handle the interruption themselves — for example, LSP request
 /// handlers that answer with `ContentModified` so the editor re-sends the
 /// request — should call the inner workspace directly instead.
+/// Project scans are delegated without retry because the scanner handles
+/// interruptions at individual indexing boundaries.
 pub struct RetryingWorkspace<W>(W);
 
 impl<W: Workspace> RetryingWorkspace<W> {
@@ -1904,9 +1906,12 @@ macro_rules! retrying_workspace_methods {
 }
 
 impl<W: Workspace> Workspace for RetryingWorkspace<W> {
+    fn scan_project(&self, params: ScanProjectParams) -> Result<ScanProjectResult, WorkspaceError> {
+        self.0.scan_project(params)
+    }
+
     retrying_workspace_methods! {
         fn open_project(params: OpenProjectParams) -> Result<OpenProjectResult, WorkspaceError>;
-        fn scan_project(params: ScanProjectParams) -> Result<ScanProjectResult, WorkspaceError>;
         fn update_settings(params: UpdateSettingsParams) -> Result<UpdateSettingsResult, WorkspaceError>;
         fn close_project(params: CloseProjectParams) -> Result<(), WorkspaceError>;
         fn open_file(params: OpenFileParams) -> Result<OpenFileResult, WorkspaceError>;

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -1885,8 +1885,8 @@ pub(crate) fn retry_on_pending_write<T>(op: impl Fn() -> T) -> T {
 /// would rather handle the interruption themselves — for example, LSP request
 /// handlers that answer with `ContentModified` so the editor re-sends the
 /// request — should call the inner workspace directly instead.
-/// Project scans are delegated without retry because the scanner handles
-/// interruptions at individual indexing boundaries.
+/// Project scans are delegated without retry because a scanner epoch queues
+/// setter-based writes until the traversal completes.
 pub struct RetryingWorkspace<W>(W);
 
 impl<W: Workspace> RetryingWorkspace<W> {

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -4215,19 +4215,25 @@ impl WorkspaceScannerBridge for WorkspaceServerWithDb<'_> {
         trigger: IndexTrigger,
     ) -> Result<(ModuleDependencies, Vec<Error>), WorkspaceError> {
         let path = path.into();
-        self.open_file_internal(
-            OpenFileReason::Index(trigger),
-            OpenFileParams {
-                project_key,
-                path,
-                content: FileContent::FromServer,
-                document_file_source: None,
-                persist_node_cache: false,
-                // TODO: review here, it feels wrong that we can't pass the inline config
-                inline_config: None,
-                editor_features: None,
-            },
-        )
+        let open_file = |path| {
+            self.open_file_internal(
+                OpenFileReason::Index(trigger),
+                OpenFileParams {
+                    project_key,
+                    path,
+                    content: FileContent::FromServer,
+                    document_file_source: None,
+                    persist_node_cache: false,
+                    // TODO: review here, it feels wrong that we can't pass the inline config
+                    inline_config: None,
+                    editor_features: None,
+                },
+            )
+        };
+        match trigger {
+            IndexTrigger::InitialScan => open_file(path),
+            IndexTrigger::Update => retry_on_pending_write(|| open_file(path.clone())),
+        }
         .map(|result| (result.dependencies, result.diagnostics))
     }
 

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -104,7 +104,7 @@ use std::panic::RefUnwindSafe;
 #[cfg(feature = "module_graph")]
 use std::rc::Rc;
 #[cfg(test)]
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::watch;
@@ -157,6 +157,9 @@ pub struct WorkspaceServer {
 
     #[cfg(test)]
     cancel_change_file_after_document_update: AtomicBool,
+
+    #[cfg(test)]
+    scanner_test_state: ScannerTestState,
 }
 
 /// A convenient wrapper around a [WorkspaceServer] that holds salsa database state.
@@ -177,6 +180,66 @@ struct ProcessFileState {
     parsed: ParsedOrigin,
     file_source: DocumentFileSource,
     db: WorkspaceDb,
+}
+
+/// Synchronization and cancellation controls for scanner concurrency tests.
+///
+/// The controls expose deterministic boundaries at file-index entry, project
+/// settings lookup, file commit, and project-scan entry.
+#[cfg(test)]
+#[derive(Default)]
+struct ScannerTestState {
+    /// Number of scanner-driven file indexing attempts.
+    file_index_attempts: AtomicUsize,
+    /// Number of project settings reads made by scanner-driven file indexing.
+    file_settings_read_attempts: AtomicUsize,
+    /// Whether scanner file indexing should pause after reaching settings lookup.
+    pause_file_settings_read: AtomicBool,
+    /// Number of scanner-driven file commit attempts.
+    file_commit_attempts: AtomicUsize,
+    /// Number of project scan attempts.
+    project_scan_attempts: AtomicUsize,
+    /// Whether the first project scan should be cancelled before it starts.
+    cancel_first_scan_attempt: AtomicBool,
+}
+
+#[cfg(test)]
+impl ScannerTestState {
+    /// Records entry into scanner-driven file indexing.
+    fn enter_file_indexing(&self, reason: OpenFileReason) {
+        if reason.is_index() {
+            self.file_index_attempts.fetch_add(1, Ordering::AcqRel);
+        }
+    }
+
+    /// Records a project settings read made by scanner-driven file indexing.
+    fn enter_file_settings_read(&self, reason: OpenFileReason) {
+        if reason.is_index() {
+            self.file_settings_read_attempts
+                .fetch_add(1, Ordering::AcqRel);
+            while self.pause_file_settings_read.load(Ordering::Acquire) {
+                std::thread::yield_now();
+            }
+        }
+    }
+
+    /// Records scanner-driven file commits after parsing and before publication.
+    fn enter_file_commit(&self, reason: OpenFileReason) {
+        if reason.is_index() {
+            self.file_commit_attempts.fetch_add(1, Ordering::AcqRel);
+        }
+    }
+
+    /// Records entry into a project scan and optionally cancels its first attempt.
+    ///
+    /// The cancellation lets tests verify that [`RetryingWorkspace`] propagates
+    /// an interrupted project scan instead of restarting the complete traversal.
+    fn enter_project_scan(&self) {
+        self.project_scan_attempts.fetch_add(1, Ordering::AcqRel);
+        if self.cancel_first_scan_attempt.swap(false, Ordering::AcqRel) {
+            std::panic::resume_unwind(Box::new(salsa::Cancelled::PendingWrite));
+        }
+    }
 }
 
 impl ProcessFileState {
@@ -374,6 +437,8 @@ impl WorkspaceServer {
             notification_tx,
             #[cfg(test)]
             cancel_change_file_after_document_update: AtomicBool::new(false),
+            #[cfg(test)]
+            scanner_test_state: ScannerTestState::default(),
         }
     }
 
@@ -694,6 +759,9 @@ impl WorkspaceServerWithDb<'_> {
         reason: OpenFileReason,
         params: OpenFileParams,
     ) -> Result<InternalOpenFileResult, WorkspaceError> {
+        #[cfg(test)]
+        self.scanner_test_state.enter_file_indexing(reason);
+
         let OpenFileParams {
             project_key,
             path: biome_path,
@@ -718,6 +786,8 @@ impl WorkspaceServerWithDb<'_> {
         }
 
         let (_, settings, query) = {
+            #[cfg(test)]
+            self.scanner_test_state.enter_file_settings_read(reason);
             let db = self.get_db();
             self.project_get_settings_query(&db, project_key, &path, inline_config)
         }
@@ -812,20 +882,13 @@ impl WorkspaceServerWithDb<'_> {
         let size = content.len();
         let limit = settings.as_ref().get_max_file_size(&path);
 
-        let mut parsed_source = None;
-        let syntax = if size > limit {
-            Some(Err(FileTooLarge { size, limit }))
+        let parsed = if size > limit {
+            Err(FileTooLarge { size, limit })
         } else if document_file_source.is_none() && !DocumentFileSource::can_parse(path.as_path()) {
-            None
+            Ok(None)
         } else {
             let mut node_cache = NodeCache::default();
-            let parse_result = self.parse(
-                &path,
-                &content,
-                &settings,
-                file_source_index,
-                &mut node_cache,
-            )?;
+            let parse_result = self.parse(&path, &content, &settings, source, &mut node_cache)?;
 
             let ParseResult {
                 any_parse,
@@ -864,10 +927,26 @@ impl WorkspaceServerWithDb<'_> {
                 .map(|(parse, content, source)| (parse, content, self.db_add_source(source)))
                 .collect();
 
-            let final_source =
-                self.db_update_parsed_file(&path, any_parse, file_source_index, embedded_snippets);
-            parsed_source = Some(final_source);
-            Some(Ok(()))
+            Ok(Some((any_parse, file_source_index, embedded_snippets)))
+        };
+
+        #[cfg(test)]
+        self.scanner_test_state.enter_file_commit(reason);
+
+        let mut parsed_source = None;
+        let syntax = match parsed {
+            Err(error) => Some(Err(error)),
+            Ok(None) => None,
+            Ok(Some((any_parse, file_source_index, embedded_snippets))) => {
+                let final_source = self.db_update_parsed_file(
+                    &path,
+                    any_parse,
+                    file_source_index,
+                    embedded_snippets,
+                );
+                parsed_source = Some(final_source);
+                Some(Ok(()))
+            }
         };
 
         let is_indexed = if
@@ -1106,10 +1185,7 @@ impl WorkspaceServerWithDb<'_> {
         node_cache: &mut NodeCache,
         settings: &SettingsWithEditor,
     ) -> Result<Vec<(AnyParse, EmbedContent, DocumentFileSource)>, WorkspaceError> {
-        let capabilities = self.get_file_capabilities(
-            path,
-            settings.as_ref().experimental_full_html_support_enabled(),
-        );
+        let capabilities = self.features.get_deprecated_capabilities(*file_source);
         let Some(parse_embedded_nodes) = capabilities.parser.parse_embedded_nodes else {
             return Ok(Default::default());
         };
@@ -1129,12 +1205,9 @@ impl WorkspaceServerWithDb<'_> {
         path: &Utf8Path,
         content: &str,
         settings: &SettingsWithEditor,
-        file_source_index: usize,
+        file_source: DocumentFileSource,
         node_cache: &mut NodeCache,
     ) -> Result<ParseResult, WorkspaceError> {
-        let file_source = self
-            .db_get_source(file_source_index)
-            .ok_or_else(|| WorkspaceError::not_found(path.to_string()))?;
         let capabilities = self.features.get_deprecated_capabilities(file_source);
 
         let parse = capabilities
@@ -1951,7 +2024,6 @@ impl WorkspaceServerWithDb<'_> {
         project_key: ProjectKey,
     ) -> Result<(), WorkspaceError> {
         let filename = path.file_name();
-        let db = self.get_db();
         if filename.is_some_and(|filename| filename == "package.json") {
             let package_path = path
                 .parent()
@@ -1960,7 +2032,10 @@ impl WorkspaceServerWithDb<'_> {
 
             match update_kind {
                 UpdateKind::AddedOrChanged(_, root) => {
-                    let send_node = root.unwrap_as_send_node(&*db);
+                    let send_node = {
+                        let db = self.get_db();
+                        root.unwrap_as_send_node(&*db)
+                    };
                     self.project_layout
                         .insert_serialized_node_manifest(package_path.clone(), &send_node);
                     self.apply_pnpm_workspace_catalog_to_package(project_key, &package_path);
@@ -1977,7 +2052,10 @@ impl WorkspaceServerWithDb<'_> {
 
             match update_kind {
                 UpdateKind::AddedOrChanged(_, root) => {
-                    let send_node = root.unwrap_as_send_node(&*db);
+                    let send_node = {
+                        let db = self.get_db();
+                        root.unwrap_as_send_node(&*db)
+                    };
                     self.project_layout
                         .insert_serialized_tsconfig(package_path, &send_node);
                 }
@@ -1996,7 +2074,10 @@ impl WorkspaceServerWithDb<'_> {
 
             match update_kind {
                 UpdateKind::AddedOrChanged(_, root) => {
-                    let send_node = root.unwrap_as_send_node(&*db);
+                    let send_node = {
+                        let db = self.get_db();
+                        root.unwrap_as_send_node(&*db)
+                    };
                     self.project_layout.insert_serialized_turbo_json(
                         package_path,
                         &send_node,
@@ -2194,14 +2275,6 @@ impl WorkspaceServerWithDb<'_> {
     // - `db_update` for operations that update existing inputs
     // - `db_remove` for operations that remove existing inputs
     // - `db_get` for operations that read data
-
-    /// Returns a previously inserted file source by index.
-    ///
-    /// File sources can be inserted using `insert_source()`.
-    fn db_get_source(&self, index: usize) -> Option<DocumentFileSource> {
-        let db = self.get_db();
-        db.source_from_index(index)
-    }
 
     /// Inserts a file source so that it can be retrieved by index later.
     ///
@@ -2531,21 +2604,9 @@ impl Workspace for LocalWorkspace {
     }
 }
 
-impl Workspace for WorkspaceServerWithDb<'_> {
-    fn open_project(&self, params: OpenProjectParams) -> Result<OpenProjectResult, WorkspaceError> {
-        let path = if params.open_uninitialized {
-            let path = params.path.to_path_buf();
-            self.find_project_root(params.path).unwrap_or(path)
-        } else {
-            self.find_project_root(params.path)?
-        };
-
-        let project_key = self.insert_project(path);
-
-        Ok(OpenProjectResult { project_key })
-    }
-
-    fn scan_project(
+impl WorkspaceServerWithDb<'_> {
+    /// Performs a project traversal using the database view selected by the caller.
+    fn scan_project_inner(
         &self,
         ScanProjectParams {
             project_key,
@@ -2564,12 +2625,12 @@ impl Workspace for WorkspaceServerWithDb<'_> {
             let manifest = path.join("package.json");
             if self.fs.path_exists(&manifest) {
                 let trigger = IndexTrigger::InitialScan;
-                let (_, _diagnostics) = self.index_file(project_key, manifest.clone(), trigger)?;
+                let (_, manifest_diagnostics) =
+                    self.index_file(project_key, manifest.clone(), trigger)?;
                 diagnostics.extend(
-                    _diagnostics
+                    manifest_diagnostics
                         .into_iter()
-                        .map(biome_diagnostics::serde::Diagnostic::new)
-                        .collect::<Vec<_>>(),
+                        .map(biome_diagnostics::serde::Diagnostic::new),
                 );
             }
             return Ok(ScanProjectResult {
@@ -2593,6 +2654,37 @@ impl Workspace for WorkspaceServerWithDb<'_> {
         result.diagnostics.extend(diagnostics);
 
         Ok(result)
+    }
+}
+
+impl Workspace for WorkspaceServerWithDb<'_> {
+    fn open_project(&self, params: OpenProjectParams) -> Result<OpenProjectResult, WorkspaceError> {
+        let path = if params.open_uninitialized {
+            let path = params.path.to_path_buf();
+            self.find_project_root(params.path).unwrap_or(path)
+        } else {
+            self.find_project_root(params.path)?
+        };
+
+        let project_key = self.insert_project(path);
+
+        Ok(OpenProjectResult { project_key })
+    }
+
+    fn scan_project(&self, params: ScanProjectParams) -> Result<ScanProjectResult, WorkspaceError> {
+        #[cfg(test)]
+        self.scanner_test_state.enter_project_scan();
+
+        let epoch = self.db_state.scanner_epoch();
+        let result = {
+            let scanner_workspace = WorkspaceServerWithDb {
+                server: self.server,
+                db_state: epoch.view(),
+            };
+            scanner_workspace.scan_project_inner(params)
+        };
+        drop(epoch);
+        result
     }
 
     /// Updates the global settings for this workspace.
@@ -3086,7 +3178,7 @@ impl Workspace for WorkspaceServerWithDb<'_> {
         let ParseResult {
             any_parse,
             language,
-        } = self.parse(&path, &content, &settings, index, &mut node_cache)?;
+        } = self.parse(&path, &content, &settings, document_source, &mut node_cache)?;
 
         let (index, document_source) = if let Some(language) = language {
             (self.db_add_source(language), language)
@@ -4123,25 +4215,19 @@ impl WorkspaceScannerBridge for WorkspaceServerWithDb<'_> {
         trigger: IndexTrigger,
     ) -> Result<(ModuleDependencies, Vec<Error>), WorkspaceError> {
         let path = path.into();
-        // Indexing this file can be interrupted when another thread updates
-        // the workspace database at the same time (this only happens in the
-        // LSP, see `DbState`). Retry until the file is fully indexed, so its
-        // data is not missing from the module graph.
-        retry_on_pending_write(|| {
-            self.open_file_internal(
-                OpenFileReason::Index(trigger),
-                OpenFileParams {
-                    project_key,
-                    path: path.clone(),
-                    content: FileContent::FromServer,
-                    document_file_source: None,
-                    persist_node_cache: false,
-                    // TODO: review here, it feels wrong that we can't pass the inline config
-                    inline_config: None,
-                    editor_features: None,
-                },
-            )
-        })
+        self.open_file_internal(
+            OpenFileReason::Index(trigger),
+            OpenFileParams {
+                project_key,
+                path,
+                content: FileContent::FromServer,
+                document_file_source: None,
+                persist_node_cache: false,
+                // TODO: review here, it feels wrong that we can't pass the inline config
+                inline_config: None,
+                editor_features: None,
+            },
+        )
         .map(|result| (result.dependencies, result.diagnostics))
     }
 
@@ -4217,8 +4303,7 @@ impl WorkspaceScannerBridge for WorkspaceServerWithDb<'_> {
             };
 
             let scan_kind = ProjectScanComputer::new(&nested_configuration).compute();
-
-            let result = self.update_settings(UpdateSettingsParams {
+            let params = UpdateSettingsParams {
                 project_key,
                 workspace_directory: nested_directory_path.map(BiomePath::from),
                 configuration: nested_configuration,
@@ -4227,7 +4312,8 @@ impl WorkspaceScannerBridge for WorkspaceServerWithDb<'_> {
                     .map(|(path, config)| (BiomePath::from(path), config))
                     .collect(),
                 module_graph_resolution_kind: ModuleGraphResolutionKind::from(&scan_kind),
-            })?;
+            };
+            let result = self.update_settings(params)?;
 
             returned_diagnostics.extend(result.diagnostics)
         }
@@ -4313,7 +4399,13 @@ impl WorkspaceScannerBridge for WorkspaceServerWithDb<'_> {
         self.project_layout.unload_folder(path);
 
         // Finally unloads the path itself.
-        self.unload_file(path, project_key)
+        self.update_service_data(path, UpdateKind::Removed, project_key)
+            .map(|(_, diagnostics)| {
+                diagnostics
+                    .into_iter()
+                    .map(biome_diagnostics::serde::Diagnostic::new)
+                    .collect()
+            })
     }
 }
 

--- a/crates/biome_service/src/workspace/server.tests.rs
+++ b/crates/biome_service/src/workspace/server.tests.rs
@@ -1036,6 +1036,119 @@ fn scanner_epoch_queues_setters_without_cancelling_scan() {
 }
 
 #[test]
+fn incremental_index_retries_pending_write() {
+    const PATH: &str = "/project/package.json";
+    const TIMEOUT: Duration = Duration::from_secs(5);
+
+    let fs = MemoryFileSystem::default();
+    fs.insert(Utf8PathBuf::from(PATH), b"{}");
+    let (watcher_tx, _) = crossbeam::channel::unbounded();
+    let (service_tx, _) = tokio::sync::watch::channel(ServiceNotification::IndexUpdated);
+    let mut workspace = LocalWorkspace::new(
+        Arc::new(fs),
+        watcher_tx,
+        service_tx,
+        Arc::new(NoopQueryProvider {}),
+        None,
+    );
+    workspace.db_state = DbState::lsp();
+    let OpenProjectResult { project_key } = workspace
+        .open_project(OpenProjectParams {
+            path: BiomePath::new("/project"),
+            open_uninitialized: true,
+        })
+        .unwrap();
+    workspace
+        .update_settings(UpdateSettingsParams {
+            project_key,
+            workspace_directory: Some(BiomePath::new("/project")),
+            configuration: Configuration::default(),
+            extended_configurations: vec![],
+            module_graph_resolution_kind: ModuleGraphResolutionKind::None,
+        })
+        .unwrap();
+
+    let retained_db = workspace.get_db();
+    let test_state = &workspace.server.scanner_test_state;
+    test_state
+        .pause_file_settings_read
+        .store(true, Ordering::Release);
+    let initial_index_attempts = test_state.file_index_attempts.load(Ordering::Acquire);
+    let initial_settings_read_attempts = test_state
+        .file_settings_read_attempts
+        .load(Ordering::Acquire);
+
+    let (setter_pending, first_attempt_paused, retry_observed, update_result, index_result) =
+        std::thread::scope(|scope| {
+            let update_workspace = &workspace;
+            let update = scope.spawn(move || {
+                update_workspace
+                    .as_workspace()
+                    .update_settings(UpdateSettingsParams {
+                        project_key,
+                        workspace_directory: Some(BiomePath::new("/project")),
+                        configuration: Configuration::default(),
+                        extended_configurations: vec![],
+                        module_graph_resolution_kind: ModuleGraphResolutionKind::None,
+                    })
+            });
+            let setter_pending = wait_until(TIMEOUT, || workspace.db_state.pending_setters() == 1);
+
+            let index = setter_pending.then(|| {
+                let index_workspace = workspace.as_workspace();
+                scope.spawn(move || {
+                    WorkspaceScannerBridge::index_file(
+                        &index_workspace,
+                        project_key,
+                        BiomePath::new(PATH),
+                        IndexTrigger::Update,
+                    )
+                })
+            });
+            let first_attempt_paused = index.as_ref().is_some_and(|_| {
+                wait_until(TIMEOUT, || {
+                    test_state
+                        .file_settings_read_attempts
+                        .load(Ordering::Acquire)
+                        > initial_settings_read_attempts
+                })
+            });
+            test_state
+                .pause_file_settings_read
+                .store(false, Ordering::Release);
+            let retry_observed = first_attempt_paused
+                && wait_until(TIMEOUT, || {
+                    test_state.file_index_attempts.load(Ordering::Acquire)
+                        >= initial_index_attempts + 2
+                });
+
+            drop(retained_db);
+            let update_result = update.join();
+            let index_result = index.map(|index| index.join());
+
+            (
+                setter_pending,
+                first_attempt_paused,
+                retry_observed,
+                update_result,
+                index_result,
+            )
+        });
+
+    assert!(setter_pending, "the settings update did not become pending");
+    assert!(first_attempt_paused, "incremental indexing did not start");
+    assert!(retry_observed, "incremental indexing was not retried");
+    assert!(matches!(update_result, Ok(Ok(_))));
+    assert!(matches!(index_result, Some(Ok(Ok(_)))));
+    assert!(
+        workspace
+            .get_db()
+            .get_parsed_source(Utf8Path::new(PATH))
+            .is_some()
+    );
+}
+
+#[test]
 fn retrying_workspace_does_not_retry_project_scan() {
     let fs = MemoryFileSystem::default();
     let (watcher_tx, _) = crossbeam::channel::unbounded();

--- a/crates/biome_service/src/workspace/server.tests.rs
+++ b/crates/biome_service/src/workspace/server.tests.rs
@@ -17,8 +17,21 @@ use biome_json_formatter::context::TrailingCommas;
 use biome_languages::css::CssEmbeddingKind;
 use biome_rowan::{TextRange, TextSize};
 use camino::Utf8Path;
+use salsa::plumbing::AsId;
 use std::panic::AssertUnwindSafe;
 use std::str::FromStr;
+use std::time::{Duration, Instant};
+
+fn wait_until(timeout: Duration, mut predicate: impl FnMut() -> bool) -> bool {
+    let deadline = Instant::now() + timeout;
+    while !predicate() {
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::yield_now();
+    }
+    true
+}
 
 #[cfg(feature = "plugins")]
 #[test]
@@ -838,6 +851,237 @@ fn change_file_resumes_module_update_after_cancellation() {
         })
         .unwrap();
     assert_eq!(diagnostics.diagnostics.len(), 1);
+}
+
+#[test]
+fn owned_scan_uses_replacement_updates() {
+    const PATH: &str = "/project/index.js";
+
+    let fs = MemoryFileSystem::default();
+    fs.insert(Utf8PathBuf::from(PATH), b"export const value = 1;");
+    let (watcher_tx, _) = crossbeam::channel::unbounded();
+    let (service_tx, _) = tokio::sync::watch::channel(ServiceNotification::IndexUpdated);
+    let mut workspace = LocalWorkspace::new(
+        Arc::new(fs),
+        watcher_tx,
+        service_tx,
+        Arc::new(NoopQueryProvider {}),
+        None,
+    );
+    workspace.db_state = DbState::lsp();
+    let OpenProjectResult { project_key } = workspace
+        .open_project(OpenProjectParams {
+            path: BiomePath::new("/project"),
+            open_uninitialized: true,
+        })
+        .unwrap();
+    workspace
+        .update_settings(UpdateSettingsParams {
+            project_key,
+            workspace_directory: Some(BiomePath::new("/project")),
+            configuration: Configuration::default(),
+            extended_configurations: vec![],
+            module_graph_resolution_kind: ModuleGraphResolutionKind::Modules,
+        })
+        .unwrap();
+
+    let scan = || {
+        workspace
+            .scan_project(ScanProjectParams {
+                project_key,
+                watch: false,
+                force: true,
+                scan_kind: ScanKind::Project,
+                verbose: false,
+            })
+            .unwrap();
+    };
+
+    scan();
+    let first = workspace
+        .get_db()
+        .get_parsed_source(Utf8Path::new(PATH))
+        .unwrap();
+    scan();
+    let second = workspace
+        .get_db()
+        .get_parsed_source(Utf8Path::new(PATH))
+        .unwrap();
+
+    assert_ne!(first.as_id(), second.as_id());
+}
+
+#[test]
+fn scanner_epoch_queues_setters_without_cancelling_scan() {
+    const PATH: &str = "/project/package.json";
+    const TIMEOUT: Duration = Duration::from_secs(5);
+
+    let fs = MemoryFileSystem::default();
+    fs.insert(Utf8PathBuf::from(PATH), b"{}");
+    let (watcher_tx, _) = crossbeam::channel::unbounded();
+    let (service_tx, _) = tokio::sync::watch::channel(ServiceNotification::IndexUpdated);
+    let mut workspace = LocalWorkspace::new(
+        Arc::new(fs),
+        watcher_tx,
+        service_tx,
+        Arc::new(NoopQueryProvider {}),
+        None,
+    );
+    workspace.db_state = DbState::lsp();
+    let OpenProjectResult { project_key } = workspace
+        .open_project(OpenProjectParams {
+            path: BiomePath::new("/project"),
+            open_uninitialized: true,
+        })
+        .unwrap();
+    workspace
+        .update_settings(UpdateSettingsParams {
+            project_key,
+            workspace_directory: Some(BiomePath::new("/project")),
+            configuration: Configuration::default(),
+            extended_configurations: vec![],
+            module_graph_resolution_kind: ModuleGraphResolutionKind::None,
+        })
+        .unwrap();
+
+    let test_state = &workspace.server.scanner_test_state;
+    test_state
+        .pause_file_settings_read
+        .store(true, Ordering::Release);
+    let initial_setter_attempts = workspace.db_state.setter_gate_attempts();
+
+    let (scan_paused, setter_queued, pending_setters, scan_result, update_result) =
+        std::thread::scope(|scope| {
+            let scan_workspace = &workspace;
+            let scan = scope.spawn(move || {
+                scan_workspace
+                    .as_workspace()
+                    .scan_project(ScanProjectParams {
+                        project_key,
+                        watch: false,
+                        force: true,
+                        scan_kind: ScanKind::Project,
+                        verbose: false,
+                    })
+            });
+            let scan_paused = wait_until(TIMEOUT, || {
+                test_state
+                    .file_settings_read_attempts
+                    .load(Ordering::Acquire)
+                    >= 1
+            });
+
+            let update = scan_paused.then(|| {
+                let update_workspace = &workspace;
+                scope.spawn(move || {
+                    update_workspace
+                        .as_workspace()
+                        .update_settings(UpdateSettingsParams {
+                            project_key,
+                            workspace_directory: Some(BiomePath::new("/project")),
+                            configuration: Configuration::default(),
+                            extended_configurations: vec![],
+                            module_graph_resolution_kind: ModuleGraphResolutionKind::None,
+                        })
+                })
+            });
+            let setter_queued = update.as_ref().is_some_and(|_| {
+                wait_until(TIMEOUT, || {
+                    workspace.db_state.setter_gate_attempts() > initial_setter_attempts
+                })
+            });
+            let pending_setters = workspace.db_state.pending_setters();
+
+            test_state
+                .pause_file_settings_read
+                .store(false, Ordering::Release);
+            let scan_result = scan.join().unwrap();
+            let update_result = update.map(|update| update.join().unwrap());
+
+            (
+                scan_paused,
+                setter_queued,
+                pending_setters,
+                scan_result,
+                update_result,
+            )
+        });
+
+    assert!(scan_paused, "the scanner did not reach the settings read");
+    assert!(
+        setter_queued,
+        "the settings update did not reach the setter gate"
+    );
+    assert_eq!(
+        pending_setters, 0,
+        "a setter queued behind the scanner epoch must not cancel reads"
+    );
+    assert!(scan_result.is_ok());
+    assert!(update_result.is_some_and(|result| result.is_ok()));
+    assert_eq!(
+        test_state.project_scan_attempts.load(Ordering::Acquire),
+        1,
+        "the project scan should not restart"
+    );
+    assert_eq!(
+        test_state.file_index_attempts.load(Ordering::Acquire),
+        1,
+        "the file indexing operation should not restart"
+    );
+    assert_eq!(
+        test_state.file_commit_attempts.load(Ordering::Acquire),
+        1,
+        "the parsed file should be committed once"
+    );
+}
+
+#[test]
+fn retrying_workspace_does_not_retry_project_scan() {
+    let fs = MemoryFileSystem::default();
+    let (watcher_tx, _) = crossbeam::channel::unbounded();
+    let (service_tx, _) = tokio::sync::watch::channel(ServiceNotification::IndexUpdated);
+    let mut workspace = LocalWorkspace::new(
+        Arc::new(fs),
+        watcher_tx,
+        service_tx,
+        Arc::new(NoopQueryProvider {}),
+        None,
+    );
+    workspace.db_state = DbState::lsp();
+    let OpenProjectResult { project_key } = workspace
+        .open_project(OpenProjectParams {
+            path: BiomePath::new("/project"),
+            open_uninitialized: true,
+        })
+        .unwrap();
+    workspace
+        .server
+        .scanner_test_state
+        .cancel_first_scan_attempt
+        .store(true, Ordering::Release);
+
+    let result = salsa::Cancelled::catch(AssertUnwindSafe(|| {
+        crate::workspace::RetryingWorkspace::new(workspace.as_workspace()).scan_project(
+            ScanProjectParams {
+                project_key,
+                watch: false,
+                force: true,
+                scan_kind: ScanKind::Project,
+                verbose: false,
+            },
+        )
+    }));
+
+    assert!(matches!(result, Err(salsa::Cancelled::PendingWrite)));
+    assert_eq!(
+        workspace
+            .server
+            .scanner_test_state
+            .project_scan_attempts
+            .load(Ordering::Acquire),
+        1,
+        "a project scan must not be retried from the beginning"
+    );
 }
 
 #[test]


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

> [!NOTE] 
> Designed by me and implemented via an agent. Used a TDD approach.

Closes https://github.com/biomejs/biome/issues/11520

The `scan_project` function was the cause, and it ran under the `retry_on_pending_write` closure. This function tells salsa to retry if something else (a thread) changed a file in the database. This would cause indexing the same file over and over again.

I fixed this by making the scanning phase "pending-write-free", meaning that new setters **can't** block the scanner until it's finished. This is an intended constraint and a possible limitation, which I think we can be OK with. The scanner is usually very fast, so it's fine to have files desynchronised for a moment. 

The solution has been implemented with the use of an epoch, which represents a read-only view of the database, and a small lock for pending setters.  

Full disclosure, the epoch solution has been in my mind for a while now; I just didn't see an evident case for using it. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added new tests that triggered the issue. I tested locally, and now files are indexed once.

<!-- What demonstrates that your implementation is correct? -->

## Docs

N/A

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
