### PR TITLE
feat(lint): support eslint jsx-no-bind options in noJsxPropsBind

### DIFF
--- a/.changeset/fix-jsx-no-bind.md
+++ b/.changeset/fix-jsx-no-bind.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#4637](https://github.com/biomejs/biome/issues/4637). The [`noJsxPropsBind`](https://biomejs.dev/linter/rules/no-jsx-props-bind/) rule now supports `allowArrowFunctions`, `allowFunctions`, `allowBind`, `ignoreDOMComponents` and `ignoreRefs` options, matching `eslint-plugin-react`'s `jsx-no-bind` behavior.

--- a/crates/biome_js_analyze/src/lint/performance/no_jsx_props_bind.rs
+++ b/crates/biome_js_analyze/src/lint/performance/no_jsx_props_bind.rs
@@ -3,14 +3,16 @@ use biome_analyze::{
 };
 use biome_diagnostics::Severity;
 use biome_js_semantic::Binding;
-use biome_js_syntax::{AnyJsExpression, JsxAttribute, binding_ext::AnyJsBindingDeclaration};
+use biome_js_syntax::{
+    AnyJsExpression, JsxAttribute, binding_ext::AnyJsBindingDeclaration, jsx_ext::AnyJsxElement,
+};
 use biome_rowan::{AstNode, TextRange};
 use biome_rule_options::no_jsx_props_bind::NoJsxPropsBindOptions;
 
 use crate::services::semantic::Semantic;
 
 declare_lint_rule! {
-    /// Disallow .bind(), arrow functions, or function expressions in JSX props
+    /// Disallow `.bind()` or arrow functions in JSX props
     ///
     /// Using `.bind()` or creating a function inline in props creates a new function
     /// on every render, changing identity and defeating memoisation,
@@ -34,6 +36,88 @@ declare_lint_rule! {
     ///
     /// ```jsx
     /// <Foo onClick={this._handleClick}></Foo>
+    /// ```
+    ///
+    /// ## Options
+    ///
+    /// ### `allowArrowFunctions`
+    ///
+    /// When `true`, arrow functions are allowed in JSX props.
+    ///
+    /// ```json,options
+    /// {
+    ///   "options": {
+    ///     "allowArrowFunctions": true
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// ```jsx,use_options
+    /// <Foo onClick={() => console.log('Hello!')} />
+    /// ```
+    ///
+    /// ### `allowFunctions`
+    ///
+    /// When `true`, function expressions are allowed.
+    ///
+    /// ```json,options
+    /// {
+    ///   "options": {
+    ///     "allowFunctions": true
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// ```jsx,use_options
+    /// <Foo onClick={function () { console.log('Hello!'); }} />
+    /// ```
+    ///
+    /// ### `allowBind`
+    ///
+    /// When `true`, `.bind()` is allowed.
+    ///
+    /// ```json,options
+    /// {
+    ///   "options": {
+    ///     "allowBind": true
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// ```jsx,use_options
+    /// <Foo onClick={this._handleClick.bind(this)} />
+    /// ```
+    ///
+    /// ### `ignoreDOMComponents`
+    ///
+    /// When `true`, DOM components like `<div>` are ignored.
+    ///
+    /// ```json,options
+    /// {
+    ///   "options": {
+    ///     "ignoreDOMComponents": true
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// ```jsx,use_options
+    /// <div onClick={() => console.log('Hello!')} />
+    /// ```
+    ///
+    /// ### `ignoreRefs`
+    ///
+    /// When `true`, `ref` props are ignored.
+    ///
+    /// ```json,options
+    /// {
+    ///   "options": {
+    ///     "ignoreRefs": true
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// ```jsx,use_options
+    /// <Foo ref={ref => this._div = ref} />
     /// ```
 
     pub NoJsxPropsBind {
@@ -74,6 +158,33 @@ impl Rule for NoJsxPropsBind {
     type Options = NoJsxPropsBindOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let options = ctx.options();
+
+        // handle ignoreRefs — bit of a hack but it works, just check attr name
+        if options.ignore_refs() {
+            if let Ok(name) = ctx.query().name() {
+                if let Ok(token) = name.name() {
+                    if token.text_trimmed() == "ref" {
+                        return None;
+                    }
+                }
+            }
+        }
+
+        // handle ignoreDOMComponents — skip DOM elements like div, span, button
+        if options.ignore_dom_components() {
+            // walk up to find the JSX element that owns this attribute
+            let is_dom = ctx
+                .query()
+                .syntax()
+                .ancestors()
+                .find_map(AnyJsxElement::cast)
+                .is_some_and(|el| !el.is_custom_component());
+            if is_dom {
+                return None;
+            }
+        }
+
         let expression: AnyJsExpression = ctx
             .query()
             .initializer()?
@@ -84,16 +195,29 @@ impl Rule for NoJsxPropsBind {
             .ok()?;
 
         match &expression {
-            AnyJsExpression::JsArrowFunctionExpression(_) => Some(NoJsxPropsBindState {
-                invalid_kind: InvalidKind::ArrowFunction,
-                attribute_range: expression.range(),
-            }),
+            AnyJsExpression::JsArrowFunctionExpression(_) => {
+                if options.allow_arrow_functions() {
+                    return None;
+                }
+                Some(NoJsxPropsBindState {
+                    invalid_kind: InvalidKind::ArrowFunction,
+                    attribute_range: expression.range(),
+                })
+            }
 
-            AnyJsExpression::JsFunctionExpression(_) => Some(NoJsxPropsBindState {
-                invalid_kind: InvalidKind::Function,
-                attribute_range: expression.range(),
-            }),
+            AnyJsExpression::JsFunctionExpression(_) => {
+                if options.allow_functions() {
+                    return None;
+                }
+                Some(NoJsxPropsBindState {
+                    invalid_kind: InvalidKind::Function,
+                    attribute_range: expression.range(),
+                })
+            }
             AnyJsExpression::JsCallExpression(call) => {
+                if options.allow_bind() {
+                    return None;
+                }
                 // TODO: This will still throw a false positive on e.g. window.bind()
                 let is_bind = call
                     .callee()
@@ -122,20 +246,38 @@ impl Rule for NoJsxPropsBind {
                         if declaration_is_global(&declaration) {
                             return None;
                         }
+                        if options.allow_functions() {
+                            return None;
+                        }
                         Some(NoJsxPropsBindState {
                             invalid_kind: InvalidKind::Function,
                             attribute_range: expression.range(),
                         })
                     }
                     AnyJsBindingDeclaration::JsVariableDeclarator(variable_declarator) => {
-                        match variable_declarator.initializer()?.expression().ok()? {
-                            AnyJsExpression::JsFunctionExpression(_)
-                            | AnyJsExpression::JsArrowFunctionExpression(_) => {
+                        let init_expr = variable_declarator.initializer()?.expression().ok()?;
+                        match init_expr {
+                            AnyJsExpression::JsFunctionExpression(_) => {
                                 if declaration_is_global(&declaration) {
+                                    return None;
+                                }
+                                if options.allow_functions() {
                                     return None;
                                 }
                                 Some(NoJsxPropsBindState {
                                     invalid_kind: InvalidKind::Function,
+                                    attribute_range: expression.range(),
+                                })
+                            }
+                            AnyJsExpression::JsArrowFunctionExpression(_) => {
+                                if declaration_is_global(&declaration) {
+                                    return None;
+                                }
+                                if options.allow_arrow_functions() {
+                                    return None;
+                                }
+                                Some(NoJsxPropsBindState {
+                                    invalid_kind: InvalidKind::ArrowFunction,
                                     attribute_range: expression.range(),
                                 })
                             }

--- a/crates/biome_js_analyze/src/lint/performance/no_jsx_props_bind.rs
+++ b/crates/biome_js_analyze/src/lint/performance/no_jsx_props_bind.rs
@@ -12,7 +12,7 @@ use biome_rule_options::no_jsx_props_bind::NoJsxPropsBindOptions;
 use crate::services::semantic::Semantic;
 
 declare_lint_rule! {
-    /// Disallow `.bind()` or arrow functions in JSX props
+    /// Disallow `.bind()`, arrow functions, and function expressions in JSX props
     ///
     /// Using `.bind()` or creating a function inline in props creates a new function
     /// on every render, changing identity and defeating memoisation,
@@ -171,9 +171,7 @@ impl Rule for NoJsxPropsBind {
             }
         }
 
-        // handle ignoreDOMComponents — skip DOM elements like div, span, button
         if options.ignore_dom_components() {
-            // walk up to find the JSX element that owns this attribute
             let is_dom = ctx
                 .query()
                 .syntax()

--- a/crates/biome_js_analyze/tests/specs/performance/noJsxPropsBind/allowArrowFunctions/options.json
+++ b/crates/biome_js_analyze/tests/specs/performance/noJsxPropsBind/allowArrowFunctions/options.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "performance": {
+        "noJsxPropsBind": {
+          "level": "error",
+          "options": {
+            "allowArrowFunctions": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_js_analyze/tests/specs/performance/noJsxPropsBind/allowArrowFunctions/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/performance/noJsxPropsBind/allowArrowFunctions/valid.jsx
@@ -1,0 +1,8 @@
+/* should not generate diagnostics */
+<Foo onClick={() => console.log('Hello!')} />
+<Foo onClick={() => alert("1337")} />
+
+function Foo() {
+  const onClick = () => {};
+  return <Bar onClick={onClick} />;
+}

--- a/crates/biome_js_analyze/tests/specs/performance/noJsxPropsBind/allowBind/options.json
+++ b/crates/biome_js_analyze/tests/specs/performance/noJsxPropsBind/allowBind/options.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "performance": {
+        "noJsxPropsBind": {
+          "level": "error",
+          "options": {
+            "allowBind": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_js_analyze/tests/specs/performance/noJsxPropsBind/allowBind/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/performance/noJsxPropsBind/allowBind/valid.jsx
@@ -1,0 +1,3 @@
+/* should not generate diagnostics */
+<Foo onClick={this._handleClick.bind(this)} />
+<Foo onClick={handleClick.bind(this)} />

--- a/crates/biome_js_analyze/tests/specs/performance/noJsxPropsBind/allowFunctions/options.json
+++ b/crates/biome_js_analyze/tests/specs/performance/noJsxPropsBind/allowFunctions/options.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "performance": {
+        "noJsxPropsBind": {
+          "level": "error",
+          "options": {
+            "allowFunctions": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_js_analyze/tests/specs/performance/noJsxPropsBind/allowFunctions/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/performance/noJsxPropsBind/allowFunctions/valid.jsx
@@ -1,0 +1,12 @@
+/* should not generate diagnostics */
+<Foo onClick={function () { console.log('Hello!'); }} />
+
+function Foo() {
+  function onClick() {}
+  return <Bar onClick={onClick} />;
+}
+
+function Foo() {
+  const onClick = function () {};
+  return <Bar onClick={onClick} />;
+}

--- a/crates/biome_js_analyze/tests/specs/performance/noJsxPropsBind/ignoreDOMComponents/options.json
+++ b/crates/biome_js_analyze/tests/specs/performance/noJsxPropsBind/ignoreDOMComponents/options.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "performance": {
+        "noJsxPropsBind": {
+          "level": "error",
+          "options": {
+            "ignoreDOMComponents": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_js_analyze/tests/specs/performance/noJsxPropsBind/ignoreDOMComponents/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/performance/noJsxPropsBind/ignoreDOMComponents/valid.jsx
@@ -1,0 +1,4 @@
+/* should not generate diagnostics */
+<div onClick={() => console.log("Hello!")} />
+<span onClick={function () { alert("1337") }} />
+<button type="button" onClick={this._handleClick.bind(this)} />

--- a/crates/biome_js_analyze/tests/specs/performance/noJsxPropsBind/ignoreRefs/options.json
+++ b/crates/biome_js_analyze/tests/specs/performance/noJsxPropsBind/ignoreRefs/options.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "performance": {
+        "noJsxPropsBind": {
+          "level": "error",
+          "options": {
+            "ignoreRefs": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_js_analyze/tests/specs/performance/noJsxPropsBind/ignoreRefs/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/performance/noJsxPropsBind/ignoreRefs/valid.jsx
@@ -1,0 +1,3 @@
+/* should not generate diagnostics */
+<Foo ref={ref => { this._div = ref; }} />
+<Foo ref={this._refCallback.bind(this)} />

--- a/crates/biome_rule_options/src/no_jsx_props_bind.rs
+++ b/crates/biome_rule_options/src/no_jsx_props_bind.rs
@@ -3,4 +3,38 @@ use serde::{Deserialize, Serialize};
 #[derive(Default, Clone, Debug, Deserialize, Deserializable, Merge, Eq, PartialEq, Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields, default)]
-pub struct NoJsxPropsBindOptions {}
+pub struct NoJsxPropsBindOptions {
+    /// Whether to allow arrow functions in JSX props. Defaults to `false`.
+    #[serde(skip_serializing_if = "Option::<_>::is_none")]
+    pub allow_arrow_functions: Option<bool>,
+    /// Whether to allow function expressions in JSX props. Defaults to `false`.
+    #[serde(skip_serializing_if = "Option::<_>::is_none")]
+    pub allow_functions: Option<bool>,
+    /// Whether to allow `.bind()` calls in JSX props. Defaults to `false`.
+    #[serde(skip_serializing_if = "Option::<_>::is_none")]
+    pub allow_bind: Option<bool>,
+    /// Whether to ignore DOM components (`<div>`, `<span>`, etc.). Defaults to `false`.
+    #[serde(skip_serializing_if = "Option::<_>::is_none")]
+    pub ignore_dom_components: Option<bool>,
+    /// Whether to ignore `ref` props. Defaults to `false`.
+    #[serde(skip_serializing_if = "Option::<_>::is_none")]
+    pub ignore_refs: Option<bool>,
+}
+
+impl NoJsxPropsBindOptions {
+    pub fn allow_arrow_functions(&self) -> bool {
+        self.allow_arrow_functions.unwrap_or(false)
+    }
+    pub fn allow_functions(&self) -> bool {
+        self.allow_functions.unwrap_or(false)
+    }
+    pub fn allow_bind(&self) -> bool {
+        self.allow_bind.unwrap_or(false)
+    }
+    pub fn ignore_dom_components(&self) -> bool {
+        self.ignore_dom_components.unwrap_or(false)
+    }
+    pub fn ignore_refs(&self) -> bool {
+        self.ignore_refs.unwrap_or(false)
+    }
+}


### PR DESCRIPTION
Fixes #4637

This extends performance/noJsxPropsBind to match eslint's react/jsx-no-bind options: allowArrowFunctions, allowFunctions, allowBind, ignoreDOMComponents and ignoreRefs. Previously these cases were always flagged; now they can be configured to allow common patterns like DOM handlers or ref callbacks.

Added test fixtures for each option.