### PR TITLE
fix(css): report duplicate generic font families

### DIFF
--- a/.changeset/shaggy-moose-enjoy.md
+++ b/.changeset/shaggy-moose-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed the [`noDuplicateFontNames`](https://biomejs.dev/linter/rules/no-duplicate-font-names/) rule so it reports repeated generic family names in `font` shorthand values such as `font: 1em sans-serif, sans-serif`, while keeping quoted family names distinct from generic keywords.

--- a/crates/biome_css_analyze/src/fonts.rs
+++ b/crates/biome_css_analyze/src/fonts.rs
@@ -22,9 +22,9 @@ use biome_string_case::StrLikeExtension;
 use std::hash::Hash;
 
 /// Particular type that holds the value of a particular font.
-/// This type implements a particular algorithm of [PartialEq] and [Hash], where the
-/// values checked are the **trimmed text of their value**, which means that
-/// nodes (raw values and ranges) aren't taken into consideration.
+/// [PartialEq] and [Hash] compare trimmed font names without considering raw nodes or ranges.
+/// Generic family keyword identifiers are case-insensitive and remain distinct from quoted
+/// strings with the same text.
 #[derive(Debug, Clone, Eq)]
 pub enum CssFontValue {
     /// Groups those font names that are represented by a multiple [CssIdentifier].
@@ -54,7 +54,14 @@ impl Hash for CssFontValue {
         match self {
             Self::SingleValue(node) => {
                 if let Some(text) = node.inner_string_text() {
-                    text.text().trim().hash(state);
+                    let is_keyword_identifier = node.is_font_family_keyword_identifier();
+                    is_keyword_identifier.hash(state);
+                    let text = text.text().trim();
+                    if is_keyword_identifier {
+                        text.to_ascii_lowercase_cow().hash(state);
+                    } else {
+                        text.hash(state);
+                    }
                 } else {
                     state.write_u8(0);
                 }
@@ -62,7 +69,14 @@ impl Hash for CssFontValue {
             Self::MultipleValue(nodes) => {
                 for node in nodes {
                     if let Some(text) = node.inner_string_text() {
-                        text.text().trim().hash(state);
+                        let is_keyword_identifier = node.is_font_family_keyword_identifier();
+                        is_keyword_identifier.hash(state);
+                        let text = text.text().trim();
+                        if is_keyword_identifier {
+                            text.to_ascii_lowercase_cow().hash(state);
+                        } else {
+                            text.hash(state);
+                        }
                     } else {
                         state.write_u8(0);
                     }
@@ -75,29 +89,13 @@ impl Hash for CssFontValue {
 impl PartialEq for CssFontValue {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (Self::SingleValue(this), Self::SingleValue(other)) => {
-                if let (Some(this), Some(other)) =
-                    (this.inner_string_text(), other.inner_string_text())
-                {
-                    this.text().trim() == other.text().trim()
-                } else {
-                    false
-                }
-            }
+            (Self::SingleValue(this), Self::SingleValue(other)) => this.has_same_name(other),
             (Self::MultipleValue(this_values), Self::MultipleValue(other_values)) => {
                 this_values.len() == other_values.len()
                     && this_values
                         .iter()
                         .zip(other_values.iter())
-                        .all(|(this, other)| {
-                            if let (Some(this), Some(other)) =
-                                (this.inner_string_text(), other.inner_string_text())
-                            {
-                                this.text().trim() == other.text().trim()
-                            } else {
-                                false
-                            }
-                        })
+                        .all(|(this, other)| this.has_same_name(other))
             }
             _ => false,
         }
@@ -105,16 +103,6 @@ impl PartialEq for CssFontValue {
 }
 
 impl CssFontValue {
-    pub fn is_identifier(&self) -> bool {
-        match self {
-            Self::MultipleValue(nodes) => nodes
-                .iter()
-                .all(|node| matches!(node, AnyCssFontValue::CssIdentifier(_))),
-            Self::SingleValue(AnyCssFontValue::CssIdentifier(_)) => true,
-            Self::SingleValue(AnyCssFontValue::CssString(_)) => false,
-        }
-    }
-
     pub fn range(&self) -> TextRange {
         match &self {
             // SAFETY: we assume the caller provides a non-empty list
@@ -158,6 +146,35 @@ declare_node_union! {
 }
 
 impl AnyCssFontValue {
+    fn has_same_name(&self, other: &Self) -> bool {
+        let is_keyword_identifier = self.is_font_family_keyword_identifier();
+        if is_keyword_identifier != other.is_font_family_keyword_identifier() {
+            return false;
+        }
+        self.inner_string_text()
+            .zip(other.inner_string_text())
+            .is_some_and(|(this, other)| {
+                let this = this.text().trim();
+                let other = other.text().trim();
+                if is_keyword_identifier {
+                    this.eq_ignore_ascii_case(other)
+                } else {
+                    this == other
+                }
+            })
+    }
+
+    fn is_font_family_keyword_identifier(&self) -> bool {
+        let Self::CssIdentifier(node) = self else {
+            return false;
+        };
+        let Ok(token) = node.value_token() else {
+            return false;
+        };
+        let text = token.text_trimmed().to_ascii_lowercase_cow();
+        is_font_family_keyword(&text)
+    }
+
     /// Returns the value without quotes
     fn inner_string_text(&self) -> Option<TokenText> {
         match self {

--- a/crates/biome_css_analyze/src/lint/suspicious/no_duplicate_font_names.rs
+++ b/crates/biome_css_analyze/src/lint/suspicious/no_duplicate_font_names.rs
@@ -1,6 +1,6 @@
 #![expect(clippy::disallowed_methods, reason = "This rule compares CSS values that can span multiple tokens.")]
 
-use crate::fonts::{CssFontValue, find_font_family, is_font_family_keyword};
+use crate::fonts::{CssFontValue, find_font_family};
 use biome_analyze::{
     Ast, Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule,
 };
@@ -84,15 +84,6 @@ impl Rule for NoDuplicateFontNames {
         let font_families = find_font_family(value_list);
 
         for css_value in font_families {
-            let value = css_value.to_string()?;
-
-            // check the case: "Arial", Arial
-            // we ignore the case of the font name is a keyword(context: https://github.com/stylelint/stylelint/issues/1284)
-            // e.g "sans-serif", sans-serif
-            if css_value.is_identifier() && is_font_family_keyword(&value) && is_font {
-                continue;
-            }
-
             if let Some(duplicate) = family_names.get(&css_value) {
                 return Some((css_value.clone(), duplicate.clone()));
             } else {

--- a/crates/biome_css_analyze/tests/specs/suspicious/noDuplicateFontNames/invalid.css
+++ b/crates/biome_css_analyze/tests/specs/suspicious/noDuplicateFontNames/invalid.css
@@ -4,3 +4,4 @@ a { fOnT-fAmIlY: "Lucida Grande", '  Lucida Grande ', sans-serif; }
 a { font-family: 'Times', Times }
 a { FONT: italic 300 16px/30px Arial, " Arial", serif; }
 b { font: normal 14px/32px -apple-system, BlinkMacSystemFont, sans-serif, sans-serif; }
+b { font: 1em serif, SERIF; }

--- a/crates/biome_css_analyze/tests/specs/suspicious/noDuplicateFontNames/invalid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/suspicious/noDuplicateFontNames/invalid.css.snap
@@ -10,6 +10,7 @@ a { fOnT-fAmIlY: "Lucida Grande", '  Lucida Grande ', sans-serif; }
 a { font-family: 'Times', Times }
 a { FONT: italic 300 16px/30px Arial, " Arial", serif; }
 b { font: normal 14px/32px -apple-system, BlinkMacSystemFont, sans-serif, sans-serif; }
+b { font: 1em serif, SERIF; }
 
 ```
 
@@ -122,7 +123,7 @@ invalid.css:5:39 lint/suspicious/noDuplicateFontNames ━━━━━━━━�
   > 5 │ a { FONT: italic 300 16px/30px Arial, " Arial", serif; }
       │                                       ^^^^^^^^
     6 │ b { font: normal 14px/32px -apple-system, BlinkMacSystemFont, sans-serif, sans-serif; }
-    7 │ 
+    7 │ b { font: 1em serif, SERIF; }
   
   i This is where the duplicate font name is found:
   
@@ -131,7 +132,57 @@ invalid.css:5:39 lint/suspicious/noDuplicateFontNames ━━━━━━━━�
   > 5 │ a { FONT: italic 300 16px/30px Arial, " Arial", serif; }
       │                                ^^^^^
     6 │ b { font: normal 14px/32px -apple-system, BlinkMacSystemFont, sans-serif, sans-serif; }
-    7 │ 
+    7 │ b { font: 1em serif, SERIF; }
+  
+  i Remove duplicate font names within the property.
+  
+
+```
+
+```
+invalid.css:6:75 lint/suspicious/noDuplicateFontNames ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Duplicate font names are redundant and unnecessary: sans-serif
+  
+    4 │ a { font-family: 'Times', Times }
+    5 │ a { FONT: italic 300 16px/30px Arial, " Arial", serif; }
+  > 6 │ b { font: normal 14px/32px -apple-system, BlinkMacSystemFont, sans-serif, sans-serif; }
+      │                                                                           ^^^^^^^^^^
+    7 │ b { font: 1em serif, SERIF; }
+    8 │ 
+  
+  i This is where the duplicate font name is found:
+  
+    4 │ a { font-family: 'Times', Times }
+    5 │ a { FONT: italic 300 16px/30px Arial, " Arial", serif; }
+  > 6 │ b { font: normal 14px/32px -apple-system, BlinkMacSystemFont, sans-serif, sans-serif; }
+      │                                                               ^^^^^^^^^^
+    7 │ b { font: 1em serif, SERIF; }
+    8 │ 
+  
+  i Remove duplicate font names within the property.
+  
+
+```
+
+```
+invalid.css:7:22 lint/suspicious/noDuplicateFontNames ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Duplicate font names are redundant and unnecessary: SERIF
+  
+    5 │ a { FONT: italic 300 16px/30px Arial, " Arial", serif; }
+    6 │ b { font: normal 14px/32px -apple-system, BlinkMacSystemFont, sans-serif, sans-serif; }
+  > 7 │ b { font: 1em serif, SERIF; }
+      │                      ^^^^^
+    8 │ 
+  
+  i This is where the duplicate font name is found:
+  
+    5 │ a { FONT: italic 300 16px/30px Arial, " Arial", serif; }
+    6 │ b { font: normal 14px/32px -apple-system, BlinkMacSystemFont, sans-serif, sans-serif; }
+  > 7 │ b { font: 1em serif, SERIF; }
+      │               ^^^^^
+    8 │ 
   
   i Remove duplicate font names within the property.
   

--- a/crates/biome_css_analyze/tests/specs/suspicious/noDuplicateFontNames/valid.css
+++ b/crates/biome_css_analyze/tests/specs/suspicious/noDuplicateFontNames/valid.css
@@ -2,6 +2,7 @@
 a { font-family: "Lucida Grande", "Arial", sans-serif; }
 a { font: 1em "Lucida Grande", 'Arial', sans-serif; }
 a { font: 1em "Lucida Grande", 'Arial', "sans-serif", sans-serif; }
+a { font-family: "sans-serif", sans-serif; }
 a { font-family: Times, serif; }
 b { font: normal 14px/32px -apple-system, BlinkMacSystemFont, sans-serif; }
 c { font-family: SF Mono, Liberation Mono, sans-serif; }

--- a/crates/biome_css_analyze/tests/specs/suspicious/noDuplicateFontNames/valid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/suspicious/noDuplicateFontNames/valid.css.snap
@@ -8,6 +8,7 @@ expression: valid.css
 a { font-family: "Lucida Grande", "Arial", sans-serif; }
 a { font: 1em "Lucida Grande", 'Arial', sans-serif; }
 a { font: 1em "Lucida Grande", 'Arial', "sans-serif", sans-serif; }
+a { font-family: "sans-serif", sans-serif; }
 a { font-family: Times, serif; }
 b { font: normal 14px/32px -apple-system, BlinkMacSystemFont, sans-serif; }
 c { font-family: SF Mono, Liberation Mono, sans-serif; }

--- a/crates/biome_css_analyze/tests/suppression/suspicious/noDuplicateFontNames/noDuplicateFontNames.css.snap
+++ b/crates/biome_css_analyze/tests/suppression/suspicious/noDuplicateFontNames/noDuplicateFontNames.css.snap
@@ -210,3 +210,39 @@ noDuplicateFontNames.css:5:39 lint/suspicious/noDuplicateFontNames  FIXABLE  ━
   
 
 ```
+
+```
+noDuplicateFontNames.css:6:75 lint/suspicious/noDuplicateFontNames  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Duplicate font names are redundant and unnecessary: sans-serif
+  
+    4 │ a { font-family: 'Times', Times }
+    5 │ a { FONT: italic 300 16px/30px Arial, " Arial", serif; }
+  > 6 │ b { font: normal 14px/32px -apple-system, BlinkMacSystemFont, sans-serif, sans-serif; }
+      │                                                                           ^^^^^^^^^^
+  
+  i This is where the duplicate font name is found:
+  
+    4 │ a { font-family: 'Times', Times }
+    5 │ a { FONT: italic 300 16px/30px Arial, " Arial", serif; }
+  > 6 │ b { font: normal 14px/32px -apple-system, BlinkMacSystemFont, sans-serif, sans-serif; }
+      │                                                               ^^^^^^^^^^
+  
+  i Remove duplicate font names within the property.
+  
+  i Safe fix: Suppress rule lint/suspicious/noDuplicateFontNames for this line.
+  
+    4 4 │   a { font-family: 'Times', Times }
+    5 5 │   a { FONT: italic 300 16px/30px Arial, " Arial", serif; }
+    6   │ - b·{·font:·normal·14px/32px·-apple-system,·BlinkMacSystemFont,·sans-serif,·sans-serif;·}
+      6 │ + /*·biome-ignore·lint/suspicious/noDuplicateFontNames:·<explanation>·*/
+      7 │ + b··{·font:·normal·14px/32px·-apple-system,·BlinkMacSystemFont,·sans-serif,·sans-serif;·}
+  
+  i Safe fix: Suppress rule lint/suspicious/noDuplicateFontNames for the whole file.
+  
+      1 │ + /**·biome-ignore-all·lint/suspicious/noDuplicateFontNames:·<explanation>·*/
+    1 2 │   a { font-family: "Lucida Grande", 'Arial', sans-serif, sans-serif; }
+    2 3 │   a { font-family: 'Arial', "Lucida Grande", Arial, sans-serif; }
+  
+
+```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

The existing invalid fixture already contains a font: shorthand with duplicate sans-serif, but the rule did not report it because unquoted generic-family keywords were skipped before being inserted into the duplicate set. 

Simply removing that skip is not sufficient: CssFontValue previously compared quoted strings and identifiers by their unquoted text, which would incorrectly treat "sans-serif" and sans-serif as the same font. 

This change preserves whether a value is a generic keyword identifier as part of CssFontValue equality and hashing, while comparing generic keywords case-insensitively. This matches CSS semantics and the Stylelint rule that Biome declares this rule equivalent to.


## Test Plan

<!-- What demonstrates that your implementation is correct? -->

The tests verify both sides of the behavior: the existing font: ... sans-serif, sans-serif fixture now produces a diagnostic, and serif, SERIF is also detected as a duplicate because generic keywords are case-insensitive. 

At the same time, "sans-serif", sans-serif remains valid because the quoted value is a font family name rather than a generic keyword, including the existing shorthand quoted/unquoted case.


## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
