### PR TITLE
fix(noUnusedVariables): keep values merged with a used namespace

### DIFF
--- a/.changeset/fix-unused-variables-merged-namespace.md
+++ b/.changeset/fix-unused-variables-merged-namespace.md
@@ -1,0 +1,13 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11519](https://github.com/biomejs/biome/issues/11519): [`noUnusedVariables`](https://biomejs.dev/linter/rules/no-unused-variables/) no longer reports a value that merges with a namespace of the same name when that namespace is referenced. Previously the merged value was only spared when the namespace was exported.
+
+Biome no longer reports `F` below:
+
+```ts
+function F() {}
+namespace F {}
+F();
+```

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_variables.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_variables.rs
@@ -698,7 +698,7 @@ fn is_namespace_merged_with_used_value(
     Some(false)
 }
 
-fn is_value_merged_with_exported_namespace(
+fn is_value_merged_with_used_namespace(
     model: &SemanticModel,
     binding: &AnyJsIdentifierBinding,
 ) -> Option<bool> {
@@ -723,7 +723,7 @@ fn is_value_merged_with_exported_namespace(
         return Some(false);
     }
 
-    Some(model.is_exported(&namespace))
+    Some(model.is_exported(&namespace) || !is_unused_by_references(model, &namespace))
 }
 
 fn is_declaration_merged_with_used(
@@ -736,7 +736,7 @@ fn is_declaration_merged_with_used(
             is_namespace_merged_with_used_value(model, binding)
         }
         _ if is_namespace_merge_value_declaration(&decl) => {
-            is_value_merged_with_exported_namespace(model, binding)
+            is_value_merged_with_used_namespace(model, binding)
         }
         _ => None,
     }
@@ -811,11 +811,24 @@ pub fn is_unused(model: &SemanticModel, binding: &AnyJsIdentifierBinding) -> boo
         return false;
     }
 
+    if !is_unused_by_references(model, binding) {
+        return false;
+    }
+    !is_declaration_merged_with_used(model, binding).unwrap_or(false)
+}
+
+/// Returns `true` when no reference to `binding` counts as a use.
+///
+/// Declaration merging is deliberately not considered here. The merge checks ask
+/// whether the other half of a merge is referenced, and routing that through
+/// [`is_unused`] would make the two halves call each other forever when both are
+/// unused.
+fn is_unused_by_references(model: &SemanticModel, binding: &AnyJsIdentifierBinding) -> bool {
     let Some(declaration) = binding.declaration() else {
         return false;
     };
     let declaration = declaration.syntax();
-    let unused_by_refs = binding
+    binding
         .all_references(model)
         .filter_map(|reference| {
             let ref_parent = reference.syntax().parent()?;
@@ -879,11 +892,7 @@ pub fn is_unused(model: &SemanticModel, binding: &AnyJsIdentifierBinding) -> boo
             }
             // Always false when the ref is outside the declaration
             false
-        });
-    if !unused_by_refs {
-        return false;
-    }
-    !is_declaration_merged_with_used(model, binding).unwrap_or(false)
+        })
 }
 
 /// Returns `true` if `expr` is unused.

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceDeclarationMerging4.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceDeclarationMerging4.ts
@@ -1,0 +1,11 @@
+/* should not generate diagnostics */
+
+function F() {}
+namespace F {}
+F();
+
+const G = () => {};
+namespace G {
+    export type Props = { id: string };
+}
+G();

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceDeclarationMerging4.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validNamespaceDeclarationMerging4.ts.snap
@@ -1,0 +1,19 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validNamespaceDeclarationMerging4.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+function F() {}
+namespace F {}
+F();
+
+const G = () => {};
+namespace G {
+    export type Props = { id: string };
+}
+G();
+
+```


### PR DESCRIPTION
## Summary

`noUnusedVariables` reports a value that merges with a namespace of the same name, even when that namespace is referenced.

```ts
function F() {}
namespace F {}
F();
```

A namespace declaration follows the value it merges with, so the scope lookup for `F` points at the namespace and the value binding itself ends up with no references. `is_value_merged_with_exported_namespace` then decided whether to spare the value, and it only asked whether the namespace was exported. An unexported but referenced namespace fell through, so the value was reported.

The check for the opposite direction, `is_namespace_merge_value_used`, already accepts either condition with `is_exported(other) || !is_unused(model, other)`. This makes the value direction agree with it.

Calling `is_unused` on the namespace directly would recurse. The namespace's own check asks whether the merged value is used, that asks about the namespace again, and two unused halves call each other forever. That case is not hypothetical, `invalidNamespaceUnused.ts` already contains it. So the reference scan is split out of `is_unused` into `is_unused_by_references`, which does not consider merging, and the merge check uses that instead.

The function is renamed to `is_value_merged_with_used_namespace` to match what it now checks.

Closes #11519.

## Test Plan

Added `validNamespaceDeclarationMerging4.ts`, covering the reported function case and a `const` variant.

Confirmed it fails without the source change: the new spec then reports both `This function F is unused.` and `This variable G is unused.`

`cargo test -p biome_js_analyze` passes 2869 tests. `invalidNamespaceUnused.ts`, which holds an unused value merged with an unused namespace, still reports and does not overflow the stack. `is_unused` is also used by `noUselessCatchBinding` and `useNamingConvention`, both covered by that run.

## Docs

No documentation change. The rustdoc already describes merged declarations as not flagged.