### PR TITLE
fix(js_analyze): don't apply noAdjacentSpacesInRegex fix inside character classes

### DIFF
--- a/.changeset/fix-no-adjacent-spaces-in-regex-character-class.md
+++ b/.changeset/fix-no-adjacent-spaces-in-regex-character-class.md
@@ -1,0 +1,16 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11419](https://github.com/biomejs/biome/issues/11419): [`noAdjacentSpacesInRegex`](https://biomejs.dev/linter/rules/no-adjacent-spaces-in-regex/) no longer applies its fix inside a regex character class (`[...]`), where it was changing what the class matches instead of just clarifying the spacing.
+
+For example, Biome used to "fix" this regex into matching different characters:
+
+```js
+const before = /[\s   ]/;
+// Biome used to rewrite this to /[\s {3}]/, which is a different regex:
+// {3} isn't a quantifier inside a character class, it's three more
+// characters to match — the fixed regex now also matches "1", "2", "{", "}".
+```
+
+Adjacent spaces outside a character class are still merged into a quantifier as before.

--- a/crates/biome_js_analyze/src/lint/complexity/no_adjacent_spaces_in_regex.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_adjacent_spaces_in_regex.rs
@@ -69,8 +69,24 @@ impl Rule for NoAdjacentSpacesInRegex {
         let mut range_list = vec![];
         let mut previous_is_space = false;
         let mut first_consecutive_space_index = 0;
+        // Inside a character class (`[...]`), adjacent spaces are redundant
+        // set members, not a countable run: `{n}` is not a quantifier there,
+        // so merging them into one would change what the class matches.
+        // Track class depth (ignoring escaped brackets) to skip those spaces.
+        let mut in_class = false;
+        let mut escaped = false;
         for (i, ch) in trimmed_text.bytes().enumerate() {
-            if ch == b' ' {
+            let is_escaped = escaped;
+            escaped = ch == b'\\' && !is_escaped;
+            if !is_escaped {
+                match ch {
+                    b'[' if !in_class => in_class = true,
+                    b']' if in_class => in_class = false,
+                    _ => {}
+                }
+            }
+
+            if ch == b' ' && !in_class {
                 if !previous_is_space {
                     previous_is_space = true;
                     first_consecutive_space_index = i;

--- a/crates/biome_js_analyze/tests/specs/complexity/noAdjacentSpacesInRegex/invalid.jsonc
+++ b/crates/biome_js_analyze/tests/specs/complexity/noAdjacentSpacesInRegex/invalid.jsonc
@@ -26,5 +26,11 @@
 	"/foo  {1,2/;",
 	"/\u200E\u2066\u2069   /gu;",
 	"/foo😀  ?/;",
-	"/foo  😀/;"
+	"/foo  😀/;",
+	// A run outside a character class is still merged into a quantifier even
+	// when the same literal also has an (untouched) run inside a class.
+	"/[a-z  ]  b/;",
+	// Escaped brackets aren't a real character class, so a run between them
+	// is still merged as usual.
+	"/\\[   \\]/;"
 ]

--- a/crates/biome_js_analyze/tests/specs/complexity/noAdjacentSpacesInRegex/invalid.jsonc.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noAdjacentSpacesInRegex/invalid.jsonc.snap
@@ -649,3 +649,51 @@ invalid.jsonc:1:5 lint/complexity/noAdjacentSpacesInRegex  FIXABLE  ━━━━
   
 
 ```
+
+# Input
+```cjs
+/[a-z  ]  b/;
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:9 lint/complexity/noAdjacentSpacesInRegex  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This regular expression contains unclear uses of consecutive spaces.
+  
+  > 1 │ /[a-z  ]  b/;
+      │         ^^
+  
+  i It's hard to visually count the amount of spaces.
+  
+  i Safe fix: Use a quantifier instead.
+  
+  - /[a-z··]··b/;
+  + /[a-z··]·{2}b/;
+  
+
+```
+
+# Input
+```cjs
+/\[   \]/;
+```
+
+# Diagnostics
+```
+invalid.jsonc:1:4 lint/complexity/noAdjacentSpacesInRegex  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This regular expression contains unclear uses of consecutive spaces.
+  
+  > 1 │ /\[   \]/;
+      │    ^^^
+  
+  i It's hard to visually count the amount of spaces.
+  
+  i Safe fix: Use a quantifier instead.
+  
+  - /\[···\]/;
+  + /\[·{3}\]/;
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/complexity/noAdjacentSpacesInRegex/valid.jsonc
+++ b/crates/biome_js_analyze/tests/specs/complexity/noAdjacentSpacesInRegex/valid.jsonc
@@ -3,5 +3,11 @@
     "/foo bar baz/;",
     "/foo bar\tbaz/;",
     "/foo /;",
-	"/\u200E\u2066\u2069/gu;"
+	"/\u200E\u2066\u2069/gu;",
+	// Adjacent spaces inside a character class are redundant set members,
+	// not a countable run: `{n}` isn't a quantifier there, so merging them
+	// would corrupt what the class matches. See issue #11419.
+	"/[\\s   ]/g;",
+	"/[   ]/;",
+	"/[a-z   ]/;"
 ]

--- a/crates/biome_js_analyze/tests/specs/complexity/noAdjacentSpacesInRegex/valid.jsonc.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noAdjacentSpacesInRegex/valid.jsonc.snap
@@ -26,3 +26,18 @@ expression: valid.jsonc
 ```cjs
 /‎⁦⁩/gu;
 ```
+
+# Input
+```cjs
+/[\s   ]/g;
+```
+
+# Input
+```cjs
+/[   ]/;
+```
+
+# Input
+```cjs
+/[a-z   ]/;
+```


### PR DESCRIPTION
## Summary

Fixes #11419.

`noAdjacentSpacesInRegex`'s `run()` scans the regex source as raw bytes with no notion of being inside a `[...]` character class. Runs of adjacent spaces found there get rewritten into a `{n}` quantifier just like anywhere else in the pattern — but `{n}` isn't a quantifier inside a character class, it's three more literal members of the set. The safe fix silently changes what the regex matches:

```js
/[\s   ]/   // -> /[\s {3}]/ — now also matches "1", "2", "{", "}"
```

Credit to @Lstarsky0's analysis in the issue, which traced this precisely to the byte-level scan having no class or escape awareness.

## Fix

Track character-class depth while scanning (toggling on unescaped `[`/`]`), and skip space runs found while `in_class`. A run outside a class in the same literal is still detected and fixed as before — the fix doesn't bail out of the whole literal, only the in-class portion is left untouched.

## Test plan
- [x] Added 3 cases to `valid.jsonc`: spaces fully inside a class no longer get a diagnostic (`/[\s   ]/g`, `/[   ]/`, `/[a-z   ]/`)
- [x] Added 2 cases to `invalid.jsonc`:
  - a mixed literal (`/[a-z  ]  b/`) confirming the outer run is still merged into a quantifier while the class is left untouched
  - escaped brackets (`/\[   \]/`) confirming they're correctly treated as literal, not a class, so the run between them is still fixed as before
- [x] `cargo test --test spec_tests` in `biome_js_analyze`: 2865 passed, 0 failed (full suite)
- [x] Added a changeset

---

This PR was written primarily by Claude Code (investigation, fix, and tests). I reviewed the change and test results before opening this PR.
