### PR TITLE
fix(parse/html): emit a diagnostic for invalid HTML comments inside tags

### DIFF
--- a/.changeset/large-clocks-wonder.md
+++ b/.changeset/large-clocks-wonder.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11542](https://github.com/biomejs/biome/issues/11542): Biome now reports HTML comments between Svelte tag attributes as parse errors.

--- a/crates/biome_html_parser/src/lexer/mod.rs
+++ b/crates/biome_html_parser/src/lexer/mod.rs
@@ -407,7 +407,23 @@ impl<'src> HtmlLexer<'src> {
         let dispatched = lookup_byte(current);
 
         match dispatched {
-            SLH if let Some(comment) = self.consume_js_comment_in_tag() => return comment,
+            LSS if self.at_start_comment() => {
+                let start = self.text_position();
+                let comment = self.consume_comment();
+                self.push_diagnostic(
+                    ParseDiagnostic::new(
+                        "HTML comments are not allowed here.",
+                        start..self.text_position(),
+                    )
+                    .with_hint(
+                        "Use a JavaScript `//` or `/* ... */` comment when inside a tag's attributes.",
+                    ),
+                );
+                return comment;
+            }
+            SLH if let Some(comment) = self.consume_js_comment_in_tag() => {
+                return comment;
+            }
             PRD => return self.consume_byte(T![.]),
             _ => {}
         }

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/html_comment_in_tag.svelte
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/html_comment_in_tag.svelte
@@ -1,0 +1,5 @@
+<input
+	type="text"
+	<!-- a comment -->
+	disabled
+>

--- a/crates/biome_html_parser/tests/html_specs/error/svelte/html_comment_in_tag.svelte.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/svelte/html_comment_in_tag.svelte.snap
@@ -1,0 +1,106 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```svelte
+<input
+	type="text"
+	<!-- a comment -->
+	disabled
+>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    frontmatter: missing (optional),
+    processing_instruction: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlSelfClosingElement {
+            l_angle_token: L_ANGLE@0..1 "<" [] [],
+            name: HtmlTagName {
+                value_token: INPUT_KW@1..6 "input" [] [],
+            },
+            attributes: HtmlAttributeList [
+                HtmlAttribute {
+                    name: HtmlAttributeName {
+                        value_token: HTML_LITERAL@6..12 "type" [Newline("\n"), Whitespace("\t")] [],
+                    },
+                    initializer: HtmlAttributeInitializerClause {
+                        eq_token: EQ@12..13 "=" [] [],
+                        value: HtmlString {
+                            value_token: HTML_STRING_LITERAL@13..19 "\"text\"" [] [],
+                        },
+                    },
+                },
+                HtmlAttribute {
+                    name: HtmlAttributeName {
+                        value_token: HTML_LITERAL@19..49 "disabled" [Newline("\n"), Whitespace("\t"), Comments("<!-- a comment -->"), Newline("\n"), Whitespace("\t")] [],
+                    },
+                    initializer: missing (optional),
+                },
+            ],
+            slash_token: missing (optional),
+            r_angle_token: R_ANGLE@49..51 ">" [Newline("\n")] [],
+        },
+    ],
+    eof_token: EOF@51..52 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..52
+  0: (empty)
+  1: (empty)
+  2: (empty)
+  3: (empty)
+  4: HTML_ELEMENT_LIST@0..51
+    0: HTML_SELF_CLOSING_ELEMENT@0..51
+      0: L_ANGLE@0..1 "<" [] []
+      1: HTML_TAG_NAME@1..6
+        0: INPUT_KW@1..6 "input" [] []
+      2: HTML_ATTRIBUTE_LIST@6..49
+        0: HTML_ATTRIBUTE@6..19
+          0: HTML_ATTRIBUTE_NAME@6..12
+            0: HTML_LITERAL@6..12 "type" [Newline("\n"), Whitespace("\t")] []
+          1: HTML_ATTRIBUTE_INITIALIZER_CLAUSE@12..19
+            0: EQ@12..13 "=" [] []
+            1: HTML_STRING@13..19
+              0: HTML_STRING_LITERAL@13..19 "\"text\"" [] []
+        1: HTML_ATTRIBUTE@19..49
+          0: HTML_ATTRIBUTE_NAME@19..49
+            0: HTML_LITERAL@19..49 "disabled" [Newline("\n"), Whitespace("\t"), Comments("<!-- a comment -->"), Newline("\n"), Whitespace("\t")] []
+          1: (empty)
+      3: (empty)
+      4: R_ANGLE@49..51 ">" [Newline("\n")] []
+  5: EOF@51..52 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+html_comment_in_tag.svelte:3:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × HTML comments are not allowed here.
+  
+    1 │ <input
+    2 │ 	type="text"
+  > 3 │ 	<!-- a comment -->
+      │ 	^^^^^^^^^^^^^^^^^^
+    4 │ 	disabled
+    5 │ >
+  
+  i Use a JavaScript `//` or `/* ... */` comment when inside a tag's attributes.
+  
+```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
We now emit a diagnostic for comments that use `<!-- foo -->` syntax inside html tags

fixes #11542

implemented by gpt 5.6 terra
<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
