### PR TITLE
fix(noDescendingSpecificity): improve specificity comparison

### DIFF
--- a/.changeset/shy-frogs-dance.md
+++ b/.changeset/shy-frogs-dance.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11512](https://github.com/biomejs/biome/issues/11512), where [`style/noDescendingSpecificity`](https://biomejs.dev/linter/rules/no-descending-specificity/) missed lower-specificity selectors after a later higher-specificity selector with the same tail selector.

--- a/crates/biome_css_analyze/src/lint/style/no_descending_specificity.rs
+++ b/crates/biome_css_analyze/src/lint/style/no_descending_specificity.rs
@@ -2,9 +2,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use biome_analyze::{Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule};
 use biome_console::markup;
-use biome_css_semantic::model::{
-    AnyRuleStart, Rule as CssSemanticRule, RuleId, Specificity,
-};
+use biome_css_semantic::model::{AnyRuleStart, Rule as CssSemanticRule, RuleId, Specificity};
 use biome_css_syntax::{AnyCssRoot, AnyCssSelector};
 use biome_diagnostics::Severity;
 use biome_rowan::TextRange;
@@ -120,15 +118,6 @@ declare_lint_rule! {
     }
 }
 
-#[derive(Debug)]
-pub struct DescendingSelector {
-    high: (TextRange, Specificity),
-    low: (TextRange, Specificity),
-}
-
-// `None` represents the top-level comparison context, which has no enclosing at-rule.
-type SelectorContexts = FxHashMap<Option<RuleId>, FxHashMap<String, (TextRange, Specificity)>>;
-
 impl Rule for NoDescendingSpecificity {
     type Query = Semantic<AnyCssRoot>;
     type State = DescendingSelector;
@@ -196,6 +185,14 @@ impl Rule for NoDescendingSpecificity {
     }
 }
 
+#[derive(Debug)]
+pub struct DescendingSelector {
+    high: (TextRange, Specificity),
+    low: (TextRange, Specificity),
+}
+
+// `None` represents the top-level comparison context, which has no enclosing at-rule.
+type SelectorContexts = FxHashMap<Option<RuleId>, FxHashMap<String, (TextRange, Specificity)>>;
 /// find tail selector
 /// ```css
 /// a b:hover {

--- a/crates/biome_css_analyze/src/lint/style/no_descending_specificity.rs
+++ b/crates/biome_css_analyze/src/lint/style/no_descending_specificity.rs
@@ -2,7 +2,9 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use biome_analyze::{Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule};
 use biome_console::markup;
-use biome_css_semantic::model::{Rule as CssSemanticRule, RuleId, SemanticModel, Specificity};
+use biome_css_semantic::model::{
+    AnyRuleStart, Rule as CssSemanticRule, RuleId, Specificity,
+};
 use biome_css_syntax::{AnyCssRoot, AnyCssSelector};
 use biome_diagnostics::Severity;
 use biome_rowan::TextRange;
