### PR TITLE
refactor: reduce generic functions per rule to reduce binary size

### DIFF
--- a/crates/biome_analyze/src/lib.rs
+++ b/crates/biome_analyze/src/lib.rs
@@ -830,9 +830,13 @@ impl<'a> RuleFilter<'a> {
     }
     /// Return `true` if the group `G` matches this filter
     pub fn match_group<G: RuleGroup>(self) -> bool {
+        self.match_group_name(G::NAME)
+    }
+
+    pub fn match_group_name(self, group_name: &str) -> bool {
         match self {
-            RuleFilter::Group(group) => group == G::NAME,
-            RuleFilter::Rule(group, _) => group == G::NAME,
+            RuleFilter::Group(group) => group == group_name,
+            RuleFilter::Rule(group, _) => group == group_name,
         }
     }
 
@@ -841,11 +845,13 @@ impl<'a> RuleFilter<'a> {
     where
         R: Rule,
     {
+        self.match_rule_name(<R::Group as RuleGroup>::NAME, R::METADATA.name)
+    }
+
+    pub fn match_rule_name(self, group_name: &str, rule_name: &str) -> bool {
         match self {
-            RuleFilter::Group(group) => group == <R::Group as RuleGroup>::NAME,
-            RuleFilter::Rule(group, rule) => {
-                group == <R::Group as RuleGroup>::NAME && rule == R::METADATA.name
-            }
+            RuleFilter::Group(group) => group == group_name,
+            RuleFilter::Rule(group, rule) => group == group_name && rule == rule_name,
         }
     }
 }
