### PR TITLE
fix(noVueDuplicateKeys): fix a range of false-positives

### DIFF
--- a/.changeset/fix-no-vue-duplicate-keys-props-derived.md
+++ b/.changeset/fix-no-vue-duplicate-keys-props-derived.md
@@ -1,0 +1,15 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed a false positive in [`noVueDuplicateKeys`](https://biomejs.dev/linter/rules/no-vue-duplicate-keys/) where a `<script setup>` variable initialized from `props` was reported as a duplicate of the prop it derives from. Biome now exempts any variable whose initializer references `props`, instead of only recognizing `defineProps()` and `toRefs(props)`, matching `eslint-plugin-vue`'s [vue/no-dupe-keys](https://eslint.vuejs.org/rules/no-dupe-keys) rule.
+
+For example, Biome no longer reports `foo` below as a duplicate key:
+
+```vue
+<script setup>
+import { toRef } from 'vue';
+const props = defineProps(['foo']);
+const foo = toRef(props, 'foo');
+</script>
+```

--- a/.changeset/fix-no-vue-duplicate-keys-props-derived.md
+++ b/.changeset/fix-no-vue-duplicate-keys-props-derived.md
@@ -2,7 +2,7 @@
 "@biomejs/biome": patch
 ---
 
-Fixed a false positive in [`noVueDuplicateKeys`](https://biomejs.dev/linter/rules/no-vue-duplicate-keys/) where a `<script setup>` variable initialized from `props` was reported as a duplicate of the prop it derives from. Biome now exempts any variable whose initializer references `props`, instead of only recognizing `defineProps()` and `toRefs(props)`, matching `eslint-plugin-vue`'s [vue/no-dupe-keys](https://eslint.vuejs.org/rules/no-dupe-keys) rule.
+Fixed a false positive in [`noVueDuplicateKeys`](https://biomejs.dev/linter/rules/no-vue-duplicate-keys/) where a `<script setup>` variable initialized from `props` was reported as a duplicate of the prop it derives from. Biome now exempts any variable whose initializer references `props`, instead of only recognizing `defineProps()` and `toRefs(props)`.
 
 For example, Biome no longer reports `foo` below as a duplicate key:
 

--- a/crates/biome_js_analyze/src/frameworks/vue/vue_call.rs
+++ b/crates/biome_js_analyze/src/frameworks/vue/vue_call.rs
@@ -48,26 +48,6 @@ pub fn is_vue_api_reference(
     )
 }
 
-/// Checks if the given call expression is a call to `toRefs` from the Vue package.
-///
-/// `toRefs` is used to convert a reactive object to a plain object where each property
-/// is a ref pointing to the corresponding property of the original object. This is commonly
-/// used with `defineProps` to destructure props while maintaining reactivity.
-///
-/// This function handles both imported `toRefs` and auto-imported `toRefs` in Vue `<script setup>`.
-///
-/// Example: `const { foo, bar } = toRefs(props)`
-pub fn is_to_refs_call(call: &JsCallExpression, model: &SemanticModel) -> bool {
-    let Some(callee) = call.callee().ok() else {
-        return false;
-    };
-    let Some(expression) = callee.inner_expression() else {
-        return false;
-    };
-
-    is_vue_api_reference(&expression, model, "toRefs")
-}
-
 const VUE_PACKAGE_NAMES: &[&str] = &["vue"];
 const VUE_GLOBAL_NAME: Option<&str> = Some("Vue");
 

--- a/crates/biome_js_analyze/src/frameworks/vue/vue_component.rs
+++ b/crates/biome_js_analyze/src/frameworks/vue/vue_component.rs
@@ -765,30 +765,31 @@ impl AnyVueSetupDeclaration {
             && let Some(initializer) = declarator.initializer()
             && let Ok(expression) = initializer.expression()
         {
-            return expression
-                .syntax()
-                .descendants()
-                .any(|node| is_props_source(&node, model));
+            return expression.syntax().descendants().any(|node| {
+                // Case 1: the `defineProps()` call itself, as in
+                // `const { foo } = defineProps(['foo'])`.
+                if let Some(call) = JsCallExpression::cast_ref(&node) {
+                    return is_vue_compiler_macro_call(&call, model, "defineProps");
+                }
+
+                // Case 2: a reference to a variable the call was assigned to, as in
+                // `const props = defineProps(['foo'])` followed by `toRef(props, 'foo')`.
+                if let Some(reference) = JsReferenceIdentifier::cast_ref(&node) {
+                    return is_props_reference(&reference, model);
+                }
+
+                false
+            });
         }
         false
     }
 }
 
-/// Checks if the node is a source of props: either the `defineProps()` call itself, or a
-/// reference to a variable that call was assigned to.
-fn is_props_source(node: &JsSyntaxNode, model: &SemanticModel) -> bool {
-    // Case 1: the `defineProps()` call itself, as in `const { foo } = defineProps(['foo'])`.
-    if let Some(call) = JsCallExpression::cast_ref(node) {
-        return is_vue_compiler_macro_call(&call, model, "defineProps");
-    }
-
-    // Case 2: a reference to a variable the call was assigned to, as in
-    // `const props = defineProps(['foo'])` followed by `toRef(props, 'foo')`.
-    let Some(reference) = JsReferenceIdentifier::cast_ref(node) else {
-        return false;
-    };
+/// Checks if the reference resolves to a variable initialized by a `defineProps()` call,
+/// as in `const props = defineProps(['foo'])`.
+fn is_props_reference(reference: &JsReferenceIdentifier, model: &SemanticModel) -> bool {
     model
-        .binding(&reference)
+        .binding(reference)
         .and_then(|binding| {
             binding
                 .syntax()

--- a/crates/biome_js_analyze/src/frameworks/vue/vue_component.rs
+++ b/crates/biome_js_analyze/src/frameworks/vue/vue_component.rs
@@ -1,6 +1,4 @@
-use crate::frameworks::vue::vue_call::{
-    is_to_refs_call, is_vue_api_reference, is_vue_compiler_macro_call,
-};
+use crate::frameworks::vue::vue_call::{is_vue_api_reference, is_vue_compiler_macro_call};
 use crate::services::semantic::Semantic;
 use crate::utils::rename::RenamableNode;
 use biome_js_semantic::SemanticModel;
@@ -13,9 +11,10 @@ use biome_js_syntax::{
     JsExportDefaultExpressionClause, JsFunctionDeclaration, JsFunctionExpression,
     JsIdentifierBinding, JsMethodObjectMember, JsModule, JsNamedImportSpecifier,
     JsNamedImportSpecifiers, JsNamespaceImportSpecifier, JsObjectBindingPattern,
-    JsPropertyObjectMember, JsShorthandNamedImportSpecifier, JsStringLiteralExpression,
-    JsSyntaxKind, JsSyntaxNode, JsVariableDeclarator, TsIdentifierBinding, TsInterfaceDeclaration,
-    TsPropertySignatureTypeMember, TsTypeAliasDeclaration,
+    JsPropertyObjectMember, JsReferenceIdentifier, JsShorthandNamedImportSpecifier,
+    JsStringLiteralExpression, JsSyntaxKind, JsSyntaxNode, JsVariableDeclarator,
+    TsIdentifierBinding, TsInterfaceDeclaration, TsPropertySignatureTypeMember,
+    TsTypeAliasDeclaration,
 };
 use biome_languages::JsFileSource;
 use biome_rowan::{
@@ -745,11 +744,18 @@ declare_node_union! {
 }
 
 impl AnyVueSetupDeclaration {
-    /// Checks if this setup declaration is assigned directly from `defineProps`.
+    /// Checks if this setup declaration derives its value from props.
     ///
-    /// This handles cases like `const { foo } = defineProps<{ foo: string }>()` where
-    /// the destructured property comes from the props definition.
-    pub fn is_assigned_to_props(&self, model: &SemanticModel) -> bool {
+    /// This is the case when its initializer contains the `defineProps()` call or a reference to
+    /// the variable that call was assigned to. Such a declaration is not an independent source of
+    /// truth for the name, so it does not conflict with the prop it is derived from:
+    ///
+    /// ```js
+    /// const props = defineProps(['foo']);
+    /// const foo = toRef(props, 'foo'); // derived from `props`
+    /// const bar = 42;                  // not derived from `props`
+    /// ```
+    pub fn is_derived_from_props(&self, model: &SemanticModel) -> bool {
         if let Self::JsIdentifierBinding(binding) = self
             && let Some(declarator) = binding
                 .syntax()
@@ -757,77 +763,44 @@ impl AnyVueSetupDeclaration {
                 .skip(1)
                 .find_map(|syntax| JsVariableDeclarator::try_cast(syntax).ok())
             && let Some(initializer) = declarator.initializer()
-            && let Some(expression) = initializer
-                .expression()
-                .ok()
-                .and_then(|expression| expression.inner_expression())
-            && let AnyJsExpression::JsCallExpression(call) = expression
+            && let Ok(expression) = initializer.expression()
         {
-            return is_vue_compiler_macro_call(&call, model, "defineProps");
+            return expression
+                .syntax()
+                .descendants()
+                .any(|node| is_props_source(&node, model));
         }
         false
     }
+}
 
-    /// Checks if this setup declaration is assigned from `toRefs(props)`.
-    ///
-    /// This handles cases like `const { foo } = toRefs(props)` where the destructured
-    /// property comes from converting props to refs. These should not be flagged as
-    /// duplicates of the props themselves.
-    ///
-    /// Only returns true if the argument to `toRefs` is either:
-    /// - A direct `defineProps()` call
-    /// - An identifier whose binding resolves to a variable initialized from `defineProps`
-    pub fn is_assigned_to_to_refs(&self, model: &SemanticModel) -> bool {
-        if let Self::JsIdentifierBinding(binding) = self
-            && let Some(declarator) = binding
+/// Checks if the node is a source of props: either the `defineProps()` call itself, or a
+/// reference to a variable that call was assigned to.
+fn is_props_source(node: &JsSyntaxNode, model: &SemanticModel) -> bool {
+    if let Some(call) = JsCallExpression::cast_ref(node) {
+        return is_vue_compiler_macro_call(&call, model, "defineProps");
+    }
+    let Some(reference) = JsReferenceIdentifier::cast_ref(node) else {
+        return false;
+    };
+    model
+        .binding(&reference)
+        .and_then(|binding| {
+            binding
                 .syntax()
                 .ancestors()
                 .skip(1)
                 .find_map(|syntax| JsVariableDeclarator::try_cast(syntax).ok())
-            && let Some(initializer) = declarator.initializer()
-            && let Some(expression) = initializer
-                .expression()
-                .ok()
-                .and_then(|expression| expression.inner_expression())
-            && let AnyJsExpression::JsCallExpression(call) = expression
-            && is_to_refs_call(&call, model)
-        {
-            // Check that the first argument to `toRefs` is the props source
-            if let Some(Ok(first_arg)) = call
-                .arguments()
-                .ok()
-                .and_then(|args| args.args().iter().next())
-                && let Some(arg_expr) = first_arg.as_any_js_expression()
-                && let Some(arg_expr) = arg_expr.inner_expression()
-            {
-                // Case 1: Direct defineProps() call: `toRefs(defineProps(...))`
-                if let AnyJsExpression::JsCallExpression(arg_call) = &arg_expr
-                    && is_vue_compiler_macro_call(arg_call, model, "defineProps")
-                {
-                    return true;
-                }
-
-                // Case 2: Identifier bound to defineProps: `const props = defineProps(...); toRefs(props)`
-                if let Some(ident_ref) = arg_expr.as_js_reference_identifier()
-                    && let Some(binding) = model.binding(&ident_ref)
-                    && let Some(declarator) = binding
-                        .syntax()
-                        .ancestors()
-                        .skip(1)
-                        .find_map(|syntax| JsVariableDeclarator::try_cast(syntax).ok())
-                    && let Some(decl_initializer) = declarator.initializer()
-                    && let Some(decl_expr) = decl_initializer
-                        .expression()
-                        .ok()
-                        .and_then(|expr| expr.inner_expression())
-                    && let AnyJsExpression::JsCallExpression(decl_call) = decl_expr
-                {
-                    return is_vue_compiler_macro_call(&decl_call, model, "defineProps");
-                }
+        })
+        .and_then(|declarator| declarator.initializer())
+        .and_then(|initializer| initializer.expression().ok())
+        .and_then(|expression| expression.inner_expression())
+        .is_some_and(|expression| match expression {
+            AnyJsExpression::JsCallExpression(call) => {
+                is_vue_compiler_macro_call(&call, model, "defineProps")
             }
-        }
-        false
-    }
+            _ => false,
+        })
 }
 
 impl VueDeclarationName for AnyVueSetupDeclaration {

--- a/crates/biome_js_analyze/src/frameworks/vue/vue_component.rs
+++ b/crates/biome_js_analyze/src/frameworks/vue/vue_component.rs
@@ -777,9 +777,13 @@ impl AnyVueSetupDeclaration {
 /// Checks if the node is a source of props: either the `defineProps()` call itself, or a
 /// reference to a variable that call was assigned to.
 fn is_props_source(node: &JsSyntaxNode, model: &SemanticModel) -> bool {
+    // Case 1: the `defineProps()` call itself, as in `const { foo } = defineProps(['foo'])`.
     if let Some(call) = JsCallExpression::cast_ref(node) {
         return is_vue_compiler_macro_call(&call, model, "defineProps");
     }
+
+    // Case 2: a reference to a variable the call was assigned to, as in
+    // `const props = defineProps(['foo'])` followed by `toRef(props, 'foo')`.
     let Some(reference) = JsReferenceIdentifier::cast_ref(node) else {
         return false;
     };

--- a/crates/biome_js_analyze/src/lint/correctness/no_vue_duplicate_keys.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_vue_duplicate_keys.rs
@@ -143,10 +143,11 @@ impl Rule for NoVueDuplicateKeys {
             VueDeclarationCollectionFilter::all() ^ VueDeclarationCollectionFilter::Watcher,
         ) {
             if let Some(name) = declaration.declaration_name() {
-                // Handle cases like `const { foo } = defineProps(...);`.
+                // A setup variable derived from props is the same value as the prop it comes
+                // from, so it doesn't compete with it. Handles cases like
+                // `const { foo } = defineProps(...)` or `const foo = toRef(props, 'foo')`.
                 if let VueDeclaration::Setup(ref setup_decl) = declaration
-                    && (setup_decl.is_assigned_to_props(model)
-                        || setup_decl.is_assigned_to_to_refs(model))
+                    && setup_decl.is_derived_from_props(model)
                 {
                     continue;
                 }

--- a/crates/biome_js_analyze/tests/specs/correctness/noVueDuplicateKeys/invalid-script-setup-unrelated-initializer.vue
+++ b/crates/biome_js_analyze/tests/specs/correctness/noVueDuplicateKeys/invalid-script-setup-unrelated-initializer.vue
@@ -1,0 +1,6 @@
+<!-- should emit diagnostics -->
+<script setup>
+const props = defineProps(['foo', 'bar'])
+const { foo } = props
+const bar = 42
+</script>

--- a/crates/biome_js_analyze/tests/specs/correctness/noVueDuplicateKeys/invalid-script-setup-unrelated-initializer.vue.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noVueDuplicateKeys/invalid-script-setup-unrelated-initializer.vue.snap
@@ -1,0 +1,41 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid-script-setup-unrelated-initializer.vue
+---
+# Input
+```vue
+<!-- should emit diagnostics -->
+<script setup>
+const props = defineProps(['foo', 'bar'])
+const { foo } = props
+const bar = 42
+</script>
+
+```
+
+# Diagnostics
+```
+invalid-script-setup-unrelated-initializer.vue:3:35 lint/correctness/noVueDuplicateKeys ━━━━━━━━━━━━
+
+  × Duplicate key bar found in Vue component.
+  
+    1 │ <!-- should emit diagnostics -->
+    2 │ <script setup>
+  > 3 │ const props = defineProps(['foo', 'bar'])
+      │                                   ^^^^^
+    4 │ const { foo } = props
+    5 │ const bar = 42
+  
+  i Key bar is also defined here.
+  
+    3 │ const props = defineProps(['foo', 'bar'])
+    4 │ const { foo } = props
+  > 5 │ const bar = 42
+      │       ^^^
+    6 │ </script>
+    7 │ 
+  
+  i Keys defined in different Vue component options (props, data, methods, computed) can conflict when accessed in the template. Rename the key to avoid conflicts.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noVueDuplicateKeys/valid-script-setup-props-member.vue
+++ b/crates/biome_js_analyze/tests/specs/correctness/noVueDuplicateKeys/valid-script-setup-props-member.vue
@@ -1,0 +1,6 @@
+<!-- should not generate diagnostics -->
+<script setup>
+const props = defineProps(['foo', 'bar'])
+const foo = props.foo
+const { bar } = props
+</script>

--- a/crates/biome_js_analyze/tests/specs/correctness/noVueDuplicateKeys/valid-script-setup-props-member.vue.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noVueDuplicateKeys/valid-script-setup-props-member.vue.snap
@@ -1,0 +1,14 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid-script-setup-props-member.vue
+---
+# Input
+```vue
+<!-- should not generate diagnostics -->
+<script setup>
+const props = defineProps(['foo', 'bar'])
+const foo = props.foo
+const { bar } = props
+</script>
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noVueDuplicateKeys/valid-script-setup-props-shorthand.vue
+++ b/crates/biome_js_analyze/tests/specs/correctness/noVueDuplicateKeys/valid-script-setup-props-shorthand.vue
@@ -1,0 +1,5 @@
+<!-- should not generate diagnostics -->
+<script setup>
+const props = defineProps(['foo']);
+const foo = useSomething({ props });
+</script>

--- a/crates/biome_js_analyze/tests/specs/correctness/noVueDuplicateKeys/valid-script-setup-props-shorthand.vue.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noVueDuplicateKeys/valid-script-setup-props-shorthand.vue.snap
@@ -1,0 +1,13 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid-script-setup-props-shorthand.vue
+---
+# Input
+```vue
+<!-- should not generate diagnostics -->
+<script setup>
+const props = defineProps(['foo']);
+const foo = useSomething({ props });
+</script>
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noVueDuplicateKeys/valid-script-setup-to-ref.vue
+++ b/crates/biome_js_analyze/tests/specs/correctness/noVueDuplicateKeys/valid-script-setup-to-ref.vue
@@ -1,0 +1,7 @@
+<!-- should not generate diagnostics -->
+<script setup>
+import { toRef } from 'vue';
+const props = defineProps(['foo', 'bar'])
+const foo = toRef(props, 'foo')
+const bar = toRef(props, 'bar')
+</script>

--- a/crates/biome_js_analyze/tests/specs/correctness/noVueDuplicateKeys/valid-script-setup-to-ref.vue.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noVueDuplicateKeys/valid-script-setup-to-ref.vue.snap
@@ -1,0 +1,15 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid-script-setup-to-ref.vue
+---
+# Input
+```vue
+<!-- should not generate diagnostics -->
+<script setup>
+import { toRef } from 'vue';
+const props = defineProps(['foo', 'bar'])
+const foo = toRef(props, 'foo')
+const bar = toRef(props, 'bar')
+</script>
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noVueDuplicateKeys/valid-script-setup-use-vmodel.vue
+++ b/crates/biome_js_analyze/tests/specs/correctness/noVueDuplicateKeys/valid-script-setup-use-vmodel.vue
@@ -1,0 +1,6 @@
+<!-- should not generate diagnostics -->
+<script setup lang="ts">
+import { useVModel } from '@vueuse/core';
+const props = defineProps<{ modelValue?: string | number }>();
+const modelValue = useVModel(props, 'modelValue');
+</script>

--- a/crates/biome_js_analyze/tests/specs/correctness/noVueDuplicateKeys/valid-script-setup-use-vmodel.vue.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noVueDuplicateKeys/valid-script-setup-use-vmodel.vue.snap
@@ -1,0 +1,14 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid-script-setup-use-vmodel.vue
+---
+# Input
+```vue
+<!-- should not generate diagnostics -->
+<script setup lang="ts">
+import { useVModel } from '@vueuse/core';
+const props = defineProps<{ modelValue?: string | number }>();
+const modelValue = useVModel(props, 'modelValue');
+</script>
+
+```


### PR DESCRIPTION
> Claude Agent has been used in the creation of this PR. The code has been reviewed and reworked by me.

## Summary

Originally I stumbled across this issue by using a third-party library in the intended way that the source rule doesn't flag:

```vue
<script setup lang="ts">
import { useVModel } from '@vueuse/core';

const props = defineProps<{ modelValue?: string | number }>();

const modelValue = useVModel(props, 'modelValue');
</script>
```

https://biomejs.dev/playground/?lintRules=noVueDuplicateKeys&tab=formatter&pane=Diagnostics&language=vue#code=PABzAGMAcgBpAHAAdAAgAHMAZQB0AHUAcAAgAGwAYQBuAGcAPQAiAHQAcwAiAD4ACgBpAG0AcABvAHIAdAAgAHsAIAB1AHMAZQBWAE0AbwBkAGUAbAAgAH0AIABmAHIAbwBtACAAJwBAAHYAdQBlAHUAcwBlAC8AYwBvAHIAZQAnADsACgAKAGMAbwBuAHMAdAAgAHAAcgBvAHAAcwAgAD0AIABkAGUAZgBpAG4AZQBQAHIAbwBwAHMAPAB7ACAAbQBvAGQAZQBsAFYAYQBsAHUAZQA%2FADoAIABzAHQAcgBpAG4AZwAgAHwAIABuAHUAbQBiAGUAcgAgAH0APgAoACkAOwAKAAoAYwBvAG4AcwB0ACAAbQBvAGQAZQBsAFYAYQBsAHUAZQAgAD0AIAB1AHMAZQBWAE0AbwBkAGUAbAAoAHAAcgBvAHAAcwAsACAAJwBtAG8AZABlAGwAVgBhAGwAdQBlACcAKQA7AAoAPAAvAHMAYwByAGkAcAB0AD4A

While fixing this I discovered that also quite a few Vue-native patterns were reported although not reported by the source rule.

The new implementation now matches the source rule.

## Test Plan

A few snapshot tests have been added.