### PR TITLE
fix(noUnusedVariables): do not flag values merged with a used namespace

### DIFF
--- a/.changeset/namespace-merge-unused-variables.md
+++ b/.changeset/namespace-merge-unused-variables.md
@@ -1,0 +1,11 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11519](https://github.com/biomejs/biome/issues/11519): [`noUnusedVariables`](https://biomejs.dev/linter/rules/no-unused-variables/) no longer reports a function, class, or variable as unused when it shares a name with a TypeScript namespace that is used in the same file.
+
+```ts
+function F() {}
+namespace F {}
+F();
+```

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_variables.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_variables.rs
@@ -100,13 +100,20 @@ declare_lint_rule! {
     /// ```
     ///
     /// TypeScript namespaces that participate in declaration merging with an exported
-    /// or referenced value of the same name are not flagged.
+    /// or referenced value of the same name are not flagged. A value merged with an
+    /// exported or referenced namespace is also not flagged.
     /// ```ts
     /// const MyComponent = () => {};
     /// namespace MyComponent {
     ///     export type Props = { id: string };
     /// }
     /// export default MyComponent;
+    /// ```
+    ///
+    /// ```ts
+    /// function F() {}
+    /// namespace F {}
+    /// F();
     /// ```
     ///
     /// In Astro files, a top-level interface or a type alias named `Props` is always ignored
@@ -475,9 +482,9 @@ fn is_implemented_overload_type_parameter(
         }
 
         signatures.iter().any(|id| {
-            model.binding_by_id(*id).is_some_and(|binding| {
-                binding.syntax().text_trimmed_range() == signature_range
-            })
+            model
+                .binding_by_id(*id)
+                .is_some_and(|binding| binding.syntax().text_trimmed_range() == signature_range)
         })
     })
 }
@@ -698,7 +705,7 @@ fn is_namespace_merged_with_used_value(
     Some(false)
 }
 
-fn is_value_merged_with_exported_namespace(
+fn is_value_merged_with_used_namespace(
     model: &SemanticModel,
     binding: &AnyJsIdentifierBinding,
 ) -> Option<bool> {
@@ -723,7 +730,30 @@ fn is_value_merged_with_exported_namespace(
         return Some(false);
     }
 
-    Some(model.is_exported(&namespace))
+    Some(namespace_has_live_use(model, &namespace))
+}
+
+/// Returns `true` if `namespace` is exported or referenced in a used expression.
+///
+/// Shared-name references bind to the later declaration, so this is also the
+/// use-check for a value merged with that namespace. Discarded identifier
+/// statements such as `F;` are not uses.
+fn namespace_has_live_use(model: &SemanticModel, namespace: &AnyJsIdentifierBinding) -> bool {
+    if model.is_exported(namespace) {
+        return true;
+    }
+
+    // `is_unused` on the namespace would recurse through the merge helpers.
+    namespace.all_references(model).any(|reference| {
+        let Some(ref_parent) = reference.syntax().parent() else {
+            return false;
+        };
+        if JsIdentifierExpression::can_cast(ref_parent.kind()) {
+            matches!(is_unused_expression(&ref_parent), Ok(false))
+        } else {
+            true
+        }
+    })
 }
 
 fn is_declaration_merged_with_used(
@@ -736,7 +766,7 @@ fn is_declaration_merged_with_used(
             is_namespace_merged_with_used_value(model, binding)
         }
         _ if is_namespace_merge_value_declaration(&decl) => {
-            is_value_merged_with_exported_namespace(model, binding)
+            is_value_merged_with_used_namespace(model, binding)
         }
         _ => None,
     }

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidNamespaceUnused.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidNamespaceUnused.ts
@@ -19,3 +19,8 @@ function useShadowed() {
     const Shadowed = 42;
     console.log(Shadowed);
 }
+
+// A discarded identifier expression is not a use of the merged name
+function Discarded() {}
+namespace Discarded {}
+Discarded;

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidNamespaceUnused.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidNamespaceUnused.ts.snap
@@ -26,6 +26,11 @@ function useShadowed() {
     console.log(Shadowed);
 }
 
+// A discarded identifier expression is not a use of the merged name
+function Discarded() {}
+namespace Discarded {}
+Discarded;
+
 ```
 
 # Diagnostics
@@ -125,6 +130,48 @@ invalidNamespaceUnused.ts:18:10 lint/correctness/noUnusedVariables  FIXABLE  ━
        18 │ + function·_useShadowed()·{
     19 19 │       const Shadowed = 42;
     20 20 │       console.log(Shadowed);
+  
+
+```
+
+```
+invalidNamespaceUnused.ts:24:10 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This function Discarded is unused.
+  
+    23 │ // A discarded identifier expression is not a use of the merged name
+  > 24 │ function Discarded() {}
+       │          ^^^^^^^^^
+    25 │ namespace Discarded {}
+    26 │ Discarded;
+  
+  i Unused variables are often the result of typos, incomplete refactors, or other sources of bugs.
+  
+  i Unsafe fix: If this is intentional, prepend Discarded with an underscore.
+  
+    22 22 │   
+    23 23 │   // A discarded identifier expression is not a use of the merged name
+    24    │ - function·Discarded()·{}
+       24 │ + function·_Discarded()·{}
+    25 25 │   namespace Discarded {}
+    26 26 │   Discarded;
+  
+
+```
+
+```
+invalidNamespaceUnused.ts:25:11 lint/correctness/noUnusedVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This variable Discarded is unused.
+  
+    23 │ // A discarded identifier expression is not a use of the merged name
+    24 │ function Discarded() {}
+  > 25 │ namespace Discarded {}
+       │           ^^^^^^^^^
+    26 │ Discarded;
+    27 │ 
+  
+  i Unused variables are often the result of typos, incomplete refactors, or other sources of bugs.
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceMergedLocalUse.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceMergedLocalUse.ts
@@ -1,0 +1,21 @@
+/* should not generate diagnostics */
+
+function F() {}
+namespace F {}
+
+F();
+
+const G = () => {};
+namespace G {
+    export type Props = { id: string };
+}
+
+G();
+export type GProps = G.Props;
+
+class H {}
+namespace H {
+    export type Options = { deep: boolean };
+}
+
+new H();

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceMergedLocalUse.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceMergedLocalUse.ts.snap
@@ -1,0 +1,29 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validNamespaceMergedLocalUse.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+function F() {}
+namespace F {}
+
+F();
+
+const G = () => {};
+namespace G {
+    export type Props = { id: string };
+}
+
+G();
+export type GProps = G.Props;
+
+class H {}
+namespace H {
+    export type Options = { deep: boolean };
+}
+
+new H();
+
+```


### PR DESCRIPTION
This PR was implemented with AI assistance (Cursor). I investigated `noUnusedVariables`, wrote the fix, and checked the fixtures and snapshots.

## Summary

Fixes #11519.

Calling a function that is merged with a TypeScript namespace of the same name no longer reports the function as unused. A reference to the shared name binds to the later namespace declaration, so the value had no references of its own. The value is now treated as used when that namespace is exported or referenced in a used expression. A discarded identifier statement (`F;`) is still not a use.

## Test Plan

`validNamespaceMergedLocalUse.ts` fails on main (`This test should not generate diagnostics`) and passes after the fix. Unused merged pairs, including `function Discarded() {} namespace Discarded {} Discarded;`, still report.

## Docs

The rule rustdoc includes a local-use merge example.