### PR TITLE
fix(useNamingConvention): ignore namespaces inside declare global

### DIFF
--- a/.changeset/fix-naming-convention-global-namespace.md
+++ b/.changeset/fix-naming-convention-global-namespace.md
@@ -1,0 +1,15 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11566](https://github.com/biomejs/biome/issues/11566): [`useNamingConvention`](https://biomejs.dev/linter/rules/use-naming-convention/) no longer reports namespaces declared inside a `declare global` block. The rule already ignored every other declaration in that position, and its safe fix renamed `namespace JSX` to `namespace Jsx`.
+
+Biome no longer reports the namespace below:
+
+```ts
+declare global {
+    namespace JSX {
+        interface IntrinsicElements {}
+    }
+}
+```

--- a/crates/biome_js_analyze/src/lint/style/use_naming_convention.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_naming_convention.rs
@@ -1249,7 +1249,7 @@ fn selector_from_binding_declaration(decl: &AnyJsBindingDeclaration) -> Option<S
             | AnyJsBindingDeclaration::JsNamedImportSpecifier(_) =>
                 Some(Selector::with_scope(Kind::ImportAlias, Scope::Global)),
             AnyJsBindingDeclaration::TsModuleDeclaration(_) =>
-                Some(Selector::with_scope(Kind::Namespace, Scope::Global)),
+                Some(Selector::with_scope(Kind::Namespace, scope_from_declaration(decl)?)),
             AnyJsBindingDeclaration::TsTypeAliasDeclaration(_) =>
                 Some(Selector::with_scope(Kind::TypeAlias, scope_from_declaration(decl)?)),
             AnyJsBindingDeclaration::JsClassDeclaration(class) => {

--- a/crates/biome_js_analyze/tests/specs/style/useNamingConvention/validGlobalNamespace.ts
+++ b/crates/biome_js_analyze/tests/specs/style/useNamingConvention/validGlobalNamespace.ts
@@ -1,0 +1,7 @@
+/* should not generate diagnostics */
+export {}
+declare global {
+    namespace JSX {
+        interface IntrinsicElements {}
+    }
+}

--- a/crates/biome_js_analyze/tests/specs/style/useNamingConvention/validGlobalNamespace.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useNamingConvention/validGlobalNamespace.ts.snap
@@ -1,0 +1,15 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validGlobalNamespace.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+export {}
+declare global {
+    namespace JSX {
+        interface IntrinsicElements {}
+    }
+}
+
+```


### PR DESCRIPTION
## Summary

`useNamingConvention` reports namespaces declared inside `declare global`, and ships a safe fix that renames `namespace JSX` to `namespace Jsx`. Running `biome check --write` on a project that declares the JSX namespace will break it.

The rule already documents "Declarations inside a global declaration" as always ignored, and an `interface` in that position is ignored today. Only namespaces are affected.

In `selector_from_binding_declaration`, the `TsModuleDeclaration` arm hardcodes `Scope::Global`, while the neighbouring arms call `scope_from_declaration(decl)?`. That helper returns `None` for `TS_GLOBAL_DECLARATION`, and returning `None` is what suppresses the diagnostic, so the namespace arm could never opt out. This change makes that arm match its neighbours.

Top level namespaces still resolve to `Scope::Global` through `JS_MODULE` and `JS_SCRIPT`, so nothing outside `declare global` changes.

Closes #11566.

## Test Plan

Added `validGlobalNamespace.ts`, next to the existing `validInterfaceOverload.ts` that covers an `interface` in the same position.

Confirmed it fails without the fix: the new spec panics with "This test should not generate diagnostics" and reports the `JSX` to `Jsx` rename. With the fix, `cargo test -p biome_js_analyze` passes, 2869 tests, including the existing `invalidNamespace.ts` that keeps ordinary namespaces checked.

## Docs

No documentation change. The rustdoc already lists this position as ignored.