@@ -52,6 +54,20 @@ declare_lint_rule! {
     /// }
     /// ```
     ///
+    /// ```css,expect_diagnostic
+    /// .a th {
+    ///   color: red;
+    /// }
+    ///
+    /// .a .b .c th {
+    ///   color: green;
+    /// }
+    ///
+    /// .a .b th {
+    ///   color: blue;
+    /// }
+    /// ```
+    ///
     ///
     /// ### Valid
     ///
@@ -82,6 +98,18 @@ declare_lint_rule! {
     /// }
     /// ```
     ///
+    /// ```css
+    /// .a th {
+    ///   color: red;
+    /// }
+    ///
+    /// @media print {
+    ///   .a .b .c th {
+    ///     color: green;
+    ///   }
+    /// }
+    /// ```
+    ///
     pub NoDescendingSpecificity {
         version: "1.9.3",
         name: "noDescendingSpecificity",
@@ -98,6 +126,9 @@ pub struct DescendingSelector {
     low: (TextRange, Specificity),
 }
 
+// `None` represents the top-level comparison context, which has no enclosing at-rule.
+type SelectorContexts = FxHashMap<Option<RuleId>, FxHashMap<String, (TextRange, Specificity)>>;
+
 impl Rule for NoDescendingSpecificity {
     type Query = Semantic<AnyCssRoot>;
     type State = DescendingSelector;
@@ -108,17 +139,41 @@ impl Rule for NoDescendingSpecificity {
         let model = ctx.model();
         let root = ctx.root();
         let mut visited_rules = FxHashSet::default();
-        let mut visited_selectors = FxHashMap::default();
+        let mut visited_selectors = SelectorContexts::default();
         let mut descending_selectors = Vec::new();
-        for rule in model.rules() {
+
+        let mut rules = model
+            .rules()
+            .into_iter()
+            .rev()
+            .map(|rule| (rule, None))
+            .collect::<Vec<_>>();
+        while let Some((rule, at_rule_context)) = rules.pop() {
+            if !visited_rules.insert(rule.id()) {
+                continue;
+            }
+
             find_descending_selector(
                 &root,
                 &rule,
-                model,
-                &mut visited_rules,
+                at_rule_context,
                 &mut visited_selectors,
                 &mut descending_selectors,
             );
+
+            let child_at_rule_context = match rule.node(&root) {
+                AnyRuleStart::CssContainerAtRule(_)
+                | AnyRuleStart::CssMediaAtRule(_)
+                | AnyRuleStart::CssScopeAtRule(_)
+                | AnyRuleStart::CssStartingStyleAtRule(_)
+                | AnyRuleStart::CssSupportsAtRule(_) => Some(rule.id()),
+                _ => at_rule_context,
+            };
+            for child_id in rule.child_ids().iter().rev() {
+                if let Some(child_rule) = model.get_rule_by_id(child_id) {
+                    rules.push((child_rule, child_at_rule_context));
+                }
+            }
         }
         descending_selectors.into_boxed_slice()
     }
@@ -165,26 +220,23 @@ fn find_tail_selector_str(selector: &AnyCssSelector) -> Option<String> {
             Some(result)
         }
         AnyCssSelector::CssComplexSelector(s) => {
+            // negligible recursion
             s.right().as_ref().ok().and_then(find_tail_selector_str)
         }
         _ => None,
     }
 }
 
-/// This function traverses the CSS rules starting from the given rule and checks for selectors that have the same tail selector.
-/// For each selector, it compares its specificity with the previously encountered specificity of the same tail selector.
+/// Checks selectors against the highest preceding specificity with the same tail selector in the same at-rule context.
 /// If a lower specificity selector is found after a higher specificity selector with the same tail selector, it records this as a descending selector.
 fn find_descending_selector(
     root: &AnyCssRoot,
     rule: &CssSemanticRule,
-    model: &SemanticModel,
-    visited_rules: &mut FxHashSet<RuleId>,
-    visited_selectors: &mut FxHashMap<String, (TextRange, Specificity)>,
+    at_rule_context: Option<RuleId>,
+    visited_selectors: &mut SelectorContexts,
     descending_selectors: &mut Vec<DescendingSelector>,
 ) {
-    if !visited_rules.insert(rule.id()) {
-        return;
-    }
+    let visited_selectors = visited_selectors.entry(at_rule_context).or_default();
 
     for selector in rule.selectors() {
         let Some(casted_selector) = AnyCssSelector::cast(selector.node(root).syntax().clone())
@@ -195,31 +247,21 @@ fn find_descending_selector(
             continue;
         };
 
-        if let Some((last_text_range, last_specificity)) = visited_selectors.get(&tail_selector_str)
-        {
-            if last_specificity > &selector.specificity() {
+        if let Some(seen) = visited_selectors.get_mut(&tail_selector_str) {
+            let (last_text_range, last_specificity) = *seen;
+            let specificity = selector.specificity();
+            if last_specificity > specificity {
                 descending_selectors.push(DescendingSelector {
-                    high: (*last_text_range, *last_specificity),
-                    low: (selector.range(root), selector.specificity()),
+                    high: (last_text_range, last_specificity),
+                    low: (selector.range(root), specificity),
                 });
+            } else if specificity > last_specificity {
+                *seen = (selector.range(root), specificity);
             }
         } else {
             visited_selectors.insert(
                 tail_selector_str,
                 (selector.range(root), selector.specificity()),
-            );
-        }
-    }
-
-    for child_id in rule.child_ids() {
-        if let Some(child_rule) = model.get_rule_by_id(child_id) {
-            find_descending_selector(
-                root,
-                &child_rule,
-                model,
-                visited_rules,
-                visited_selectors,
-                descending_selectors,
             );
         }
     }

--- a/crates/biome_css_analyze/tests/specs/style/noDescendingSpecificity/invalid_issue_11512.css
+++ b/crates/biome_css_analyze/tests/specs/style/noDescendingSpecificity/invalid_issue_11512.css
@@ -1,0 +1,12 @@
+/* should generate diagnostics */
+.a th {
+    color: red;
+}
+
+.a .b .c th {
+    color: green;
+}
+
+.a .b th {
+    color: blue;
+}

--- a/crates/biome_css_analyze/tests/specs/style/noDescendingSpecificity/invalid_issue_11512.css.snap
+++ b/crates/biome_css_analyze/tests/specs/style/noDescendingSpecificity/invalid_issue_11512.css.snap
@@ -1,0 +1,47 @@
+---
+source: crates/biome_css_analyze/tests/spec_tests.rs
+expression: invalid_issue_11512.css
+---
+# Input
+```css
+/* should generate diagnostics */
+.a th {
+    color: red;
+}
+
+.a .b .c th {
+    color: green;
+}
+
+.a .b th {
+    color: blue;
+}
+
+```
+
+# Diagnostics
+```
+invalid_issue_11512.css:10:1 lint/style/noDescendingSpecificity ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Descending specificity selector found. This selector specificity is (0, 2, 1)
+  
+     8 │ }
+     9 │ 
+  > 10 │ .a .b th {
+       │ ^^^^^^^^
+    11 │     color: blue;
+    12 │ }
+  
+  i This selector specificity is (0, 3, 1)
+  
+    4 │ }
+    5 │ 
+  > 6 │ .a .b .c th {
+      │ ^^^^^^^^^^^
+    7 │     color: green;
+    8 │ }
+  
+  i Descending specificity selector may not be applied. Consider rearranging the order of the selectors. See MDN web docs for more details.
+  
+
+```

--- a/crates/biome_css_analyze/tests/specs/style/noDescendingSpecificity/valid_issue_11512_at_rule_context.css
+++ b/crates/biome_css_analyze/tests/specs/style/noDescendingSpecificity/valid_issue_11512_at_rule_context.css
@@ -1,0 +1,40 @@
+/* should not generate diagnostics */
+.a th {
+    color: red;
+}
+
+@media print {
+    .a .b .c th {
+        color: green;
+    }
+}
+
+@supports (display: grid) {
+    .a .b .c th {
+        color: green;
+    }
+}
+
+@container (min-width: 0px) {
+    .a .b .c th {
+        color: green;
+    }
+}
+
+@scope (.scope) {
+    .a .b .c th {
+        color: green;
+    }
+}
+
+.start {
+    @starting-style {
+        .a .b .c th {
+            color: green;
+        }
+    }
+}
+
+.a .b th {
+    color: blue;
+}

--- a/crates/biome_css_analyze/tests/specs/style/noDescendingSpecificity/valid_issue_11512_at_rule_context.css.snap
+++ b/crates/biome_css_analyze/tests/specs/style/noDescendingSpecificity/valid_issue_11512_at_rule_context.css.snap
@@ -1,0 +1,48 @@
+---
+source: crates/biome_css_analyze/tests/spec_tests.rs
+expression: valid_issue_11512_at_rule_context.css
+---
+# Input
+```css
+/* should not generate diagnostics */
+.a th {
+    color: red;
+}
+
+@media print {
+    .a .b .c th {
+        color: green;
+    }
+}
+
+@supports (display: grid) {
+    .a .b .c th {
+        color: green;
+    }
+}
+
+@container (min-width: 0px) {
+    .a .b .c th {
+        color: green;
+    }
+}
+
+@scope (.scope) {
+    .a .b .c th {
+        color: green;
+    }
+}
+
+.start {
+    @starting-style {
+        .a .b .c th {
+            color: green;
+        }
+    }
+}
+
+.a .b th {
+    color: blue;
+}
+
+```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Used a coding agent.

Closes #11512 

The previous solution didn't account for at-rules, so it broke the ecosystem CI. 

I refactored `find_descending_selector` to not be recursive.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added new tests

<!-- What demonstrates that your implementation is correct? -->

## Docs

I added new cases to the docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
