### PR TITLE
fix(type_inference): infer non-cyclic declarations in module cycles

### DIFF
--- a/.changeset/curly-lines-tap.md
+++ b/.changeset/curly-lines-tap.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11529](https://github.com/biomejs/biome/issues/11529), where [`noFloatingPromises`](https://biomejs.dev/linter/rules/no-floating-promises/) missed unhandled Promise chains when the imported function's module belonged to an import cycle. Cyclic modules now preserve types for exports that do not participate in recursive type dependencies.

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue11529/consumer.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue11529/consumer.ts
@@ -1,0 +1,7 @@
+/* should generate diagnostics */
+
+import { load } from "./loader";
+
+export interface Consumer {}
+
+load().then(() => {});

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue11529/consumer.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue11529/consumer.ts.snap
@@ -1,0 +1,34 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: consumer.ts
+---
+# Input
+```ts
+/* should generate diagnostics */
+
+import { load } from "./loader";
+
+export interface Consumer {}
+
+load().then(() => {});
+
+```
+
+# Diagnostics
+```
+consumer.ts:7:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    5 │ export interface Consumer {}
+    6 │ 
+  > 7 │ load().then(() => {});
+      │ ^^^^^^^^^^^^^^^^^^^^^^
+    8 │ 
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue11529/loader.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue11529/loader.ts
@@ -1,0 +1,7 @@
+import type { Consumer } from "./consumer";
+
+export function load(): Promise<void> {
+	return Promise.resolve();
+}
+
+export type LoaderConsumer = Consumer;

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue11529/loader.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue11529/loader.ts.snap
@@ -1,0 +1,15 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: loader.ts
+---
+# Input
+```ts
+import type { Consumer } from "./consumer";
+
+export function load(): Promise<void> {
+	return Promise.resolve();
+}
+
+export type LoaderConsumer = Consumer;
+
+```

--- a/crates/biome_module_graph/benches/type_inference.rs
+++ b/crates/biome_module_graph/benches/type_inference.rs
@@ -10,8 +10,9 @@ use biome_module_graph::{
     BindingTypeInput, CallArgumentTypeInput, ExpressionTypeInput, LocalTypeInput, ModuleDb,
     ModuleInfo, ModuleInfoKind, NormalizeTypeInput, PathInfoCache, SymbolFromModuleInfo,
     TypeInferenceMode, infer_binding_type, infer_call_argument_type, infer_export_type,
-    infer_expression_is_promise, infer_expression_type, infer_local_type, infer_module_types,
-    infer_module_types_bottom_up, normalize_type, resolve_js_module_with_inference_mode,
+    infer_expression_is_array_of_promises, infer_expression_is_promise, infer_expression_type,
+    infer_local_type, infer_module_types, infer_module_types_bottom_up, normalize_type,
+    resolve_js_module_with_inference_mode, type_inference::TypeInferenceClassification,
 };
 use biome_project_layout::ProjectLayout;
 use biome_rowan::TextRange;
@@ -201,6 +202,35 @@ fn bench_distinct_binding_lookup_queries(bencher: Bencher) {
                 let input = BindingTypeInput::new(&*db, *module, *range);
                 divan::black_box(infer_binding_type(&*db, input));
             }
+        });
+}
+
+#[divan::bench(name = "bench_cyclic_declaration_promise_lookup")]
+fn bench_cyclic_declaration_promise_lookup(bencher: Bencher) {
+    let (db, module, range) = cyclic_declaration_promise_lookup_input();
+    let input = ExpressionTypeInput::new(&db, module, range);
+    divan::black_box(infer_expression_is_array_of_promises(&db, input));
+    assert_eq!(
+        infer_expression_is_promise(&db, input),
+        TypeInferenceClassification::Indeterminate
+    );
+    let ty = infer_expression_type(&db, input).expect("Promise chain must have a type");
+    let ty = normalize_type(&db, NormalizeTypeInput::new(&db, module, ty));
+    assert!(
+        ty.is_promise_instance(&db),
+        "Promise chain must resolve to a Promise, got {ty:?}"
+    );
+
+    bencher
+        .with_inputs(cyclic_declaration_promise_lookup_input)
+        .bench_local_values(|(db, module, range)| {
+            let input = ExpressionTypeInput::new(&db, module, range);
+            divan::black_box(infer_expression_is_array_of_promises(&db, input));
+            divan::black_box(infer_expression_is_promise(&db, input));
+            let ty = infer_expression_type(&db, input).expect("Promise chain must have a type");
+            let input = NormalizeTypeInput::new(&db, module, ty);
+            divan::black_box(normalize_type(&db, input));
+            db
         });
 }
 
@@ -558,6 +588,71 @@ fn declaration_heavy_source(declaration_count: usize) -> String {
         ));
     }
     source
+}
+
+fn cyclic_declaration_promise_lookup_input() -> (WorkspaceDb, ModuleInfo, TextRange) {
+    const CONSUMER_SOURCE: &str = r#"
+        import { load } from "./loader";
+        export interface Consumer {}
+        load().then(() => {});
+    "#;
+
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/loader.ts".into(),
+        r#"
+            import type { Consumer } from "./consumer";
+            export function load(): Promise<void> {
+                return Promise.resolve();
+            }
+            export type LoaderConsumer = Consumer;
+        "#,
+    );
+    fs.insert("/src/consumer.ts".into(), CONSUMER_SOURCE);
+
+    let db = WorkspaceDb::default();
+    let path_info_cache = PathInfoCache::default();
+    let mut consumer = None;
+    for name in ["/src/loader.ts", "/src/consumer.ts"] {
+        let path = BiomePath::new(name);
+        let root = get_js_root(&fs, &path);
+        let semantic_model = Arc::new(semantic_model(&root, SemanticModelOptions::default()));
+        let (module_info, _, _) = resolve_js_module_with_inference_mode(
+            root,
+            &path,
+            &fs,
+            &ProjectLayout::default(),
+            semantic_model,
+            &path_info_cache,
+            TypeInferenceMode::RawTypesOnly,
+        );
+        let module = ModuleInfo::new(
+            &db,
+            path.as_path().to_path_buf(),
+            ModuleInfoKind::Js(module_info),
+        );
+        db.modules
+            .pin()
+            .insert(path.as_path().to_path_buf(), module);
+        if name == "/src/consumer.ts" {
+            consumer = Some(module);
+        }
+    }
+
+    let consumer = consumer.expect("consumer module must exist");
+    let ModuleInfoKind::Js(info) = consumer.kind(&db) else {
+        panic!("consumer module must contain JavaScript information");
+    };
+    let range = info
+        .raw_expressions
+        .keys()
+        .copied()
+        .find(|range| {
+            CONSUMER_SOURCE.get(usize::from(range.start())..usize::from(range.end()))
+                == Some("load().then(() => {})")
+        })
+        .expect("Promise chain must be collected");
+    (db, consumer, range)
 }
 
 fn expression_query_inputs(count: usize) -> (WorkspaceDb, ModuleInfo, Vec<TextRange>) {

--- a/crates/biome_module_graph/src/db/queries/type_inference/lookups.rs
+++ b/crates/biome_module_graph/src/db/queries/type_inference/lookups.rs
@@ -149,7 +149,15 @@ fn infer_binding_type_impl<'db>(
 
     let reference = js_info.raw_binding_types.get(&range)?.clone();
     let mut ctx = ResolutionCtx::new(db, module, &js_info, import_resolution);
-    Some(ctx.resolve(&reference))
+    let ty = ctx.resolve(&reference);
+    // Build a declaration graph only when the selected lookup crosses an
+    // import cycle. Local and acyclic lookups stay on the ordinary tracked
+    // query path.
+    Some(if ctx.encountered_inference_cycle() {
+        ctx.resolve_root_binding(range)
+    } else {
+        ty
+    })
 }
 
 fn infer_local_type_impl<'db>(
@@ -166,8 +174,16 @@ fn infer_local_type_impl<'db>(
         return None;
     }
 
+    let type_id = TypeId::new(type_id.index());
     let mut ctx = ResolutionCtx::new(db, module, &js_info, import_resolution);
-    Some(ctx.resolve_raw_type_id(TypeId::new(type_id.index())))
+    let ty = ctx.resolve_raw_type_id(type_id);
+    // The initial pass preserves the cheaper lookup path. A cycle activates a
+    // root retry that can distinguish an import cycle from a dependency cycle.
+    Some(if ctx.encountered_inference_cycle() {
+        ctx.resolve_root_declaration(type_id)
+    } else {
+        ty
+    })
 }
 
 // #endregion

--- a/crates/biome_module_graph/src/db/type_inference/expressions.rs
+++ b/crates/biome_module_graph/src/db/type_inference/expressions.rs
@@ -122,6 +122,12 @@ impl<'db> ResolutionCtx<'db, '_> {
                 self.resolve_conditional_expression(test, consequent, alternate)
             }
             RawTypeofExpression::Destructure(expression) => {
+                if self.resolves_declarations_directly()
+                    && let RawDestructureField::Name(name) = &expression.destructure_field
+                    && let Some(ty) = self.resolve_namespace_import_member(&expression.ty, name)
+                {
+                    return Some(ty);
+                }
                 let subject = self.resolve(&expression.ty);
                 match &expression.destructure_field {
                     RawDestructureField::Index(index) => {
@@ -176,10 +182,22 @@ impl<'db> ResolutionCtx<'db, '_> {
                 self.resolve_nullish_coalescing_expression(left, right)
             }
             RawTypeofExpression::StaticMember(expression) => {
+                if self.resolves_declarations_directly()
+                    && let Some(ty) =
+                        self.resolve_namespace_import_member(&expression.object, &expression.member)
+                {
+                    return Some(ty);
+                }
                 let object = self.resolve_static_member_object(&expression.object);
                 self.resolve_static_member_expression(object, expression.member.text())
             }
             RawTypeofExpression::OptionalChainStaticMember(expression) => {
+                if self.resolves_declarations_directly()
+                    && let Some(ty) =
+                        self.resolve_namespace_import_member(&expression.object, &expression.member)
+                {
+                    return Some(ty);
+                }
                 let object = self.resolve_static_member_object(&expression.object);
                 self.resolve_static_member_expression(object, expression.member.text())
                     .map(|result| self.optional_chain_result(object, result))

--- a/crates/biome_module_graph/src/db/type_inference/imports.rs
+++ b/crates/biome_module_graph/src/db/type_inference/imports.rs
@@ -1,7 +1,7 @@
 use super::{
     InferredModuleTypes,
     globals::global_type,
-    resolver::{MAX_RAW_TYPE_RESOLUTION_DEPTH, ResolutionCtx},
+    resolver::{MAX_RAW_TYPE_RESOLUTION_DEPTH, OnDemandDeclaration, ResolutionCtx},
 };
 use crate::db::queries::{
     BindingTypeInput, BindingTypeWithImportBudgetInput, LocalTypeInput,
@@ -26,6 +26,7 @@ use rustc_hash::FxHashSet;
 use salsa::plumbing::AsId;
 
 const MAX_EXPORT_RESOLUTION_STEPS: usize = 1024;
+pub(super) const MAX_NAMESPACE_IMPORT_MEMBER_STEPS: usize = 64;
 
 /// Result of searching for the declaration behind a named export.
 #[derive(Clone, Debug, Eq, PartialEq, salsa::Update)]
@@ -344,6 +345,90 @@ impl<'db> ResolutionCtx<'db, '_> {
         self.resolve_import_symbol(module, &qualifier.symbol)
     }
 
+    /// Projects `member` through an import without building the full namespace.
+    ///
+    /// Projection follows namespace imports, namespace re-exports, and bindings
+    /// that alias a namespace. `None` means available graph data and the
+    /// remaining work budget cannot establish such a projection. A supported
+    /// projection whose target cannot be inferred returns `Some(Unknown)`.
+    pub(super) fn resolve_import_member_with_steps(
+        &self,
+        qualifier: &TypeImportQualifier,
+        member: &Text,
+        remaining_projection_steps: usize,
+    ) -> Option<InferredTypeData<'db>> {
+        let remaining_projection_steps = remaining_projection_steps.checked_sub(1)?;
+        let module = self.module_for_resolved_path(&qualifier.resolved_path)?;
+        let export_name = match &qualifier.symbol {
+            ImportSymbol::All => {
+                return Some(
+                    self.resolve_import_symbol(module, &ImportSymbol::Named(member.clone())),
+                );
+            }
+            ImportSymbol::Default => "default",
+            ImportSymbol::Named(name) => name.text(),
+        };
+
+        let symbol = SymbolFromModuleInfo::new(self.db, export_name.to_string(), module);
+        let ExportOriginResult::Found { module, name } = resolved_export_origin(self.db, symbol)
+        else {
+            return None;
+        };
+        let ModuleInfoKind::Js(js_info) = module.kind(self.db) else {
+            return None;
+        };
+        let Some(JsExport::Own(own_export) | JsExport::OwnType(own_export)) =
+            js_info.exports.get(name.text())
+        else {
+            return None;
+        };
+        match own_export {
+            JsOwnExport::Namespace(reexport) => {
+                if reexport.import.symbol != ImportSymbol::All {
+                    return None;
+                }
+                Some(
+                    self.module_for_resolved_path(&reexport.import.resolved_path)
+                        .map_or(InferredTypeData::Unknown, |module| {
+                            self.resolve_import_symbol(module, &ImportSymbol::Named(member.clone()))
+                        }),
+                )
+            }
+            JsOwnExport::Binding(range) => {
+                let reference = js_info.raw_binding_types.get(range)?.clone();
+                let mut ctx = match self.import_resolution {
+                    super::ImportResolution::OnDemand { remaining } => {
+                        let resolve_declarations_directly = if self.resolves_declarations_directly()
+                        {
+                            let sccs =
+                                inference_module_sccs(self.db, ModuleGraphGeneration::get(self.db));
+                            *module == self.module
+                                || sccs.contains_cycle_between(self.module, *module)
+                        } else {
+                            false
+                        };
+                        self.for_on_demand_import(
+                            *module,
+                            &js_info,
+                            remaining,
+                            resolve_declarations_directly,
+                        )
+                    }
+                    import_resolution @ (super::ImportResolution::FromTables { .. }
+                    | super::ImportResolution::CycleFallback(_)) => {
+                        ResolutionCtx::new(self.db, *module, &js_info, import_resolution)
+                    }
+                };
+                ctx.resolve_namespace_import_member_with_steps(
+                    &reference,
+                    member,
+                    remaining_projection_steps,
+                )
+            }
+            JsOwnExport::Type(_) => None,
+        }
+    }
+
     fn module_for_resolved_path(&self, resolved_path: &ResolvedPath) -> Option<ModuleInfo> {
         let path = resolved_path.as_path()?;
         self.db.module_for_path(path)
@@ -374,10 +459,11 @@ impl<'db> ResolutionCtx<'db, '_> {
     /// Resolves only the requested import through export and lookup queries.
     ///
     /// Unlike [`Self::resolve_import_symbol_from_tables`], this path does not
-    /// infer the imported module's complete type tables. Dependency graphs that
-    /// exceed the on-demand traversal budget use bottom-up whole-module
-    /// inference instead. The fallback returns `Unknown` if those module tables
-    /// cannot be inferred.
+    /// infer the imported module's complete type tables. Declarations in a
+    /// module SCC are evaluated directly; other declarations use tracked
+    /// lookup queries. Dependency graphs that exceed the on-demand traversal
+    /// budget use bottom-up whole-module inference instead. The fallback
+    /// returns `Unknown` if those module tables cannot be inferred.
     fn resolve_import_symbol_on_demand(
         &self,
         module: ModuleInfo,
@@ -403,30 +489,40 @@ impl<'db> ResolutionCtx<'db, '_> {
                     self.resolve_import_symbol_from_tables(module, types, symbol)
                 }),
             super::ImportResolution::OnDemand { remaining } => {
-                let sccs = inference_module_sccs(self.db, ModuleGraphGeneration::get(self.db));
-                if module == self.module || sccs.contains_cycle_between(self.module, module) {
-                    return InferredTypeData::Unknown;
-                }
-                if remaining == 0 {
-                    return infer_module_types_bottom_up_for_import_depth(self.db, module)
-                        .map_or(InferredTypeData::Unknown, |types| {
-                            self.resolve_import_symbol_from_tables(module, types, symbol)
-                        });
-                }
-
                 let ModuleInfoKind::Js(js_info) = module.kind(self.db) else {
                     return InferredTypeData::Unknown;
                 };
                 if !js_info.infer_types {
                     return InferredTypeData::Unknown;
                 }
-                let ctx = ResolutionCtx::new(
-                    self.db,
+                let sccs = inference_module_sccs(self.db, ModuleGraphGeneration::get(self.db));
+                let in_same_cycle = sccs.contains_cycle_between(self.module, module);
+                let resolve_declarations_directly = module == self.module || in_same_cycle;
+                if resolve_declarations_directly && !self.resolves_declarations_directly() {
+                    self.mark_inference_cycle();
+                }
+                if remaining == 0 && !resolve_declarations_directly {
+                    return infer_module_types_bottom_up_for_import_depth(self.db, module)
+                        .map_or(InferredTypeData::Unknown, |types| {
+                            self.resolve_import_symbol_from_tables(module, types, symbol)
+                        });
+                }
+
+                // Imports inside the active import SCC use the declaration
+                // evaluator's work limit. Spending the import-depth budget on
+                // these edges could force complete-module inference, whose
+                // cycle fallback cannot recover acyclic declarations from the
+                // blocked component.
+                let remaining = if resolve_declarations_directly {
+                    remaining
+                } else {
+                    remaining - 1
+                };
+                let ctx = self.for_on_demand_import(
                     module,
                     &js_info,
-                    super::ImportResolution::OnDemand {
-                        remaining: remaining - 1,
-                    },
+                    remaining,
+                    resolve_declarations_directly,
                 );
                 ctx.resolve_import_symbol_on_demand(module, symbol)
             }
@@ -532,22 +628,38 @@ impl<'db> ResolutionCtx<'db, '_> {
             return ExportResolution::Missing;
         };
 
+        let resolve_declaration_directly = if self.resolves_declarations_directly() {
+            let sccs = inference_module_sccs(self.db, ModuleGraphGeneration::get(self.db));
+            *module == self.module || sccs.contains_cycle_between(self.module, *module)
+        } else {
+            false
+        };
+
         let ty = match own_export {
             JsOwnExport::Binding(range) => inferred_type_from_binding_on_demand(
-                self.db,
+                self,
                 *module,
                 &js_info,
                 *range,
-                self.import_resolution,
+                resolve_declaration_directly,
             ),
             JsOwnExport::Type(resolved_id) => inferred_type_from_resolved_id_on_demand(
-                self.db,
+                self,
                 *module,
                 &js_info,
                 ResolvedTypeId::Local(*resolved_id),
-                self.import_resolution,
+                resolve_declaration_directly,
             ),
-            JsOwnExport::Namespace(reexport) => self.resolve_js_import(&reexport.import),
+            JsOwnExport::Namespace(reexport) => {
+                match (resolve_declaration_directly, self.import_resolution) {
+                    (true, super::ImportResolution::OnDemand { .. }) => self
+                        .resolve_on_demand_declaration(OnDemandDeclaration::Namespace {
+                            module: *module,
+                            name: name.clone(),
+                        }),
+                    _ => self.resolve_js_import(&reexport.import),
+                }
+            }
         };
         ExportResolution::Resolved(ResolvedExport {
             identity: ExportIdentity {
@@ -556,6 +668,17 @@ impl<'db> ResolutionCtx<'db, '_> {
             },
             ty,
         })
+    }
+
+    pub(super) fn resolve_own_namespace_export(&self, name: &str) -> InferredTypeData<'db> {
+        let Some(
+            JsExport::Own(JsOwnExport::Namespace(reexport))
+            | JsExport::OwnType(JsOwnExport::Namespace(reexport)),
+        ) = self.js_info.exports.get(name)
+        else {
+            return InferredTypeData::Unknown;
+        };
+        self.resolve_js_import(&reexport.import)
     }
 
     /// Builds a namespace from whole-module tables during cycle fallback.
@@ -821,34 +944,38 @@ fn is_namespace_export_collectible(infer_types: bool, export: &JsExport) -> bool
 }
 
 fn inferred_type_from_binding_on_demand<'db>(
-    db: &'db dyn ModuleDb,
+    resolution_ctx: &ResolutionCtx<'db, '_>,
     module: ModuleInfo,
     js_info: &crate::JsModuleInfo,
     range: TextRange,
-    import_resolution: super::ImportResolution<'_>,
+    resolve_declaration_directly: bool,
 ) -> InferredTypeData<'db> {
     if let Some(TypeReference::Resolved(resolved_id)) = js_info.raw_binding_types.get(&range)
         && resolved_id.level() == TypeResolverLevel::Thin
         && js_info.is_named_type(resolved_id.id())
     {
         return InferredTypeData::Local(LocalTypeHandle::new(
-            db,
+            resolution_ctx.db,
             ModuleKey::new(module.as_id()),
             LocalTypeId::new(resolved_id.index()),
         ));
     }
 
+    let db = resolution_ctx.db;
     let input = BindingTypeInput::new(db, module, range);
-    match import_resolution {
+    match resolution_ctx.import_resolution {
+        super::ImportResolution::OnDemand { remaining } if resolve_declaration_directly => {
+            let mut ctx = resolution_ctx.for_on_demand_import(module, js_info, remaining, true);
+            ctx.resolve_local_binding(range)
+        }
         super::ImportResolution::OnDemand { remaining } => {
             let input = BindingTypeWithImportBudgetInput::new(db, input, remaining);
-            infer_binding_type_with_import_budget(db, input)
+            infer_binding_type_with_import_budget(db, input).unwrap_or(InferredTypeData::Unknown)
         }
         super::ImportResolution::FromTables { .. } | super::ImportResolution::CycleFallback(_) => {
-            infer_binding_type(db, input)
+            infer_binding_type(db, input).unwrap_or(InferredTypeData::Unknown)
         }
     }
-    .unwrap_or(InferredTypeData::Unknown)
 }
 
 /// Resolves an exported type ID from complete inferred module tables.
@@ -887,15 +1014,16 @@ fn inferred_type_from_resolved_id_from_tables<'db>(
 /// Resolves an exported type ID without inferring complete module tables.
 ///
 /// Named declarations remain symbolic local handles so recursive types retain
-/// their module identity. Other local types are requested through the lookup
-/// query.
+/// their module identity. Other local types use tracked lookup queries outside
+/// the current module SCC and direct declaration evaluation within it.
 fn inferred_type_from_resolved_id_on_demand<'db>(
-    db: &'db dyn ModuleDb,
+    resolution_ctx: &ResolutionCtx<'db, '_>,
     module: ModuleInfo,
     js_info: &crate::JsModuleInfo,
     resolved_id: ResolvedTypeId,
-    import_resolution: super::ImportResolution<'_>,
+    resolve_declaration_directly: bool,
 ) -> InferredTypeData<'db> {
+    let db = resolution_ctx.db;
     match resolved_id.level() {
         TypeResolverLevel::Thin => {
             let local_type_id = LocalTypeId::new(resolved_id.index());
@@ -907,15 +1035,24 @@ fn inferred_type_from_resolved_id_on_demand<'db>(
                 ))
             } else {
                 let input = LocalTypeInput::new(db, module, local_type_id);
-                match import_resolution {
+                match resolution_ctx.import_resolution {
+                    super::ImportResolution::OnDemand { remaining }
+                        if resolve_declaration_directly =>
+                    {
+                        let mut ctx =
+                            resolution_ctx.for_on_demand_import(module, js_info, remaining, true);
+                        ctx.resolve_local_declaration(resolved_id.id())
+                    }
                     super::ImportResolution::OnDemand { remaining } => {
                         let input = LocalTypeWithImportBudgetInput::new(db, input, remaining);
                         infer_local_type_with_import_budget(db, input)
+                            .unwrap_or(InferredTypeData::Unknown)
                     }
                     super::ImportResolution::FromTables { .. }
-                    | super::ImportResolution::CycleFallback(_) => infer_local_type(db, input),
+                    | super::ImportResolution::CycleFallback(_) => {
+                        infer_local_type(db, input).unwrap_or(InferredTypeData::Unknown)
+                    }
                 }
-                .unwrap_or(InferredTypeData::Unknown)
             }
         }
         TypeResolverLevel::Global => GlobalTypeId::try_from_type_id(resolved_id.id())

--- a/crates/biome_module_graph/src/db/type_inference/qualifiers.rs
+++ b/crates/biome_module_graph/src/db/type_inference/qualifiers.rs
@@ -1,4 +1,4 @@
-use super::resolver::ResolutionCtx;
+use super::{imports::MAX_NAMESPACE_IMPORT_MEMBER_STEPS, resolver::ResolutionCtx};
 use crate::js_module_info::TsBindingReferenceExt;
 use biome_js_type_info::{
     Path, TypeImportQualifier, TypeReference, TypeReferenceQualifier, TypeResolverLevel,
@@ -99,7 +99,31 @@ impl<'db> ResolutionCtx<'db, '_> {
                 .and_then(|reference| reference.get_binding_id_for_qualifier(qualifier))
                 .and_then(|id| self.js_info.semantic_model.binding_by_id(id));
             if let Some(binding) = binding {
-                let mut target = if binding.is_imported()
+                let binding_is_imported = binding.is_imported();
+                let resolves_declarations_directly = self.resolves_declarations_directly();
+                // Project the selected namespace member before resolving its
+                // base. Building the complete namespace here would add
+                // unrelated exports to the declaration graph and could turn
+                // an acyclic lookup into a dependency cycle.
+                let projected_member = resolves_declarations_directly.then(|| {
+                    members.first().and_then(|member| {
+                        self.resolve_namespace_import_member(
+                            &TypeReference::Qualifier(Box::new(TypeReferenceQualifier {
+                                path: Path::from(identifier.clone()),
+                                type_parameters: Box::default(),
+                                scope_id: qualifier.scope_id,
+                                type_only: qualifier.type_only,
+                                excluded_binding_id: qualifier.excluded_binding_id,
+                            })),
+                            member,
+                        )
+                    })
+                });
+                let projected_member = projected_member.flatten();
+                let consumed_first_member = projected_member.is_some();
+                let mut target = if let Some(projected_member) = projected_member {
+                    projected_member
+                } else if binding_is_imported
                     && let Some(import) = self.js_info.static_imports.get(identifier.text())
                 {
                     self.resolve_import(&TypeImportQualifier {
@@ -107,6 +131,8 @@ impl<'db> ResolutionCtx<'db, '_> {
                         resolved_path: import.resolved_path.clone(),
                         type_only: qualifier.type_only,
                     })
+                } else if resolves_declarations_directly {
+                    self.resolve_local_binding(binding.syntax().text_trimmed_range())
                 } else {
                     self.js_info
                         .raw_binding_types
@@ -117,7 +143,7 @@ impl<'db> ResolutionCtx<'db, '_> {
                         })
                 };
 
-                for member in &members {
+                for member in members.iter().skip(usize::from(consumed_first_member)) {
                     let Some(member_ty) =
                         self.resolve_static_member_expression(target, member.text())
                     else {
@@ -237,6 +263,116 @@ impl<'db> ResolutionCtx<'db, '_> {
         }
 
         InferredTypeData::Unknown
+    }
+
+    /// Projects one member from a reference that leads to a namespace import.
+    ///
+    /// Direct declaration evaluation uses this path to avoid resolving every
+    /// export on the namespace. Returns `None` when the reference does not lead
+    /// to a supported namespace import or the bounded projection cannot finish.
+    pub(super) fn resolve_namespace_import_member(
+        &mut self,
+        reference: &TypeReference,
+        member: &Text,
+    ) -> Option<InferredTypeData<'db>> {
+        self.resolve_namespace_import_member_with_steps(
+            reference,
+            member,
+            MAX_NAMESPACE_IMPORT_MEMBER_STEPS,
+        )
+    }
+
+    /// Follows local aliases and qualifiers until it reaches the import that
+    /// supplies `member`.
+    ///
+    /// Each iteration through the `TypeReference` chain consumes one step.
+    /// Entering `resolve_import_member_with_steps` consumes another step for
+    /// the cross-module projection. Walking parent scopes has a separate limit
+    /// and does not consume this budget.
+    pub(super) fn resolve_namespace_import_member_with_steps(
+        &mut self,
+        reference: &TypeReference,
+        member: &Text,
+        mut remaining_projection_steps: usize,
+    ) -> Option<InferredTypeData<'db>> {
+        let mut reference = reference.clone();
+        while remaining_projection_steps > 0 {
+            remaining_projection_steps -= 1;
+            if let TypeReference::Import(import) = &reference {
+                return self.resolve_import_member_with_steps(
+                    import,
+                    member,
+                    remaining_projection_steps,
+                );
+            }
+
+            if let TypeReference::Resolved(resolved_id) = &reference {
+                if resolved_id.level() != TypeResolverLevel::Thin {
+                    return None;
+                }
+                let raw = self.js_info.raw_types.get(resolved_id.id().index())?;
+                if let biome_js_type_info::RawTypeData::Reference(next) = raw {
+                    reference = next.clone();
+                    continue;
+                }
+                if let biome_js_type_info::RawTypeData::TypeofValue(value) = raw
+                    && value.ty.is_unknown()
+                {
+                    reference =
+                        TypeReference::Qualifier(Box::new(TypeReferenceQualifier::from_path(
+                            value.scope_id.unwrap_or(biome_js_semantic::ScopeId::GLOBAL),
+                            value.identifier.clone(),
+                        )));
+                    continue;
+                }
+                return None;
+            }
+
+            let TypeReference::Qualifier(qualifier) = &reference else {
+                return None;
+            };
+            let identifier = qualifier.path.identifier()?;
+            let mut scope = self
+                .js_info
+                .semantic_model
+                .scope_from_id(qualifier.scope_id);
+            let mut next = None;
+            for _ in 0..MAX_SCOPE_RESOLUTION_STEPS {
+                let binding = scope
+                    .get_binding_reference(identifier.text())
+                    .and_then(|binding_reference| {
+                        binding_reference.get_binding_id_for_qualifier(qualifier)
+                    })
+                    .and_then(|id| self.js_info.semantic_model.binding_by_id(id));
+                if let Some(binding) = binding {
+                    if binding.is_imported() {
+                        let import = self.js_info.static_imports.get(identifier.text())?;
+                        return self.resolve_import_member_with_steps(
+                            &TypeImportQualifier {
+                                symbol: import.symbol.clone(),
+                                resolved_path: import.resolved_path.clone(),
+                                type_only: qualifier.type_only,
+                            },
+                            member,
+                            remaining_projection_steps,
+                        );
+                    }
+                    next = self
+                        .js_info
+                        .raw_binding_types
+                        .get(&binding.syntax().text_trimmed_range())
+                        .cloned();
+                    break;
+                }
+                let Some(parent) = scope.parent() else {
+                    break;
+                };
+                scope = parent;
+            }
+            reference = next?;
+        }
+
+        None
     }
 
     fn resolve_global_member_qualifier(

--- a/crates/biome_module_graph/src/db/type_inference/resolver.rs
+++ b/crates/biome_module_graph/src/db/type_inference/resolver.rs
@@ -1,9 +1,27 @@
+//! Raw type resolution and declaration-level cycle recovery.
+//!
+//! A strongly connected component in the import graph does not imply that
+//! every declaration in those modules depends on a cycle. When an on-demand
+//! lookup crosses such a component, the root lookup retries with a shared
+//! declaration evaluator. The evaluator records the exact bindings, local
+//! types, and namespace exports requested by that lookup. Acyclic declarations
+//! can then settle independently. Cycle breaking marks only declarations in a
+//! dependency cycle as `Unknown`; exhausting the evaluator's work limit marks
+//! every unfinished declaration as `Unknown`.
+//!
+//! Dependency discovery is iterative. An unfinished dependency supplies a
+//! provisional `Unknown`, and the declaration using it waits instead of
+//! keeping that provisional result. The evaluator retries waiting declarations
+//! after their dependencies settle. Imported resolution contexts share the
+//! evaluator, which keeps the declaration graph intact across module
+//! boundaries without recursing through it on the Rust stack.
+
 use super::{BindingTypeData, InferredModuleTypes, globals::global_type};
 use crate::db::queries::{
     LocalTypeInput, infer_local_type, infer_module_types, infer_module_types_from_tables,
     inference_module_sccs,
 };
-use crate::module_graph::ModuleInfo;
+use crate::module_graph::{ModuleInfo, ModuleInfoKind};
 use crate::{JsModuleInfo, ModuleDb, ModuleGraphGeneration, module_for_key};
 use biome_js_syntax::TsModuleDeclaration;
 use biome_js_type_info::{
@@ -15,10 +33,14 @@ use biome_js_type_info::{
         TypeMember as InferredTypeMember, TypeMemberKind as InferredTypeMemberKind,
     },
 };
-use biome_rowan::AstNode;
+use biome_rowan::{AstNode, Text, TextRange};
 use rustc_hash::{FxHashMap, FxHashSet};
 use salsa::plumbing::AsId;
-use std::cell::Cell;
+use std::{
+    cell::{Cell, RefCell},
+    collections::VecDeque,
+    rc::Rc,
+};
 
 // This limit guards Rust stack recursion. Each `ResolutionCtx::resolve` frame
 // clones a raw type and runs a conversion walk. Named declarations become local
@@ -28,6 +50,10 @@ pub(super) const MAX_RAW_TYPE_RESOLUTION_DEPTH: usize = 64;
 pub(super) const MAX_ON_DEMAND_IMPORT_DEPTH: u8 = 128;
 const MAX_INFERRED_EXPRESSION_WRAPPER_STEPS: usize = 64;
 const MAX_LOCAL_TYPE_RESOLUTION_STEPS: usize = 1024;
+// Bounds retries when resolving a dynamically discovered declaration graph.
+// The graph itself is stored on the heap, so this is a work limit rather than
+// a recursion limit.
+const MAX_ON_DEMAND_DECLARATION_ATTEMPTS: usize = 16_384;
 
 /// Selects how a resolution context follows references into imported modules.
 ///
@@ -54,6 +80,128 @@ impl ImportResolution<'_> {
     }
 }
 
+/// Identifies one declaration in the dependency graph for a selected lookup.
+///
+/// Module identity is part of the key because one evaluator follows
+/// declarations across every module in the active import component.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(super) enum OnDemandDeclaration {
+    Binding {
+        module: ModuleInfo,
+        range: TextRange,
+    },
+    Type {
+        module: ModuleInfo,
+        type_id: TypeId,
+    },
+    Namespace {
+        module: ModuleInfo,
+        name: Text,
+    },
+}
+
+/// Progress of one declaration in the on-demand evaluation state machine.
+///
+/// A queued declaration becomes evaluating. The attempt either resolves it or
+/// leaves it waiting on discovered dependencies. Settling a dependency queues
+/// its waiting dependents for another attempt. `Resolved` is terminal.
+#[derive(Clone, Copy)]
+enum OnDemandDeclarationState<'db> {
+    Queued,
+    Evaluating,
+    Waiting,
+    Resolved(InferredTypeData<'db>),
+}
+
+/// Shared worklist and dependency graph for one root declaration lookup.
+///
+/// `dependencies` supports cycle detection. The reverse `dependents` edges
+/// identify which waiting declarations become eligible for another attempt
+/// when a dependency settles.
+#[derive(Default)]
+struct OnDemandDeclarationEvaluator<'db> {
+    states: FxHashMap<OnDemandDeclaration, OnDemandDeclarationState<'db>>,
+    queue: VecDeque<OnDemandDeclaration>,
+    current: Option<OnDemandDeclaration>,
+    current_has_unresolved_dependencies: bool,
+    dependencies: FxHashMap<OnDemandDeclaration, FxHashSet<OnDemandDeclaration>>,
+    dependents: FxHashMap<OnDemandDeclaration, FxHashSet<OnDemandDeclaration>>,
+    attempts: usize,
+}
+
+type SharedOnDemandDeclarationEvaluator<'db> = Rc<RefCell<OnDemandDeclarationEvaluator<'db>>>;
+
+/// Returns every node that belongs to a multi-node component or has a self-edge.
+///
+/// Both passes are iterative because declaration depth comes from source code
+/// and must not consume the Rust stack.
+fn cyclic_dependency_ids(edges: &[Vec<usize>]) -> FxHashSet<usize> {
+    let mut visited = vec![false; edges.len()];
+    let mut next_edge = vec![0; edges.len()];
+    let mut finish_order = Vec::with_capacity(edges.len());
+    let mut stack = Vec::new();
+
+    for start in 0..edges.len() {
+        if visited[start] {
+            continue;
+        }
+        visited[start] = true;
+        stack.push(start);
+        while let Some(&node) = stack.last() {
+            if let Some(&next) = edges[node].get(next_edge[node]) {
+                next_edge[node] += 1;
+                if !visited[next] {
+                    visited[next] = true;
+                    stack.push(next);
+                }
+            } else {
+                finish_order.push(node);
+                stack.pop();
+            }
+        }
+    }
+
+    let mut reverse_edges = vec![Vec::new(); edges.len()];
+    for (from, targets) in edges.iter().enumerate() {
+        for &to in targets {
+            reverse_edges[to].push(from);
+        }
+    }
+
+    let mut component_by_id = vec![usize::MAX; edges.len()];
+    let mut component_sizes = Vec::new();
+    for start in finish_order.into_iter().rev() {
+        if component_by_id[start] != usize::MAX {
+            continue;
+        }
+        let component = component_sizes.len();
+        component_sizes.push(0);
+        stack.push(start);
+        while let Some(node) = stack.pop() {
+            if component_by_id[node] != usize::MAX {
+                continue;
+            }
+            component_by_id[node] = component;
+            component_sizes[component] += 1;
+            stack.extend(
+                reverse_edges[node]
+                    .iter()
+                    .copied()
+                    .filter(|&predecessor| component_by_id[predecessor] == usize::MAX),
+            );
+        }
+    }
+
+    edges
+        .iter()
+        .enumerate()
+        .filter_map(|(id, targets)| {
+            let component = component_by_id[id];
+            (component_sizes[component] > 1 || targets.contains(&id)).then_some(id)
+        })
+        .collect()
+}
+
 pub(in crate::db) struct ResolutionCtx<'db, 'a> {
     pub(in crate::db::type_inference) db: &'db dyn ModuleDb,
     pub(in crate::db::type_inference) module: ModuleInfo,
@@ -63,6 +211,8 @@ pub(in crate::db) struct ResolutionCtx<'db, 'a> {
     pub(in crate::db::type_inference) resolved: FxHashMap<TypeId, InferredTypeData<'db>>,
     pub(in crate::db::type_inference) in_progress: FxHashSet<TypeId>,
     pub(in crate::db::type_inference) resolution_depth: Cell<usize>,
+    encountered_inference_cycle: Cell<bool>,
+    on_demand_declarations: Option<SharedOnDemandDeclarationEvaluator<'db>>,
 }
 
 pub(in crate::db) fn resolve_raw_types<'db>(
@@ -112,6 +262,16 @@ impl<'db, 'a> ResolutionCtx<'db, 'a> {
         js_info: &'a JsModuleInfo,
         import_resolution: ImportResolution<'a>,
     ) -> Self {
+        Self::new_with_declarations(db, module, js_info, import_resolution, None)
+    }
+
+    fn new_with_declarations(
+        db: &'db dyn ModuleDb,
+        module: ModuleInfo,
+        js_info: &'a JsModuleInfo,
+        import_resolution: ImportResolution<'a>,
+        on_demand_declarations: Option<SharedOnDemandDeclarationEvaluator<'db>>,
+    ) -> Self {
         Self {
             db,
             module,
@@ -121,7 +281,367 @@ impl<'db, 'a> ResolutionCtx<'db, 'a> {
             resolved: FxHashMap::default(),
             in_progress: FxHashSet::default(),
             resolution_depth: Cell::new(0),
+            encountered_inference_cycle: Cell::new(false),
+            on_demand_declarations,
         }
+    }
+
+    pub(super) fn for_on_demand_import<'info>(
+        &self,
+        module: ModuleInfo,
+        js_info: &'info JsModuleInfo,
+        remaining: u8,
+        resolve_declarations_directly: bool,
+    ) -> ResolutionCtx<'db, 'info> {
+        // Contexts inside the active import component must contribute to the
+        // same declaration graph. An ordinary imported lookup keeps its own
+        // tracked-query boundary and does not need this shared state.
+        let on_demand_declarations = resolve_declarations_directly.then(|| {
+            self.on_demand_declarations
+                .as_ref()
+                .map_or_else(Rc::default, Rc::clone)
+        });
+        ResolutionCtx::new_with_declarations(
+            self.db,
+            module,
+            js_info,
+            ImportResolution::OnDemand { remaining },
+            on_demand_declarations,
+        )
+    }
+
+    pub(in crate::db) fn resolve_local_binding(
+        &mut self,
+        range: TextRange,
+    ) -> InferredTypeData<'db> {
+        let Some(reference) = self.js_info.raw_binding_types.get(&range).cloned() else {
+            return InferredTypeData::Unknown;
+        };
+        if !matches!(self.import_resolution, ImportResolution::OnDemand { .. })
+            || self.on_demand_declarations.is_none()
+        {
+            return self.resolve(&reference);
+        }
+
+        let declaration = OnDemandDeclaration::Binding {
+            module: self.module,
+            range,
+        };
+        self.resolve_on_demand_declaration(declaration)
+    }
+
+    pub(in crate::db) fn resolve_root_binding(
+        &mut self,
+        range: TextRange,
+    ) -> InferredTypeData<'db> {
+        self.on_demand_declarations.get_or_insert_with(Rc::default);
+        self.resolve_on_demand_declaration(OnDemandDeclaration::Binding {
+            module: self.module,
+            range,
+        })
+    }
+
+    pub(in crate::db) fn resolve_local_declaration(
+        &mut self,
+        type_id: TypeId,
+    ) -> InferredTypeData<'db> {
+        if !matches!(self.import_resolution, ImportResolution::OnDemand { .. })
+            || self.on_demand_declarations.is_none()
+        {
+            return self.resolve_raw_type_id(type_id);
+        }
+
+        let declaration = OnDemandDeclaration::Type {
+            module: self.module,
+            type_id,
+        };
+        self.resolve_on_demand_declaration(declaration)
+    }
+
+    pub(in crate::db) fn resolve_root_declaration(
+        &mut self,
+        type_id: TypeId,
+    ) -> InferredTypeData<'db> {
+        self.on_demand_declarations.get_or_insert_with(Rc::default);
+        self.resolve_on_demand_declaration(OnDemandDeclaration::Type {
+            module: self.module,
+            type_id,
+        })
+    }
+
+    /// Resolves the selected declaration and every declaration it reaches.
+    ///
+    /// Nested requests register dependency edges and return provisional
+    /// `Unknown` values. Results containing those placeholders are discarded
+    /// until their dependencies settle. Exhausting the attempt budget makes
+    /// every unfinished declaration `Unknown`; a dependency cycle affects only
+    /// the declarations in that cycle.
+    pub(super) fn resolve_on_demand_declaration(
+        &self,
+        declaration: OnDemandDeclaration,
+    ) -> InferredTypeData<'db> {
+        if self.on_demand_declarations().borrow().current.is_some() {
+            return self.request_on_demand_declaration(declaration);
+        }
+
+        self.on_demand_declarations().borrow_mut().attempts = 0;
+        self.schedule_on_demand_declaration(declaration.clone());
+        loop {
+            if let Some(OnDemandDeclarationState::Resolved(ty)) = self
+                .on_demand_declarations()
+                .borrow()
+                .states
+                .get(&declaration)
+                .copied()
+            {
+                return ty;
+            }
+
+            let next = self.on_demand_declarations().borrow_mut().queue.pop_front();
+            if let Some(next) = next {
+                if !self.begin_on_demand_declaration_attempt(&next) {
+                    self.abort_on_demand_declarations();
+                    return InferredTypeData::Unknown;
+                }
+                let ty = self.evaluate_on_demand_declaration(&next);
+                self.finish_on_demand_declaration_attempt(next, ty);
+            } else if !self.resolve_on_demand_declaration_cycles() {
+                self.abort_on_demand_declarations();
+                return InferredTypeData::Unknown;
+            }
+        }
+    }
+
+    fn abort_on_demand_declarations(&self) {
+        let mut evaluator = self.on_demand_declarations().borrow_mut();
+        evaluator.queue.clear();
+        evaluator.current = None;
+        evaluator.current_has_unresolved_dependencies = false;
+        for state in evaluator.states.values_mut() {
+            if !matches!(state, OnDemandDeclarationState::Resolved(_)) {
+                *state = OnDemandDeclarationState::Resolved(InferredTypeData::Unknown);
+            }
+        }
+    }
+
+    fn request_on_demand_declaration(
+        &self,
+        declaration: OnDemandDeclaration,
+    ) -> InferredTypeData<'db> {
+        let mut evaluator = self.on_demand_declarations().borrow_mut();
+        if let Some(OnDemandDeclarationState::Resolved(ty)) =
+            evaluator.states.get(&declaration).copied()
+        {
+            return ty;
+        }
+
+        let Some(current) = evaluator.current.clone() else {
+            return InferredTypeData::Unknown;
+        };
+        evaluator.current_has_unresolved_dependencies = true;
+        evaluator
+            .dependencies
+            .entry(current.clone())
+            .or_default()
+            .insert(declaration.clone());
+        evaluator
+            .dependents
+            .entry(declaration.clone())
+            .or_default()
+            .insert(current);
+        if !evaluator.states.contains_key(&declaration) {
+            evaluator
+                .states
+                .insert(declaration.clone(), OnDemandDeclarationState::Queued);
+            evaluator.queue.push_back(declaration);
+        }
+        InferredTypeData::Unknown
+    }
+
+    fn schedule_on_demand_declaration(&self, declaration: OnDemandDeclaration) {
+        let mut evaluator = self.on_demand_declarations().borrow_mut();
+        if !evaluator.states.contains_key(&declaration) {
+            evaluator
+                .states
+                .insert(declaration.clone(), OnDemandDeclarationState::Queued);
+            evaluator.queue.push_back(declaration);
+        }
+    }
+
+    fn begin_on_demand_declaration_attempt(&self, declaration: &OnDemandDeclaration) -> bool {
+        let mut evaluator = self.on_demand_declarations().borrow_mut();
+        if evaluator.attempts >= MAX_ON_DEMAND_DECLARATION_ATTEMPTS {
+            return false;
+        }
+        evaluator.attempts += 1;
+
+        // A retry can discover fewer dependencies after provisional values
+        // have settled. Removing the old edges prevents those stale
+        // dependencies from creating a false cycle.
+        if let Some(previous) = evaluator.dependencies.remove(declaration) {
+            for dependency in previous {
+                if let Some(dependents) = evaluator.dependents.get_mut(&dependency) {
+                    dependents.remove(declaration);
+                }
+            }
+        }
+        evaluator.current = Some(declaration.clone());
+        evaluator.current_has_unresolved_dependencies = false;
+        evaluator
+            .states
+            .insert(declaration.clone(), OnDemandDeclarationState::Evaluating);
+        true
+    }
+
+    fn finish_on_demand_declaration_attempt(
+        &self,
+        declaration: OnDemandDeclaration,
+        ty: InferredTypeData<'db>,
+    ) {
+        let mut evaluator = self.on_demand_declarations().borrow_mut();
+        evaluator.current = None;
+        if evaluator.current_has_unresolved_dependencies {
+            // `ty` contains at least one provisional `Unknown`. Discard it so
+            // the declaration is evaluated again with settled dependencies.
+            evaluator
+                .states
+                .insert(declaration, OnDemandDeclarationState::Waiting);
+        } else {
+            evaluator
+                .states
+                .insert(declaration.clone(), OnDemandDeclarationState::Resolved(ty));
+            Self::schedule_waiting_dependents(&mut evaluator, &declaration);
+        }
+    }
+
+    fn schedule_waiting_dependents(
+        evaluator: &mut OnDemandDeclarationEvaluator<'db>,
+        declaration: &OnDemandDeclaration,
+    ) {
+        let dependents = evaluator
+            .dependents
+            .get(declaration)
+            .cloned()
+            .unwrap_or_default();
+        for dependent in dependents {
+            if matches!(
+                evaluator.states.get(&dependent),
+                Some(OnDemandDeclarationState::Waiting)
+            ) {
+                evaluator
+                    .states
+                    .insert(dependent.clone(), OnDemandDeclarationState::Queued);
+                evaluator.queue.push_back(dependent);
+            }
+        }
+    }
+
+    fn evaluate_on_demand_declaration(
+        &self,
+        declaration: &OnDemandDeclaration,
+    ) -> InferredTypeData<'db> {
+        let module = match declaration {
+            OnDemandDeclaration::Binding { module, .. }
+            | OnDemandDeclaration::Type { module, .. }
+            | OnDemandDeclaration::Namespace { module, .. } => *module,
+        };
+        let ModuleInfoKind::Js(js_info) = module.kind(self.db) else {
+            return InferredTypeData::Unknown;
+        };
+        if !js_info.infer_types {
+            return InferredTypeData::Unknown;
+        }
+
+        let ImportResolution::OnDemand { remaining } = self.import_resolution else {
+            return InferredTypeData::Unknown;
+        };
+        let mut ctx = self.for_on_demand_import(module, &js_info, remaining, true);
+        match declaration {
+            OnDemandDeclaration::Binding { range, .. } => js_info
+                .raw_binding_types
+                .get(range)
+                .cloned()
+                .map_or(InferredTypeData::Unknown, |reference| {
+                    ctx.resolve(&reference)
+                }),
+            OnDemandDeclaration::Type { type_id, .. } => ctx.resolve_raw_type_id(*type_id),
+            OnDemandDeclaration::Namespace { name, .. } => {
+                ctx.resolve_own_namespace_export(name.text())
+            }
+        }
+    }
+
+    fn resolve_on_demand_declaration_cycles(&self) -> bool {
+        let mut evaluator = self.on_demand_declarations().borrow_mut();
+        let waiting = evaluator
+            .states
+            .iter()
+            .filter_map(|(declaration, state)| {
+                matches!(state, OnDemandDeclarationState::Waiting).then_some(declaration.clone())
+            })
+            .collect::<Vec<_>>();
+        if waiting.is_empty() {
+            return false;
+        }
+
+        let id_by_declaration = waiting
+            .iter()
+            .cloned()
+            .enumerate()
+            .map(|(id, declaration)| (declaration, id))
+            .collect::<FxHashMap<_, _>>();
+        let edges = waiting
+            .iter()
+            .map(|declaration| {
+                evaluator
+                    .dependencies
+                    .get(declaration)
+                    .into_iter()
+                    .flatten()
+                    .filter_map(|dependency| id_by_declaration.get(dependency).copied())
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        let cyclic = cyclic_dependency_ids(&edges);
+        if cyclic.is_empty() {
+            return false;
+        }
+
+        // Only declarations in dependency components become `Unknown`.
+        // Treating them as settled lets acyclic declarations that refer to a
+        // cyclic result finish with as much surrounding structure as possible.
+        let cyclic_declarations = cyclic
+            .into_iter()
+            .map(|id| waiting[id].clone())
+            .collect::<Vec<_>>();
+        for declaration in &cyclic_declarations {
+            evaluator.states.insert(
+                declaration.clone(),
+                OnDemandDeclarationState::Resolved(InferredTypeData::Unknown),
+            );
+        }
+        for declaration in cyclic_declarations {
+            Self::schedule_waiting_dependents(&mut evaluator, &declaration);
+        }
+        true
+    }
+
+    fn on_demand_declarations(&self) -> &SharedOnDemandDeclarationEvaluator<'db> {
+        self.on_demand_declarations
+            .as_ref()
+            .expect("on-demand declaration evaluation must be initialized")
+    }
+
+    pub(super) fn resolves_declarations_directly(&self) -> bool {
+        self.on_demand_declarations.is_some()
+    }
+
+    pub(in crate::db) fn encountered_inference_cycle(&self) -> bool {
+        self.encountered_inference_cycle.get()
+    }
+
+    pub(super) fn mark_inference_cycle(&self) {
+        self.encountered_inference_cycle.set(true);
     }
 
     /// Infers `module` as a dependency of the module currently being resolved.
@@ -245,6 +765,7 @@ impl<'db, 'a> ResolutionCtx<'db, 'a> {
             }
             _ => return fallback,
         };
+        let resolves_declarations_directly = self.resolves_declarations_directly();
         let members = self
             .js_info
             .semantic_model
@@ -277,16 +798,17 @@ impl<'db, 'a> ResolutionCtx<'db, 'a> {
                     .ok()?
                     .token_text_trimmed()
                     .into();
-                let reference = self
-                    .js_info
-                    .raw_binding_types
-                    .get(&binding.syntax().text_trimmed_range())?
-                    .clone();
-                Some((name, reference))
+                let range = binding.syntax().text_trimmed_range();
+                let reference = self.js_info.raw_binding_types.get(&range)?.clone();
+                Some((name, range, reference))
             })
-            .map(|(name, reference)| InferredTypeMember {
+            .map(|(name, range, reference)| InferredTypeMember {
                 kind: InferredTypeMemberKind::NamedStatic(name),
-                ty: self.resolve(&reference),
+                ty: if resolves_declarations_directly {
+                    self.resolve_local_binding(range)
+                } else {
+                    self.resolve(&reference)
+                },
             })
             .collect::<Box<[_]>>();
 

--- a/crates/biome_module_graph/tests/spec_tests/cycles.test.rs
+++ b/crates/biome_module_graph/tests/spec_tests/cycles.test.rs
@@ -1,5 +1,7 @@
 use super::*;
-use biome_module_graph::{BindingTypeInput, find_member_type, infer_binding_type};
+use biome_module_graph::{
+    BindingTypeInput, LocalTypeInput, find_member_type, infer_binding_type, infer_local_type,
+};
 
 fn unwrap_typeof_values<'db>(
     db: &'db dyn ModuleDb,
@@ -12,6 +14,20 @@ fn unwrap_typeof_values<'db>(
         ty = value.ty(db);
     }
     ty
+}
+
+fn local_type_id_by_name(db: &dyn ModuleDb, module: ModuleInfo, name: &str) -> InferredLocalTypeId {
+    let ModuleInfoKind::Js(js_info) = module.kind(db) else {
+        panic!("module must contain JavaScript information");
+    };
+    (0..js_info.raw_types.len())
+        .map(InferredLocalTypeId::new)
+        .find(|type_id| {
+            js_info
+                .local_type_name(*type_id)
+                .is_some_and(|type_name| type_name.text() == name)
+        })
+        .unwrap_or_else(|| panic!("{name} local type must exist"))
 }
 
 fn insert_import_chain(fs: &MemoryFileSystem, import_count: usize) -> Vec<String> {
@@ -239,9 +255,10 @@ fn test_binding_query_preserves_acyclic_data_next_to_an_import_cycle() {
     fs.insert(
         "/src/a.ts".into(),
         r#"
-            import { b } from "./b.ts";
+            import { b, wrapper } from "./b.ts";
             export const stable = 1;
             export const a = b;
+            export const outer = wrapper;
         "#,
     );
     fs.insert(
@@ -249,13 +266,15 @@ fn test_binding_query_preserves_acyclic_data_next_to_an_import_cycle() {
         r#"
             import { a, stable } from "./a.ts";
             export const b = { a, stable };
+            export const wrapper = { cyclic: a, stable };
         "#,
     );
     fs.insert(
         "/src/index.ts".into(),
         r#"
-            import { a, stable } from "./a.ts";
-            export const result = { a, stable };
+            import { a, outer, stable } from "./a.ts";
+            import { wrapper } from "./b.ts";
+            export const result = { a, outer, stable, wrapper };
         "#,
     );
 
@@ -269,6 +288,14 @@ fn test_binding_query_preserves_acyclic_data_next_to_an_import_cycle() {
         binding_range_by_name(&db, index_module, "result"),
     );
 
+    let a_module = db
+        .module_for_path(Utf8Path::new("/src/a.ts"))
+        .expect("a module must exist");
+    let cyclic_input =
+        BindingTypeInput::new(&db, a_module, binding_range_by_name(&db, a_module, "a"));
+    let cyclic = infer_binding_type(&db, cyclic_input).expect("cyclic type must be inferred");
+    assert_eq!(unwrap_typeof_values(&db, cyclic), InferredTypeData::Unknown);
+
     let result = infer_binding_type(&db, input).expect("result type must be inferred");
     let cyclic = find_member_type(&db, result, "a").expect("cyclic member must be present");
     let cyclic = unwrap_typeof_values(&db, cyclic);
@@ -279,6 +306,485 @@ fn test_binding_query_preserves_acyclic_data_next_to_an_import_cycle() {
     assert!(
         is_inferred_number(&db, stable),
         "stable member must be numeric, got {stable:?}"
+    );
+
+    let wrapper = find_member_type(&db, result, "wrapper").expect("wrapper must be inferred");
+    let wrapper = unwrap_typeof_values(&db, wrapper);
+    let wrapper_cyclic =
+        find_member_type(&db, wrapper, "cyclic").expect("cyclic member must be present");
+    let wrapper_cyclic = unwrap_typeof_values(&db, wrapper_cyclic);
+    assert_eq!(wrapper_cyclic, InferredTypeData::Unknown);
+    let wrapper_stable =
+        find_member_type(&db, wrapper, "stable").expect("stable member must be inferred");
+    let wrapper_stable = unwrap_typeof_values(&db, wrapper_stable);
+    assert!(
+        is_inferred_number(&db, wrapper_stable),
+        "wrapper stable member must be numeric, got {wrapper_stable:?}"
+    );
+
+    let outer = find_member_type(&db, result, "outer").expect("outer must be inferred");
+    let outer = unwrap_typeof_values(&db, outer);
+    let outer_stable =
+        find_member_type(&db, outer, "stable").expect("outer stable member must be inferred");
+    let outer_stable = unwrap_typeof_values(&db, outer_stable);
+    assert!(
+        is_inferred_number(&db, outer_stable),
+        "outer stable member must be numeric, got {outer_stable:?}"
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/a.ts", "/src/b.ts", "/src/index.ts"], true);
+    let index_module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("index module must exist");
+    let result_input = BindingTypeInput::new(
+        &db,
+        index_module,
+        binding_range_by_name(&db, index_module, "result"),
+    );
+    let result = infer_binding_type(&db, result_input).expect("result type must be inferred");
+    let stable = find_member_type(&db, result, "stable").expect("stable member must be present");
+    assert!(is_inferred_number(&db, unwrap_typeof_values(&db, stable)));
+
+    let a_module = db
+        .module_for_path(Utf8Path::new("/src/a.ts"))
+        .expect("a module must exist");
+    let cyclic_input =
+        BindingTypeInput::new(&db, a_module, binding_range_by_name(&db, a_module, "a"));
+    let cyclic = infer_binding_type(&db, cyclic_input).expect("cyclic type must be inferred");
+    assert_eq!(unwrap_typeof_values(&db, cyclic), InferredTypeData::Unknown);
+}
+
+#[test]
+fn test_binding_query_ignores_unselected_namespace_exports_in_an_import_cycle() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/a.ts".into(),
+        r#"
+            import * as b from "./b.ts";
+            export const value = b.stable;
+        "#,
+    );
+    fs.insert(
+        "/src/b.ts".into(),
+        r#"
+            import { value } from "./a.ts";
+            export const stable = 1;
+            export const unrelatedCycle = value;
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/a.ts", "/src/b.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/a.ts"))
+        .expect("a module must exist");
+    let input = BindingTypeInput::new(&db, module, binding_range_by_name(&db, module, "value"));
+
+    let ty = infer_binding_type(&db, input).expect("value must be inferred");
+    let ty = unwrap_typeof_values(&db, ty);
+    assert!(
+        is_inferred_number(&db, ty),
+        "selected namespace export must be numeric, got {ty:?}"
+    );
+}
+
+#[test]
+fn test_binding_query_projects_a_namespace_member_through_a_local_alias() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/a.ts".into(),
+        r#"
+            import * as b from "./b.ts";
+            const alias = b;
+            export const value = alias.stable;
+        "#,
+    );
+    fs.insert(
+        "/src/b.ts".into(),
+        r#"
+            import { value } from "./a.ts";
+            export const stable = 1;
+            export const unrelatedCycle = value;
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/a.ts", "/src/b.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/a.ts"))
+        .expect("a module must exist");
+    let input = BindingTypeInput::new(&db, module, binding_range_by_name(&db, module, "value"));
+
+    let ty = infer_binding_type(&db, input).expect("value must be inferred");
+    let ty = unwrap_typeof_values(&db, ty);
+    assert!(
+        is_inferred_number(&db, ty),
+        "selected namespace export must be numeric through an alias, got {ty:?}"
+    );
+}
+
+#[test]
+fn test_binding_query_bounds_namespace_projection_scope_traversal() {
+    std::thread::Builder::new()
+        .stack_size(32 * 1024 * 1024)
+        .spawn(|| {
+            const SCOPE_DEPTH: usize = 1025;
+
+            let fs = MemoryFileSystem::default();
+            let mut source = String::from(
+                r#"
+                    import * as values from "./b.ts";
+                    export const selected = (() => {
+                "#,
+            );
+            source.push_str(&"{".repeat(SCOPE_DEPTH));
+            source.push_str("return values.stable;");
+            source.push_str(&"}".repeat(SCOPE_DEPTH));
+            source.push_str("})();");
+            fs.insert("/src/a.ts".into(), source);
+            fs.insert(
+                "/src/b.ts".into(),
+                r#"
+                    import { selected } from "./a.ts";
+                    export const stable = 1;
+                    export const root = selected;
+                "#,
+            );
+
+            let db = build_js_test_module_db(&fs, &["/src/a.ts", "/src/b.ts"], true);
+            let module = db
+                .module_for_path(Utf8Path::new("/src/b.ts"))
+                .expect("b module must exist");
+            let input =
+                BindingTypeInput::new(&db, module, binding_range_by_name(&db, module, "root"));
+
+            let ty = infer_binding_type(&db, input).expect("root must be inferred");
+            assert_eq!(unwrap_typeof_values(&db, ty), InferredTypeData::Unknown);
+        })
+        .expect("scope traversal test thread must spawn")
+        .join()
+        .expect("scope traversal test thread must complete");
+}
+
+#[test]
+fn test_binding_query_resolves_a_selected_namespace_reexport_member_in_an_import_cycle() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/a.ts".into(),
+        r#"
+            export * as values from "./b.ts";
+        "#,
+    );
+    fs.insert(
+        "/src/b.ts".into(),
+        r#"
+            import { values } from "./a.ts";
+            export const stable = 1;
+            export const selected = values.stable;
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/a.ts", "/src/b.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/b.ts"))
+        .expect("b module must exist");
+    let input = BindingTypeInput::new(&db, module, binding_range_by_name(&db, module, "selected"));
+
+    let ty = infer_binding_type(&db, input).expect("selected must be inferred");
+    let ty = unwrap_typeof_values(&db, ty);
+    assert!(
+        is_inferred_number(&db, ty),
+        "selected namespace member must be numeric, got {ty:?}"
+    );
+}
+
+#[test]
+fn test_binding_query_projects_a_member_through_an_exported_namespace_alias() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/a.ts".into(),
+        r#"
+            import * as values from "./b.ts";
+            export { values };
+        "#,
+    );
+    fs.insert(
+        "/src/b.ts".into(),
+        r#"
+            import { values } from "./a.ts";
+            export const stable = 1;
+            export const selected = values.stable;
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/a.ts", "/src/b.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/b.ts"))
+        .expect("b module must exist");
+    let input = BindingTypeInput::new(&db, module, binding_range_by_name(&db, module, "selected"));
+
+    let ty = infer_binding_type(&db, input).expect("selected must be inferred");
+    let ty = unwrap_typeof_values(&db, ty);
+    assert!(
+        is_inferred_number(&db, ty),
+        "selected exported namespace member must be numeric, got {ty:?}"
+    );
+}
+
+#[test]
+fn test_binding_query_projects_a_destructured_namespace_member() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/a.ts".into(),
+        r#"
+            import * as values from "./b.ts";
+            export const { stable } = values;
+        "#,
+    );
+    fs.insert(
+        "/src/b.ts".into(),
+        r#"
+            import { stable as selected } from "./a.ts";
+            export const stable = 1;
+            export const unrelatedCycle = selected;
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/a.ts", "/src/b.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/a.ts"))
+        .expect("a module must exist");
+    let input = BindingTypeInput::new(&db, module, binding_range_by_name(&db, module, "stable"));
+
+    let ty = infer_binding_type(&db, input).expect("stable must be inferred");
+    let ty = unwrap_typeof_values(&db, ty);
+    assert!(
+        is_inferred_number(&db, ty),
+        "destructured namespace member must be numeric, got {ty:?}"
+    );
+}
+
+#[test]
+fn test_binding_query_bounds_an_actual_namespace_declaration_cycle() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/a.ts".into(),
+        r#"
+            export * as values from "./b.ts";
+        "#,
+    );
+    fs.insert(
+        "/src/b.ts".into(),
+        r#"
+            import { values } from "./a.ts";
+            export const recursive = values;
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/a.ts", "/src/b.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/b.ts"))
+        .expect("b module must exist");
+    let input = BindingTypeInput::new(&db, module, binding_range_by_name(&db, module, "recursive"));
+
+    let ty = infer_binding_type(&db, input).expect("recursive must be inferred");
+    assert_eq!(unwrap_typeof_values(&db, ty), InferredTypeData::Unknown);
+}
+
+#[test]
+fn test_local_type_query_preserves_an_acyclic_type_in_an_import_cycle() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/a.ts".into(),
+        r#"
+            import type { Back } from "./b.ts";
+            export interface Stable { value: number }
+            export type Link = Back;
+        "#,
+    );
+    fs.insert(
+        "/src/b.ts".into(),
+        r#"
+            import type { Stable } from "./a.ts";
+            export type Back = Stable;
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/a.ts", "/src/b.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/a.ts"))
+        .expect("a module must exist");
+    let input = LocalTypeInput::new(&db, module, local_type_id_by_name(&db, module, "Stable"));
+
+    let ty = infer_local_type(&db, input).expect("Stable must be inferred");
+    let value = find_member_type(&db, ty, "value").expect("value member must be inferred");
+    assert!(
+        is_inferred_number(&db, value),
+        "value member must be numeric, got {value:?}"
+    );
+}
+
+#[test]
+fn test_binding_query_marks_a_structural_root_declaration_cycle_unknown() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/a.ts".into(),
+        r#"
+            import { b } from "./b.ts";
+            export const a = { b, stable: 1 };
+        "#,
+    );
+    fs.insert(
+        "/src/b.ts".into(),
+        r#"
+            import { a } from "./a.ts";
+            export const b = c;
+            export const c = { a, stable: 2 };
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/a.ts", "/src/b.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/a.ts"))
+        .expect("a module must exist");
+    let input = BindingTypeInput::new(&db, module, binding_range_by_name(&db, module, "a"));
+
+    let ty = infer_binding_type(&db, input).expect("a type must be inferred");
+    assert_eq!(unwrap_typeof_values(&db, ty), InferredTypeData::Unknown);
+
+    let module = db
+        .module_for_path(Utf8Path::new("/src/b.ts"))
+        .expect("b module must exist");
+    let input = BindingTypeInput::new(&db, module, binding_range_by_name(&db, module, "c"));
+    let ty = infer_binding_type(&db, input).expect("c type must be inferred");
+    assert_eq!(unwrap_typeof_values(&db, ty), InferredTypeData::Unknown);
+}
+
+#[test]
+fn test_binding_query_marks_a_structural_self_import_cycle_unknown() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/self.ts".into(),
+        r#"
+            import { b as importedB } from "./self.ts";
+            export const a = { b: importedB, stable: 1 };
+            export const b = a;
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/self.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/self.ts"))
+        .expect("self module must exist");
+    let input = BindingTypeInput::new(&db, module, binding_range_by_name(&db, module, "a"));
+
+    let ty = infer_binding_type(&db, input).expect("a type must be inferred");
+    assert_eq!(unwrap_typeof_values(&db, ty), InferredTypeData::Unknown);
+}
+
+#[test]
+fn test_binding_query_evaluates_a_deep_declaration_chain_in_an_import_cycle() {
+    const MODULE_COUNT: usize = 132;
+
+    let fs = MemoryFileSystem::default();
+    let paths = (0..MODULE_COUNT)
+        .map(|index| format!("/src/branch{index}.ts"))
+        .collect::<Vec<_>>();
+
+    for (index, path) in paths.iter().enumerate() {
+        if index == 0 {
+            fs.insert(
+                path.into(),
+                format!(
+                    "import {{ value{} as unused }} from \"./branch{}.ts\"; export const value0 = {{ leaf: 1 }}; export {{ unused }};",
+                    MODULE_COUNT - 1,
+                    MODULE_COUNT - 1
+                ),
+            );
+            continue;
+        }
+
+        let dependencies = [index - 1];
+        let imports = dependencies
+            .iter()
+            .map(|dependency| {
+                format!("import {{ value{dependency} }} from \"./branch{dependency}.ts\";")
+            })
+            .collect::<String>();
+        let members = dependencies
+            .iter()
+            .map(|dependency| format!("value{dependency}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        fs.insert(
+            path.into(),
+            format!("{imports} export const value{index} = {{ {members} }};"),
+        );
+    }
+
+    let path_refs = paths.iter().map(String::as_str).collect::<Vec<_>>();
+    let db = build_js_test_module_db(&fs, &path_refs, true);
+    let root = db
+        .module_for_path(Utf8Path::new(
+            paths.last().expect("a module path must exist"),
+        ))
+        .expect("root module must exist");
+    let input = BindingTypeInput::new(
+        &db,
+        root,
+        binding_range_by_name(&db, root, &format!("value{}", MODULE_COUNT - 1)),
+    );
+
+    db.clear_salsa_events();
+    let mut ty = infer_binding_type(&db, input).expect("type must be inferred");
+
+    for index in (1..MODULE_COUNT).rev() {
+        ty = find_member_type(&db, ty, &format!("value{}", index - 1))
+            .expect("the preceding branch must be inferred");
+        ty = unwrap_typeof_values(&db, ty);
+    }
+    let leaf = find_member_type(&db, ty, "leaf").expect("the leaf must be inferred");
+    let leaf = unwrap_typeof_values(&db, leaf);
+    assert!(
+        is_inferred_number(&db, leaf),
+        "leaf must be numeric, got {leaf:?}"
+    );
+
+    let events = db.take_salsa_events();
+    let query_count = function_query_will_execute_count_by_name(
+        &db,
+        "infer_binding_type_with_import_budget",
+        &events,
+    );
+    assert_eq!(query_count, 0);
+}
+
+#[test]
+fn test_binding_query_does_not_cache_a_depth_limited_declaration() {
+    const ALIAS_COUNT: usize = 80;
+    const DIRECT_ALIAS: usize = 20;
+
+    let fs = MemoryFileSystem::default();
+    let mut source = String::from("const target = 1;\nconst value0 = target;\n");
+    for index in 1..ALIAS_COUNT {
+        source.push_str(&format!("const value{index} = value{};\n", index - 1));
+    }
+    source.push_str(&format!(
+        "export const root = {{ deep: value{}, direct: value{DIRECT_ALIAS} }};",
+        ALIAS_COUNT - 1,
+    ));
+    fs.insert("/src/a.ts".into(), source);
+
+    let db = build_js_test_module_db(&fs, &["/src/a.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/a.ts"))
+        .expect("a module must exist");
+    let input = BindingTypeInput::new(&db, module, binding_range_by_name(&db, module, "root"));
+
+    let ty = infer_binding_type(&db, input).expect("root must be inferred");
+    let direct = find_member_type(&db, ty, "direct").expect("direct must be inferred");
+    let direct = unwrap_typeof_values(&db, direct);
+    assert!(
+        is_inferred_number(&db, direct),
+        "direct must be numeric, got {direct:?}"
     );
 }
 

--- a/crates/biome_module_graph/tests/spec_tests/queries.test.rs
+++ b/crates/biome_module_graph/tests/spec_tests/queries.test.rs
@@ -40,6 +40,7 @@ fn expression_range_by_source(
 
 const BUDGETED_BINDING_QUERY: &str = "infer_binding_type_with_import_budget";
 const IMPORT_DEPTH_PREPARATION_QUERY: &str = "prepare_module_types_bottom_up_for_import_depth";
+const INFERENCE_SCC_QUERY: &str = "inference_module_sccs";
 
 #[test]
 fn test_binding_query_does_not_infer_complete_module_tables() {
@@ -60,6 +61,60 @@ fn test_binding_query_does_not_infer_complete_module_tables() {
 
     assert_function_query_was_run(&db, infer_binding_type, input, &events);
     assert_function_query_was_not_run(&db, infer_module_types, module, &events);
+}
+
+#[test]
+fn test_local_lookups_skip_cycle_detection_for_unrelated_imports() {
+    let fs = MemoryFileSystem::default();
+    fs.insert("/src/source.ts".into(), "export const unused = 1;");
+    fs.insert(
+        "/src/binding.ts".into(),
+        "import { unused } from './source.ts'; export const value = 1;",
+    );
+    fs.insert(
+        "/src/type.ts".into(),
+        "import { unused } from './source.ts'; export interface Value { field: string; }",
+    );
+
+    let db = build_js_test_module_db(
+        &fs,
+        &["/src/source.ts", "/src/binding.ts", "/src/type.ts"],
+        true,
+    );
+    let binding_module = db
+        .module_for_path(Utf8Path::new("/src/binding.ts"))
+        .expect("binding module must exist");
+    let type_module = db
+        .module_for_path(Utf8Path::new("/src/type.ts"))
+        .expect("type module must exist");
+
+    db.clear_salsa_events();
+    let binding = infer_binding_type(
+        &db,
+        BindingTypeInput::new(
+            &db,
+            binding_module,
+            binding_range_by_name(&db, binding_module, "value"),
+        ),
+    )
+    .expect("value type must be inferred");
+    let local = infer_local_type(
+        &db,
+        LocalTypeInput::new(
+            &db,
+            type_module,
+            local_type_id_by_name(&db, type_module, "Value"),
+        ),
+    )
+    .expect("Value type must be inferred");
+    assert!(InferredType::new(&db, binding).is_inferred());
+    assert!(InferredType::new(&db, local).is_inferred());
+    let events = db.take_salsa_events();
+
+    assert_eq!(
+        function_query_will_execute_count_by_name(&db, INFERENCE_SCC_QUERY, &events),
+        0
+    );
 }
 
 #[test]


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
#11010 introduced an SCC check that prevents type inference from traversing import cycles. This restriction, however, is a bit heavy handed, because import cycles for types is supported by typescript. Type inference should work across import cycles at the module level. This does not mean that the types themselves are allowed to have cyclic dependencies on each other. 


example:
```ts
// a.ts
import type { B } from "./b";

export function importedPromise(): Promise<void> {
  return Promise.resolve();
}

export type A = B;
```

```ts
// b.ts
import { importedPromise } from "./a";

export interface B {}

importedPromise().then(() => {});
```

in this example, the modules _do_ create an import cycle. however, the type of `A`, `B`, and everything else is still fully resolvable.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #11529
<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots. i also had the agent make a benchmark and do a performance pass. ran it through ecosystem CI and didn't see it flag anything

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
