### PR TITLE
fix(format/html): avoid duplicating Svelte render comments

### DIFF
--- a/.changeset/smooth-lamps-serve.md
+++ b/.changeset/smooth-lamps-serve.md
@@ -1,0 +1,13 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11541](https://github.com/biomejs/biome/issues/11541): formatting a Svelte render tag followed by an HTML comment no longer duplicates the comment.
+
+```diff
+ <div>
+   {@render children?.()}
+   <!-- comment -->
+-  <!-- comment -->
+ </div>
+```

--- a/crates/biome_html_formatter/src/svelte/auxiliary/render_block.rs
+++ b/crates/biome_html_formatter/src/svelte/auxiliary/render_block.rs
@@ -32,4 +32,13 @@ impl FormatNodeRule<SvelteRenderBlock> for FormatSvelteRenderBlock {
         // handled by element list formatter
         Ok(())
     }
+
+    fn fmt_trailing_comments(
+        &self,
+        _node: &SvelteRenderBlock,
+        _f: &mut HtmlFormatter,
+    ) -> FormatResult<()> {
+        // handled by element list formatter
+        Ok(())
+    }
 }

--- a/crates/biome_html_formatter/tests/specs/html/svelte/comments/render.svelte
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/comments/render.svelte
@@ -1,3 +1,8 @@
 <!-- 1 -->
 {@render sum(1, 2)}
 <!-- 2 -->
+
+<div>
+	{@render children?.()}
+	<!-- comment -->
+</div>

--- a/crates/biome_html_formatter/tests/specs/html/svelte/comments/render.svelte.snap
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/comments/render.svelte.snap
@@ -10,6 +10,11 @@ info: svelte/comments/render.svelte
 {@render sum(1, 2)}
 <!-- 2 -->
 
+<div>
+	{@render children?.()}
+	<!-- comment -->
+</div>
+
 ```
 
 
@@ -19,5 +24,10 @@ info: svelte/comments/render.svelte
 <!-- 1 -->
 {@render sum(1, 2)}
 <!-- 2 -->
+
+<div>
+	{@render children?.()}
+	<!-- comment -->
+</div>
 
 ```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
fixes #11541, a comment duplication bug

implemented by gpt 5.6 sol

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