@@ -913,26 +919,41 @@ impl<'analysis> AnalysisFilter<'analysis> {
 
     /// Return `true` if the group `G` matches this filter
     pub fn match_group<G: RuleGroup>(&self) -> bool {
-        self.match_category::<G::Category>()
+        self.match_group_name(<G::Category as GroupCategory>::CATEGORY, G::NAME)
+    }
+
+    fn match_group_name(&self, category: RuleCategory, group_name: &str) -> bool {
+        self.categories.contains(category)
             && self.enabled_rules.is_none_or(|enabled_rules| {
-                enabled_rules.iter().any(|filter| filter.match_group::<G>())
+                enabled_rules
+                    .iter()
+                    .any(|filter| filter.match_group_name(group_name))
             })
-            && !self
-                .disabled_rules
-                .iter()
-                .any(|filter| matches!(filter, RuleFilter::Group(_)) && filter.match_group::<G>())
+            && !self.disabled_rules.iter().any(|filter| {
+                matches!(filter, RuleFilter::Group(_)) && filter.match_group_name(group_name)
+            })
     }
 
     /// Return `true` if the rule `R` matches this filter
     pub fn match_rule<R: Rule>(&self) -> bool {
-        self.match_category::<<R::Group as RuleGroup>::Category>()
+        self.match_rule_name(
+            <<R::Group as RuleGroup>::Category as GroupCategory>::CATEGORY,
+            <R::Group as RuleGroup>::NAME,
+            R::METADATA.name,
+        )
+    }
+
+    fn match_rule_name(&self, category: RuleCategory, group_name: &str, rule_name: &str) -> bool {
+        self.categories.contains(category)
             && self.enabled_rules.is_none_or(|enabled_rules| {
-                enabled_rules.iter().any(|filter| filter.match_rule::<R>())
+                enabled_rules
+                    .iter()
+                    .any(|filter| filter.match_rule_name(group_name, rule_name))
             })
             && !self
                 .disabled_rules
                 .iter()
-                .any(|filter| filter.match_rule::<R>())
+                .any(|filter| filter.match_rule_name(group_name, rule_name))
     }
 
     /// Return `true` if analyzer plugins match this filter.

--- a/crates/biome_analyze/src/lib.rs
+++ b/crates/biome_analyze/src/lib.rs
@@ -833,6 +833,7 @@ impl<'a> RuleFilter<'a> {
         self.match_group_name(G::NAME)
     }
 
+    #[inline]
     pub fn match_group_name(self, group_name: &str) -> bool {
         match self {
             RuleFilter::Group(group) => group == group_name,
@@ -848,6 +849,7 @@ impl<'a> RuleFilter<'a> {
         self.match_rule_name(<R::Group as RuleGroup>::NAME, R::METADATA.name)
     }
 
+    #[inline]
     pub fn match_rule_name(self, group_name: &str, rule_name: &str) -> bool {
         match self {
             RuleFilter::Group(group) => group == group_name,
@@ -919,41 +921,34 @@ impl<'analysis> AnalysisFilter<'analysis> {
 
     /// Return `true` if the group `G` matches this filter
     pub fn match_group<G: RuleGroup>(&self) -> bool {
-        self.match_group_name(<G::Category as GroupCategory>::CATEGORY, G::NAME)
+        self.match_category::<G::Category>() && self.match_group_name(G::NAME)
     }
 
-    fn match_group_name(&self, category: RuleCategory, group_name: &str) -> bool {
-        self.categories.contains(category)
-            && self.enabled_rules.is_none_or(|enabled_rules| {
-                enabled_rules
-                    .iter()
-                    .any(|filter| filter.match_group_name(group_name))
-            })
-            && !self.disabled_rules.iter().any(|filter| {
-                matches!(filter, RuleFilter::Group(_)) && filter.match_group_name(group_name)
-            })
+    fn match_group_name(&self, group_name: &'static str) -> bool {
+        self.enabled_rules.is_none_or(|enabled_rules| {
+            enabled_rules
+                .iter()
+                .any(|filter| filter.match_group_name(group_name))
+        }) && !self.disabled_rules.iter().any(|filter| {
+            matches!(filter, RuleFilter::Group(_)) && filter.match_group_name(group_name)
+        })
     }
 
     /// Return `true` if the rule `R` matches this filter
     pub fn match_rule<R: Rule>(&self) -> bool {
-        self.match_rule_name(
-            <<R::Group as RuleGroup>::Category as GroupCategory>::CATEGORY,
-            <R::Group as RuleGroup>::NAME,
-            R::METADATA.name,
-        )
+        self.match_category::<<R::Group as RuleGroup>::Category>()
+            && self.match_rule_name(<R::Group as RuleGroup>::NAME, R::METADATA.name)
     }
 
-    fn match_rule_name(&self, category: RuleCategory, group_name: &str, rule_name: &str) -> bool {
-        self.categories.contains(category)
-            && self.enabled_rules.is_none_or(|enabled_rules| {
-                enabled_rules
-                    .iter()
-                    .any(|filter| filter.match_rule_name(group_name, rule_name))
-            })
-            && !self
-                .disabled_rules
+    fn match_rule_name(&self, group_name: &'static str, rule_name: &'static str) -> bool {
+        self.enabled_rules.is_none_or(|enabled_rules| {
+            enabled_rules
                 .iter()
                 .any(|filter| filter.match_rule_name(group_name, rule_name))
+        }) && !self
+            .disabled_rules
+            .iter()
+            .any(|filter| filter.match_rule_name(group_name, rule_name))
     }
 
     /// Return `true` if analyzer plugins match this filter.

--- a/crates/biome_analyze/src/registry.rs
+++ b/crates/biome_analyze/src/registry.rs
@@ -170,11 +170,20 @@ impl<L: Language + Default + 'static> RegistryVisitor<L> for RuleRegistryBuilder
         let phase = R::phase() as usize;
         let phase = &mut self.registry.phase_rules[phase];
 
-        let rule = RegistryRule::new::<R>(phase.rule_states.len());
+        phase.insert_rule(
+            <R::Query as Queryable>::key(),
+            RegistryRule::new::<R>(phase.rule_states.len()),
+        );
 
-        match <R::Query as Queryable>::key() {
+        <R::Query as Queryable>::build_visitor(&mut self.visitors, self.root);
+    }
+}
+
+impl<L: Language + Default + 'static> PhaseRules<L> {
+    fn insert_rule(&mut self, key: QueryKey<L>, rule: RegistryRule<L>) {
+        match key {
             QueryKey::Syntax(key) => {
-                let TypeRules::SyntaxRules { rules } = phase
+                let TypeRules::SyntaxRules { rules } = self
                     .type_rules
                     .entry(TypeId::of::<SyntaxNode<L>>())
                     .or_insert_with(|| TypeRules::SyntaxRules { rules: Vec::new() })
@@ -197,14 +206,14 @@ impl<L: Language + Default + 'static> RegistryVisitor<L> for RuleRegistryBuilder
                         rules.resize_with(index + 1, SyntaxKindRules::new);
                     }
 
-                    // Insert a handle to the rule `R` into the `SyntaxKindRules` entry
+                    // Insert a handle to the rule into the `SyntaxKindRules` entry
                     // corresponding to the SyntaxKind index
                     let node = &mut rules[index];
                     node.rules.push(rule);
                 }
             }
             QueryKey::TypeId(key) => {
-                let TypeRules::TypeRules { rules } = phase
+                let TypeRules::TypeRules { rules } = self
                     .type_rules
                     .entry(key)
                     .or_insert_with(|| TypeRules::TypeRules { rules: Vec::new() })
@@ -218,9 +227,7 @@ impl<L: Language + Default + 'static> RegistryVisitor<L> for RuleRegistryBuilder
             }
         }
 
-        phase.rule_states.push(RuleState::default());
-
-        <R::Query as Queryable>::build_visitor(&mut self.visitors, self.root);
+        self.rule_states.push(RuleState::default());
     }
 }
 

--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -1452,43 +1452,13 @@ pub trait Rule: RuleMeta + Sized {
     where
         Self: 'static,
     {
-        let category = <Self::Group as RuleGroup>::Category::CATEGORY;
-        if matches!(
-            category,
-            RuleCategory::Lint | RuleCategory::Action | RuleCategory::Syntax
-        ) {
-            let rule_category = format!(
-                "{}/{}/{}",
-                category.as_suppression_category(),
-                <Self::Group as RuleGroup>::NAME,
-                Self::METADATA.name
-            );
-            let suppression_text = format!("biome-ignore-all {rule_category}");
-            let root = ctx.root();
-
-            if let Some(first_token) = root.syntax().first_token() {
-                let mut mutation = root.begin();
-                let comment =
-                    suppression_action.suppression_top_level_comment(suppression_text.as_str());
-                suppression_action.apply_top_level_suppression(
-                    &mut mutation,
-                    first_token,
-                    comment.as_str(),
-                );
-                let message = if category == RuleCategory::Action {
-                    "action"
-                } else {
-                    "rule"
-                };
-                return Some(SuppressAction {
-                    mutation,
-                    message:
-                        markup! { "Suppress " {message} " " {rule_category} " for the whole file."}
-                            .to_owned(),
-                });
-            }
-        }
-        None
+        build_top_level_suppression(
+            ctx.root(),
+            <Self::Group as RuleGroup>::Category::CATEGORY,
+            <Self::Group as RuleGroup>::NAME,
+            Self::METADATA.name,
+            suppression_action,
+        )
     }
 
     /// Create a code action that allows you to suppress the rule. The function
@@ -1502,44 +1472,15 @@ pub trait Rule: RuleMeta + Sized {
     where
         Self: 'static,
     {
-        // if the rule belongs to `Lint`, we auto generate an action to suppress the rule
-        let category = <Self::Group as RuleGroup>::Category::CATEGORY;
-        if matches!(
-            category,
-            RuleCategory::Lint | RuleCategory::Action | RuleCategory::Syntax
-        ) {
-            let rule_category = format!(
-                "{}/{}/{}",
-                category.as_suppression_category(),
-                <Self::Group as RuleGroup>::NAME,
-                Self::METADATA.name
-            );
-            let suppression_text = format!("biome-ignore {rule_category}");
-            let root = ctx.root();
-            let token = root.syntax().token_at_offset(text_range.start());
-            let mut mutation = root.begin();
-            suppression_action.inline_suppression(SuppressionCommentEmitterPayload {
-                suppression_text: suppression_text.as_str(),
-                mutation: &mut mutation,
-                token_offset: token,
-                diagnostic_text_range: text_range,
-                suppression_reason: suppression_reason.unwrap_or("<explanation>"),
-            });
-
-            let message = if category == RuleCategory::Action {
-                "action"
-            } else {
-                "rule"
-            };
-
-            Some(SuppressAction {
-                mutation,
-                message: markup! { "Suppress " {message} " " {rule_category} " for this line."}
-                    .to_owned(),
-            })
-        } else {
-            None
-        }
+        build_inline_suppression(
+            ctx.root(),
+            text_range,
+            <Self::Group as RuleGroup>::Category::CATEGORY,
+            <Self::Group as RuleGroup>::NAME,
+            Self::METADATA.name,
+            suppression_action,
+            suppression_reason,
+        )
     }
 
     /// Returns a mutation to apply to the code
@@ -1547,6 +1488,99 @@ pub trait Rule: RuleMeta + Sized {
         _ctx: &RuleContext<Self>,
         _state: &Self::State,
     ) -> Option<BatchMutation<RuleLanguage<Self>>> {
+        None
+    }
+}
+fn build_top_level_suppression<L: Language>(
+    root: L::Root,
+    category: RuleCategory,
+    group_name: &'static str,
+    rule_name: &'static str,
+    suppression_action: &dyn SuppressionAction<Language = L>,
+) -> Option<SuppressAction<L>> {
+    if matches!(
+        category,
+        RuleCategory::Lint | RuleCategory::Action | RuleCategory::Syntax
+    ) {
+        let rule_category = format!(
+            "{}/{}/{}",
+            category.as_suppression_category(),
+            group_name,
+            rule_name
+        );
+        let suppression_text = format!("biome-ignore-all {rule_category}");
+
+        if let Some(first_token) = root.syntax().first_token() {
+            let mut mutation = root.begin();
+            let comment =
+                suppression_action.suppression_top_level_comment(suppression_text.as_str());
+            suppression_action.apply_top_level_suppression(
+                &mut mutation,
+                first_token,
+                comment.as_str(),
+            );
+            let message = if category == RuleCategory::Action {
+                "action"
+            } else {
+                "rule"
+            };
+            return Some(SuppressAction {
+                mutation,
+                message:
+                    markup! { "Suppress " {message} " " {rule_category} " for the whole file."}
+                        .to_owned(),
+            });
+        }
+    }
+    None
+}
+
+/// Body of [Rule::inline_suppression], kept outside the trait so it is
+/// monomorphized once per language instead of once per rule: the rule only
+/// contributes its category, group name, and rule name.
+fn build_inline_suppression<L: Language>(
+    root: L::Root,
+    text_range: &TextRange,
+    category: RuleCategory,
+    group_name: &'static str,
+    rule_name: &'static str,
+    suppression_action: &dyn SuppressionAction<Language = L>,
+    suppression_reason: Option<&str>,
+) -> Option<SuppressAction<L>> {
+    // if the rule belongs to `Lint`, we auto generate an action to suppress the rule
+    if matches!(
+        category,
+        RuleCategory::Lint | RuleCategory::Action | RuleCategory::Syntax
+    ) {
+        let rule_category = format!(
+            "{}/{}/{}",
+            category.as_suppression_category(),
+            group_name,
+            rule_name
+        );
+        let suppression_text = format!("biome-ignore {rule_category}");
+        let token = root.syntax().token_at_offset(text_range.start());
+        let mut mutation = root.begin();
+        suppression_action.inline_suppression(SuppressionCommentEmitterPayload {
+            suppression_text: suppression_text.as_str(),
+            mutation: &mut mutation,
+            token_offset: token,
+            diagnostic_text_range: text_range,
+            suppression_reason: suppression_reason.unwrap_or("<explanation>"),
+        });
+
+        let message = if category == RuleCategory::Action {
+            "action"
+        } else {
+            "rule"
+        };
+
+        Some(SuppressAction {
+            mutation,
+            message: markup! { "Suppress " {message} " " {rule_category} " for this line."}
+                .to_owned(),
+        })
+    } else {
         None
     }
 }

--- a/crates/biome_analyze/src/signals.rs
+++ b/crates/biome_analyze/src/signals.rs
@@ -8,7 +8,7 @@ use crate::{
     categories::ActionCategory,
     context::RuleContext,
     registry::{RuleLanguage, RuleRoot},
-    rule::Rule,
+    rule::{Rule, RuleAction, RuleMetadata, SuppressAction},
 };
 use biome_console::{MarkupBuf, markup};
 use biome_diagnostics::{Applicability, CodeSuggestion, Error, advice::CodeSuggestionAdvice};
@@ -532,32 +532,20 @@ where
         )
         .ok()?;
 
-        R::diagnostic(&ctx, &self.state).map(|mut diagnostic| {
-            diagnostic.severity = ctx.metadata().severity;
-
-            if let Some(issue_number) = ctx.metadata().issue_number {
-                let url = format!("https://github.com/biomejs/biome/issues/{}", issue_number);
-                diagnostic = diagnostic.note(markup! {
-                 "This rule is still being actively worked on, so it may be missing features or have rough edges. Visit "<Hyperlink href={url.as_str()}>{url.as_str()}</Hyperlink>" for more information or to report possible bugs."
-                });
-            }
-            if <R::Group as RuleGroup>::NAME == "nursery" {
-                diagnostic = diagnostic.note(markup! {
-                    "This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit "<Hyperlink href="https://biomejs.dev/linter/#nursery">"https://biomejs.dev/linter/#nursery"</Hyperlink>" for more information."
-                });
-            }
-            AnalyzerDiagnostic::from(diagnostic)
+        R::diagnostic(&ctx, &self.state).map(|diagnostic| {
+            build_analyzer_diagnostic(diagnostic, ctx.metadata(), <R::Group as RuleGroup>::NAME)
         })
     }
 
     fn actions(&self, filter: ActionFilter) -> AnalyzerActionIter<RuleLanguage<R>> {
         let globals = self.options.globals();
+        let configured_fix_kind = self.options.rule_fix_kind::<R>();
 
         // When fix is set to "none", disable the rule fix but still allow
         // suppression actions.
-        let fix_disabled = matches!(self.options.rule_fix_kind::<R>(), Some(FixKind::None));
+        let fix_disabled = matches!(configured_fix_kind, Some(FixKind::None));
         let configured_applicability = if filter.is_rule_fix() && !fix_disabled {
-            if let Some(fix_kind) = self.options.rule_fix_kind::<R>() {
+            if let Some(fix_kind) = configured_fix_kind {
                 match fix_kind {
                     FixKind::None => None,
                     FixKind::Safe => Some(Applicability::Always),
@@ -588,18 +576,17 @@ where
         .ok();
         let mut actions = Vec::new();
         if let Some(ctx) = ctx {
+            let rule_name = (<R::Group as RuleGroup>::NAME, R::METADATA.name);
+
             if filter.is_rule_fix()
                 && !fix_disabled
                 && let Some(action) = R::action(&ctx, &self.state)
             {
-                actions.push(AnalyzerAction {
-                    rule_name: Some((<R::Group as RuleGroup>::NAME, R::METADATA.name)),
-                    applicability: configured_applicability.unwrap_or(action.applicability()),
-                    category: action.category,
-                    mutation: action.mutation,
-                    message: action.message,
-                    text_edit: None,
-                });
+                actions.push(rule_action_to_analyzer_action(
+                    rule_name,
+                    configured_applicability,
+                    action,
+                ));
             }
 
             if filter.is_inline_suppression()
@@ -611,30 +598,22 @@ where
                     self.options.suppression_reason.as_deref(),
                 )
             {
-                let action = AnalyzerAction {
-                    rule_name: Some((<R::Group as RuleGroup>::NAME, R::METADATA.name)),
-                    category: ActionCategory::Other(OtherActionCategory::InlineSuppression),
-                    applicability: Applicability::Always,
-                    mutation: suppression_action.mutation,
-                    message: suppression_action.message,
-                    text_edit: None,
-                };
-                actions.push(action);
+                actions.push(suppress_action_to_analyzer_action(
+                    rule_name,
+                    ActionCategory::Other(OtherActionCategory::InlineSuppression),
+                    suppression_action,
+                ));
             }
 
             if filter.is_toplevel_suppression()
                 && let Some(suppression_action) =
                     R::top_level_suppression(&ctx, self.suppression_action)
             {
-                let action = AnalyzerAction {
-                    rule_name: Some((<R::Group as RuleGroup>::NAME, R::METADATA.name)),
-                    category: ActionCategory::Other(OtherActionCategory::ToplevelSuppression),
-                    applicability: Applicability::Always,
-                    mutation: suppression_action.mutation,
-                    message: suppression_action.message,
-                    text_edit: None,
-                };
-                actions.push(action);
+                actions.push(suppress_action_to_analyzer_action(
+                    rule_name,
+                    ActionCategory::Other(OtherActionCategory::ToplevelSuppression),
+                    suppression_action,
+                ));
             }
 
             AnalyzerActionIter::new(actions)
@@ -644,51 +623,12 @@ where
     }
 
     fn actions_metadata(&self) -> Vec<ActionMetadata> {
-        let rule_name = Some((<R::Group as RuleGroup>::NAME, R::METADATA.name));
-        let rule_category = <<R::Group as RuleGroup>::Category as GroupCategory>::CATEGORY;
-        let has_suppression = matches!(
-            rule_category,
-            RuleCategory::Lint | RuleCategory::Action | RuleCategory::Syntax
-        );
-
-        let mut metadata = Vec::new();
-
-        // Rule fix metadata — only if the rule declares a fix
-        let fix_kind = self.options.rule_fix_kind::<R>();
-        let is_disabled = matches!(fix_kind, Some(FixKind::None));
-        if !is_disabled && R::METADATA.fix_kind != FixKind::None {
-            let applicability = match fix_kind {
-                Some(FixKind::Safe) => Applicability::Always,
-                Some(FixKind::Unsafe) => Applicability::MaybeIncorrect,
-                _ => match R::METADATA.fix_kind {
-                    FixKind::Safe => Applicability::Always,
-                    _ => Applicability::MaybeIncorrect,
-                },
-            };
-            let action_category =
-                R::METADATA.action_category(rule_category, <R::Group as RuleGroup>::NAME);
-            metadata.push(ActionMetadata {
-                rule_name,
-                category: action_category,
-                applicability,
-            });
-        }
-
-        // Suppression metadata
-        if has_suppression {
-            metadata.push(ActionMetadata {
-                rule_name,
-                category: ActionCategory::Other(OtherActionCategory::InlineSuppression),
-                applicability: Applicability::Always,
-            });
-            metadata.push(ActionMetadata {
-                rule_name,
-                category: ActionCategory::Other(OtherActionCategory::ToplevelSuppression),
-                applicability: Applicability::Always,
-            });
-        }
-
-        metadata
+        build_actions_metadata(
+            (<R::Group as RuleGroup>::NAME, R::METADATA.name),
+            <<R::Group as RuleGroup>::Category as GroupCategory>::CATEGORY,
+            self.options.rule_fix_kind::<R>(),
+            &R::METADATA,
+        )
     }
 
     fn transformations(&self) -> AnalyzerTransformationIter<RuleLanguage<R>> {
@@ -722,4 +662,108 @@ where
             AnalyzerTransformationIter::new(vec![])
         }
     }
+}
+
+/// Post-processing of [AnalyzerSignal::diagnostic] for [RuleSignal], kept out
+/// of the generic method so it is compiled once instead of once per rule.
+fn build_analyzer_diagnostic(
+    mut diagnostic: RuleDiagnostic,
+    metadata: &RuleMetadata,
+    group_name: &'static str,
+) -> AnalyzerDiagnostic {
+    diagnostic.severity = metadata.severity;
+
+    if let Some(issue_number) = metadata.issue_number {
+        let url = format!("https://github.com/biomejs/biome/issues/{issue_number}");
+        diagnostic = diagnostic.note(markup! {
+         "This rule is still being actively worked on, so it may be missing features or have rough edges. Visit "<Hyperlink href={url.as_str()}>{url.as_str()}</Hyperlink>" for more information or to report possible bugs."
+        });
+    }
+    if group_name == "nursery" {
+        diagnostic = diagnostic.note(markup! {
+            "This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit "<Hyperlink href="https://biomejs.dev/linter/#nursery">"https://biomejs.dev/linter/#nursery"</Hyperlink>" for more information."
+        });
+    }
+    AnalyzerDiagnostic::from(diagnostic)
+}
+
+fn rule_action_to_analyzer_action<L: Language>(
+    rule_name: (&'static str, &'static str),
+    configured_applicability: Option<Applicability>,
+    action: RuleAction<L>,
+) -> AnalyzerAction<L> {
+    AnalyzerAction {
+        rule_name: Some(rule_name),
+        applicability: configured_applicability.unwrap_or(action.applicability()),
+        category: action.category,
+        mutation: action.mutation,
+        message: action.message,
+        text_edit: None,
+    }
+}
+
+fn suppress_action_to_analyzer_action<L: Language>(
+    rule_name: (&'static str, &'static str),
+    category: ActionCategory,
+    action: SuppressAction<L>,
+) -> AnalyzerAction<L> {
+    AnalyzerAction {
+        rule_name: Some(rule_name),
+        category,
+        applicability: Applicability::Always,
+        mutation: action.mutation,
+        message: action.message,
+        text_edit: None,
+    }
+}
+
+fn build_actions_metadata(
+    rule_name: (&'static str, &'static str),
+    rule_category: RuleCategory,
+    configured_fix_kind: Option<FixKind>,
+    metadata: &RuleMetadata,
+) -> Vec<ActionMetadata> {
+    let (group_name, _) = rule_name;
+    let rule_name = Some(rule_name);
+    let has_suppression = matches!(
+        rule_category,
+        RuleCategory::Lint | RuleCategory::Action | RuleCategory::Syntax
+    );
+
+    let mut actions_metadata = Vec::new();
+
+    // Rule fix metadata — only if the rule declares a fix
+    let is_disabled = matches!(configured_fix_kind, Some(FixKind::None));
+    if !is_disabled && metadata.fix_kind != FixKind::None {
+        let applicability = match configured_fix_kind {
+            Some(FixKind::Safe) => Applicability::Always,
+            Some(FixKind::Unsafe) => Applicability::MaybeIncorrect,
+            _ => match metadata.fix_kind {
+                FixKind::Safe => Applicability::Always,
+                _ => Applicability::MaybeIncorrect,
+            },
+        };
+        let action_category = metadata.action_category(rule_category, group_name);
+        actions_metadata.push(ActionMetadata {
+            rule_name,
+            category: action_category,
+            applicability,
+        });
+    }
+
+    // Suppression metadata
+    if has_suppression {
+        actions_metadata.push(ActionMetadata {
+            rule_name,
+            category: ActionCategory::Other(OtherActionCategory::InlineSuppression),
+            applicability: Applicability::Always,
+        });
+        actions_metadata.push(ActionMetadata {
+            rule_name,
+            category: ActionCategory::Other(OtherActionCategory::ToplevelSuppression),
+            applicability: Applicability::Always,
+        });
+    }
+
+    actions_metadata
 }

--- a/crates/biome_cli/src/reporter/sarif.rs
+++ b/crates/biome_cli/src/reporter/sarif.rs
@@ -10,7 +10,6 @@ use biome_html_syntax::HtmlLanguage;
 use biome_js_syntax::JsLanguage;
 use biome_json_syntax::JsonLanguage;
 use biome_markdown_syntax::MarkdownLanguage;
-use biome_rowan::Language;
 use camino::{Utf8Path, Utf8PathBuf};
 use serde::Serialize;
 use std::collections::{BTreeMap, HashSet};
@@ -59,19 +58,13 @@ impl<'a> SarifReporterVisitor<'a> {
         visitor
     }
 
-    fn store_rule<R, L>(&mut self)
-    where
-        L: Language,
-        R: Rule<Options: Default, Query: Queryable<Language = L, Output: Clone>> + 'static,
-    {
-        let category = <R::Group as RuleGroup>::Category::CATEGORY;
+    fn store_rule(&mut self, category: RuleCategory, rule_name: &'static str, docs: &'static str) {
         if matches!(
             category,
             RuleCategory::Syntax | RuleCategory::Lint | RuleCategory::Action
         ) {
-            let first_line: &'static str =
-                R::METADATA.docs.lines().next().unwrap_or_default().trim();
-            self.rule_descriptions.insert(R::METADATA.name, first_line);
+            let first_line = docs.lines().next().unwrap_or_default().trim();
+            self.rule_descriptions.insert(rule_name, first_line);
         }
     }
 }
@@ -81,7 +74,11 @@ impl RegistryVisitor<JsLanguage> for SarifReporterVisitor<'_> {
     where
         R: Rule<Options: Default, Query: Queryable<Language = JsLanguage, Output: Clone>> + 'static,
     {
-        self.store_rule::<R, JsLanguage>();
+        self.store_rule(
+            <R::Group as RuleGroup>::Category::CATEGORY,
+            R::METADATA.name,
+            R::METADATA.docs,
+        );
     }
 }
 
@@ -91,7 +88,11 @@ impl RegistryVisitor<JsonLanguage> for SarifReporterVisitor<'_> {
         R: Rule<Options: Default, Query: Queryable<Language = JsonLanguage, Output: Clone>>
             + 'static,
     {
-        self.store_rule::<R, JsonLanguage>();
+        self.store_rule(
+            <R::Group as RuleGroup>::Category::CATEGORY,
+            R::METADATA.name,
+            R::METADATA.docs,
+        );
     }
 }
 
@@ -101,7 +102,11 @@ impl RegistryVisitor<CssLanguage> for SarifReporterVisitor<'_> {
         R: Rule<Options: Default, Query: Queryable<Language = CssLanguage, Output: Clone>>
             + 'static,
     {
-        self.store_rule::<R, CssLanguage>();
+        self.store_rule(
+            <R::Group as RuleGroup>::Category::CATEGORY,
+            R::METADATA.name,
+            R::METADATA.docs,
+        );
     }
 }
 
@@ -111,7 +116,11 @@ impl RegistryVisitor<GraphqlLanguage> for SarifReporterVisitor<'_> {
         R: Rule<Options: Default, Query: Queryable<Language = GraphqlLanguage, Output: Clone>>
             + 'static,
     {
-        self.store_rule::<R, GraphqlLanguage>();
+        self.store_rule(
+            <R::Group as RuleGroup>::Category::CATEGORY,
+            R::METADATA.name,
+            R::METADATA.docs,
+        );
     }
 }
 
@@ -121,7 +130,11 @@ impl RegistryVisitor<HtmlLanguage> for SarifReporterVisitor<'_> {
         R: Rule<Options: Default, Query: Queryable<Language = HtmlLanguage, Output: Clone>>
             + 'static,
     {
-        self.store_rule::<R, HtmlLanguage>();
+        self.store_rule(
+            <R::Group as RuleGroup>::Category::CATEGORY,
+            R::METADATA.name,
+            R::METADATA.docs,
+        );
     }
 }
 
@@ -131,7 +144,11 @@ impl RegistryVisitor<MarkdownLanguage> for SarifReporterVisitor<'_> {
         R: Rule<Options: Default, Query: Queryable<Language = MarkdownLanguage, Output: Clone>>
             + 'static,
     {
-        self.store_rule::<R, MarkdownLanguage>();
+        self.store_rule(
+            <R::Group as RuleGroup>::Category::CATEGORY,
+            R::METADATA.name,
+            R::METADATA.docs,
+        );
     }
 }
 

--- a/crates/biome_configuration/src/analyzer/mod.rs
+++ b/crates/biome_configuration/src/analyzer/mod.rs
@@ -575,13 +575,10 @@ pub enum AnalyzerSelector {
 }
 
 impl AnalyzerSelector {
-    pub fn match_rule<R>(&self) -> bool
-    where
-        R: Rule,
-    {
+    pub fn match_rule_name(&self, group_name: &str, rule_name: &str) -> bool {
         match self {
-            Self::Rule(rule) => rule.match_rule::<R>(),
-            Self::Domain(domain) => domain.match_rule::<R>(),
+            Self::Rule(rule) => rule.match_rule_name(group_name, rule_name),
+            Self::Domain(domain) => domain.match_rule_name(group_name, rule_name),
             Self::Plugin => false,
         }
     }
@@ -761,7 +758,14 @@ impl RuleSelector {
     where
         R: Rule,
     {
-        RuleFilter::from(*self).match_rule::<R>()
+        self.match_rule_name(
+            <R::Group as biome_analyze::RuleGroup>::NAME,
+            R::METADATA.name,
+        )
+    }
+
+    fn match_rule_name(&self, group_name: &str, rule_name: &str) -> bool {
+        RuleFilter::from(*self).match_rule_name(group_name, rule_name)
     }
 }
 

--- a/crates/biome_configuration/src/generated/domain_selector.rs
+++ b/crates/biome_configuration/src/generated/domain_selector.rs
@@ -1,7 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
 use crate::analyzer::DomainSelector;
-use biome_analyze::{Rule, RuleFilter};
+use biome_analyze::{Rule, RuleFilter, RuleGroup};
 use std::sync::LazyLock;
 static ASTRO_FILTERS: LazyLock<Vec<RuleFilter<'static>>> = LazyLock::new(|| {
     vec![
@@ -230,34 +230,55 @@ impl DomainSelector {
     where
         R: Rule,
     {
+        self.match_rule_name(<R::Group as RuleGroup>::NAME, R::METADATA.name)
+    }
+    pub(crate) fn match_rule_name(&self, group_name: &str, rule_name: &str) -> bool {
         match self.0 {
-            "astro" => ASTRO_FILTERS.iter().any(|filter| filter.match_rule::<R>()),
+            "astro" => ASTRO_FILTERS
+                .iter()
+                .any(|filter| filter.match_rule_name(group_name, rule_name)),
             "drizzle" => DRIZZLE_FILTERS
                 .iter()
-                .any(|filter| filter.match_rule::<R>()),
-            "next" => NEXT_FILTERS.iter().any(|filter| filter.match_rule::<R>()),
+                .any(|filter| filter.match_rule_name(group_name, rule_name)),
+            "next" => NEXT_FILTERS
+                .iter()
+                .any(|filter| filter.match_rule_name(group_name, rule_name)),
             "playwright" => PLAYWRIGHT_FILTERS
                 .iter()
-                .any(|filter| filter.match_rule::<R>()),
+                .any(|filter| filter.match_rule_name(group_name, rule_name)),
             "project" => PROJECT_FILTERS
                 .iter()
-                .any(|filter| filter.match_rule::<R>()),
-            "qwik" => QWIK_FILTERS.iter().any(|filter| filter.match_rule::<R>()),
-            "react" => REACT_FILTERS.iter().any(|filter| filter.match_rule::<R>()),
+                .any(|filter| filter.match_rule_name(group_name, rule_name)),
+            "qwik" => QWIK_FILTERS
+                .iter()
+                .any(|filter| filter.match_rule_name(group_name, rule_name)),
+            "react" => REACT_FILTERS
+                .iter()
+                .any(|filter| filter.match_rule_name(group_name, rule_name)),
             "reactNative" => REACTNATIVE_FILTERS
                 .iter()
-                .any(|filter| filter.match_rule::<R>()),
-            "solid" => SOLID_FILTERS.iter().any(|filter| filter.match_rule::<R>()),
-            "svelte" => SVELTE_FILTERS.iter().any(|filter| filter.match_rule::<R>()),
+                .any(|filter| filter.match_rule_name(group_name, rule_name)),
+            "solid" => SOLID_FILTERS
+                .iter()
+                .any(|filter| filter.match_rule_name(group_name, rule_name)),
+            "svelte" => SVELTE_FILTERS
+                .iter()
+                .any(|filter| filter.match_rule_name(group_name, rule_name)),
             "tailwind" => TAILWIND_FILTERS
                 .iter()
-                .any(|filter| filter.match_rule::<R>()),
-            "test" => TEST_FILTERS.iter().any(|filter| filter.match_rule::<R>()),
+                .any(|filter| filter.match_rule_name(group_name, rule_name)),
+            "test" => TEST_FILTERS
+                .iter()
+                .any(|filter| filter.match_rule_name(group_name, rule_name)),
             "turborepo" => TURBOREPO_FILTERS
                 .iter()
-                .any(|filter| filter.match_rule::<R>()),
-            "types" => TYPES_FILTERS.iter().any(|filter| filter.match_rule::<R>()),
-            "vue" => VUE_FILTERS.iter().any(|filter| filter.match_rule::<R>()),
+                .any(|filter| filter.match_rule_name(group_name, rule_name)),
+            "types" => TYPES_FILTERS
+                .iter()
+                .any(|filter| filter.match_rule_name(group_name, rule_name)),
+            "vue" => VUE_FILTERS
+                .iter()
+                .any(|filter| filter.match_rule_name(group_name, rule_name)),
             _ => false,
         }
     }

--- a/crates/biome_service/src/configuration.rs
+++ b/crates/biome_service/src/configuration.rs
@@ -3,6 +3,7 @@ use crate::settings::Settings;
 use crate::workspace::ScanKind;
 use biome_analyze::{
     AnalyzerRules, Queryable, RegistryVisitor, Rule, RuleDomain, RuleFilter, RuleGroup,
+    RuleMetadata,
 };
 use biome_configuration::analyzer::{AnalyzerSelector, RuleDomainValue};
 use biome_configuration::diagnostics::{
@@ -899,26 +900,34 @@ impl<'a> ProjectScanComputer<'a> {
         }
     }
 
+    #[inline]
     fn check_rule<R, L>(&mut self)
     where
         L: Language,
         R: Rule<Options: Default, Query: Queryable<Language = L, Output: Clone>> + 'static,
     {
-        let filter = RuleFilter::Rule(<R::Group as RuleGroup>::NAME, R::METADATA.name);
+        self.check_rule_name(<R::Group as RuleGroup>::NAME, &R::METADATA);
+    }
+
+    fn check_rule_name(&mut self, group_name: &'static str, metadata: &RuleMetadata) {
+        let filter = RuleFilter::Rule(group_name, metadata.name);
 
         if !self.only.is_empty() {
             for selector in self.only.iter() {
-                if selector.match_rule::<R>() {
-                    let domains = R::METADATA.domains;
+                if selector.match_rule_name(group_name, metadata.name) {
+                    let domains = metadata.domains;
                     self.requires_project_scan |= domains.contains(&RuleDomain::Project);
                     self.requires_types |= domains.contains(&RuleDomain::Types);
                     break;
                 }
             }
-        } else if !self.skip.iter().any(|s| s.match_rule::<R>())
+        } else if !self
+            .skip
+            .iter()
+            .any(|s| s.match_rule_name(group_name, metadata.name))
             && self.enabled_rules.contains(&filter)
         {
-            let domains = R::METADATA.domains;
+            let domains = metadata.domains;
             self.requires_project_scan |= domains.contains(&RuleDomain::Project);
             self.requires_types |= domains.contains(&RuleDomain::Types);
         }

--- a/xtask/codegen/src/generate_configuration.rs
+++ b/xtask/codegen/src/generate_configuration.rs
@@ -1002,14 +1002,14 @@ fn generate_for_domains(
             #domain_as_string => #domain_filters.clone()
         });
         match_rule_arms.push(quote! {
-            #domain_as_string => #domain_filters.iter().any(|filter| filter.match_rule::<R>())
+            #domain_as_string => #domain_filters.iter().any(|filter| filter.match_rule_name(group_name, rule_name))
         });
     }
 
     let stream = quote! {
         use std::sync::LazyLock;
         use crate::analyzer::DomainSelector;
-        use biome_analyze::{Rule, RuleFilter};
+        use biome_analyze::{Rule, RuleFilter, RuleGroup};
 
         #( #lazy_locks )*
 
@@ -1028,6 +1028,10 @@ fn generate_for_domains(
                 where
                     R: Rule,
             {
+                self.match_rule_name(<R::Group as RuleGroup>::NAME, R::METADATA.name)
+            }
+
+            pub(crate) fn match_rule_name(&self, group_name: &str, rule_name: &str) -> bool {
                 match self.0 {
                     #( #match_rule_arms ),*,
                     _ => false,


### PR DESCRIPTION
## Summary

> [!NOTE]
> **AI Assistance Disclosure**: I used Claude Agent to investigate binary size and make code changes. I have reviewed all the diff before submitting.

Biome has many generic functions per rule, which bloats the binary size because the code is essentially copied for each rule. If the function is long and is the same among all rules, using non-generic one will help reducing the binary size.

Measured with macOS Arm64, thin-LTO, rustflags `-C strip=symbols -C codegen-units=1`:

|Before (main)|After (HEAD)|Δ|
|---|---|---|
|64,088,048 bytes|59,412,016 bytes|-4,676,032 bytes|

## Test Plan

Existing tests should pass

## Docs

N/A