### PR TITLE
fix(useExplicitLengthCheck): keep leading trivia when replacing the checked node

### DIFF
--- a/.changeset/use-explicit-length-check-leading-trivia.md
+++ b/.changeset/use-explicit-length-check-leading-trivia.md
@@ -1,0 +1,12 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#7984](https://github.com/biomejs/biome/issues/7984): the [`useExplicitLengthCheck`](https://biomejs.dev/linter/rules/use-explicit-length-check/) unsafe fix no longer discards the line break, indentation, and comments that precede the expression it rewrites. Previously the rewritten expression was pulled onto the previous line, which commented it out when that line ended with a `//` comment.
+
+```js
+if (
+  !showThinking && // while it's thinking there is hope to get suggestions
+  !comments?.length
+) {}
+```

--- a/crates/biome_js_analyze/src/lint/style/use_explicit_length_check.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_explicit_length_check.rs
@@ -267,9 +267,19 @@ impl Rule for UseExplicitLengthCheck {
 
         let mut new_node = new_binary_expr.into_syntax();
         let parent = state.node.syntax().parent()?;
-        // In cases like `export default!foo.length` -> `export default foo.length === 0`
-        // we need to add a space between keyword and expression
-        if does_node_needs_space_before_child(&parent) {
+        let replaced_first_token = state.node.syntax().first_token()?;
+        // When the checked node wraps the member expression, as in `!foo.length`, the wrapper holds
+        // the trivia belonging at this position, so it replaces the member expression's own.
+        let wraps_member_expr = replaced_first_token != member_expr.syntax().first_token()?;
+        let replaced_leading_trivia = replaced_first_token.leading_trivia();
+
+        if wraps_member_expr && !replaced_leading_trivia.is_empty() {
+            new_node = new_node
+                .trim_leading_trivia()?
+                .prepend_trivia_pieces(replaced_leading_trivia.pieces())?;
+        } else if does_node_needs_space_before_child(&parent) {
+            // In cases like `export default!foo.length` -> `export default foo.length === 0`
+            // we need to add a space between keyword and expression
             // Make fake token to get leading trivia
             let leading_trivia = make::token_decorated_with_space(T![=])
                 .leading_trivia()

--- a/crates/biome_js_analyze/tests/specs/style/useExplicitLengthCheck/invalidComment.js
+++ b/crates/biome_js_analyze/tests/specs/style/useExplicitLengthCheck/invalidComment.js
@@ -1,0 +1,30 @@
+function useQueryAssistant() {
+  if (
+    !showThinking && // while it's thinking there is hope to get suggestions
+    !comments?.length
+  ) {
+    console.log();
+  }
+}
+
+const isEmpty =
+  // leading comment
+  !foo.length;
+
+const isNotEmpty =
+  Boolean(foo.length);
+
+if (
+  // check length
+  foo.length
+) {}
+
+const isEmptyToo =
+  // check length
+  foo.length < 1;
+
+while (
+  bar ||
+  // own line
+  foo.length
+) {}

--- a/crates/biome_js_analyze/tests/specs/style/useExplicitLengthCheck/invalidComment.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useExplicitLengthCheck/invalidComment.js.snap
@@ -1,0 +1,172 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidComment.js
+---
+# Input
+```js
+function useQueryAssistant() {
+  if (
+    !showThinking && // while it's thinking there is hope to get suggestions
+    !comments?.length
+  ) {
+    console.log();
+  }
+}
+
+const isEmpty =
+  // leading comment
+  !foo.length;
+
+const isNotEmpty =
+  Boolean(foo.length);
+
+if (
+  // check length
+  foo.length
+) {}
+
+const isEmptyToo =
+  // check length
+  foo.length < 1;
+
+while (
+  bar ||
+  // own line
+  foo.length
+) {}
+
+```
+
+# Diagnostics
+```
+invalidComment.js:4:5 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use .length === 0 when checking .length is zero.
+  
+    2 │   if (
+    3 │     !showThinking && // while it's thinking there is hope to get suggestions
+  > 4 │     !comments?.length
+      │     ^^^^^^^^^^^^^^^^^
+    5 │   ) {
+    6 │     console.log();
+  
+  i Unsafe fix: Replace .length with .length === 0
+  
+     2  2 │     if (
+     3  3 │       !showThinking && // while it's thinking there is hope to get suggestions
+     4    │ - ····!comments?.length
+        4 │ + ····comments?.length·===·0
+     5  5 │     ) {
+     6  6 │       console.log();
+  
+
+```
+
+```
+invalidComment.js:12:3 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use .length === 0 when checking .length is zero.
+  
+    10 │ const isEmpty =
+    11 │   // leading comment
+  > 12 │   !foo.length;
+       │   ^^^^^^^^^^^
+    13 │ 
+    14 │ const isNotEmpty =
+  
+  i Unsafe fix: Replace .length with .length === 0
+  
+    10 10 │   const isEmpty =
+    11 11 │     // leading comment
+    12    │ - ··!foo.length;
+       12 │ + ··foo.length·===·0;
+    13 13 │   
+    14 14 │   const isNotEmpty =
+  
+
+```
+
+```
+invalidComment.js:15:3 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use .length > 0 when checking .length is not zero.
+  
+    14 │ const isNotEmpty =
+  > 15 │   Boolean(foo.length);
+       │   ^^^^^^^^^^^^^^^^^^^
+    16 │ 
+    17 │ if (
+  
+  i Unsafe fix: Replace .length with .length > 0
+  
+    13 13 │   
+    14 14 │   const isNotEmpty =
+    15    │ - ··Boolean(foo.length);
+       15 │ + ··foo.length·>·0;
+    16 16 │   
+    17 17 │   if (
+  
+
+```
+
+```
+invalidComment.js:19:3 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use .length > 0 when checking .length is not zero.
+  
+    17 │ if (
+    18 │   // check length
+  > 19 │   foo.length
+       │   ^^^^^^^^^^
+    20 │ ) {}
+    21 │ 
+  
+  i Unsafe fix: Replace .length with .length > 0
+  
+    19 │ ··foo.length·>·0
+       │             ++++
+
+```
+
+```
+invalidComment.js:24:3 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use .length === 0 when checking .length is zero.
+  
+    22 │ const isEmptyToo =
+    23 │   // check length
+  > 24 │   foo.length < 1;
+       │   ^^^^^^^^^^^^^^
+    25 │ 
+    26 │ while (
+  
+  i Unsafe fix: Replace .length with .length === 0
+  
+    22 22 │   const isEmptyToo =
+    23 23 │     // check length
+    24    │ - ··foo.length·<·1;
+       24 │ + ··foo.length·===·0;
+    25 25 │   
+    26 26 │   while (
+  
+
+```
+
+```
+invalidComment.js:29:3 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use .length > 0 when checking .length is not zero.
+  
+    27 │   bar ||
+    28 │   // own line
+  > 29 │   foo.length
+       │   ^^^^^^^^^^
+    30 │ ) {}
+    31 │ 
+  
+  i Unsafe fix: Replace .length with .length > 0
+  
+    29 │ ··foo.length·>·0
+       │             ++++
+
+```


### PR DESCRIPTION
## Summary

Closes #7984.

The `useExplicitLengthCheck` fix replaced the checked node with
`replace_element_discard_trivia`. The replacement is rebuilt from the `.length`
member expression, so it carries `foo`'s trivia. When the checked node wraps that
expression, as in `!foo.length` or `Boolean(foo.length)`, the line break and
indentation belong to the wrapper and were dropped, moving the rewritten
expression onto the previous line. If that line ended in a `//` comment, the fix
commented out its own output and the result no longer parsed.

The action now carries the wrapper's leading trivia across. It skips the transfer
when the checked node starts at the member expression itself, since the rebuilt
expression already has that trivia and prepending it again duplicates comments.

Not addressed here: the trailing side has the same class of bug. A trailing `//`
swallows the appended operator, and in one shape that inverts the condition
(`!foo.length && other` becomes `foo.length && other`). It is a different position
from what the issue reports, so I kept the diff to #7984. Happy to file it separately.

## Test Plan

Added `invalidComment.js` to the rule's specs. Reverting only the source change and
keeping the test fails in `assert_errors_are_absent`, because the fixed output does
not parse, so a regenerated snapshot cannot mask it.

`cargo test -p biome_js_analyze` (2865 passed, existing snapshots unchanged),
`cargo test -p biome_cli` (979 passed), clippy with `--deny warnings`,
`cargo fmt --check`, and `just gen-rules` / `gen-configuration` / `lint-rules` with
no generated-file diff. The `js_analyzer` criterion bench shows no regression, which
matters here because it calls `event.actions(ActionFilter::all())`.

## Docs

None. Rule behaviour and examples are unchanged; only the formatting of the emitted fix.

This pull request, including this description, was written by Claude Code.
