### PR TITLE
fix(schema): list linter.domains keys for editor autocomplete

### DIFF
--- a/.changeset/domains-schema-keys.md
+++ b/.changeset/domains-schema-keys.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11525](https://github.com/biomejs/biome/issues/11525): the JSON schema for `linter.domains` now lists domain keys so editors can autocomplete them.

--- a/crates/biome_configuration/src/analyzer/linter/mod.rs
+++ b/crates/biome_configuration/src/analyzer/linter/mod.rs
@@ -101,8 +101,26 @@ impl schemars::JsonSchema for RuleDomains {
     fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
         let _names = generator.subschema_for::<RuleDomain>();
         let _values = generator.subschema_for::<RuleDomainValue>();
+        // Editors complete object keys from `properties`, not `propertyNames`.
         schemars::json_schema!({
             "type": "object",
+            "properties": {
+                "astro": { "$ref": "#/$defs/RuleDomainValue" },
+                "drizzle": { "$ref": "#/$defs/RuleDomainValue" },
+                "react": { "$ref": "#/$defs/RuleDomainValue" },
+                "reactNative": { "$ref": "#/$defs/RuleDomainValue" },
+                "test": { "$ref": "#/$defs/RuleDomainValue" },
+                "solid": { "$ref": "#/$defs/RuleDomainValue" },
+                "next": { "$ref": "#/$defs/RuleDomainValue" },
+                "qwik": { "$ref": "#/$defs/RuleDomainValue" },
+                "svelte": { "$ref": "#/$defs/RuleDomainValue" },
+                "vue": { "$ref": "#/$defs/RuleDomainValue" },
+                "project": { "$ref": "#/$defs/RuleDomainValue" },
+                "tailwind": { "$ref": "#/$defs/RuleDomainValue" },
+                "turborepo": { "$ref": "#/$defs/RuleDomainValue" },
+                "playwright": { "$ref": "#/$defs/RuleDomainValue" },
+                "types": { "$ref": "#/$defs/RuleDomainValue" }
+            },
             "propertyNames": {
                 "$ref": "#/$defs/RuleDomain"
             },

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -8085,6 +8085,23 @@
 		},
 		"RuleDomains": {
 			"type": "object",
+			"properties": {
+				"astro": { "$ref": "#/$defs/RuleDomainValue" },
+				"drizzle": { "$ref": "#/$defs/RuleDomainValue" },
+				"react": { "$ref": "#/$defs/RuleDomainValue" },
+				"reactNative": { "$ref": "#/$defs/RuleDomainValue" },
+				"test": { "$ref": "#/$defs/RuleDomainValue" },
+				"solid": { "$ref": "#/$defs/RuleDomainValue" },
+				"next": { "$ref": "#/$defs/RuleDomainValue" },
+				"qwik": { "$ref": "#/$defs/RuleDomainValue" },
+				"svelte": { "$ref": "#/$defs/RuleDomainValue" },
+				"vue": { "$ref": "#/$defs/RuleDomainValue" },
+				"project": { "$ref": "#/$defs/RuleDomainValue" },
+				"tailwind": { "$ref": "#/$defs/RuleDomainValue" },
+				"turborepo": { "$ref": "#/$defs/RuleDomainValue" },
+				"playwright": { "$ref": "#/$defs/RuleDomainValue" },
+				"types": { "$ref": "#/$defs/RuleDomainValue" }
+			},
 			"additionalProperties": { "$ref": "#/$defs/RuleDomainValue" },
 			"propertyNames": { "$ref": "#/$defs/RuleDomain" }
 		},


### PR DESCRIPTION
## Summary

`linter.domains` is typed as a map whose keys are `RuleDomain`. The generated JSON Schema only set `propertyNames` + `additionalProperties`. VS Code (and most editors) complete object keys from `properties`, so the domain names never showed up.

This emits an explicit `properties` entry for each domain (`astro`, `react`, `next`, …) while keeping `propertyNames` for validation.

## Test

Cannot run `cargo codegen` here (`rustc 1.85`, repo toolchain is `1.98.0`). Verified the committed schema:

- before: `RuleDomains.properties` missing
- after: keys `astro`, `drizzle`, `next`, `playwright`, `project`, `qwik`, `react`, `reactNative`, `solid`, `svelte`, `tailwind`, `test`, `turborepo`, `types`, `vue`

Fixes #11525
