### PR TITLE
fix(parse/tailwind): make whitespace not trivia anymore

### DIFF
--- a/.changeset/metal-games-share.md
+++ b/.changeset/metal-games-share.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Improved the Tailwind parser's ability to recover from parsing failures. Whitespace now always allows the parser to recover and start parsing a new class.

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/arbitrary_value_match.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/arbitrary_value_match.rs
@@ -630,7 +630,7 @@ fn is_vector(list: &CssGenericComponentValueList) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use biome_rowan::AstNodeList;
+    use biome_rowan::AstSeparatedList;
     use biome_tailwind_parser::parse_tailwind;
     use biome_tailwind_syntax::{AnyTwCandidate, AnyTwValue, CssGenericComponentValueList};
 
@@ -642,7 +642,7 @@ mod tests {
 
     fn parse_arbitrary_value(source: &str) -> CssGenericComponentValueList {
         let parsed = parse_tailwind(source);
-        let full = parsed.tree().candidates().iter().next().unwrap();
+        let full = parsed.tree().candidates().iter().next().unwrap().unwrap();
         let full = full.as_tw_full_candidate().unwrap();
         let candidate = full.candidate().unwrap();
         let AnyTwCandidate::TwFunctionalCandidate(functional) = candidate else {
@@ -765,7 +765,7 @@ mod tests {
         assert!(value_matches_type(&parse_value!("THIN"), CssDataType::LineWidth));
         assert!(value_matches_type(&parse_value!("2px"), CssDataType::LineWidth));
         assert!(value_matches_type(
-            &parse_value!("1px 2px"),
+            &parse_value!("1px_2px"),
             CssDataType::LineWidth
         ));
         assert!(!value_matches_type(&parse_value!("solid"), CssDataType::LineWidth));
@@ -804,15 +804,15 @@ mod tests {
         assert!(value_matches_type(&parse_value!("top"), CssDataType::Position));
         assert!(value_matches_type(&parse_value!("TOP"), CssDataType::Position));
         assert!(value_matches_type(
-            &parse_value!("top left"),
+            &parse_value!("top_left"),
             CssDataType::Position
         ));
         assert!(value_matches_type(
-            &parse_value!("50% 10px"),
+            &parse_value!("50%_10px"),
             CssDataType::Position
         ));
         assert!(value_matches_type(
-            &parse_value!("top var(--pos)"),
+            &parse_value!("top_var(--pos)"),
             CssDataType::Position
         ));
         assert!(!value_matches_type(
@@ -820,7 +820,7 @@ mod tests {
             CssDataType::Position
         ));
         assert!(!value_matches_type(
-            &parse_value!("var(--pos) top"),
+            &parse_value!("var(--pos)_top"),
             CssDataType::Position
         ));
         assert!(!value_matches_type(&parse_value!("foo"), CssDataType::Position));
@@ -833,7 +833,7 @@ mod tests {
         assert!(value_matches_type(&parse_value!("auto"), CssDataType::BgSize));
         assert!(value_matches_type(&parse_value!("AUTO"), CssDataType::BgSize));
         assert!(value_matches_type(
-            &parse_value!("200px 100%"),
+            &parse_value!("200px_100%"),
             CssDataType::BgSize
         ));
         assert!(value_matches_type(
@@ -845,16 +845,16 @@ mod tests {
             CssDataType::BgSize
         ));
         assert!(!value_matches_type(
-            &parse_value!("200px 100% 50%"),
+            &parse_value!("200px_100%_50%"),
             CssDataType::BgSize
         ));
     }
 
     #[test]
     fn vector_matches_exactly_three_numbers() {
-        assert!(value_matches_type(&parse_value!("1 2 3"), CssDataType::Vector));
-        assert!(!value_matches_type(&parse_value!("1 2"), CssDataType::Vector));
-        assert!(!value_matches_type(&parse_value!("1px 2 3"), CssDataType::Vector));
+        assert!(value_matches_type(&parse_value!("1_2_3"), CssDataType::Vector));
+        assert!(!value_matches_type(&parse_value!("1_2"), CssDataType::Vector));
+        assert!(!value_matches_type(&parse_value!("1px_2_3"), CssDataType::Vector));
     }
 
     // endregion: multi-value

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_v4.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_v4.rs
@@ -1,6 +1,8 @@
 use std::cmp::Ordering;
 
-use biome_rowan::{AstNode, AstNodeList, SyntaxNodeText, TextRange, TextSize, TokenText};
+use biome_rowan::{
+    AstNode, AstSeparatedList, SyntaxNodeText, TextRange, TextSize, TokenText,
+};
 use biome_string_case::Collator;
 use biome_tailwind_syntax::{
     AnyTwCandidate, AnyTwFullCandidate, AnyTwModifier, AnyTwValue, CssGenericComponentValueList,
@@ -31,7 +33,7 @@ pub fn sort_class_list(root: &TwRoot) -> String {
     // weight in a second pass.
     let mut pending: Vec<(PendingSortKey, SyntaxNodeText)> =
         Vec::with_capacity(candidates.len());
-    for candidate in candidates {
+    for candidate in candidates.iter().flatten() {
         let text = candidate.syntax().text_trimmed();
         let key = PendingSortKey::from_candidate(&candidate);
         pending.push((key, text));
@@ -797,7 +799,7 @@ mod tests {
     /// candidate `x`, for tests that only exercise the placement.
     fn known(property_idx: u16, property_count: u8) -> SortKey {
         let parsed = parse_tailwind("x");
-        let candidate = parsed.tree().candidates().iter().next().unwrap();
+        let candidate = parsed.tree().candidates().iter().next().unwrap().unwrap();
         SortKey::Known {
             variant_weight: VariantWeight::default(),
             signature: Signature::Property(property_idx),
@@ -821,7 +823,7 @@ mod tests {
 
     fn classify(input: &str) -> SortKey {
         let parsed = parse_tailwind(input);
-        let full = parsed.tree().candidates().iter().next().unwrap();
+        let full = parsed.tree().candidates().iter().next().unwrap().unwrap();
         let pending = PendingSortKey::from_candidate(&full);
         // Groups from this one candidate; a plain utility gets empty
         // `variant_weight`.
@@ -855,6 +857,7 @@ mod tests {
             .tree()
             .candidates()
             .iter()
+            .flatten()
             .map(|c| CandidateText(c.syntax().clone()))
             .collect();
         for a in &texts {
@@ -882,6 +885,7 @@ mod tests {
             .tree()
             .candidates()
             .iter()
+            .flatten()
             .map(|candidate| PendingSortKey::from_candidate(&candidate))
             .collect();
         let groups = VariantGroups::new(
@@ -901,7 +905,7 @@ mod tests {
 
     fn functional_parts(input: &str) -> (AnyTwValue, Option<AnyTwModifier>) {
         let parsed = parse_tailwind(input);
-        let full = parsed.tree().candidates().iter().next().unwrap();
+        let full = parsed.tree().candidates().iter().next().unwrap().unwrap();
         let full = full.as_tw_full_candidate().unwrap();
         let candidate = full.candidate().unwrap();
         let AnyTwCandidate::TwFunctionalCandidate(functional) = candidate else {
@@ -1088,7 +1092,13 @@ mod tests {
             ArbitraryBranch::Typed(CssDataType::Number, ModifierKind::None, 10, 1),
             ArbitraryBranch::Fallback(ModifierKind::None, 20, 1),
         ];
-        let full = parse_tailwind("p-[10px]").tree().candidates().iter().next().unwrap();
+        let full = parse_tailwind("p-[10px]")
+            .tree()
+            .candidates()
+            .iter()
+            .next()
+            .unwrap()
+            .unwrap();
         let full = full.as_tw_full_candidate().unwrap();
         let candidate = full.candidate().unwrap();
         let AnyTwCandidate::TwFunctionalCandidate(functional) = candidate else {
@@ -1110,6 +1120,7 @@ mod tests {
             .candidates()
             .iter()
             .next()
+            .unwrap()
             .unwrap();
         let full = full.as_tw_full_candidate().unwrap();
         let candidate = full.candidate().unwrap();

--- a/crates/biome_tailwind_factory/src/generated/node_factory.rs
+++ b/crates/biome_tailwind_factory/src/generated/node_factory.rs
@@ -433,16 +433,22 @@ pub fn tw_root(candidates: TwCandidateList, eof_token: SyntaxToken) -> TwRootBui
         candidates,
         eof_token,
         bom_token: None,
+        leading_whitespace_token: None,
     }
 }
 pub struct TwRootBuilder {
     candidates: TwCandidateList,
     eof_token: SyntaxToken,
     bom_token: Option<SyntaxToken>,
+    leading_whitespace_token: Option<SyntaxToken>,
 }
 impl TwRootBuilder {
     pub fn with_bom_token(mut self, bom_token: SyntaxToken) -> Self {
         self.bom_token = Some(bom_token);
+        self
+    }
+    pub fn with_leading_whitespace_token(mut self, leading_whitespace_token: SyntaxToken) -> Self {
+        self.leading_whitespace_token = Some(leading_whitespace_token);
         self
     }
     pub fn build(self) -> TwRoot {
@@ -450,6 +456,8 @@ impl TwRootBuilder {
             TailwindSyntaxKind::TW_ROOT,
             [
                 self.bom_token.map(|token| SyntaxElement::Token(token)),
+                self.leading_whitespace_token
+                    .map(|token| SyntaxElement::Token(token)),
                 Some(SyntaxElement::Node(self.candidates.into_syntax())),
                 Some(SyntaxElement::Token(self.eof_token)),
             ],
@@ -561,16 +569,25 @@ where
         }),
     ))
 }
-pub fn tw_candidate_list<I>(items: I) -> TwCandidateList
+pub fn tw_candidate_list<I, S>(items: I, separators: S) -> TwCandidateList
 where
     I: IntoIterator<Item = AnyTwFullCandidate>,
     I::IntoIter: ExactSizeIterator,
+    S: IntoIterator<Item = TailwindSyntaxToken>,
+    S::IntoIter: ExactSizeIterator,
 {
+    let mut items = items.into_iter();
+    let mut separators = separators.into_iter();
+    let length = items.len() + separators.len();
     TwCandidateList::unwrap_cast(SyntaxNode::new_detached(
         TailwindSyntaxKind::TW_CANDIDATE_LIST,
-        items
-            .into_iter()
-            .map(|item| Some(item.into_syntax().into())),
+        (0..length).map(|index| {
+            if index % 2 == 0 {
+                Some(items.next()?.into_syntax().into())
+            } else {
+                Some(separators.next()?.into())
+            }
+        }),
     ))
 }
 pub fn tw_variant_list<I, S>(items: I, separators: S) -> TwVariantList

--- a/crates/biome_tailwind_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_tailwind_factory/src/generated/syntax_factory.rs
@@ -876,10 +876,17 @@ impl SyntaxFactory for TailwindSyntaxFactory {
             }
             TW_ROOT => {
                 let mut elements = (&children).into_iter();
-                let mut slots: RawNodeSlots<3usize> = RawNodeSlots::default();
+                let mut slots: RawNodeSlots<4usize> = RawNodeSlots::default();
                 let mut current_element = elements.next();
                 if let Some(element) = &current_element
                     && element.kind() == T![UNICODE_BOM]
+                {
+                    slots.mark_present();
+                    current_element = elements.next();
+                }
+                slots.next_slot();
+                if let Some(element) = &current_element
+                    && element.kind() == T![' ']
                 {
                     slots.mark_present();
                     current_element = elements.next();
@@ -976,9 +983,13 @@ impl SyntaxFactory for TailwindSyntaxFactory {
                 T ! [,],
                 true,
             ),
-            TW_CANDIDATE_LIST => {
-                Self::make_node_list_syntax(kind, children, AnyTwFullCandidate::can_cast)
-            }
+            TW_CANDIDATE_LIST => Self::make_separated_list_syntax(
+                kind,
+                children,
+                AnyTwFullCandidate::can_cast,
+                T![' '],
+                true,
+            ),
             TW_VARIANT_LIST => Self::make_separated_list_syntax(
                 kind,
                 children,

--- a/crates/biome_tailwind_logic/src/snapshots/biome_tailwind_logic__use_tailwind_shorthand_classes__tests__invalid_cases.snap
+++ b/crates/biome_tailwind_logic/src/snapshots/biome_tailwind_logic__use_tailwind_shorthand_classes__tests__invalid_cases.snap
@@ -533,3 +533,35 @@ Violations: 2
   replacements: ["truncate"]
   static replacements: ["truncate"]
 Fixed: `hover:truncate focus:truncate`
+
+## Input
+
+```text
+text-red-500 pl-2
+pr-2
+```
+
+Violations: 1
+- Violation 1
+  nodes: ["pl-2", "pr-2"]
+  replacements: ["px"]
+  static replacements: []
+Fixed: `text-red-500
+px-2`
+
+## Input
+
+```text
+w-4 ml-2 h-4 mr-2
+```
+
+Violations: 2
+- Violation 1
+  nodes: ["w-4", "h-4"]
+  replacements: ["size"]
+  static replacements: []
+- Violation 2
+  nodes: ["ml-2", "mr-2"]
+  replacements: ["mx"]
+  static replacements: []
+Fixed: `size-4 mx-2`

--- a/crates/biome_tailwind_logic/src/use_tailwind_shorthand_classes.rs
+++ b/crates/biome_tailwind_logic/src/use_tailwind_shorthand_classes.rs
@@ -1,7 +1,7 @@
 use std::hash::Hash;
 
 use biome_rowan::{
-    AstNode, AstNodeList, BatchMutation, BatchMutationExt, Direction, TextRange, TokenText,
+    AstNode, AstSeparatedList, BatchMutation, BatchMutationExt, Direction, TextRange, TokenText,
     WalkEvent,
 };
 use biome_tailwind_factory::make;
@@ -112,6 +112,7 @@ fn find_static_class_candidate(
 ) -> Option<TwFullCandidate> {
     candidates
         .iter()
+        .flatten()
         .filter_map(|candidate| candidate.as_tw_full_candidate().cloned())
         .find(|candidate| {
             (candidate_matches(candidate, base, "")
@@ -144,6 +145,7 @@ fn check_truncate_shorthand(candidates: &TwCandidateList) -> Vec<TailwindShortha
     let (first_base, first_value) = TRUNCATE_PARTS[0];
     for first in candidates
         .iter()
+        .flatten()
         .filter_map(|candidate| candidate.as_tw_full_candidate().cloned())
     {
         if !candidate_matches(&first, first_base, first_value)
@@ -158,6 +160,7 @@ fn check_truncate_shorthand(candidates: &TwCandidateList) -> Vec<TailwindShortha
         for &(base, value) in TRUNCATE_PARTS {
             let Some(candidate) = candidates
                 .iter()
+                .flatten()
                 .filter_map(|candidate| candidate.as_tw_full_candidate().cloned())
                 .find(|candidate| {
                     candidate_matches(candidate, base, value)
@@ -281,6 +284,7 @@ pub fn analyze_tailwind_shorthand(candidates: &TwCandidateList) -> Vec<TailwindS
     let mut groups: FxHashMap<GroupKey, GroupCandidates> = FxHashMap::default();
     for candidate in candidates
         .iter()
+        .flatten()
         .filter_map(|candidate| candidate.as_tw_full_candidate().cloned())
     {
         let Some((key, base)) = extract_key_and_base(&candidate) else {
@@ -419,7 +423,7 @@ pub fn auto_fix(
     state: &TailwindShorthandViolation,
 ) -> Option<BatchMutation<TailwindLanguage>> {
     let mut mutation = root.clone().begin();
-    apply_auto_fix(&mut mutation, state)?;
+    apply_auto_fix(&mut mutation, state, &mut FxHashSet::default())?;
 
     Some(mutation)
 }
@@ -429,8 +433,9 @@ pub fn auto_fix_all(
     states: &[TailwindShorthandViolation],
 ) -> Option<BatchMutation<TailwindLanguage>> {
     let mut mutation = root.clone().begin();
+    let mut removed_separators = FxHashSet::default();
     for state in states {
-        apply_auto_fix(&mut mutation, state)?;
+        apply_auto_fix(&mut mutation, state, &mut removed_separators)?;
     }
 
     Some(mutation)
@@ -439,6 +444,7 @@ pub fn auto_fix_all(
 fn apply_auto_fix(
     mutation: &mut BatchMutation<TailwindLanguage>,
     state: &TailwindShorthandViolation,
+    removed_separators: &mut FxHashSet<TextRange>,
 ) -> Option<()> {
     let mut old_candidates = state.uncompressed_nodes.clone();
     old_candidates.extend(state.existing_replacement.iter().cloned());
@@ -524,6 +530,22 @@ fn apply_auto_fix(
     }
 
     for to_remove in old_candidates {
+        let syntax = to_remove.syntax();
+        let separator = [
+            syntax.prev_sibling_or_token(),
+            syntax.next_sibling_or_token(),
+        ]
+        .into_iter()
+        .flatten()
+        .filter_map(|element| element.into_token())
+        .find(|token| {
+            token.kind() == TailwindSyntaxKind::WHITESPACE
+                && removed_separators.insert(token.text_range())
+        });
+
+        if let Some(separator) = separator {
+            mutation.remove_token(separator);
+        }
         mutation.remove_node(to_remove);
     }
 
@@ -672,6 +694,8 @@ mod tests {
         "hover:overflow-hidden focus:overflow-hidden focus:text-ellipsis focus:whitespace-nowrap",
         "overflow-hidden! text-ellipsis! whitespace-nowrap!",
         "hover:overflow-hidden hover:text-ellipsis hover:whitespace-nowrap focus:overflow-hidden focus:text-ellipsis focus:whitespace-nowrap",
+        "text-red-500 pl-2\npr-2",
+        "w-4 ml-2 h-4 mr-2",
     ];
 
     const VALID_CASES: &[&str] = &[

--- a/crates/biome_tailwind_parser/src/lexer/mod.rs
+++ b/crates/biome_tailwind_parser/src/lexer/mod.rs
@@ -5,7 +5,7 @@ use crate::lexer::base_name_store::{BASENAME_STORE, is_delimiter};
 use crate::token_source::TailwindLexContext;
 use biome_parser::diagnostic::ParseDiagnostic;
 use biome_parser::lexer::{Lexer, LexerCheckpoint, LexerWithCheckpoint, ReLexer, TokenFlags};
-use biome_rowan::{SyntaxKind, TextLen};
+use biome_rowan::TextLen;
 use biome_tailwind_syntax::T;
 use biome_tailwind_syntax::TailwindSyntaxKind::*;
 use biome_tailwind_syntax::{TailwindSyntaxKind, TextSize};
@@ -20,7 +20,6 @@ pub(crate) struct TailwindLexer<'src> {
     current_start: TextSize,
     diagnostics: Vec<ParseDiagnostic>,
     current_flags: TokenFlags,
-    preceding_line_break: bool,
     after_newline: bool,
     unicode_bom_length: usize,
 }
@@ -34,7 +33,6 @@ impl<'src> TailwindLexer<'src> {
             current_start: TextSize::default(),
             diagnostics: Vec::new(),
             current_flags: TokenFlags::empty(),
-            preceding_line_break: false,
             after_newline: false,
             unicode_bom_length: 0,
         }
@@ -43,7 +41,7 @@ impl<'src> TailwindLexer<'src> {
     fn consume_token(&mut self, current: u8) -> TailwindSyntaxKind {
         let dispatched = lookup_byte(current);
         match dispatched {
-            WHS => self.consume_newline_or_whitespaces(),
+            WHS => self.consume_whitespace_token(),
             PNO => self.consume_byte(T!['(']),
             PNC => self.consume_byte(T![')']),
             BTO => self.consume_byte(T!['[']),
@@ -83,7 +81,7 @@ impl<'src> TailwindLexer<'src> {
     fn consume_token_saw_negative(&mut self, current: u8) -> TailwindSyntaxKind {
         let dispatched = lookup_byte(current);
         match dispatched {
-            WHS => self.consume_newline_or_whitespaces(),
+            WHS => self.consume_whitespace_token(),
             PNO => self.consume_byte(T!['(']),
             PNC => self.consume_byte(T![')']),
             BTO => self.consume_byte(T!['[']),
@@ -108,7 +106,7 @@ impl<'src> TailwindLexer<'src> {
             PNC => self.consume_byte(T![')']),
             BTO => self.consume_byte(T!['[']),
             BTC => self.consume_byte(T![']']),
-            WHS => self.consume_newline_or_whitespaces(),
+            WHS => self.consume_whitespace_token(),
             _ if self.current_kind == T!['['] => self.consume_bracketed_thing(TW_SELECTOR, BTC),
             _ => self.consume_named_value(),
         }
@@ -122,7 +120,7 @@ impl<'src> TailwindLexer<'src> {
             PNC => self.consume_byte(T![')']),
             BTO => self.consume_byte(T!['[']),
             BTC => self.consume_byte(T![']']),
-            WHS => self.consume_newline_or_whitespaces(),
+            WHS => self.consume_whitespace_token(),
             COL => self.consume_byte(T![:]),
             _ if self.current_kind == T!['['] => self.consume_bracketed_thing(TW_PROPERTY, COL),
             _ if self.current_kind == T![:] => self.consume_token_css_value(current),
@@ -133,7 +131,7 @@ impl<'src> TailwindLexer<'src> {
     fn consume_token_variant_segment(&mut self, current: u8) -> TailwindSyntaxKind {
         let dispatched = lookup_byte(current);
         match dispatched {
-            WHS => self.consume_newline_or_whitespaces(),
+            WHS => self.consume_whitespace_token(),
             PNO => self.consume_byte(T!['(']),
             PNC => self.consume_byte(T![')']),
             BTO => self.consume_byte(T!['[']),
@@ -152,7 +150,7 @@ impl<'src> TailwindLexer<'src> {
     fn consume_token_css_value(&mut self, current: u8) -> TailwindSyntaxKind {
         let dispatched = lookup_byte(current);
         match dispatched {
-            WHS => self.consume_newline_or_whitespaces(),
+            WHS => self.consume_whitespace_token(),
             PNO => self.consume_byte(T!['(']),
             PNC => self.consume_byte(T![')']),
             BTO => self.consume_byte(T!['[']),
@@ -184,7 +182,7 @@ impl<'src> TailwindLexer<'src> {
     fn consume_token_css_url_raw_value(&mut self, current: u8) -> TailwindSyntaxKind {
         match lookup_byte(current) {
             PNC => self.consume_byte(T![')']),
-            WHS => self.consume_newline_or_whitespaces(),
+            WHS => self.consume_whitespace_token(),
             QOT => self.consume_css_string(current),
             _ => self.consume_css_url_raw_value(),
         }
@@ -347,11 +345,19 @@ impl<'src> TailwindLexer<'src> {
     fn consume_css_string(&mut self, quote: u8) -> TailwindSyntaxKind {
         self.advance(1);
         while let Some(byte) = self.current_byte() {
+            if lookup_byte(byte) == WHS {
+                break;
+            }
+
             self.advance(1);
             if byte == quote {
                 break;
             }
-            if byte == b'\\' && !self.is_eof() {
+            if byte == b'\\'
+                && self
+                    .current_byte()
+                    .is_some_and(|escaped| lookup_byte(escaped) != WHS)
+            {
                 self.advance(1);
             }
         }
@@ -373,6 +379,31 @@ impl<'src> TailwindLexer<'src> {
         while self.current_byte() == Some(b'_') {
             self.advance(1);
         }
+        CSS_WHITESPACE
+    }
+
+    fn consume_whitespace_token(&mut self) -> TailwindSyntaxKind {
+        while let Some(byte) = self.current_byte() {
+            if lookup_byte(byte) != WHS {
+                break;
+            }
+
+            match byte {
+                b'\t' | b' ' | b'\r' | b'\n' => self.advance(1),
+                _ => {
+                    let start = self.text_position();
+                    self.advance(1);
+                    self.push_diagnostic(
+                        ParseDiagnostic::new(
+                            "The CSS standard only allows tabs, whitespace, carriage return and line feed whitespace.",
+                            start..self.text_position(),
+                        )
+                        .with_hint("Use a regular whitespace character instead."),
+                    );
+                }
+            }
+        }
+
         WHITESPACE
     }
 
@@ -521,7 +552,7 @@ impl<'src> TailwindLexer<'src> {
                 bracket_depth += 1;
             } else if dispatched == BTC && bracket_depth > 0 {
                 bracket_depth -= 1;
-            } else if (dispatched == looking_for || dispatched == WHS) && bracket_depth == 0 {
+            } else if dispatched == WHS || (dispatched == looking_for && bracket_depth == 0) {
                 break;
             }
             let char = self.current_char_unchecked();
@@ -561,7 +592,7 @@ impl<'src> TailwindLexer<'src> {
 }
 
 impl<'src> Lexer<'src> for TailwindLexer<'src> {
-    const NEWLINE: Self::Kind = NEWLINE;
+    const NEWLINE: Self::Kind = WHITESPACE;
     const WHITESPACE: Self::Kind = WHITESPACE;
     type Kind = TailwindSyntaxKind;
     type LexContext = TailwindLexContext;
@@ -612,15 +643,16 @@ impl<'src> Lexer<'src> for TailwindLexer<'src> {
             .set(TokenFlags::PRECEDING_LINE_BREAK, self.after_newline);
         self.current_kind = kind;
 
-        if !kind.is_trivia() {
-            self.after_newline = false;
-        }
+        self.after_newline = kind == WHITESPACE
+            && self.source[self.current_range()]
+                .bytes()
+                .any(|byte| matches!(byte, b'\r' | b'\n'));
 
         kind
     }
 
     fn has_preceding_line_break(&self) -> bool {
-        self.preceding_line_break
+        self.current_flags.has_preceding_line_break()
     }
 
     fn has_unicode_escape(&self) -> bool {

--- a/crates/biome_tailwind_parser/src/lexer/tests.rs
+++ b/crates/biome_tailwind_parser/src/lexer/tests.rs
@@ -134,6 +134,48 @@ fn basic_multiple() {
 }
 
 #[test]
+fn whitespace_includes_newlines() {
+    assert_lex!(
+        " \t\r\n\n ",
+        WHITESPACE:6,
+    );
+}
+
+#[test]
+fn css_underscore_whitespace_has_its_own_kind() {
+    assert_lex!(
+        TailwindLexContext::CssValue,
+        "foo__bar",
+        IDENT:3,
+        CSS_WHITESPACE:2,
+        IDENT:3,
+    );
+}
+
+#[test]
+fn css_strings_stop_at_whitespace() {
+    assert_lex!(
+        TailwindLexContext::CssValue,
+        "\"foo bar\"",
+        CSS_STRING_LITERAL:4,
+        WHITESPACE:1,
+        IDENT:3,
+        CSS_STRING_LITERAL:1,
+    );
+}
+
+#[test]
+fn nested_brackets_stop_at_whitespace() {
+    assert_lex!(
+        "[foo[bar baz]]",
+        L_BRACKET:1,
+        TW_SELECTOR:7,
+        WHITESPACE:1,
+        TW_BASE:5,
+    );
+}
+
+#[test]
 fn basic_modifier() {
     assert_lex!(
         "bg-primary/10",
@@ -250,10 +292,10 @@ fn arbitrary_css_underscores_are_whitespace() {
         "0px_2px_4px",
         CSS_DIMENSION_VALUE:1,
         PX_KW:2,
-        WHITESPACE:1,
+        CSS_WHITESPACE:1,
         CSS_DIMENSION_VALUE:1,
         PX_KW:2,
-        WHITESPACE:1,
+        CSS_WHITESPACE:1,
         CSS_DIMENSION_VALUE:1,
         PX_KW:2,
     );

--- a/crates/biome_tailwind_parser/src/syntax/css_value.rs
+++ b/crates/biome_tailwind_parser/src/syntax/css_value.rs
@@ -26,7 +26,7 @@ impl ParseNodeList for CssGenericComponentValueList {
     }
 
     fn is_at_list_end(&self, p: &mut Self::Parser<'_>) -> bool {
-        p.at(T![']'])
+        p.at(T![']']) || is_at_class_separator(p)
     }
 
     fn recover(
@@ -36,7 +36,10 @@ impl ParseNodeList for CssGenericComponentValueList {
     ) -> biome_parser::parse_recovery::RecoveryResult {
         parsed_element.or_recover_with_token_set(
             p,
-            &ParseRecoveryTokenSet::new(CSS_BOGUS_PROPERTY_VALUE, token_set![T![']'], EOF]),
+            &ParseRecoveryTokenSet::new(
+                CSS_BOGUS_PROPERTY_VALUE,
+                token_set![T![']'], WHITESPACE, EOF],
+            ),
             crate::syntax::parse_error::expected_value,
         )
     }
@@ -269,7 +272,7 @@ impl ParseSeparatedList for ParameterList {
     }
 
     fn is_at_list_end(&self, p: &mut Self::Parser<'_>) -> bool {
-        p.at_ts(token_set![T![')'], T![']']])
+        p.at_ts(token_set![T![')'], T![']']]) || is_at_class_separator(p)
     }
 
     fn recover(
@@ -281,7 +284,7 @@ impl ParseSeparatedList for ParameterList {
             p,
             &ParseRecoveryTokenSet::new(
                 CSS_BOGUS_PROPERTY_VALUE,
-                token_set![T![,], T![')'], T![']']],
+                token_set![T![,], T![')'], T![']'], WHITESPACE],
             ),
             crate::syntax::parse_error::expected_value,
         )
@@ -330,7 +333,7 @@ fn parse_any_expression(p: &mut TailwindParser) -> ParsedSyntax {
 const BINARY_OPERATION_TOKEN: TokenSet<TailwindSyntaxKind> = token_set![T![+], T![-], T![*], T![/]];
 const UNARY_OPERATION_TOKEN: TokenSet<TailwindSyntaxKind> = token_set![T![+], T![-], T![*]];
 const COMPONENT_VALUE_EXPRESSION_RECOVERY_SET: TokenSet<TailwindSyntaxKind> =
-    token_set![T![')'], T![,], T![']']].union(BINARY_OPERATION_TOKEN);
+    token_set![T![')'], T![,], T![']'], WHITESPACE].union(BINARY_OPERATION_TOKEN);
 
 #[inline]
 fn is_at_binary_operator(p: &mut TailwindParser) -> bool {
@@ -402,6 +405,7 @@ impl ParseNodeList for ComponentValueExpressionList {
 
     fn is_at_list_end(&self, p: &mut Self::Parser<'_>) -> bool {
         p.at_ts(BINARY_OPERATION_TOKEN.union(token_set![T![,], T![')'], T![']']]))
+            || is_at_class_separator(p)
     }
 
     fn recover(
@@ -437,6 +441,10 @@ fn is_at_any_value(p: &mut TailwindParser) -> bool {
             CSS_COLOR_LITERAL,
             T!['(']
         ])
+}
+
+fn is_at_class_separator(p: &mut TailwindParser) -> bool {
+    p.at(WHITESPACE)
 }
 
 #[inline]

--- a/crates/biome_tailwind_parser/src/syntax/mod.rs
+++ b/crates/biome_tailwind_parser/src/syntax/mod.rs
@@ -4,7 +4,7 @@ use crate::syntax::parse_error::*;
 use crate::syntax::value::parse_value;
 use crate::syntax::variant::VariantList;
 use crate::token_source::TailwindLexContext;
-use biome_parser::parse_lists::{ParseNodeList, ParseSeparatedList};
+use biome_parser::parse_lists::ParseSeparatedList;
 use biome_parser::parsed_syntax::ParsedSyntax::{Absent, Present};
 use biome_parser::prelude::*;
 use biome_parser::{Parser, parse_recovery::ParseRecoveryTokenSet, token_set};
@@ -23,6 +23,7 @@ pub fn parse_root(p: &mut TailwindParser) {
     if p.at(UNICODE_BOM) {
         p.eat(UNICODE_BOM);
     }
+    p.eat(WHITESPACE);
     CandidateList.parse_list(p);
 
     m.complete(p, TW_ROOT);
@@ -31,7 +32,7 @@ pub fn parse_root(p: &mut TailwindParser) {
 #[derive(Default)]
 struct CandidateList;
 
-impl ParseNodeList for CandidateList {
+impl ParseSeparatedList for CandidateList {
     type Kind = TailwindSyntaxKind;
     type Parser<'source> = TailwindParser<'source>;
     const LIST_KIND: Self::Kind = TW_CANDIDATE_LIST;
@@ -40,8 +41,16 @@ impl ParseNodeList for CandidateList {
         parse_full_candidate(p)
     }
 
+    fn separating_element_kind(&mut self) -> Self::Kind {
+        WHITESPACE
+    }
+
     fn is_at_list_end(&self, p: &mut Self::Parser<'_>) -> bool {
         p.at(EOF)
+    }
+
+    fn allow_trailing_separating_element(&self) -> bool {
+        true
     }
 
     fn recover(
@@ -51,8 +60,7 @@ impl ParseNodeList for CandidateList {
     ) -> biome_parser::parse_recovery::RecoveryResult {
         parsed_element.or_recover_with_token_set(
             p,
-            &ParseRecoveryTokenSet::new(TW_BOGUS_CANDIDATE, token_set![WHITESPACE])
-                .enable_recovery_on_line_break(),
+            &ParseRecoveryTokenSet::new(TW_BOGUS_CANDIDATE, token_set![WHITESPACE]),
             expected_candidate,
         )
     }
@@ -85,8 +93,7 @@ fn parse_full_candidate(p: &mut TailwindParser) -> ParsedSyntax {
         .or_else(|| parse_functional_or_static_candidate(p))
         .or_recover_with_token_set(
             p,
-            &ParseRecoveryTokenSet::new(TW_BOGUS_CANDIDATE, token_set![WHITESPACE])
-                .enable_recovery_on_line_break(),
+            &ParseRecoveryTokenSet::new(TW_BOGUS_CANDIDATE, token_set![WHITESPACE]),
             expected_candidate,
         );
 
@@ -101,7 +108,7 @@ fn parse_full_candidate(p: &mut TailwindParser) -> ParsedSyntax {
 
     // The trailing `!` must be glued to the utility; whitespace before it
     // means the next class starts with the legacy `!` instead.
-    if p.at(T![!]) && !p.source().had_trivia_before() {
+    if p.at(T![!]) {
         if legacy_important {
             p.error(duplicate_important(p, p.cur_range()));
         }
@@ -120,7 +127,6 @@ fn parse_functional_or_static_candidate(p: &mut TailwindParser) -> ParsedSyntax 
     let m = p.start();
 
     p.bump(TW_BASE);
-    let pos = p.source().position();
     if p.at(T![:]) {
         // Oops, this is a Variant!
         m.abandon(p);
@@ -132,7 +138,7 @@ fn parse_functional_or_static_candidate(p: &mut TailwindParser) -> ParsedSyntax 
         // A modifier can glue straight onto a bare name
         // (`@container/sidebar` names the container); whitespace before
         // the `/` means the next class starts instead.
-        if p.at(T![/]) && !p.source().had_trivia_before() {
+        if p.at(T![/]) {
             parse_modifier(p).or_add_diagnostic(p, expected_modifier);
             if p.at(T![:]) {
                 // A `:` after the modifier means this was a (malformed)
@@ -145,24 +151,10 @@ fn parse_functional_or_static_candidate(p: &mut TailwindParser) -> ParsedSyntax 
         }
         return Present(m.complete(p, TW_STATIC_CANDIDATE));
     }
-    if p.source().had_trivia_before() {
-        // Whitespace is not allowed in tailwind candidates
-        // Theres whitespace between these tokens, so it can't be a functional candidate
-        return Present(m.complete(p, TW_STATIC_CANDIDATE));
-    }
-    if let Some(last_trivia) = p.source().trivia_list.last()
-        && pos < last_trivia.text_range().start()
-    {
-        // Whitespace is not allowed in tailwind candidates
-        // Theres whitespace between these tokens, so it can't be a functional candidate
-        return Present(m.complete(p, TW_STATIC_CANDIDATE));
-    }
-
     p.expect(T![-]);
     match parse_value(p).or_recover_with_token_set(
         p,
-        &ParseRecoveryTokenSet::new(TW_BOGUS_VALUE, token_set![WHITESPACE, T![!]])
-            .enable_recovery_on_line_break(),
+        &ParseRecoveryTokenSet::new(TW_BOGUS_VALUE, token_set![WHITESPACE, T![!]]),
         expected_value,
     ) {
         Ok(_) => {}
@@ -268,7 +260,7 @@ pub(crate) fn parse_modifier(p: &mut TailwindParser) -> ParsedSyntax {
     }
     match parse_value(p).or_recover_with_token_set(
         p,
-        &ParseRecoveryTokenSet::new(TW_BOGUS_MODIFIER, token_set![WHITESPACE, NEWLINE, T![!]]),
+        &ParseRecoveryTokenSet::new(TW_BOGUS_MODIFIER, token_set![WHITESPACE, T![!]]),
         expected_value,
     ) {
         Ok(_) => {}

--- a/crates/biome_tailwind_parser/src/syntax/variant.rs
+++ b/crates/biome_tailwind_parser/src/syntax/variant.rs
@@ -124,7 +124,7 @@ fn parse_variant_expression(p: &mut TailwindParser) -> ParsedSyntax {
 
     segments.complete(p, TW_VARIANT_SEGMENT_LIST);
 
-    if p.at(T!['[']) && !p.source().had_trivia_before() {
+    if p.at(T!['[']) {
         // A bracketed value can glue directly to the last segment with no
         // `-` separator: `@[400px]:` is the container root plus an
         // arbitrary size. Whitespace before the `[` means it starts the

--- a/crates/biome_tailwind_parser/src/token_source.rs
+++ b/crates/biome_tailwind_parser/src/token_source.rs
@@ -12,11 +12,8 @@ use biome_tailwind_syntax::{TailwindSyntaxKind, TextRange};
 pub(crate) struct TailwindTokenSource<'source> {
     lexer: BufferedLexer<TailwindSyntaxKind, TailwindLexer<'source>>,
 
-    /// List of the skipped trivia. Needed to construct the CST and compute the non-trivia token offsets.
+    /// Trivia emitted by the lexer and tokens skipped during parser recovery.
     pub(super) trivia_list: Vec<Trivia>,
-
-    /// Whether the lexer encountered any trivia between the previous non-trivia token and the current non-trivia token.
-    had_trivia_before: bool,
 }
 pub(crate) type TailwindTokenSourceCheckpoint = TokenSourceCheckpoint<TailwindSyntaxKind>;
 
@@ -65,34 +62,20 @@ impl<'source> TailwindTokenSource<'source> {
         Self {
             lexer,
             trivia_list: vec![],
-            had_trivia_before: false,
         }
     }
 
     fn next_non_trivia_token(&mut self, context: TailwindLexContext, first_token: bool) {
-        let mut trailing = !first_token;
-        self.had_trivia_before = false;
+        let trailing = !first_token;
 
         loop {
             let kind = self.lexer.next_token(context);
+            let Ok(trivia_kind) = TriviaPieceKind::try_from(kind) else {
+                break;
+            };
 
-            let trivia_kind = TriviaPieceKind::try_from(kind);
-
-            match trivia_kind {
-                Err(_) => {
-                    // Not trivia
-                    break;
-                }
-                Ok(trivia_kind) => {
-                    if trivia_kind.is_newline() {
-                        trailing = false;
-                    }
-
-                    self.had_trivia_before = true;
-                    self.trivia_list
-                        .push(Trivia::new(trivia_kind, self.current_range(), trailing));
-                }
-            }
+            self.trivia_list
+                .push(Trivia::new(trivia_kind, self.current_range(), trailing));
         }
     }
 
@@ -109,11 +92,6 @@ impl<'source> TailwindTokenSource<'source> {
         assert!(self.trivia_list.len() >= checkpoint.trivia_len as usize);
         self.trivia_list.truncate(checkpoint.trivia_len as usize);
         self.lexer.rewind(checkpoint.lexer_checkpoint);
-    }
-
-    /// Whether the lexer encountered any trivia between the previous non-trivia token and the current non-trivia token.
-    pub fn had_trivia_before(&self) -> bool {
-        self.had_trivia_before
     }
 
     pub fn re_lex_current_in_context(&mut self, context: TailwindLexContext) -> TailwindSyntaxKind {

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/error/arbitrary-candidate/missing-property.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/error/arbitrary-candidate/missing-property.txt.snap
@@ -16,6 +16,7 @@ expression: snapshot
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -25,16 +26,29 @@ TwRoot {
                 items: [
                     L_BRACKET@0..1 "[" [] [],
                     TW_SELECTOR@1..6 ":40px" [] [],
-                    R_BRACKET@6..8 "]" [] [Whitespace(" ")],
-                    TW_BASE@8..9 "w" [] [],
-                    DASH@9..10 "-" [] [],
-                    TW_NUMBER@10..11 "5" [] [],
+                    R_BRACKET@6..7 "]" [] [],
                 ],
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@7..8 " " [] [],
+        TwFullCandidate {
+            variants: TwVariantList [],
+            legacy_important_token: missing (optional),
+            negative_token: missing (optional),
+            candidate: TwFunctionalCandidate {
+                base_token: TW_BASE@8..9 "w" [] [],
+                minus_token: DASH@9..10 "-" [] [],
+                value: TwNumberValue {
+                    value_token: TW_NUMBER@10..11 "5" [] [],
+                },
+                modifier: missing (optional),
+            },
+            excl_token: missing (optional),
+        },
+        WHITESPACE@11..12 "\n" [] [],
     ],
-    eof_token: EOF@11..12 "" [Newline("\n")] [],
+    eof_token: EOF@12..12 "" [] [],
 }
 ```
 
@@ -43,20 +57,31 @@ TwRoot {
 ```
 0: TW_ROOT@0..12
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..11
-    0: TW_FULL_CANDIDATE@0..11
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..12
+    0: TW_FULL_CANDIDATE@0..7
       0: TW_VARIANT_LIST@0..0
       1: (empty)
       2: (empty)
-      3: TW_BOGUS_CANDIDATE@0..11
+      3: TW_BOGUS_CANDIDATE@0..7
         0: L_BRACKET@0..1 "[" [] []
         1: TW_SELECTOR@1..6 ":40px" [] []
-        2: R_BRACKET@6..8 "]" [] [Whitespace(" ")]
-        3: TW_BASE@8..9 "w" [] []
-        4: DASH@9..10 "-" [] []
-        5: TW_NUMBER@10..11 "5" [] []
+        2: R_BRACKET@6..7 "]" [] []
       4: (empty)
-  2: EOF@11..12 "" [Newline("\n")] []
+    1: WHITESPACE@7..8 " " [] []
+    2: TW_FULL_CANDIDATE@8..11
+      0: TW_VARIANT_LIST@8..8
+      1: (empty)
+      2: (empty)
+      3: TW_FUNCTIONAL_CANDIDATE@8..11
+        0: TW_BASE@8..9 "w" [] []
+        1: DASH@9..10 "-" [] []
+        2: TW_NUMBER_VALUE@10..11
+          0: TW_NUMBER@10..11 "5" [] []
+        3: (empty)
+      4: (empty)
+    3: WHITESPACE@11..12 "\n" [] []
+  3: EOF@12..12 "" [] []
 
 ```
 
@@ -65,16 +90,16 @@ TwRoot {
 ```
 missing-property.txt:1:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Expected a candidate but instead found '[:40px] w-5'.
+  × Expected a candidate but instead found '[:40px]'.
   
   > 1 │ [:40px] w-5
-      │ ^^^^^^^^^^^
+      │ ^^^^^^^
     2 │ 
   
   i Expected a candidate here.
   
   > 1 │ [:40px] w-5
-      │ ^^^^^^^^^^^
+      │ ^^^^^^^
     2 │ 
   
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/error/arbitrary-candidate/missing-value-in-arbitrary.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/error/arbitrary-candidate/missing-value-in-arbitrary.txt.snap
@@ -16,6 +16,7 @@ expression: snapshot
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -26,11 +27,12 @@ TwRoot {
                 property_token: TW_PROPERTY@1..6 "width" [] [],
                 colon_token: COLON@6..7 ":" [] [],
                 value: CssGenericComponentValueList [],
-                r_brack_token: R_BRACKET@7..9 "]" [] [Whitespace(" ")],
+                r_brack_token: R_BRACKET@7..8 "]" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@8..9 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -45,8 +47,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@12..13 "\n" [] [],
     ],
-    eof_token: EOF@12..13 "" [Newline("\n")] [],
+    eof_token: EOF@13..13 "" [] [],
 }
 ```
 
@@ -55,20 +58,22 @@ TwRoot {
 ```
 0: TW_ROOT@0..13
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..12
-    0: TW_FULL_CANDIDATE@0..9
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..13
+    0: TW_FULL_CANDIDATE@0..8
       0: TW_VARIANT_LIST@0..0
       1: (empty)
       2: (empty)
-      3: TW_ARBITRARY_CANDIDATE@0..9
+      3: TW_ARBITRARY_CANDIDATE@0..8
         0: L_BRACKET@0..1 "[" [] []
         1: TW_PROPERTY@1..6 "width" [] []
         2: COLON@6..7 ":" [] []
         3: CSS_GENERIC_COMPONENT_VALUE_LIST@7..7
-        4: R_BRACKET@7..9 "]" [] [Whitespace(" ")]
+        4: R_BRACKET@7..8 "]" [] []
         5: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@9..12
+    1: WHITESPACE@8..9 " " [] []
+    2: TW_FULL_CANDIDATE@9..12
       0: TW_VARIANT_LIST@9..9
       1: (empty)
       2: (empty)
@@ -79,7 +84,8 @@ TwRoot {
           0: TW_NUMBER@11..12 "5" [] []
         3: (empty)
       4: (empty)
-  2: EOF@12..13 "" [Newline("\n")] []
+    3: WHITESPACE@12..13 "\n" [] []
+  3: EOF@13..13 "" [] []
 
 ```
 

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/error/candidate-modifier-before-colon.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/error/candidate-modifier-before-colon.txt.snap
@@ -16,6 +16,7 @@ expression: snapshot
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -34,8 +35,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@15..16 "\n" [] [],
     ],
-    eof_token: EOF@15..16 "" [Newline("\n")] [],
+    eof_token: EOF@16..16 "" [] [],
 }
 ```
 
@@ -44,7 +46,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..16
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..15
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..16
     0: TW_FULL_CANDIDATE@0..15
       0: TW_VARIANT_LIST@0..0
       1: (empty)
@@ -58,7 +61,8 @@ TwRoot {
         5: COLON@13..14 ":" [] []
         6: TW_BASE@14..15 "x" [] []
       4: (empty)
-  2: EOF@15..16 "" [Newline("\n")] []
+    1: WHITESPACE@15..16 "\n" [] []
+  3: EOF@16..16 "" [] []
 
 ```
 

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/error/css-arbitrary-values.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/error/css-arbitrary-values.txt.snap
@@ -16,6 +16,7 @@ w-[calc(100%_-)] bg-[rgb(0_0_0/)] bg-[url(/img/mountains.jpg] [width:calc(100%_-
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -49,12 +50,13 @@ TwRoot {
                             r_paren_token: R_PAREN@14..15 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@15..17 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@15..16 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@16..17 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -92,12 +94,13 @@ TwRoot {
                             r_paren_token: R_PAREN@31..32 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@32..34 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@32..33 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@33..34 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -108,33 +111,54 @@ TwRoot {
                 value: TwBogusValue {
                     items: [
                         L_BRACKET@37..38 "[" [] [],
-                        TwBogus {
-                            items: [
-                                CssUrlFunction {
-                                    url_token: URL_KW@38..41 "url" [] [],
-                                    l_paren_token: L_PAREN@41..42 "(" [] [],
-                                    value: CssUrlValueRaw {
-                                        value_token: CSS_URL_VALUE_RAW_LITERAL@42..62 "/img/mountains.jpg]" [] [Whitespace(" ")],
-                                    },
-                                    r_paren_token: missing (required),
-                                },
-                                CssBogusPropertyValue {
-                                    items: [
-                                        CSS_URL_VALUE_RAW_LITERAL@62..80 "[width:calc(100%_-" [] [],
-                                        R_PAREN@80..81 ")" [] [],
-                                    ],
-                                },
-                            ],
-                        },
-                        R_BRACKET@81..82 "]" [] [],
+                        TW_SELECTOR@38..60 "url(/img/mountains.jpg" [] [],
+                        R_BRACKET@60..61 "]" [] [],
                     ],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@61..62 " " [] [],
+        TwFullCandidate {
+            variants: TwVariantList [],
+            legacy_important_token: missing (optional),
+            negative_token: missing (optional),
+            candidate: TwArbitraryCandidate {
+                l_brack_token: L_BRACKET@62..63 "[" [] [],
+                property_token: TW_PROPERTY@63..68 "width" [] [],
+                colon_token: COLON@68..69 ":" [] [],
+                value: CssGenericComponentValueList [
+                    CssFunction {
+                        name: CssIdentifier {
+                            ident_token: IDENT@69..73 "calc" [] [],
+                        },
+                        l_paren_token: L_PAREN@73..74 "(" [] [],
+                        parameters: CssParameterList [
+                            CssBinaryExpression {
+                                left: CssListOfComponentValuesExpression {
+                                    css_component_value_list: CssComponentValueList [
+                                        CssPercentage {
+                                            value_token: CSS_NUMBER_LITERAL@74..77 "100" [] [],
+                                            remainder_token: PERCENT@77..79 "%" [] [Whitespace("_")],
+                                        },
+                                    ],
+                                },
+                                operator: DASH@79..80 "-" [] [],
+                                right: missing (required),
+                            },
+                        ],
+                        r_paren_token: R_PAREN@80..81 ")" [] [],
+                    },
+                ],
+                r_brack_token: R_BRACKET@81..82 "]" [] [],
+                modifier: missing (optional),
+            },
+            excl_token: missing (optional),
+        },
+        WHITESPACE@82..83 "\n" [] [],
     ],
-    eof_token: EOF@82..83 "" [Newline("\n")] [],
+    eof_token: EOF@83..83 "" [] [],
 }
 ```
 
@@ -143,15 +167,16 @@ TwRoot {
 ```
 0: TW_ROOT@0..83
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..82
-    0: TW_FULL_CANDIDATE@0..17
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..83
+    0: TW_FULL_CANDIDATE@0..16
       0: TW_VARIANT_LIST@0..0
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@0..17
+      3: TW_FUNCTIONAL_CANDIDATE@0..16
         0: TW_BASE@0..1 "w" [] []
         1: DASH@1..2 "-" [] []
-        2: TW_ARBITRARY_VALUE@2..17
+        2: TW_ARBITRARY_VALUE@2..16
           0: L_BRACKET@2..3 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@3..15
             0: CSS_FUNCTION@3..15
@@ -168,17 +193,18 @@ TwRoot {
                   1: DASH@13..14 "-" [] []
                   2: (empty)
               3: R_PAREN@14..15 ")" [] []
-          2: R_BRACKET@15..17 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@15..16 "]" [] []
         3: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@17..34
+    1: WHITESPACE@16..17 " " [] []
+    2: TW_FULL_CANDIDATE@17..33
       0: TW_VARIANT_LIST@17..17
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@17..34
+      3: TW_FUNCTIONAL_CANDIDATE@17..33
         0: TW_BASE@17..19 "bg" [] []
         1: DASH@19..20 "-" [] []
-        2: TW_ARBITRARY_VALUE@20..34
+        2: TW_ARBITRARY_VALUE@20..33
           0: L_BRACKET@20..21 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@21..32
             0: CSS_FUNCTION@21..32
@@ -198,32 +224,52 @@ TwRoot {
                   1: SLASH@30..31 "/" [] []
                   2: (empty)
               3: R_PAREN@31..32 ")" [] []
-          2: R_BRACKET@32..34 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@32..33 "]" [] []
         3: (empty)
       4: (empty)
-    2: TW_FULL_CANDIDATE@34..82
+    3: WHITESPACE@33..34 " " [] []
+    4: TW_FULL_CANDIDATE@34..61
       0: TW_VARIANT_LIST@34..34
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@34..82
+      3: TW_FUNCTIONAL_CANDIDATE@34..61
         0: TW_BASE@34..36 "bg" [] []
         1: DASH@36..37 "-" [] []
-        2: TW_BOGUS_VALUE@37..82
+        2: TW_BOGUS_VALUE@37..61
           0: L_BRACKET@37..38 "[" [] []
-          1: TW_BOGUS@38..81
-            0: CSS_URL_FUNCTION@38..62
-              0: URL_KW@38..41 "url" [] []
-              1: L_PAREN@41..42 "(" [] []
-              2: CSS_URL_VALUE_RAW@42..62
-                0: CSS_URL_VALUE_RAW_LITERAL@42..62 "/img/mountains.jpg]" [] [Whitespace(" ")]
-              3: (empty)
-            1: CSS_BOGUS_PROPERTY_VALUE@62..81
-              0: CSS_URL_VALUE_RAW_LITERAL@62..80 "[width:calc(100%_-" [] []
-              1: R_PAREN@80..81 ")" [] []
-          2: R_BRACKET@81..82 "]" [] []
+          1: TW_SELECTOR@38..60 "url(/img/mountains.jpg" [] []
+          2: R_BRACKET@60..61 "]" [] []
         3: (empty)
       4: (empty)
-  2: EOF@82..83 "" [Newline("\n")] []
+    5: WHITESPACE@61..62 " " [] []
+    6: TW_FULL_CANDIDATE@62..82
+      0: TW_VARIANT_LIST@62..62
+      1: (empty)
+      2: (empty)
+      3: TW_ARBITRARY_CANDIDATE@62..82
+        0: L_BRACKET@62..63 "[" [] []
+        1: TW_PROPERTY@63..68 "width" [] []
+        2: COLON@68..69 ":" [] []
+        3: CSS_GENERIC_COMPONENT_VALUE_LIST@69..81
+          0: CSS_FUNCTION@69..81
+            0: CSS_IDENTIFIER@69..73
+              0: IDENT@69..73 "calc" [] []
+            1: L_PAREN@73..74 "(" [] []
+            2: CSS_PARAMETER_LIST@74..80
+              0: CSS_BINARY_EXPRESSION@74..80
+                0: CSS_LIST_OF_COMPONENT_VALUES_EXPRESSION@74..79
+                  0: CSS_COMPONENT_VALUE_LIST@74..79
+                    0: CSS_PERCENTAGE@74..79
+                      0: CSS_NUMBER_LITERAL@74..77 "100" [] []
+                      1: PERCENT@77..79 "%" [] [Whitespace("_")]
+                1: DASH@79..80 "-" [] []
+                2: (empty)
+            3: R_PAREN@80..81 ")" [] []
+        4: R_BRACKET@81..82 "]" [] []
+        5: (empty)
+      4: (empty)
+    7: WHITESPACE@82..83 "\n" [] []
+  3: EOF@83..83 "" [] []
 
 ```
 
@@ -258,14 +304,32 @@ css-arbitrary-values.txt:1:32 parse ━━━━━━━━━━━━━━�
       │                                ^
     2 │ 
   
-css-arbitrary-values.txt:1:63 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+css-arbitrary-values.txt:1:38 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × expected `)` but instead found `[width:calc(100%_-`
+  × Expected a value but instead found '[url(/img/mountains.jpg]'.
   
   > 1 │ w-[calc(100%_-)] bg-[rgb(0_0_0/)] bg-[url(/img/mountains.jpg] [width:calc(100%_-)]
-      │                                                               ^^^^^^^^^^^^^^^^^^
+      │                                      ^^^^^^^^^^^^^^^^^^^^^^^^
     2 │ 
   
-  i Remove [width:calc(100%_-
+  i Expected a value here.
+  
+  > 1 │ w-[calc(100%_-)] bg-[rgb(0_0_0/)] bg-[url(/img/mountains.jpg] [width:calc(100%_-)]
+      │                                      ^^^^^^^^^^^^^^^^^^^^^^^^
+    2 │ 
+  
+css-arbitrary-values.txt:1:81 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a value but instead found ')'.
+  
+  > 1 │ w-[calc(100%_-)] bg-[rgb(0_0_0/)] bg-[url(/img/mountains.jpg] [width:calc(100%_-)]
+      │                                                                                 ^
+    2 │ 
+  
+  i Expected a value here.
+  
+  > 1 │ w-[calc(100%_-)] bg-[rgb(0_0_0/)] bg-[url(/img/mountains.jpg] [width:calc(100%_-)]
+      │                                                                                 ^
+    2 │ 
   
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/error/css-number-exponents.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/error/css-number-exponents.txt.snap
@@ -16,6 +16,7 @@ w-[1e] w-[1e+]
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -32,12 +33,13 @@ TwRoot {
                             unit_token: IDENT@4..5 "e" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@5..7 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@5..6 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@6..7 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -63,8 +65,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@14..15 "\n" [] [],
     ],
-    eof_token: EOF@14..15 "" [Newline("\n")] [],
+    eof_token: EOF@15..15 "" [] [],
 }
 ```
 
@@ -73,24 +76,26 @@ TwRoot {
 ```
 0: TW_ROOT@0..15
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..14
-    0: TW_FULL_CANDIDATE@0..7
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..15
+    0: TW_FULL_CANDIDATE@0..6
       0: TW_VARIANT_LIST@0..0
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@0..7
+      3: TW_FUNCTIONAL_CANDIDATE@0..6
         0: TW_BASE@0..1 "w" [] []
         1: DASH@1..2 "-" [] []
-        2: TW_ARBITRARY_VALUE@2..7
+        2: TW_ARBITRARY_VALUE@2..6
           0: L_BRACKET@2..3 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@3..5
             0: CSS_UNKNOWN_DIMENSION@3..5
               0: CSS_NUMBER_LITERAL@3..4 "1" [] []
               1: IDENT@4..5 "e" [] []
-          2: R_BRACKET@5..7 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@5..6 "]" [] []
         3: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@7..14
+    1: WHITESPACE@6..7 " " [] []
+    2: TW_FULL_CANDIDATE@7..14
       0: TW_VARIANT_LIST@7..7
       1: (empty)
       2: (empty)
@@ -109,7 +114,8 @@ TwRoot {
           2: R_BRACKET@13..14 "]" [] []
         3: (empty)
       4: (empty)
-  2: EOF@14..15 "" [Newline("\n")] []
+    3: WHITESPACE@14..15 "\n" [] []
+  3: EOF@15..15 "" [] []
 
 ```
 

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/error/css-string-whitespace.txt
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/error/css-string-whitespace.txt
@@ -1,0 +1,3 @@
+bg-[url("/img/with space.png")] flex
+bg-[url("/img/with
+newline.png")] flex

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/error/css-string-whitespace.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/error/css-string-whitespace.txt.snap
@@ -1,0 +1,218 @@
+---
+source: crates/biome_tailwind_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```text
+bg-[url("/img/with space.png")] flex
+bg-[url("/img/with
+newline.png")] flex
+
+```
+
+
+## AST
+
+```
+TwRoot {
+    bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
+    candidates: TwCandidateList [
+        TwFullCandidate {
+            variants: TwVariantList [],
+            legacy_important_token: missing (optional),
+            negative_token: missing (optional),
+            candidate: TwFunctionalCandidate {
+                base_token: TW_BASE@0..2 "bg" [] [],
+                minus_token: DASH@2..3 "-" [] [],
+                value: TwBogusValue {
+                    items: [
+                        L_BRACKET@3..4 "[" [] [],
+                        TW_SELECTOR@4..18 "url(\"/img/with" [] [],
+                    ],
+                },
+                modifier: missing (optional),
+            },
+            excl_token: missing (optional),
+        },
+        WHITESPACE@18..19 " " [] [],
+        TwFullCandidate {
+            variants: TwVariantList [],
+            legacy_important_token: missing (optional),
+            negative_token: missing (optional),
+            candidate: TwStaticCandidate {
+                base_token: TW_BASE@19..31 "space.png\")]" [] [],
+                modifier: missing (optional),
+            },
+            excl_token: missing (optional),
+        },
+        WHITESPACE@31..32 " " [] [],
+        TwFullCandidate {
+            variants: TwVariantList [],
+            legacy_important_token: missing (optional),
+            negative_token: missing (optional),
+            candidate: TwStaticCandidate {
+                base_token: TW_BASE@32..36 "flex" [] [],
+                modifier: missing (optional),
+            },
+            excl_token: missing (optional),
+        },
+        WHITESPACE@36..37 "\n" [] [],
+        TwFullCandidate {
+            variants: TwVariantList [],
+            legacy_important_token: missing (optional),
+            negative_token: missing (optional),
+            candidate: TwFunctionalCandidate {
+                base_token: TW_BASE@37..39 "bg" [] [],
+                minus_token: DASH@39..40 "-" [] [],
+                value: TwBogusValue {
+                    items: [
+                        L_BRACKET@40..41 "[" [] [],
+                        TW_SELECTOR@41..55 "url(\"/img/with" [] [],
+                    ],
+                },
+                modifier: missing (optional),
+            },
+            excl_token: missing (optional),
+        },
+        WHITESPACE@55..56 "\n" [] [],
+        TwFullCandidate {
+            variants: TwVariantList [],
+            legacy_important_token: missing (optional),
+            negative_token: missing (optional),
+            candidate: TwStaticCandidate {
+                base_token: TW_BASE@56..70 "newline.png\")]" [] [],
+                modifier: missing (optional),
+            },
+            excl_token: missing (optional),
+        },
+        WHITESPACE@70..71 " " [] [],
+        TwFullCandidate {
+            variants: TwVariantList [],
+            legacy_important_token: missing (optional),
+            negative_token: missing (optional),
+            candidate: TwStaticCandidate {
+                base_token: TW_BASE@71..75 "flex" [] [],
+                modifier: missing (optional),
+            },
+            excl_token: missing (optional),
+        },
+        WHITESPACE@75..76 "\n" [] [],
+    ],
+    eof_token: EOF@76..76 "" [] [],
+}
+```
+
+## CST
+
+```
+0: TW_ROOT@0..76
+  0: (empty)
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..76
+    0: TW_FULL_CANDIDATE@0..18
+      0: TW_VARIANT_LIST@0..0
+      1: (empty)
+      2: (empty)
+      3: TW_FUNCTIONAL_CANDIDATE@0..18
+        0: TW_BASE@0..2 "bg" [] []
+        1: DASH@2..3 "-" [] []
+        2: TW_BOGUS_VALUE@3..18
+          0: L_BRACKET@3..4 "[" [] []
+          1: TW_SELECTOR@4..18 "url(\"/img/with" [] []
+        3: (empty)
+      4: (empty)
+    1: WHITESPACE@18..19 " " [] []
+    2: TW_FULL_CANDIDATE@19..31
+      0: TW_VARIANT_LIST@19..19
+      1: (empty)
+      2: (empty)
+      3: TW_STATIC_CANDIDATE@19..31
+        0: TW_BASE@19..31 "space.png\")]" [] []
+        1: (empty)
+      4: (empty)
+    3: WHITESPACE@31..32 " " [] []
+    4: TW_FULL_CANDIDATE@32..36
+      0: TW_VARIANT_LIST@32..32
+      1: (empty)
+      2: (empty)
+      3: TW_STATIC_CANDIDATE@32..36
+        0: TW_BASE@32..36 "flex" [] []
+        1: (empty)
+      4: (empty)
+    5: WHITESPACE@36..37 "\n" [] []
+    6: TW_FULL_CANDIDATE@37..55
+      0: TW_VARIANT_LIST@37..37
+      1: (empty)
+      2: (empty)
+      3: TW_FUNCTIONAL_CANDIDATE@37..55
+        0: TW_BASE@37..39 "bg" [] []
+        1: DASH@39..40 "-" [] []
+        2: TW_BOGUS_VALUE@40..55
+          0: L_BRACKET@40..41 "[" [] []
+          1: TW_SELECTOR@41..55 "url(\"/img/with" [] []
+        3: (empty)
+      4: (empty)
+    7: WHITESPACE@55..56 "\n" [] []
+    8: TW_FULL_CANDIDATE@56..70
+      0: TW_VARIANT_LIST@56..56
+      1: (empty)
+      2: (empty)
+      3: TW_STATIC_CANDIDATE@56..70
+        0: TW_BASE@56..70 "newline.png\")]" [] []
+        1: (empty)
+      4: (empty)
+    9: WHITESPACE@70..71 " " [] []
+    10: TW_FULL_CANDIDATE@71..75
+      0: TW_VARIANT_LIST@71..71
+      1: (empty)
+      2: (empty)
+      3: TW_STATIC_CANDIDATE@71..75
+        0: TW_BASE@71..75 "flex" [] []
+        1: (empty)
+      4: (empty)
+    11: WHITESPACE@75..76 "\n" [] []
+  3: EOF@76..76 "" [] []
+
+```
+
+## Diagnostics
+
+```
+css-string-whitespace.txt:1:4 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a value but instead found '[url("/img/with'.
+  
+  > 1 │ bg-[url("/img/with space.png")] flex
+      │    ^^^^^^^^^^^^^^^
+    2 │ bg-[url("/img/with
+    3 │ newline.png")] flex
+  
+  i Expected a value here.
+  
+  > 1 │ bg-[url("/img/with space.png")] flex
+      │    ^^^^^^^^^^^^^^^
+    2 │ bg-[url("/img/with
+    3 │ newline.png")] flex
+  
+css-string-whitespace.txt:2:4 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a value but instead found '[url("/img/with'.
+  
+    1 │ bg-[url("/img/with space.png")] flex
+  > 2 │ bg-[url("/img/with
+      │    ^^^^^^^^^^^^^^^
+    3 │ newline.png")] flex
+    4 │ 
+  
+  i Expected a value here.
+  
+    1 │ bg-[url("/img/with space.png")] flex
+  > 2 │ bg-[url("/img/with
+      │    ^^^^^^^^^^^^^^^
+    3 │ newline.png")] flex
+    4 │ 
+  
+```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/error/duplicate-important.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/error/duplicate-important.txt.snap
@@ -16,6 +16,7 @@ expression: snapshot
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -25,8 +26,9 @@ TwRoot {
                 base_token: TW_BASE@1..5 "flex" [] [],
                 modifier: missing (optional),
             },
-            excl_token: BANG@5..7 "!" [] [Whitespace(" ")],
+            excl_token: BANG@5..6 "!" [] [],
         },
+        WHITESPACE@6..7 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -35,12 +37,13 @@ TwRoot {
                 base_token: TW_BASE@7..8 "p" [] [],
                 minus_token: DASH@8..9 "-" [] [],
                 value: TwNumberValue {
-                    value_token: TW_NUMBER@9..11 "4" [] [Whitespace(" ")],
+                    value_token: TW_NUMBER@9..10 "4" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@10..11 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -60,8 +63,9 @@ TwRoot {
                 base_token: TW_BASE@15..19 "flex" [] [],
                 modifier: missing (optional),
             },
-            excl_token: BANG@19..21 "!" [] [Whitespace(" ")],
+            excl_token: BANG@19..20 "!" [] [],
         },
+        WHITESPACE@20..21 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -72,19 +76,32 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@25..26 "\n" [] [],
         TwFullCandidate {
             variants: TwVariantList [],
-            legacy_important_token: BANG@25..27 "!" [Newline("\n")] [],
+            legacy_important_token: BANG@26..27 "!" [] [],
             negative_token: missing (optional),
             candidate: TwBogusCandidate {
                 items: [
                     TW_BASE@27..32 "hover" [] [],
                     COLON@32..33 ":" [] [],
-                    TW_BASE@33..38 "flex" [] [Whitespace(" ")],
-                    TW_BASE@38..39 "p" [] [],
-                    DASH@39..40 "-" [] [],
-                    TW_NUMBER@40..41 "4" [] [],
+                    TW_BASE@33..37 "flex" [] [],
                 ],
+            },
+            excl_token: missing (optional),
+        },
+        WHITESPACE@37..38 " " [] [],
+        TwFullCandidate {
+            variants: TwVariantList [],
+            legacy_important_token: missing (optional),
+            negative_token: missing (optional),
+            candidate: TwFunctionalCandidate {
+                base_token: TW_BASE@38..39 "p" [] [],
+                minus_token: DASH@39..40 "-" [] [],
+                value: TwNumberValue {
+                    value_token: TW_NUMBER@40..41 "4" [] [],
+                },
+                modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
@@ -98,27 +115,30 @@ TwRoot {
 ```
 0: TW_ROOT@0..41
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..41
-    0: TW_FULL_CANDIDATE@0..7
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..41
+    0: TW_FULL_CANDIDATE@0..6
       0: TW_VARIANT_LIST@0..0
       1: BANG@0..1 "!" [] []
       2: (empty)
       3: TW_STATIC_CANDIDATE@1..5
         0: TW_BASE@1..5 "flex" [] []
         1: (empty)
-      4: BANG@5..7 "!" [] [Whitespace(" ")]
-    1: TW_FULL_CANDIDATE@7..11
+      4: BANG@5..6 "!" [] []
+    1: WHITESPACE@6..7 " " [] []
+    2: TW_FULL_CANDIDATE@7..10
       0: TW_VARIANT_LIST@7..7
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@7..11
+      3: TW_FUNCTIONAL_CANDIDATE@7..10
         0: TW_BASE@7..8 "p" [] []
         1: DASH@8..9 "-" [] []
-        2: TW_NUMBER_VALUE@9..11
-          0: TW_NUMBER@9..11 "4" [] [Whitespace(" ")]
+        2: TW_NUMBER_VALUE@9..10
+          0: TW_NUMBER@9..10 "4" [] []
         3: (empty)
       4: (empty)
-    2: TW_FULL_CANDIDATE@11..21
+    3: WHITESPACE@10..11 " " [] []
+    4: TW_FULL_CANDIDATE@11..20
       0: TW_VARIANT_LIST@11..14
         0: TW_VARIANT_EXPRESSION@11..13
           0: TW_VARIANT_SEGMENT_LIST@11..13
@@ -132,8 +152,9 @@ TwRoot {
       3: TW_STATIC_CANDIDATE@15..19
         0: TW_BASE@15..19 "flex" [] []
         1: (empty)
-      4: BANG@19..21 "!" [] [Whitespace(" ")]
-    3: TW_FULL_CANDIDATE@21..25
+      4: BANG@19..20 "!" [] []
+    5: WHITESPACE@20..21 " " [] []
+    6: TW_FULL_CANDIDATE@21..25
       0: TW_VARIANT_LIST@21..21
       1: (empty)
       2: (empty)
@@ -141,19 +162,29 @@ TwRoot {
         0: TW_BASE@21..25 "flex" [] []
         1: (empty)
       4: (empty)
-    4: TW_FULL_CANDIDATE@25..41
-      0: TW_VARIANT_LIST@25..25
-      1: BANG@25..27 "!" [Newline("\n")] []
+    7: WHITESPACE@25..26 "\n" [] []
+    8: TW_FULL_CANDIDATE@26..37
+      0: TW_VARIANT_LIST@26..26
+      1: BANG@26..27 "!" [] []
       2: (empty)
-      3: TW_BOGUS_CANDIDATE@27..41
+      3: TW_BOGUS_CANDIDATE@27..37
         0: TW_BASE@27..32 "hover" [] []
         1: COLON@32..33 ":" [] []
-        2: TW_BASE@33..38 "flex" [] [Whitespace(" ")]
-        3: TW_BASE@38..39 "p" [] []
-        4: DASH@39..40 "-" [] []
-        5: TW_NUMBER@40..41 "4" [] []
+        2: TW_BASE@33..37 "flex" [] []
       4: (empty)
-  2: EOF@41..41 "" [] []
+    9: WHITESPACE@37..38 " " [] []
+    10: TW_FULL_CANDIDATE@38..41
+      0: TW_VARIANT_LIST@38..38
+      1: (empty)
+      2: (empty)
+      3: TW_FUNCTIONAL_CANDIDATE@38..41
+        0: TW_BASE@38..39 "p" [] []
+        1: DASH@39..40 "-" [] []
+        2: TW_NUMBER_VALUE@40..41
+          0: TW_NUMBER@40..41 "4" [] []
+        3: (empty)
+      4: (empty)
+  3: EOF@41..41 "" [] []
 
 ```
 
@@ -182,16 +213,16 @@ duplicate-important.txt:1:20 parse ━━━━━━━━━━━━━━━
   
 duplicate-important.txt:2:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Expected a candidate but instead found 'hover:flex p-4'.
+  × Expected a candidate but instead found 'hover:flex'.
   
     1 │ !flex! p-4 md:!flex! flex
   > 2 │ !hover:flex p-4
-      │  ^^^^^^^^^^^^^^
+      │  ^^^^^^^^^^
   
   i Expected a candidate here.
   
     1 │ !flex! p-4 md:!flex! flex
   > 2 │ !hover:flex p-4
-      │  ^^^^^^^^^^^^^^
+      │  ^^^^^^^^^^
   
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/error/formfeed-separators.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/error/formfeed-separators.txt.snap
@@ -15,17 +15,19 @@ flexhover:flexfocus:flex uppercase
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@0..5 "flex" [] [Whitespace("\u{c}")],
+                base_token: TW_BASE@0..4 "flex" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@4..5 "\u{c}" [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -42,11 +44,12 @@ TwRoot {
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@11..16 "flex" [] [Whitespace("\u{b}")],
+                base_token: TW_BASE@11..15 "flex" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@15..16 "\u{b}" [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -63,11 +66,12 @@ TwRoot {
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@22..27 "flex" [] [Whitespace(" ")],
+                base_token: TW_BASE@22..26 "flex" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@26..27 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -88,16 +92,18 @@ TwRoot {
 ```
 0: TW_ROOT@0..36
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..36
-    0: TW_FULL_CANDIDATE@0..5
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..36
+    0: TW_FULL_CANDIDATE@0..4
       0: TW_VARIANT_LIST@0..0
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@0..5
-        0: TW_BASE@0..5 "flex" [] [Whitespace("\u{c}")]
+      3: TW_STATIC_CANDIDATE@0..4
+        0: TW_BASE@0..4 "flex" [] []
         1: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@5..16
+    1: WHITESPACE@4..5 "\u{c}" [] []
+    2: TW_FULL_CANDIDATE@5..15
       0: TW_VARIANT_LIST@5..11
         0: TW_VARIANT_EXPRESSION@5..10
           0: TW_VARIANT_SEGMENT_LIST@5..10
@@ -108,11 +114,12 @@ TwRoot {
         1: COLON@10..11 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@11..16
-        0: TW_BASE@11..16 "flex" [] [Whitespace("\u{b}")]
+      3: TW_STATIC_CANDIDATE@11..15
+        0: TW_BASE@11..15 "flex" [] []
         1: (empty)
       4: (empty)
-    2: TW_FULL_CANDIDATE@16..27
+    3: WHITESPACE@15..16 "\u{b}" [] []
+    4: TW_FULL_CANDIDATE@16..26
       0: TW_VARIANT_LIST@16..22
         0: TW_VARIANT_EXPRESSION@16..21
           0: TW_VARIANT_SEGMENT_LIST@16..21
@@ -123,11 +130,12 @@ TwRoot {
         1: COLON@21..22 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@22..27
-        0: TW_BASE@22..27 "flex" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@22..26
+        0: TW_BASE@22..26 "flex" [] []
         1: (empty)
       4: (empty)
-    3: TW_FULL_CANDIDATE@27..36
+    5: WHITESPACE@26..27 " " [] []
+    6: TW_FULL_CANDIDATE@27..36
       0: TW_VARIANT_LIST@27..27
       1: (empty)
       2: (empty)
@@ -135,7 +143,7 @@ TwRoot {
         0: TW_BASE@27..36 "uppercase" [] []
         1: (empty)
       4: (empty)
-  2: EOF@36..36 "" [] []
+  3: EOF@36..36 "" [] []
 
 ```
 

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/error/incomplete-arbitrary-value-0.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/error/incomplete-arbitrary-value-0.txt.snap
@@ -16,6 +16,7 @@ text-[
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -33,8 +34,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@6..7 "\n" [] [],
     ],
-    eof_token: EOF@6..7 "" [Newline("\n")] [],
+    eof_token: EOF@7..7 "" [] [],
 }
 ```
 
@@ -43,7 +45,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..7
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..6
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..7
     0: TW_FULL_CANDIDATE@0..6
       0: TW_VARIANT_LIST@0..0
       1: (empty)
@@ -55,7 +58,8 @@ TwRoot {
           0: L_BRACKET@5..6 "[" [] []
         3: (empty)
       4: (empty)
-  2: EOF@6..7 "" [Newline("\n")] []
+    1: WHITESPACE@6..7 "\n" [] []
+  3: EOF@7..7 "" [] []
 
 ```
 

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/error/incomplete-arbitrary-value-1.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/error/incomplete-arbitrary-value-1.txt.snap
@@ -16,6 +16,7 @@ text-[#ff0000
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -34,8 +35,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@13..14 "\n" [] [],
     ],
-    eof_token: EOF@13..14 "" [Newline("\n")] [],
+    eof_token: EOF@14..14 "" [] [],
 }
 ```
 
@@ -44,7 +46,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..14
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..13
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..14
     0: TW_FULL_CANDIDATE@0..13
       0: TW_VARIANT_LIST@0..0
       1: (empty)
@@ -57,7 +60,8 @@ TwRoot {
           1: TW_SELECTOR@6..13 "#ff0000" [] []
         3: (empty)
       4: (empty)
-  2: EOF@13..14 "" [Newline("\n")] []
+    1: WHITESPACE@13..14 "\n" [] []
+  3: EOF@14..14 "" [] []
 
 ```
 

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/error/incomplete-arbitrary-value-2.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/error/incomplete-arbitrary-value-2.txt.snap
@@ -16,6 +16,7 @@ text-[ text-sm bg-red-500
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -26,21 +27,46 @@ TwRoot {
                 minus_token: DASH@4..5 "-" [] [],
                 value: TwBogusValue {
                     items: [
-                        L_BRACKET@5..7 "[" [] [Whitespace(" ")],
-                        TW_BASE@7..11 "text" [] [],
-                        DASH@11..12 "-" [] [],
-                        TW_VALUE@12..15 "sm" [] [Whitespace(" ")],
-                        TW_BASE@15..17 "bg" [] [],
-                        DASH@17..18 "-" [] [],
-                        TW_VALUE@18..25 "red-500" [] [],
+                        L_BRACKET@5..6 "[" [] [],
                     ],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@6..7 " " [] [],
+        TwFullCandidate {
+            variants: TwVariantList [],
+            legacy_important_token: missing (optional),
+            negative_token: missing (optional),
+            candidate: TwFunctionalCandidate {
+                base_token: TW_BASE@7..11 "text" [] [],
+                minus_token: DASH@11..12 "-" [] [],
+                value: TwNamedValue {
+                    value_token: TW_VALUE@12..14 "sm" [] [],
+                },
+                modifier: missing (optional),
+            },
+            excl_token: missing (optional),
+        },
+        WHITESPACE@14..15 " " [] [],
+        TwFullCandidate {
+            variants: TwVariantList [],
+            legacy_important_token: missing (optional),
+            negative_token: missing (optional),
+            candidate: TwFunctionalCandidate {
+                base_token: TW_BASE@15..17 "bg" [] [],
+                minus_token: DASH@17..18 "-" [] [],
+                value: TwNamedValue {
+                    value_token: TW_VALUE@18..25 "red-500" [] [],
+                },
+                modifier: missing (optional),
+            },
+            excl_token: missing (optional),
+        },
+        WHITESPACE@25..26 "\n" [] [],
     ],
-    eof_token: EOF@25..26 "" [Newline("\n")] [],
+    eof_token: EOF@26..26 "" [] [],
 }
 ```
 
@@ -49,25 +75,45 @@ TwRoot {
 ```
 0: TW_ROOT@0..26
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..25
-    0: TW_FULL_CANDIDATE@0..25
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..26
+    0: TW_FULL_CANDIDATE@0..6
       0: TW_VARIANT_LIST@0..0
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@0..25
+      3: TW_FUNCTIONAL_CANDIDATE@0..6
         0: TW_BASE@0..4 "text" [] []
         1: DASH@4..5 "-" [] []
-        2: TW_BOGUS_VALUE@5..25
-          0: L_BRACKET@5..7 "[" [] [Whitespace(" ")]
-          1: TW_BASE@7..11 "text" [] []
-          2: DASH@11..12 "-" [] []
-          3: TW_VALUE@12..15 "sm" [] [Whitespace(" ")]
-          4: TW_BASE@15..17 "bg" [] []
-          5: DASH@17..18 "-" [] []
-          6: TW_VALUE@18..25 "red-500" [] []
+        2: TW_BOGUS_VALUE@5..6
+          0: L_BRACKET@5..6 "[" [] []
         3: (empty)
       4: (empty)
-  2: EOF@25..26 "" [Newline("\n")] []
+    1: WHITESPACE@6..7 " " [] []
+    2: TW_FULL_CANDIDATE@7..14
+      0: TW_VARIANT_LIST@7..7
+      1: (empty)
+      2: (empty)
+      3: TW_FUNCTIONAL_CANDIDATE@7..14
+        0: TW_BASE@7..11 "text" [] []
+        1: DASH@11..12 "-" [] []
+        2: TW_NAMED_VALUE@12..14
+          0: TW_VALUE@12..14 "sm" [] []
+        3: (empty)
+      4: (empty)
+    3: WHITESPACE@14..15 " " [] []
+    4: TW_FULL_CANDIDATE@15..25
+      0: TW_VARIANT_LIST@15..15
+      1: (empty)
+      2: (empty)
+      3: TW_FUNCTIONAL_CANDIDATE@15..25
+        0: TW_BASE@15..17 "bg" [] []
+        1: DASH@17..18 "-" [] []
+        2: TW_NAMED_VALUE@18..25
+          0: TW_VALUE@18..25 "red-500" [] []
+        3: (empty)
+      4: (empty)
+    5: WHITESPACE@25..26 "\n" [] []
+  3: EOF@26..26 "" [] []
 
 ```
 
@@ -76,16 +122,16 @@ TwRoot {
 ```
 incomplete-arbitrary-value-2.txt:1:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Expected a value but instead found '[ text-sm bg-red-500'.
+  × Expected a value but instead found '['.
   
   > 1 │ text-[ text-sm bg-red-500
-      │      ^^^^^^^^^^^^^^^^^^^^
+      │      ^
     2 │ 
   
   i Expected a value here.
   
   > 1 │ text-[ text-sm bg-red-500
-      │      ^^^^^^^^^^^^^^^^^^^^
+      │      ^
     2 │ 
   
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/error/incomplete-arbitrary-variant.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/error/incomplete-arbitrary-variant.txt.snap
@@ -16,6 +16,7 @@ aria-[foo:text-sm
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -34,8 +35,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@17..18 "\n" [] [],
     ],
-    eof_token: EOF@17..18 "" [Newline("\n")] [],
+    eof_token: EOF@18..18 "" [] [],
 }
 ```
 
@@ -44,7 +46,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..18
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..17
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..18
     0: TW_FULL_CANDIDATE@0..17
       0: TW_VARIANT_LIST@0..0
       1: (empty)
@@ -57,7 +60,8 @@ TwRoot {
           1: TW_SELECTOR@6..17 "foo:text-sm" [] []
         3: (empty)
       4: (empty)
-  2: EOF@17..18 "" [Newline("\n")] []
+    1: WHITESPACE@17..18 "\n" [] []
+  3: EOF@18..18 "" [] []
 
 ```
 

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/error/invalid-variant-segment.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/error/invalid-variant-segment.txt.snap
@@ -16,6 +16,7 @@ group-%:flex
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -33,8 +34,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@12..13 "\n" [] [],
     ],
-    eof_token: EOF@12..13 "" [Newline("\n")] [],
+    eof_token: EOF@13..13 "" [] [],
 }
 ```
 
@@ -43,7 +45,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..13
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..12
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..13
     0: TW_FULL_CANDIDATE@0..12
       0: TW_VARIANT_LIST@0..0
       1: (empty)
@@ -56,7 +59,8 @@ TwRoot {
         4: COLON@7..8 ":" [] []
         5: TW_BASE@8..12 "flex" [] []
       4: (empty)
-  2: EOF@12..13 "" [Newline("\n")] []
+    1: WHITESPACE@12..13 "\n" [] []
+  3: EOF@13..13 "" [] []
 
 ```
 

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/error/missing-modifier-value-1.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/error/missing-modifier-value-1.txt.snap
@@ -16,6 +16,7 @@ bg-green-500/!
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -40,8 +41,9 @@ TwRoot {
             },
             excl_token: BANG@13..14 "!" [] [],
         },
+        WHITESPACE@14..15 "\n" [] [],
     ],
-    eof_token: EOF@14..15 "" [Newline("\n")] [],
+    eof_token: EOF@15..15 "" [] [],
 }
 ```
 
@@ -50,7 +52,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..15
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..14
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..15
     0: TW_FULL_CANDIDATE@0..14
       0: TW_VARIANT_LIST@0..0
       1: (empty)
@@ -65,7 +68,8 @@ TwRoot {
           1: TW_BOGUS_MODIFIER@13..13
             0: ERROR_TOKEN@13..13 "" [] []
       4: BANG@13..14 "!" [] []
-  2: EOF@14..15 "" [Newline("\n")] []
+    1: WHITESPACE@14..15 "\n" [] []
+  3: EOF@15..15 "" [] []
 
 ```
 

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/error/missing-modifier-value.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/error/missing-modifier-value.txt.snap
@@ -16,6 +16,7 @@ bg-green-500/
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -33,8 +34,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@13..14 "\n" [] [],
     ],
-    eof_token: EOF@13..14 "" [Newline("\n")] [],
+    eof_token: EOF@14..14 "" [] [],
 }
 ```
 
@@ -43,7 +45,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..14
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..13
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..14
     0: TW_FULL_CANDIDATE@0..13
       0: TW_VARIANT_LIST@0..0
       1: (empty)
@@ -55,24 +58,28 @@ TwRoot {
           0: TW_VALUE@3..12 "green-500" [] []
         3: SLASH@12..13 "/" [] []
       4: (empty)
-  2: EOF@13..14 "" [Newline("\n")] []
+    1: WHITESPACE@13..14 "\n" [] []
+  3: EOF@14..14 "" [] []
 
 ```
 
 ## Diagnostics
 
 ```
-missing-modifier-value.txt:2:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+missing-modifier-value.txt:1:14 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Expected a value but instead found the end of the file.
+  × Expected a value but instead found '
+    '.
   
-    1 │ bg-green-500/
+  > 1 │ bg-green-500/
+      │              
   > 2 │ 
       │ 
   
   i Expected a value here.
   
-    1 │ bg-green-500/
+  > 1 │ bg-green-500/
+      │              
   > 2 │ 
       │ 
   

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/error/missing-value.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/error/missing-value.txt.snap
@@ -16,6 +16,7 @@ text-
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -29,8 +30,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@5..6 "\n" [] [],
     ],
-    eof_token: EOF@5..6 "" [Newline("\n")] [],
+    eof_token: EOF@6..6 "" [] [],
 }
 ```
 
@@ -39,7 +41,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..6
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..5
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..6
     0: TW_FULL_CANDIDATE@0..5
       0: TW_VARIANT_LIST@0..0
       1: (empty)
@@ -48,7 +51,8 @@ TwRoot {
         0: TW_BASE@0..4 "text" [] []
         1: DASH@4..5 "-" [] []
       4: (empty)
-  2: EOF@5..6 "" [Newline("\n")] []
+    1: WHITESPACE@5..6 "\n" [] []
+  3: EOF@6..6 "" [] []
 
 ```
 

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/error/nested-bracket-whitespace.txt
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/error/nested-bracket-whitespace.txt
@@ -1,0 +1,1 @@
+bg-[foo[bar baz]] flex

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/error/nested-bracket-whitespace.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/error/nested-bracket-whitespace.txt.snap
@@ -1,0 +1,125 @@
+---
+source: crates/biome_tailwind_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```text
+bg-[foo[bar baz]] flex
+
+```
+
+
+## AST
+
+```
+TwRoot {
+    bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
+    candidates: TwCandidateList [
+        TwFullCandidate {
+            variants: TwVariantList [],
+            legacy_important_token: missing (optional),
+            negative_token: missing (optional),
+            candidate: TwFunctionalCandidate {
+                base_token: TW_BASE@0..2 "bg" [] [],
+                minus_token: DASH@2..3 "-" [] [],
+                value: TwBogusValue {
+                    items: [
+                        L_BRACKET@3..4 "[" [] [],
+                        TW_SELECTOR@4..11 "foo[bar" [] [],
+                    ],
+                },
+                modifier: missing (optional),
+            },
+            excl_token: missing (optional),
+        },
+        WHITESPACE@11..12 " " [] [],
+        TwFullCandidate {
+            variants: TwVariantList [],
+            legacy_important_token: missing (optional),
+            negative_token: missing (optional),
+            candidate: TwStaticCandidate {
+                base_token: TW_BASE@12..17 "baz]]" [] [],
+                modifier: missing (optional),
+            },
+            excl_token: missing (optional),
+        },
+        WHITESPACE@17..18 " " [] [],
+        TwFullCandidate {
+            variants: TwVariantList [],
+            legacy_important_token: missing (optional),
+            negative_token: missing (optional),
+            candidate: TwStaticCandidate {
+                base_token: TW_BASE@18..22 "flex" [] [],
+                modifier: missing (optional),
+            },
+            excl_token: missing (optional),
+        },
+        WHITESPACE@22..23 "\n" [] [],
+    ],
+    eof_token: EOF@23..23 "" [] [],
+}
+```
+
+## CST
+
+```
+0: TW_ROOT@0..23
+  0: (empty)
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..23
+    0: TW_FULL_CANDIDATE@0..11
+      0: TW_VARIANT_LIST@0..0
+      1: (empty)
+      2: (empty)
+      3: TW_FUNCTIONAL_CANDIDATE@0..11
+        0: TW_BASE@0..2 "bg" [] []
+        1: DASH@2..3 "-" [] []
+        2: TW_BOGUS_VALUE@3..11
+          0: L_BRACKET@3..4 "[" [] []
+          1: TW_SELECTOR@4..11 "foo[bar" [] []
+        3: (empty)
+      4: (empty)
+    1: WHITESPACE@11..12 " " [] []
+    2: TW_FULL_CANDIDATE@12..17
+      0: TW_VARIANT_LIST@12..12
+      1: (empty)
+      2: (empty)
+      3: TW_STATIC_CANDIDATE@12..17
+        0: TW_BASE@12..17 "baz]]" [] []
+        1: (empty)
+      4: (empty)
+    3: WHITESPACE@17..18 " " [] []
+    4: TW_FULL_CANDIDATE@18..22
+      0: TW_VARIANT_LIST@18..18
+      1: (empty)
+      2: (empty)
+      3: TW_STATIC_CANDIDATE@18..22
+        0: TW_BASE@18..22 "flex" [] []
+        1: (empty)
+      4: (empty)
+    5: WHITESPACE@22..23 "\n" [] []
+  3: EOF@23..23 "" [] []
+
+```
+
+## Diagnostics
+
+```
+nested-bracket-whitespace.txt:1:4 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a value but instead found '[foo[bar'.
+  
+  > 1 │ bg-[foo[bar baz]] flex
+      │    ^^^^^^^^
+    2 │ 
+  
+  i Expected a value here.
+  
+  > 1 │ bg-[foo[bar baz]] flex
+      │    ^^^^^^^^
+    2 │ 
+  
+```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/error/unterminated-container-size.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/error/unterminated-container-size.txt.snap
@@ -16,6 +16,7 @@ expression: snapshot
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -27,9 +28,23 @@ TwRoot {
                 value: TwBogusValue {
                     items: [
                         L_BRACKET@5..6 "[" [] [],
-                        TW_SELECTOR@6..17 "400px:flex" [] [Whitespace(" ")],
-                        TW_BASE@17..21 "@max" [] [],
-                        DASH@21..22 "-" [] [],
+                        TW_SELECTOR@6..16 "400px:flex" [] [],
+                    ],
+                },
+                modifier: missing (optional),
+            },
+            excl_token: missing (optional),
+        },
+        WHITESPACE@16..17 " " [] [],
+        TwFullCandidate {
+            variants: TwVariantList [],
+            legacy_important_token: missing (optional),
+            negative_token: missing (optional),
+            candidate: TwFunctionalCandidate {
+                base_token: TW_BASE@17..21 "@max" [] [],
+                minus_token: DASH@21..22 "-" [] [],
+                value: TwBogusValue {
+                    items: [
                         L_BRACKET@22..23 "[" [] [],
                         TW_SELECTOR@23..26 "959" [] [],
                     ],
@@ -38,8 +53,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@26..27 "\n" [] [],
     ],
-    eof_token: EOF@26..27 "" [Newline("\n")] [],
+    eof_token: EOF@27..27 "" [] [],
 }
 ```
 
@@ -48,24 +64,35 @@ TwRoot {
 ```
 0: TW_ROOT@0..27
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..26
-    0: TW_FULL_CANDIDATE@0..26
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..27
+    0: TW_FULL_CANDIDATE@0..16
       0: TW_VARIANT_LIST@0..0
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@0..26
+      3: TW_FUNCTIONAL_CANDIDATE@0..16
         0: TW_BASE@0..4 "@min" [] []
         1: DASH@4..5 "-" [] []
-        2: TW_BOGUS_VALUE@5..26
+        2: TW_BOGUS_VALUE@5..16
           0: L_BRACKET@5..6 "[" [] []
-          1: TW_SELECTOR@6..17 "400px:flex" [] [Whitespace(" ")]
-          2: TW_BASE@17..21 "@max" [] []
-          3: DASH@21..22 "-" [] []
-          4: L_BRACKET@22..23 "[" [] []
-          5: TW_SELECTOR@23..26 "959" [] []
+          1: TW_SELECTOR@6..16 "400px:flex" [] []
         3: (empty)
       4: (empty)
-  2: EOF@26..27 "" [Newline("\n")] []
+    1: WHITESPACE@16..17 " " [] []
+    2: TW_FULL_CANDIDATE@17..26
+      0: TW_VARIANT_LIST@17..17
+      1: (empty)
+      2: (empty)
+      3: TW_FUNCTIONAL_CANDIDATE@17..26
+        0: TW_BASE@17..21 "@max" [] []
+        1: DASH@21..22 "-" [] []
+        2: TW_BOGUS_VALUE@22..26
+          0: L_BRACKET@22..23 "[" [] []
+          1: TW_SELECTOR@23..26 "959" [] []
+        3: (empty)
+      4: (empty)
+    3: WHITESPACE@26..27 "\n" [] []
+  3: EOF@27..27 "" [] []
 
 ```
 
@@ -74,16 +101,30 @@ TwRoot {
 ```
 unterminated-container-size.txt:1:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Expected a value but instead found '[400px:flex @max-[959'.
+  × Expected a value but instead found '[400px:flex'.
   
   > 1 │ @min-[400px:flex @max-[959
-      │      ^^^^^^^^^^^^^^^^^^^^^
+      │      ^^^^^^^^^^^
     2 │ 
   
   i Expected a value here.
   
   > 1 │ @min-[400px:flex @max-[959
-      │      ^^^^^^^^^^^^^^^^^^^^^
+      │      ^^^^^^^^^^^
+    2 │ 
+  
+unterminated-container-size.txt:1:23 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a value but instead found '[959'.
+  
+  > 1 │ @min-[400px:flex @max-[959
+      │                       ^^^^
+    2 │ 
+  
+  i Expected a value here.
+  
+  > 1 │ @min-[400px:flex @max-[959
+      │                       ^^^^
     2 │ 
   
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/brackets/css-functions.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/brackets/css-functions.txt.snap
@@ -16,6 +16,7 @@ w-[calc(100%_-_theme(spacing.4))] bg-[rgb(255_0_0/0.5)] bg-[color-mix(in_oklab,_
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -71,12 +72,13 @@ TwRoot {
                             r_paren_token: R_PAREN@31..32 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@32..34 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@32..33 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@33..34 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -116,12 +118,13 @@ TwRoot {
                             r_paren_token: R_PAREN@53..54 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@54..56 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@54..55 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@55..56 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -172,12 +175,13 @@ TwRoot {
                             r_paren_token: R_PAREN@93..94 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@94..96 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@94..95 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@95..96 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -231,12 +235,13 @@ TwRoot {
                             r_paren_token: R_PAREN@134..135 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@135..137 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@135..136 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@136..137 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -300,8 +305,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@174..175 "\n" [] [],
     ],
-    eof_token: EOF@174..175 "" [Newline("\n")] [],
+    eof_token: EOF@175..175 "" [] [],
 }
 ```
 
@@ -310,15 +316,16 @@ TwRoot {
 ```
 0: TW_ROOT@0..175
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..174
-    0: TW_FULL_CANDIDATE@0..34
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..175
+    0: TW_FULL_CANDIDATE@0..33
       0: TW_VARIANT_LIST@0..0
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@0..34
+      3: TW_FUNCTIONAL_CANDIDATE@0..33
         0: TW_BASE@0..1 "w" [] []
         1: DASH@1..2 "-" [] []
-        2: TW_ARBITRARY_VALUE@2..34
+        2: TW_ARBITRARY_VALUE@2..33
           0: L_BRACKET@2..3 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@3..32
             0: CSS_FUNCTION@3..32
@@ -348,17 +355,18 @@ TwRoot {
                                 0: CSS_NUMBER_LITERAL@28..30 ".4" [] []
                         3: R_PAREN@30..31 ")" [] []
               3: R_PAREN@31..32 ")" [] []
-          2: R_BRACKET@32..34 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@32..33 "]" [] []
         3: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@34..56
+    1: WHITESPACE@33..34 " " [] []
+    2: TW_FULL_CANDIDATE@34..55
       0: TW_VARIANT_LIST@34..34
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@34..56
+      3: TW_FUNCTIONAL_CANDIDATE@34..55
         0: TW_BASE@34..36 "bg" [] []
         1: DASH@36..37 "-" [] []
-        2: TW_ARBITRARY_VALUE@37..56
+        2: TW_ARBITRARY_VALUE@37..55
           0: L_BRACKET@37..38 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@38..54
             0: CSS_FUNCTION@38..54
@@ -379,17 +387,18 @@ TwRoot {
                       2: CSS_NUMBER@50..53
                         0: CSS_NUMBER_LITERAL@50..53 "0.5" [] []
               3: R_PAREN@53..54 ")" [] []
-          2: R_BRACKET@54..56 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@54..55 "]" [] []
         3: (empty)
       4: (empty)
-    2: TW_FULL_CANDIDATE@56..96
+    3: WHITESPACE@55..56 " " [] []
+    4: TW_FULL_CANDIDATE@56..95
       0: TW_VARIANT_LIST@56..56
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@56..96
+      3: TW_FUNCTIONAL_CANDIDATE@56..95
         0: TW_BASE@56..58 "bg" [] []
         1: DASH@58..59 "-" [] []
-        2: TW_ARBITRARY_VALUE@59..96
+        2: TW_ARBITRARY_VALUE@59..95
           0: L_BRACKET@59..60 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@60..94
             0: CSS_FUNCTION@60..94
@@ -417,17 +426,18 @@ TwRoot {
                     0: CSS_IDENTIFIER@89..93
                       0: IDENT@89..93 "blue" [] []
               3: R_PAREN@93..94 ")" [] []
-          2: R_BRACKET@94..96 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@94..95 "]" [] []
         3: (empty)
       4: (empty)
-    3: TW_FULL_CANDIDATE@96..137
+    5: WHITESPACE@95..96 " " [] []
+    6: TW_FULL_CANDIDATE@96..136
       0: TW_VARIANT_LIST@96..96
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@96..137
+      3: TW_FUNCTIONAL_CANDIDATE@96..136
         0: TW_BASE@96..102 "shadow" [] []
         1: DASH@102..103 "-" [] []
-        2: TW_ARBITRARY_VALUE@103..137
+        2: TW_ARBITRARY_VALUE@103..136
           0: L_BRACKET@103..104 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@104..135
             0: CSS_IDENTIFIER@104..110
@@ -458,10 +468,11 @@ TwRoot {
                       2: CSS_NUMBER@130..134
                         0: CSS_NUMBER_LITERAL@130..134 "0.25" [] []
               3: R_PAREN@134..135 ")" [] []
-          2: R_BRACKET@135..137 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@135..136 "]" [] []
         3: (empty)
       4: (empty)
-    4: TW_FULL_CANDIDATE@137..174
+    7: WHITESPACE@136..137 " " [] []
+    8: TW_FULL_CANDIDATE@137..174
       0: TW_VARIANT_LIST@137..137
       1: (empty)
       2: (empty)
@@ -503,6 +514,7 @@ TwRoot {
           2: R_BRACKET@173..174 "]" [] []
         3: (empty)
       4: (empty)
-  2: EOF@174..175 "" [Newline("\n")] []
+    9: WHITESPACE@174..175 "\n" [] []
+  3: EOF@175..175 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/brackets/css-math-functions.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/brackets/css-math-functions.txt.snap
@@ -17,6 +17,7 @@ w-[calc(min(100%,_20rem)_-_max(1rem,_2vw))] w-[clamp(min(10px,_1vw),_calc(50%_-_
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -57,12 +58,13 @@ TwRoot {
                             r_paren_token: R_PAREN@19..20 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@20..22 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@20..21 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@21..22 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -100,12 +102,13 @@ TwRoot {
                             r_paren_token: R_PAREN@39..40 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@40..42 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@40..41 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@41..42 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -143,12 +146,13 @@ TwRoot {
                             r_paren_token: R_PAREN@59..60 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@60..62 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@60..61 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@61..62 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -195,12 +199,13 @@ TwRoot {
                             r_paren_token: R_PAREN@86..87 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@87..89 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@87..88 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@88..89 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -238,12 +243,13 @@ TwRoot {
                             r_paren_token: R_PAREN@105..106 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@106..108 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@106..107 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@107..108 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -281,12 +287,13 @@ TwRoot {
                             r_paren_token: R_PAREN@124..125 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@125..127 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@125..126 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@126..127 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -315,12 +322,13 @@ TwRoot {
                             r_paren_token: R_PAREN@139..140 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@140..142 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@140..141 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@141..142 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -349,12 +357,13 @@ TwRoot {
                             r_paren_token: R_PAREN@154..155 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@155..157 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@155..156 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@156..157 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -383,12 +392,13 @@ TwRoot {
                             r_paren_token: R_PAREN@169..170 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@170..172 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@170..171 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@171..172 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -416,12 +426,13 @@ TwRoot {
                             r_paren_token: R_PAREN@183..184 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@184..186 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@184..185 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@185..186 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -449,12 +460,13 @@ TwRoot {
                             r_paren_token: R_PAREN@197..198 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@198..200 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@198..199 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@199..200 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -482,12 +494,13 @@ TwRoot {
                             r_paren_token: R_PAREN@209..210 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@210..212 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@210..211 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@211..212 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -523,12 +536,13 @@ TwRoot {
                             r_paren_token: R_PAREN@225..226 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@226..228 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@226..227 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@227..228 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -564,12 +578,13 @@ TwRoot {
                             r_paren_token: R_PAREN@239..240 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@240..242 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@240..241 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@241..242 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -597,12 +612,13 @@ TwRoot {
                             r_paren_token: R_PAREN@251..252 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@252..254 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@252..253 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@253..254 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -638,12 +654,13 @@ TwRoot {
                             r_paren_token: R_PAREN@267..268 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@268..270 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@268..269 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@269..270 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -671,12 +688,13 @@ TwRoot {
                             r_paren_token: R_PAREN@279..280 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@280..282 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@280..281 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@281..282 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -704,12 +722,13 @@ TwRoot {
                             r_paren_token: R_PAREN@290..291 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@291..293 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@291..292 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@292..293 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -744,12 +763,13 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@310..311 "\n" [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwFunctionalCandidate {
-                base_token: TW_BASE@310..312 "w" [Newline("\n")] [],
+                base_token: TW_BASE@311..312 "w" [] [],
                 minus_token: DASH@312..313 "-" [] [],
                 value: TwArbitraryValue {
                     l_brack_token: L_BRACKET@313..314 "[" [] [],
@@ -827,12 +847,13 @@ TwRoot {
                             r_paren_token: R_PAREN@352..353 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@353..355 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@353..354 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@354..355 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -947,12 +968,13 @@ TwRoot {
                             r_paren_token: R_PAREN@412..413 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@413..415 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@413..414 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@414..415 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -1027,12 +1049,13 @@ TwRoot {
                             r_paren_token: R_PAREN@444..445 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@445..447 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@445..446 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@446..447 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -1096,12 +1119,13 @@ TwRoot {
                             r_paren_token: R_PAREN@478..479 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@479..481 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@479..480 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@480..481 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -1164,12 +1188,13 @@ TwRoot {
                             r_paren_token: R_PAREN@509..510 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@510..512 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@510..511 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@511..512 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -1235,8 +1260,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@540..541 "\n" [] [],
     ],
-    eof_token: EOF@540..541 "" [Newline("\n")] [],
+    eof_token: EOF@541..541 "" [] [],
 }
 ```
 
@@ -1245,15 +1271,16 @@ TwRoot {
 ```
 0: TW_ROOT@0..541
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..540
-    0: TW_FULL_CANDIDATE@0..22
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..541
+    0: TW_FULL_CANDIDATE@0..21
       0: TW_VARIANT_LIST@0..0
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@0..22
+      3: TW_FUNCTIONAL_CANDIDATE@0..21
         0: TW_BASE@0..1 "w" [] []
         1: DASH@1..2 "-" [] []
-        2: TW_ARBITRARY_VALUE@2..22
+        2: TW_ARBITRARY_VALUE@2..21
           0: L_BRACKET@2..3 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@3..20
             0: CSS_FUNCTION@3..20
@@ -1274,17 +1301,18 @@ TwRoot {
                         0: CSS_NUMBER_LITERAL@15..16 "1" [] []
                         1: IDENT@16..19 "rem" [] []
               3: R_PAREN@19..20 ")" [] []
-          2: R_BRACKET@20..22 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@20..21 "]" [] []
         3: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@22..42
+    1: WHITESPACE@21..22 " " [] []
+    2: TW_FULL_CANDIDATE@22..41
       0: TW_VARIANT_LIST@22..22
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@22..42
+      3: TW_FUNCTIONAL_CANDIDATE@22..41
         0: TW_BASE@22..23 "w" [] []
         1: DASH@23..24 "-" [] []
-        2: TW_ARBITRARY_VALUE@24..42
+        2: TW_ARBITRARY_VALUE@24..41
           0: L_BRACKET@24..25 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@25..40
             0: CSS_FUNCTION@25..40
@@ -1304,17 +1332,18 @@ TwRoot {
                       0: CSS_NUMBER_LITERAL@35..37 "20" [] []
                       1: IDENT@37..39 "px" [] []
               3: R_PAREN@39..40 ")" [] []
-          2: R_BRACKET@40..42 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@40..41 "]" [] []
         3: (empty)
       4: (empty)
-    2: TW_FULL_CANDIDATE@42..62
+    3: WHITESPACE@41..42 " " [] []
+    4: TW_FULL_CANDIDATE@42..61
       0: TW_VARIANT_LIST@42..42
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@42..62
+      3: TW_FUNCTIONAL_CANDIDATE@42..61
         0: TW_BASE@42..43 "w" [] []
         1: DASH@43..44 "-" [] []
-        2: TW_ARBITRARY_VALUE@44..62
+        2: TW_ARBITRARY_VALUE@44..61
           0: L_BRACKET@44..45 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@45..60
             0: CSS_FUNCTION@45..60
@@ -1334,17 +1363,18 @@ TwRoot {
                       0: CSS_NUMBER_LITERAL@55..57 "20" [] []
                       1: IDENT@57..59 "px" [] []
               3: R_PAREN@59..60 ")" [] []
-          2: R_BRACKET@60..62 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@60..61 "]" [] []
         3: (empty)
       4: (empty)
-    3: TW_FULL_CANDIDATE@62..89
+    5: WHITESPACE@61..62 " " [] []
+    6: TW_FULL_CANDIDATE@62..88
       0: TW_VARIANT_LIST@62..62
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@62..89
+      3: TW_FUNCTIONAL_CANDIDATE@62..88
         0: TW_BASE@62..63 "w" [] []
         1: DASH@63..64 "-" [] []
-        2: TW_ARBITRARY_VALUE@64..89
+        2: TW_ARBITRARY_VALUE@64..88
           0: L_BRACKET@64..65 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@65..87
             0: CSS_FUNCTION@65..87
@@ -1370,17 +1400,18 @@ TwRoot {
                       0: CSS_NUMBER_LITERAL@82..84 "20" [] []
                       1: IDENT@84..86 "px" [] []
               3: R_PAREN@86..87 ")" [] []
-          2: R_BRACKET@87..89 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@87..88 "]" [] []
         3: (empty)
       4: (empty)
-    4: TW_FULL_CANDIDATE@89..108
+    7: WHITESPACE@88..89 " " [] []
+    8: TW_FULL_CANDIDATE@89..107
       0: TW_VARIANT_LIST@89..89
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@89..108
+      3: TW_FUNCTIONAL_CANDIDATE@89..107
         0: TW_BASE@89..90 "w" [] []
         1: DASH@90..91 "-" [] []
-        2: TW_ARBITRARY_VALUE@91..108
+        2: TW_ARBITRARY_VALUE@91..107
           0: L_BRACKET@91..92 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@92..106
             0: CSS_FUNCTION@92..106
@@ -1400,17 +1431,18 @@ TwRoot {
                       0: CSS_NUMBER_LITERAL@102..103 "3" [] []
                       1: IDENT@103..105 "px" [] []
               3: R_PAREN@105..106 ")" [] []
-          2: R_BRACKET@106..108 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@106..107 "]" [] []
         3: (empty)
       4: (empty)
-    5: TW_FULL_CANDIDATE@108..127
+    9: WHITESPACE@107..108 " " [] []
+    10: TW_FULL_CANDIDATE@108..126
       0: TW_VARIANT_LIST@108..108
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@108..127
+      3: TW_FUNCTIONAL_CANDIDATE@108..126
         0: TW_BASE@108..109 "w" [] []
         1: DASH@109..110 "-" [] []
-        2: TW_ARBITRARY_VALUE@110..127
+        2: TW_ARBITRARY_VALUE@110..126
           0: L_BRACKET@110..111 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@111..125
             0: CSS_FUNCTION@111..125
@@ -1430,17 +1462,18 @@ TwRoot {
                       0: CSS_NUMBER_LITERAL@121..122 "3" [] []
                       1: IDENT@122..124 "px" [] []
               3: R_PAREN@124..125 ")" [] []
-          2: R_BRACKET@125..127 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@125..126 "]" [] []
         3: (empty)
       4: (empty)
-    6: TW_FULL_CANDIDATE@127..142
+    11: WHITESPACE@126..127 " " [] []
+    12: TW_FULL_CANDIDATE@127..141
       0: TW_VARIANT_LIST@127..127
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@127..142
+      3: TW_FUNCTIONAL_CANDIDATE@127..141
         0: TW_BASE@127..128 "w" [] []
         1: DASH@128..129 "-" [] []
-        2: TW_ARBITRARY_VALUE@129..142
+        2: TW_ARBITRARY_VALUE@129..141
           0: L_BRACKET@129..130 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@130..140
             0: CSS_FUNCTION@130..140
@@ -1454,17 +1487,18 @@ TwRoot {
                       0: CSS_NUMBER_LITERAL@134..136 "45" [] []
                       1: IDENT@136..139 "deg" [] []
               3: R_PAREN@139..140 ")" [] []
-          2: R_BRACKET@140..142 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@140..141 "]" [] []
         3: (empty)
       4: (empty)
-    7: TW_FULL_CANDIDATE@142..157
+    13: WHITESPACE@141..142 " " [] []
+    14: TW_FULL_CANDIDATE@142..156
       0: TW_VARIANT_LIST@142..142
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@142..157
+      3: TW_FUNCTIONAL_CANDIDATE@142..156
         0: TW_BASE@142..143 "w" [] []
         1: DASH@143..144 "-" [] []
-        2: TW_ARBITRARY_VALUE@144..157
+        2: TW_ARBITRARY_VALUE@144..156
           0: L_BRACKET@144..145 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@145..155
             0: CSS_FUNCTION@145..155
@@ -1478,17 +1512,18 @@ TwRoot {
                       0: CSS_NUMBER_LITERAL@149..151 "45" [] []
                       1: IDENT@151..154 "deg" [] []
               3: R_PAREN@154..155 ")" [] []
-          2: R_BRACKET@155..157 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@155..156 "]" [] []
         3: (empty)
       4: (empty)
-    8: TW_FULL_CANDIDATE@157..172
+    15: WHITESPACE@156..157 " " [] []
+    16: TW_FULL_CANDIDATE@157..171
       0: TW_VARIANT_LIST@157..157
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@157..172
+      3: TW_FUNCTIONAL_CANDIDATE@157..171
         0: TW_BASE@157..158 "w" [] []
         1: DASH@158..159 "-" [] []
-        2: TW_ARBITRARY_VALUE@159..172
+        2: TW_ARBITRARY_VALUE@159..171
           0: L_BRACKET@159..160 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@160..170
             0: CSS_FUNCTION@160..170
@@ -1502,17 +1537,18 @@ TwRoot {
                       0: CSS_NUMBER_LITERAL@164..166 "45" [] []
                       1: IDENT@166..169 "deg" [] []
               3: R_PAREN@169..170 ")" [] []
-          2: R_BRACKET@170..172 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@170..171 "]" [] []
         3: (empty)
       4: (empty)
-    9: TW_FULL_CANDIDATE@172..186
+    17: WHITESPACE@171..172 " " [] []
+    18: TW_FULL_CANDIDATE@172..185
       0: TW_VARIANT_LIST@172..172
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@172..186
+      3: TW_FUNCTIONAL_CANDIDATE@172..185
         0: TW_BASE@172..173 "w" [] []
         1: DASH@173..174 "-" [] []
-        2: TW_ARBITRARY_VALUE@174..186
+        2: TW_ARBITRARY_VALUE@174..185
           0: L_BRACKET@174..175 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@175..184
             0: CSS_FUNCTION@175..184
@@ -1525,17 +1561,18 @@ TwRoot {
                     0: CSS_NUMBER@180..183
                       0: CSS_NUMBER_LITERAL@180..183 "0.5" [] []
               3: R_PAREN@183..184 ")" [] []
-          2: R_BRACKET@184..186 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@184..185 "]" [] []
         3: (empty)
       4: (empty)
-    10: TW_FULL_CANDIDATE@186..200
+    19: WHITESPACE@185..186 " " [] []
+    20: TW_FULL_CANDIDATE@186..199
       0: TW_VARIANT_LIST@186..186
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@186..200
+      3: TW_FUNCTIONAL_CANDIDATE@186..199
         0: TW_BASE@186..187 "w" [] []
         1: DASH@187..188 "-" [] []
-        2: TW_ARBITRARY_VALUE@188..200
+        2: TW_ARBITRARY_VALUE@188..199
           0: L_BRACKET@188..189 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@189..198
             0: CSS_FUNCTION@189..198
@@ -1548,17 +1585,18 @@ TwRoot {
                     0: CSS_NUMBER@194..197
                       0: CSS_NUMBER_LITERAL@194..197 "0.5" [] []
               3: R_PAREN@197..198 ")" [] []
-          2: R_BRACKET@198..200 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@198..199 "]" [] []
         3: (empty)
       4: (empty)
-    11: TW_FULL_CANDIDATE@200..212
+    21: WHITESPACE@199..200 " " [] []
+    22: TW_FULL_CANDIDATE@200..211
       0: TW_VARIANT_LIST@200..200
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@200..212
+      3: TW_FUNCTIONAL_CANDIDATE@200..211
         0: TW_BASE@200..201 "w" [] []
         1: DASH@201..202 "-" [] []
-        2: TW_ARBITRARY_VALUE@202..212
+        2: TW_ARBITRARY_VALUE@202..211
           0: L_BRACKET@202..203 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@203..210
             0: CSS_FUNCTION@203..210
@@ -1571,17 +1609,18 @@ TwRoot {
                     0: CSS_NUMBER@208..209
                       0: CSS_NUMBER_LITERAL@208..209 "1" [] []
               3: R_PAREN@209..210 ")" [] []
-          2: R_BRACKET@210..212 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@210..211 "]" [] []
         3: (empty)
       4: (empty)
-    12: TW_FULL_CANDIDATE@212..228
+    23: WHITESPACE@211..212 " " [] []
+    24: TW_FULL_CANDIDATE@212..227
       0: TW_VARIANT_LIST@212..212
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@212..228
+      3: TW_FUNCTIONAL_CANDIDATE@212..227
         0: TW_BASE@212..213 "w" [] []
         1: DASH@213..214 "-" [] []
-        2: TW_ARBITRARY_VALUE@214..228
+        2: TW_ARBITRARY_VALUE@214..227
           0: L_BRACKET@214..215 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@215..226
             0: CSS_FUNCTION@215..226
@@ -1599,17 +1638,18 @@ TwRoot {
                     0: CSS_NUMBER@224..225
                       0: CSS_NUMBER_LITERAL@224..225 "1" [] []
               3: R_PAREN@225..226 ")" [] []
-          2: R_BRACKET@226..228 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@226..227 "]" [] []
         3: (empty)
       4: (empty)
-    13: TW_FULL_CANDIDATE@228..242
+    25: WHITESPACE@227..228 " " [] []
+    26: TW_FULL_CANDIDATE@228..241
       0: TW_VARIANT_LIST@228..228
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@228..242
+      3: TW_FUNCTIONAL_CANDIDATE@228..241
         0: TW_BASE@228..229 "w" [] []
         1: DASH@229..230 "-" [] []
-        2: TW_ARBITRARY_VALUE@230..242
+        2: TW_ARBITRARY_VALUE@230..241
           0: L_BRACKET@230..231 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@231..240
             0: CSS_FUNCTION@231..240
@@ -1627,17 +1667,18 @@ TwRoot {
                     0: CSS_NUMBER@238..239
                       0: CSS_NUMBER_LITERAL@238..239 "3" [] []
               3: R_PAREN@239..240 ")" [] []
-          2: R_BRACKET@240..242 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@240..241 "]" [] []
         3: (empty)
       4: (empty)
-    14: TW_FULL_CANDIDATE@242..254
+    27: WHITESPACE@241..242 " " [] []
+    28: TW_FULL_CANDIDATE@242..253
       0: TW_VARIANT_LIST@242..242
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@242..254
+      3: TW_FUNCTIONAL_CANDIDATE@242..253
         0: TW_BASE@242..243 "w" [] []
         1: DASH@243..244 "-" [] []
-        2: TW_ARBITRARY_VALUE@244..254
+        2: TW_ARBITRARY_VALUE@244..253
           0: L_BRACKET@244..245 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@245..252
             0: CSS_FUNCTION@245..252
@@ -1650,17 +1691,18 @@ TwRoot {
                     0: CSS_NUMBER@250..251
                       0: CSS_NUMBER_LITERAL@250..251 "4" [] []
               3: R_PAREN@251..252 ")" [] []
-          2: R_BRACKET@252..254 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@252..253 "]" [] []
         3: (empty)
       4: (empty)
-    15: TW_FULL_CANDIDATE@254..270
+    29: WHITESPACE@253..254 " " [] []
+    30: TW_FULL_CANDIDATE@254..269
       0: TW_VARIANT_LIST@254..254
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@254..270
+      3: TW_FUNCTIONAL_CANDIDATE@254..269
         0: TW_BASE@254..255 "w" [] []
         1: DASH@255..256 "-" [] []
-        2: TW_ARBITRARY_VALUE@256..270
+        2: TW_ARBITRARY_VALUE@256..269
           0: L_BRACKET@256..257 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@257..268
             0: CSS_FUNCTION@257..268
@@ -1678,17 +1720,18 @@ TwRoot {
                     0: CSS_NUMBER@266..267
                       0: CSS_NUMBER_LITERAL@266..267 "4" [] []
               3: R_PAREN@267..268 ")" [] []
-          2: R_BRACKET@268..270 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@268..269 "]" [] []
         3: (empty)
       4: (empty)
-    16: TW_FULL_CANDIDATE@270..282
+    31: WHITESPACE@269..270 " " [] []
+    32: TW_FULL_CANDIDATE@270..281
       0: TW_VARIANT_LIST@270..270
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@270..282
+      3: TW_FUNCTIONAL_CANDIDATE@270..281
         0: TW_BASE@270..271 "w" [] []
         1: DASH@271..272 "-" [] []
-        2: TW_ARBITRARY_VALUE@272..282
+        2: TW_ARBITRARY_VALUE@272..281
           0: L_BRACKET@272..273 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@273..280
             0: CSS_FUNCTION@273..280
@@ -1701,17 +1744,18 @@ TwRoot {
                     0: CSS_NUMBER@277..279
                       0: CSS_NUMBER_LITERAL@277..279 "10" [] []
               3: R_PAREN@279..280 ")" [] []
-          2: R_BRACKET@280..282 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@280..281 "]" [] []
         3: (empty)
       4: (empty)
-    17: TW_FULL_CANDIDATE@282..293
+    33: WHITESPACE@281..282 " " [] []
+    34: TW_FULL_CANDIDATE@282..292
       0: TW_VARIANT_LIST@282..282
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@282..293
+      3: TW_FUNCTIONAL_CANDIDATE@282..292
         0: TW_BASE@282..283 "w" [] []
         1: DASH@283..284 "-" [] []
-        2: TW_ARBITRARY_VALUE@284..293
+        2: TW_ARBITRARY_VALUE@284..292
           0: L_BRACKET@284..285 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@285..291
             0: CSS_FUNCTION@285..291
@@ -1724,10 +1768,11 @@ TwRoot {
                     0: CSS_NUMBER@289..290
                       0: CSS_NUMBER_LITERAL@289..290 "1" [] []
               3: R_PAREN@290..291 ")" [] []
-          2: R_BRACKET@291..293 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@291..292 "]" [] []
         3: (empty)
       4: (empty)
-    18: TW_FULL_CANDIDATE@293..310
+    35: WHITESPACE@292..293 " " [] []
+    36: TW_FULL_CANDIDATE@293..310
       0: TW_VARIANT_LIST@293..293
       1: (empty)
       2: (empty)
@@ -1751,14 +1796,15 @@ TwRoot {
           2: R_BRACKET@309..310 "]" [] []
         3: (empty)
       4: (empty)
-    19: TW_FULL_CANDIDATE@310..355
-      0: TW_VARIANT_LIST@310..310
+    37: WHITESPACE@310..311 "\n" [] []
+    38: TW_FULL_CANDIDATE@311..354
+      0: TW_VARIANT_LIST@311..311
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@310..355
-        0: TW_BASE@310..312 "w" [Newline("\n")] []
+      3: TW_FUNCTIONAL_CANDIDATE@311..354
+        0: TW_BASE@311..312 "w" [] []
         1: DASH@312..313 "-" [] []
-        2: TW_ARBITRARY_VALUE@313..355
+        2: TW_ARBITRARY_VALUE@313..354
           0: L_BRACKET@313..314 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@314..353
             0: CSS_FUNCTION@314..353
@@ -1807,17 +1853,18 @@ TwRoot {
                                 1: IDENT@349..351 "vw" [] []
                         3: R_PAREN@351..352 ")" [] []
               3: R_PAREN@352..353 ")" [] []
-          2: R_BRACKET@353..355 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@353..354 "]" [] []
         3: (empty)
       4: (empty)
-    20: TW_FULL_CANDIDATE@355..415
+    39: WHITESPACE@354..355 " " [] []
+    40: TW_FULL_CANDIDATE@355..414
       0: TW_VARIANT_LIST@355..355
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@355..415
+      3: TW_FUNCTIONAL_CANDIDATE@355..414
         0: TW_BASE@355..356 "w" [] []
         1: DASH@356..357 "-" [] []
-        2: TW_ARBITRARY_VALUE@357..415
+        2: TW_ARBITRARY_VALUE@357..414
           0: L_BRACKET@357..358 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@358..413
             0: CSS_FUNCTION@358..413
@@ -1886,17 +1933,18 @@ TwRoot {
                               1: IDENT@409..411 "vw" [] []
                       3: R_PAREN@411..412 ")" [] []
               3: R_PAREN@412..413 ")" [] []
-          2: R_BRACKET@413..415 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@413..414 "]" [] []
         3: (empty)
       4: (empty)
-    21: TW_FULL_CANDIDATE@415..447
+    41: WHITESPACE@414..415 " " [] []
+    42: TW_FULL_CANDIDATE@415..446
       0: TW_VARIANT_LIST@415..415
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@415..447
+      3: TW_FUNCTIONAL_CANDIDATE@415..446
         0: TW_BASE@415..416 "w" [] []
         1: DASH@416..417 "-" [] []
-        2: TW_ARBITRARY_VALUE@417..447
+        2: TW_ARBITRARY_VALUE@417..446
           0: L_BRACKET@417..418 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@418..445
             0: CSS_FUNCTION@418..445
@@ -1938,17 +1986,18 @@ TwRoot {
                               3: R_PAREN@442..443 ")" [] []
                       3: R_PAREN@443..444 ")" [] []
               3: R_PAREN@444..445 ")" [] []
-          2: R_BRACKET@445..447 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@445..446 "]" [] []
         3: (empty)
       4: (empty)
-    22: TW_FULL_CANDIDATE@447..481
+    43: WHITESPACE@446..447 " " [] []
+    44: TW_FULL_CANDIDATE@447..480
       0: TW_VARIANT_LIST@447..447
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@447..481
+      3: TW_FUNCTIONAL_CANDIDATE@447..480
         0: TW_BASE@447..448 "w" [] []
         1: DASH@448..449 "-" [] []
-        2: TW_ARBITRARY_VALUE@449..481
+        2: TW_ARBITRARY_VALUE@449..480
           0: L_BRACKET@449..450 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@450..479
             0: CSS_FUNCTION@450..479
@@ -1984,17 +2033,18 @@ TwRoot {
                               1: IDENT@474..477 "deg" [] []
                       3: R_PAREN@477..478 ")" [] []
               3: R_PAREN@478..479 ")" [] []
-          2: R_BRACKET@479..481 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@479..480 "]" [] []
         3: (empty)
       4: (empty)
-    23: TW_FULL_CANDIDATE@481..512
+    45: WHITESPACE@480..481 " " [] []
+    46: TW_FULL_CANDIDATE@481..511
       0: TW_VARIANT_LIST@481..481
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@481..512
+      3: TW_FUNCTIONAL_CANDIDATE@481..511
         0: TW_BASE@481..482 "w" [] []
         1: DASH@482..483 "-" [] []
-        2: TW_ARBITRARY_VALUE@483..512
+        2: TW_ARBITRARY_VALUE@483..511
           0: L_BRACKET@483..484 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@484..510
             0: CSS_FUNCTION@484..510
@@ -2029,10 +2079,11 @@ TwRoot {
                               0: CSS_NUMBER_LITERAL@506..508 "10" [] []
                       3: R_PAREN@508..509 ")" [] []
               3: R_PAREN@509..510 ")" [] []
-          2: R_BRACKET@510..512 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@510..511 "]" [] []
         3: (empty)
       4: (empty)
-    24: TW_FULL_CANDIDATE@512..540
+    47: WHITESPACE@511..512 " " [] []
+    48: TW_FULL_CANDIDATE@512..540
       0: TW_VARIANT_LIST@512..512
       1: (empty)
       2: (empty)
@@ -2076,6 +2127,7 @@ TwRoot {
           2: R_BRACKET@539..540 "]" [] []
         3: (empty)
       4: (empty)
-  2: EOF@540..541 "" [Newline("\n")] []
+    49: WHITESPACE@540..541 "\n" [] []
+  3: EOF@541..541 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/brackets/css-number-exponents.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/brackets/css-number-exponents.txt.snap
@@ -16,6 +16,7 @@ w-[1e2px] w-[1E+2%] w-[1e-2]
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -32,12 +33,13 @@ TwRoot {
                             unit_token: IDENT@6..8 "px" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@8..10 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@8..9 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@9..10 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -53,12 +55,13 @@ TwRoot {
                             remainder_token: PERCENT@17..18 "%" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@18..20 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@18..19 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@19..20 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -79,8 +82,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@28..29 "\n" [] [],
     ],
-    eof_token: EOF@28..29 "" [Newline("\n")] [],
+    eof_token: EOF@29..29 "" [] [],
 }
 ```
 
@@ -89,40 +93,43 @@ TwRoot {
 ```
 0: TW_ROOT@0..29
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..28
-    0: TW_FULL_CANDIDATE@0..10
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..29
+    0: TW_FULL_CANDIDATE@0..9
       0: TW_VARIANT_LIST@0..0
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@0..10
+      3: TW_FUNCTIONAL_CANDIDATE@0..9
         0: TW_BASE@0..1 "w" [] []
         1: DASH@1..2 "-" [] []
-        2: TW_ARBITRARY_VALUE@2..10
+        2: TW_ARBITRARY_VALUE@2..9
           0: L_BRACKET@2..3 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@3..8
             0: CSS_REGULAR_DIMENSION@3..8
               0: CSS_NUMBER_LITERAL@3..6 "1e2" [] []
               1: IDENT@6..8 "px" [] []
-          2: R_BRACKET@8..10 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@8..9 "]" [] []
         3: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@10..20
+    1: WHITESPACE@9..10 " " [] []
+    2: TW_FULL_CANDIDATE@10..19
       0: TW_VARIANT_LIST@10..10
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@10..20
+      3: TW_FUNCTIONAL_CANDIDATE@10..19
         0: TW_BASE@10..11 "w" [] []
         1: DASH@11..12 "-" [] []
-        2: TW_ARBITRARY_VALUE@12..20
+        2: TW_ARBITRARY_VALUE@12..19
           0: L_BRACKET@12..13 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@13..18
             0: CSS_PERCENTAGE@13..18
               0: CSS_NUMBER_LITERAL@13..17 "1E+2" [] []
               1: PERCENT@17..18 "%" [] []
-          2: R_BRACKET@18..20 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@18..19 "]" [] []
         3: (empty)
       4: (empty)
-    2: TW_FULL_CANDIDATE@20..28
+    3: WHITESPACE@19..20 " " [] []
+    4: TW_FULL_CANDIDATE@20..28
       0: TW_VARIANT_LIST@20..20
       1: (empty)
       2: (empty)
@@ -137,6 +144,7 @@ TwRoot {
           2: R_BRACKET@27..28 "]" [] []
         3: (empty)
       4: (empty)
-  2: EOF@28..29 "" [Newline("\n")] []
+    5: WHITESPACE@28..29 "\n" [] []
+  3: EOF@29..29 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/brackets/css-urls.txt
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/brackets/css-urls.txt
@@ -1,1 +1,1 @@
-bg-[url(/img/mountains.jpg)] bg-[url(https://example.com/assets/bg.svg)] bg-[url(var(--hero-image))] bg-[url("/img/with space.png")]
+bg-[url(/img/mountains.jpg)] bg-[url(https://example.com/assets/bg.svg)] bg-[url(var(--hero-image))]

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/brackets/css-urls.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/brackets/css-urls.txt.snap
@@ -6,7 +6,7 @@ expression: snapshot
 ## Input
 
 ```text
-bg-[url(/img/mountains.jpg)] bg-[url(https://example.com/assets/bg.svg)] bg-[url(var(--hero-image))] bg-[url("/img/with space.png")]
+bg-[url(/img/mountains.jpg)] bg-[url(https://example.com/assets/bg.svg)] bg-[url(var(--hero-image))]
 
 ```
 
@@ -16,6 +16,7 @@ bg-[url(/img/mountains.jpg)] bg-[url(https://example.com/assets/bg.svg)] bg-[url
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -36,12 +37,13 @@ TwRoot {
                             r_paren_token: R_PAREN@26..27 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@27..29 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@27..28 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@28..29 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -61,12 +63,13 @@ TwRoot {
                             r_paren_token: R_PAREN@70..71 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@71..73 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@71..72 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@72..73 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -105,56 +108,33 @@ TwRoot {
                             r_paren_token: R_PAREN@98..99 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@99..101 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@99..100 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
-        TwFullCandidate {
-            variants: TwVariantList [],
-            legacy_important_token: missing (optional),
-            negative_token: missing (optional),
-            candidate: TwFunctionalCandidate {
-                base_token: TW_BASE@101..103 "bg" [] [],
-                minus_token: DASH@103..104 "-" [] [],
-                value: TwArbitraryValue {
-                    l_brack_token: L_BRACKET@104..105 "[" [] [],
-                    value: CssGenericComponentValueList [
-                        CssUrlFunction {
-                            url_token: URL_KW@105..108 "url" [] [],
-                            l_paren_token: L_PAREN@108..109 "(" [] [],
-                            value: CssString {
-                                value_token: CSS_STRING_LITERAL@109..130 "\"/img/with space.png\"" [] [],
-                            },
-                            r_paren_token: R_PAREN@130..131 ")" [] [],
-                        },
-                    ],
-                    r_brack_token: R_BRACKET@131..132 "]" [] [],
-                },
-                modifier: missing (optional),
-            },
-            excl_token: missing (optional),
-        },
+        WHITESPACE@100..101 "\n" [] [],
     ],
-    eof_token: EOF@132..133 "" [Newline("\n")] [],
+    eof_token: EOF@101..101 "" [] [],
 }
 ```
 
 ## CST
 
 ```
-0: TW_ROOT@0..133
+0: TW_ROOT@0..101
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..132
-    0: TW_FULL_CANDIDATE@0..29
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..101
+    0: TW_FULL_CANDIDATE@0..28
       0: TW_VARIANT_LIST@0..0
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@0..29
+      3: TW_FUNCTIONAL_CANDIDATE@0..28
         0: TW_BASE@0..2 "bg" [] []
         1: DASH@2..3 "-" [] []
-        2: TW_ARBITRARY_VALUE@3..29
+        2: TW_ARBITRARY_VALUE@3..28
           0: L_BRACKET@3..4 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@4..27
             0: CSS_URL_FUNCTION@4..27
@@ -163,17 +143,18 @@ TwRoot {
               2: CSS_URL_VALUE_RAW@8..26
                 0: CSS_URL_VALUE_RAW_LITERAL@8..26 "/img/mountains.jpg" [] []
               3: R_PAREN@26..27 ")" [] []
-          2: R_BRACKET@27..29 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@27..28 "]" [] []
         3: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@29..73
+    1: WHITESPACE@28..29 " " [] []
+    2: TW_FULL_CANDIDATE@29..72
       0: TW_VARIANT_LIST@29..29
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@29..73
+      3: TW_FUNCTIONAL_CANDIDATE@29..72
         0: TW_BASE@29..31 "bg" [] []
         1: DASH@31..32 "-" [] []
-        2: TW_ARBITRARY_VALUE@32..73
+        2: TW_ARBITRARY_VALUE@32..72
           0: L_BRACKET@32..33 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@33..71
             0: CSS_URL_FUNCTION@33..71
@@ -182,17 +163,18 @@ TwRoot {
               2: CSS_URL_VALUE_RAW@37..70
                 0: CSS_URL_VALUE_RAW_LITERAL@37..70 "https://example.com/assets/bg.svg" [] []
               3: R_PAREN@70..71 ")" [] []
-          2: R_BRACKET@71..73 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@71..72 "]" [] []
         3: (empty)
       4: (empty)
-    2: TW_FULL_CANDIDATE@73..101
+    3: WHITESPACE@72..73 " " [] []
+    4: TW_FULL_CANDIDATE@73..100
       0: TW_VARIANT_LIST@73..73
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@73..101
+      3: TW_FUNCTIONAL_CANDIDATE@73..100
         0: TW_BASE@73..75 "bg" [] []
         1: DASH@75..76 "-" [] []
-        2: TW_ARBITRARY_VALUE@76..101
+        2: TW_ARBITRARY_VALUE@76..100
           0: L_BRACKET@76..77 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@77..99
             0: CSS_URL_FUNCTION@77..99
@@ -212,28 +194,10 @@ TwRoot {
                               0: IDENT@85..97 "--hero-image" [] []
                       3: R_PAREN@97..98 ")" [] []
               3: R_PAREN@98..99 ")" [] []
-          2: R_BRACKET@99..101 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@99..100 "]" [] []
         3: (empty)
       4: (empty)
-    3: TW_FULL_CANDIDATE@101..132
-      0: TW_VARIANT_LIST@101..101
-      1: (empty)
-      2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@101..132
-        0: TW_BASE@101..103 "bg" [] []
-        1: DASH@103..104 "-" [] []
-        2: TW_ARBITRARY_VALUE@104..132
-          0: L_BRACKET@104..105 "[" [] []
-          1: CSS_GENERIC_COMPONENT_VALUE_LIST@105..131
-            0: CSS_URL_FUNCTION@105..131
-              0: URL_KW@105..108 "url" [] []
-              1: L_PAREN@108..109 "(" [] []
-              2: CSS_STRING@109..130
-                0: CSS_STRING_LITERAL@109..130 "\"/img/with space.png\"" [] []
-              3: R_PAREN@130..131 ")" [] []
-          2: R_BRACKET@131..132 "]" [] []
-        3: (empty)
-      4: (empty)
-  2: EOF@132..133 "" [Newline("\n")] []
+    5: WHITESPACE@100..101 "\n" [] []
+  3: EOF@101..101 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/brackets/css-values.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/brackets/css-values.txt.snap
@@ -16,6 +16,7 @@ w-[12px] w-[-12px] w-[1.5rem] w-[.5rem] w-[100%] w-[12foo] bg-[#ff0000] shadow-[
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -32,12 +33,13 @@ TwRoot {
                             unit_token: IDENT@5..7 "px" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@7..9 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@7..8 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@8..9 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -53,12 +55,13 @@ TwRoot {
                             unit_token: IDENT@15..17 "px" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@17..19 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@17..18 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@18..19 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -74,12 +77,13 @@ TwRoot {
                             unit_token: IDENT@25..28 "rem" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@28..30 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@28..29 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@29..30 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -95,12 +99,13 @@ TwRoot {
                             unit_token: IDENT@35..38 "rem" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@38..40 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@38..39 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@39..40 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -116,12 +121,13 @@ TwRoot {
                             remainder_token: PERCENT@46..47 "%" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@47..49 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@47..48 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@48..49 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -137,12 +143,13 @@ TwRoot {
                             unit_token: IDENT@54..57 "foo" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@57..59 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@57..58 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@58..59 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -157,12 +164,13 @@ TwRoot {
                             value_token: CSS_COLOR_LITERAL@63..70 "#ff0000" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@70..72 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@70..71 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@71..72 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -186,12 +194,13 @@ TwRoot {
                             unit_token: IDENT@89..91 "px" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@91..93 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@91..92 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@92..93 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -231,12 +240,13 @@ TwRoot {
                             r_paren_token: R_PAREN@110..111 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@111..113 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@111..112 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@112..113 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -276,12 +286,13 @@ TwRoot {
                             r_paren_token: R_PAREN@132..133 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@133..135 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@133..134 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@134..135 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -301,12 +312,13 @@ TwRoot {
                             r_paren_token: R_PAREN@161..162 ")" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@162..164 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@162..163 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@163..164 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -321,11 +333,12 @@ TwRoot {
                         unit_token: IDENT@173..175 "px" [] [],
                     },
                 ],
-                r_brack_token: R_BRACKET@175..177 "]" [] [Whitespace(" ")],
+                r_brack_token: R_BRACKET@175..176 "]" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@176..177 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -364,11 +377,12 @@ TwRoot {
                         r_paren_token: R_PAREN@201..202 ")" [] [],
                     },
                 ],
-                r_brack_token: R_BRACKET@202..204 "]" [] [Whitespace(" ")],
+                r_brack_token: R_BRACKET@202..203 "]" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@203..204 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwArbitraryVariant {
@@ -390,8 +404,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@214..215 "\n" [] [],
     ],
-    eof_token: EOF@214..215 "" [Newline("\n")] [],
+    eof_token: EOF@215..215 "" [] [],
 }
 ```
 
@@ -400,126 +415,134 @@ TwRoot {
 ```
 0: TW_ROOT@0..215
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..214
-    0: TW_FULL_CANDIDATE@0..9
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..215
+    0: TW_FULL_CANDIDATE@0..8
       0: TW_VARIANT_LIST@0..0
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@0..9
+      3: TW_FUNCTIONAL_CANDIDATE@0..8
         0: TW_BASE@0..1 "w" [] []
         1: DASH@1..2 "-" [] []
-        2: TW_ARBITRARY_VALUE@2..9
+        2: TW_ARBITRARY_VALUE@2..8
           0: L_BRACKET@2..3 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@3..7
             0: CSS_REGULAR_DIMENSION@3..7
               0: CSS_NUMBER_LITERAL@3..5 "12" [] []
               1: IDENT@5..7 "px" [] []
-          2: R_BRACKET@7..9 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@7..8 "]" [] []
         3: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@9..19
+    1: WHITESPACE@8..9 " " [] []
+    2: TW_FULL_CANDIDATE@9..18
       0: TW_VARIANT_LIST@9..9
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@9..19
+      3: TW_FUNCTIONAL_CANDIDATE@9..18
         0: TW_BASE@9..10 "w" [] []
         1: DASH@10..11 "-" [] []
-        2: TW_ARBITRARY_VALUE@11..19
+        2: TW_ARBITRARY_VALUE@11..18
           0: L_BRACKET@11..12 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@12..17
             0: CSS_REGULAR_DIMENSION@12..17
               0: CSS_NUMBER_LITERAL@12..15 "-12" [] []
               1: IDENT@15..17 "px" [] []
-          2: R_BRACKET@17..19 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@17..18 "]" [] []
         3: (empty)
       4: (empty)
-    2: TW_FULL_CANDIDATE@19..30
+    3: WHITESPACE@18..19 " " [] []
+    4: TW_FULL_CANDIDATE@19..29
       0: TW_VARIANT_LIST@19..19
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@19..30
+      3: TW_FUNCTIONAL_CANDIDATE@19..29
         0: TW_BASE@19..20 "w" [] []
         1: DASH@20..21 "-" [] []
-        2: TW_ARBITRARY_VALUE@21..30
+        2: TW_ARBITRARY_VALUE@21..29
           0: L_BRACKET@21..22 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@22..28
             0: CSS_REGULAR_DIMENSION@22..28
               0: CSS_NUMBER_LITERAL@22..25 "1.5" [] []
               1: IDENT@25..28 "rem" [] []
-          2: R_BRACKET@28..30 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@28..29 "]" [] []
         3: (empty)
       4: (empty)
-    3: TW_FULL_CANDIDATE@30..40
+    5: WHITESPACE@29..30 " " [] []
+    6: TW_FULL_CANDIDATE@30..39
       0: TW_VARIANT_LIST@30..30
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@30..40
+      3: TW_FUNCTIONAL_CANDIDATE@30..39
         0: TW_BASE@30..31 "w" [] []
         1: DASH@31..32 "-" [] []
-        2: TW_ARBITRARY_VALUE@32..40
+        2: TW_ARBITRARY_VALUE@32..39
           0: L_BRACKET@32..33 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@33..38
             0: CSS_REGULAR_DIMENSION@33..38
               0: CSS_NUMBER_LITERAL@33..35 ".5" [] []
               1: IDENT@35..38 "rem" [] []
-          2: R_BRACKET@38..40 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@38..39 "]" [] []
         3: (empty)
       4: (empty)
-    4: TW_FULL_CANDIDATE@40..49
+    7: WHITESPACE@39..40 " " [] []
+    8: TW_FULL_CANDIDATE@40..48
       0: TW_VARIANT_LIST@40..40
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@40..49
+      3: TW_FUNCTIONAL_CANDIDATE@40..48
         0: TW_BASE@40..41 "w" [] []
         1: DASH@41..42 "-" [] []
-        2: TW_ARBITRARY_VALUE@42..49
+        2: TW_ARBITRARY_VALUE@42..48
           0: L_BRACKET@42..43 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@43..47
             0: CSS_PERCENTAGE@43..47
               0: CSS_NUMBER_LITERAL@43..46 "100" [] []
               1: PERCENT@46..47 "%" [] []
-          2: R_BRACKET@47..49 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@47..48 "]" [] []
         3: (empty)
       4: (empty)
-    5: TW_FULL_CANDIDATE@49..59
+    9: WHITESPACE@48..49 " " [] []
+    10: TW_FULL_CANDIDATE@49..58
       0: TW_VARIANT_LIST@49..49
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@49..59
+      3: TW_FUNCTIONAL_CANDIDATE@49..58
         0: TW_BASE@49..50 "w" [] []
         1: DASH@50..51 "-" [] []
-        2: TW_ARBITRARY_VALUE@51..59
+        2: TW_ARBITRARY_VALUE@51..58
           0: L_BRACKET@51..52 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@52..57
             0: CSS_UNKNOWN_DIMENSION@52..57
               0: CSS_NUMBER_LITERAL@52..54 "12" [] []
               1: IDENT@54..57 "foo" [] []
-          2: R_BRACKET@57..59 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@57..58 "]" [] []
         3: (empty)
       4: (empty)
-    6: TW_FULL_CANDIDATE@59..72
+    11: WHITESPACE@58..59 " " [] []
+    12: TW_FULL_CANDIDATE@59..71
       0: TW_VARIANT_LIST@59..59
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@59..72
+      3: TW_FUNCTIONAL_CANDIDATE@59..71
         0: TW_BASE@59..61 "bg" [] []
         1: DASH@61..62 "-" [] []
-        2: TW_ARBITRARY_VALUE@62..72
+        2: TW_ARBITRARY_VALUE@62..71
           0: L_BRACKET@62..63 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@63..70
             0: CSS_COLOR@63..70
               0: CSS_COLOR_LITERAL@63..70 "#ff0000" [] []
-          2: R_BRACKET@70..72 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@70..71 "]" [] []
         3: (empty)
       4: (empty)
-    7: TW_FULL_CANDIDATE@72..93
+    13: WHITESPACE@71..72 " " [] []
+    14: TW_FULL_CANDIDATE@72..92
       0: TW_VARIANT_LIST@72..72
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@72..93
+      3: TW_FUNCTIONAL_CANDIDATE@72..92
         0: TW_BASE@72..78 "shadow" [] []
         1: DASH@78..79 "-" [] []
-        2: TW_ARBITRARY_VALUE@79..93
+        2: TW_ARBITRARY_VALUE@79..92
           0: L_BRACKET@79..80 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@80..91
             0: CSS_REGULAR_DIMENSION@80..84
@@ -531,17 +554,18 @@ TwRoot {
             2: CSS_REGULAR_DIMENSION@88..91
               0: CSS_NUMBER_LITERAL@88..89 "4" [] []
               1: IDENT@89..91 "px" [] []
-          2: R_BRACKET@91..93 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@91..92 "]" [] []
         3: (empty)
       4: (empty)
-    8: TW_FULL_CANDIDATE@93..113
+    15: WHITESPACE@92..93 " " [] []
+    16: TW_FULL_CANDIDATE@93..112
       0: TW_VARIANT_LIST@93..93
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@93..113
+      3: TW_FUNCTIONAL_CANDIDATE@93..112
         0: TW_BASE@93..95 "bg" [] []
         1: DASH@95..96 "-" [] []
-        2: TW_ARBITRARY_VALUE@96..113
+        2: TW_ARBITRARY_VALUE@96..112
           0: L_BRACKET@96..97 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@97..111
             0: CSS_FUNCTION@97..111
@@ -562,17 +586,18 @@ TwRoot {
                       2: CSS_NUMBER@107..110
                         0: CSS_NUMBER_LITERAL@107..110 "0.5" [] []
               3: R_PAREN@110..111 ")" [] []
-          2: R_BRACKET@111..113 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@111..112 "]" [] []
         3: (empty)
       4: (empty)
-    9: TW_FULL_CANDIDATE@113..135
+    17: WHITESPACE@112..113 " " [] []
+    18: TW_FULL_CANDIDATE@113..134
       0: TW_VARIANT_LIST@113..113
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@113..135
+      3: TW_FUNCTIONAL_CANDIDATE@113..134
         0: TW_BASE@113..114 "w" [] []
         1: DASH@114..115 "-" [] []
-        2: TW_ARBITRARY_VALUE@115..135
+        2: TW_ARBITRARY_VALUE@115..134
           0: L_BRACKET@115..116 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@116..133
             0: CSS_FUNCTION@116..133
@@ -593,17 +618,18 @@ TwRoot {
                         0: CSS_NUMBER_LITERAL@128..129 "1" [] []
                         1: IDENT@129..132 "rem" [] []
               3: R_PAREN@132..133 ")" [] []
-          2: R_BRACKET@133..135 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@133..134 "]" [] []
         3: (empty)
       4: (empty)
-    10: TW_FULL_CANDIDATE@135..164
+    19: WHITESPACE@134..135 " " [] []
+    20: TW_FULL_CANDIDATE@135..163
       0: TW_VARIANT_LIST@135..135
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@135..164
+      3: TW_FUNCTIONAL_CANDIDATE@135..163
         0: TW_BASE@135..137 "bg" [] []
         1: DASH@137..138 "-" [] []
-        2: TW_ARBITRARY_VALUE@138..164
+        2: TW_ARBITRARY_VALUE@138..163
           0: L_BRACKET@138..139 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@139..162
             0: CSS_URL_FUNCTION@139..162
@@ -612,14 +638,15 @@ TwRoot {
               2: CSS_URL_VALUE_RAW@143..161
                 0: CSS_URL_VALUE_RAW_LITERAL@143..161 "/img/mountains.jpg" [] []
               3: R_PAREN@161..162 ")" [] []
-          2: R_BRACKET@162..164 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@162..163 "]" [] []
         3: (empty)
       4: (empty)
-    11: TW_FULL_CANDIDATE@164..177
+    21: WHITESPACE@163..164 " " [] []
+    22: TW_FULL_CANDIDATE@164..176
       0: TW_VARIANT_LIST@164..164
       1: (empty)
       2: (empty)
-      3: TW_ARBITRARY_CANDIDATE@164..177
+      3: TW_ARBITRARY_CANDIDATE@164..176
         0: L_BRACKET@164..165 "[" [] []
         1: TW_PROPERTY@165..170 "width" [] []
         2: COLON@170..171 ":" [] []
@@ -627,14 +654,15 @@ TwRoot {
           0: CSS_REGULAR_DIMENSION@171..175
             0: CSS_NUMBER_LITERAL@171..173 "12" [] []
             1: IDENT@173..175 "px" [] []
-        4: R_BRACKET@175..177 "]" [] [Whitespace(" ")]
+        4: R_BRACKET@175..176 "]" [] []
         5: (empty)
       4: (empty)
-    12: TW_FULL_CANDIDATE@177..204
+    23: WHITESPACE@176..177 " " [] []
+    24: TW_FULL_CANDIDATE@177..203
       0: TW_VARIANT_LIST@177..177
       1: (empty)
       2: (empty)
-      3: TW_ARBITRARY_CANDIDATE@177..204
+      3: TW_ARBITRARY_CANDIDATE@177..203
         0: L_BRACKET@177..178 "[" [] []
         1: TW_PROPERTY@178..184 "margin" [] []
         2: COLON@184..185 ":" [] []
@@ -657,10 +685,11 @@ TwRoot {
                       0: CSS_NUMBER_LITERAL@197..198 "1" [] []
                       1: IDENT@198..201 "rem" [] []
             3: R_PAREN@201..202 ")" [] []
-        4: R_BRACKET@202..204 "]" [] [Whitespace(" ")]
+        4: R_BRACKET@202..203 "]" [] []
         5: (empty)
       4: (empty)
-    13: TW_FULL_CANDIDATE@204..214
+    25: WHITESPACE@203..204 " " [] []
+    26: TW_FULL_CANDIDATE@204..214
       0: TW_VARIANT_LIST@204..210
         0: TW_ARBITRARY_VARIANT@204..209
           0: L_BRACKET@204..205 "[" [] []
@@ -676,6 +705,7 @@ TwRoot {
           0: TW_NUMBER@213..214 "2" [] []
         3: (empty)
       4: (empty)
-  2: EOF@214..215 "" [Newline("\n")] []
+    27: WHITESPACE@214..215 "\n" [] []
+  3: EOF@215..215 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/brackets/gradient.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/brackets/gradient.txt.snap
@@ -16,6 +16,7 @@ bg-radial-[at_50%_75%] from-sky-200 via-blue-400 to-indigo-900 to-90%
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -39,12 +40,13 @@ TwRoot {
                             remainder_token: PERCENT@20..21 "%" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@21..23 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@21..22 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@22..23 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -53,12 +55,13 @@ TwRoot {
                 base_token: TW_BASE@23..27 "from" [] [],
                 minus_token: DASH@27..28 "-" [] [],
                 value: TwNamedValue {
-                    value_token: TW_VALUE@28..36 "sky-200" [] [Whitespace(" ")],
+                    value_token: TW_VALUE@28..35 "sky-200" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@35..36 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -67,12 +70,13 @@ TwRoot {
                 base_token: TW_BASE@36..39 "via" [] [],
                 minus_token: DASH@39..40 "-" [] [],
                 value: TwNamedValue {
-                    value_token: TW_VALUE@40..49 "blue-400" [] [Whitespace(" ")],
+                    value_token: TW_VALUE@40..48 "blue-400" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@48..49 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -81,12 +85,13 @@ TwRoot {
                 base_token: TW_BASE@49..51 "to" [] [],
                 minus_token: DASH@51..52 "-" [] [],
                 value: TwNamedValue {
-                    value_token: TW_VALUE@52..63 "indigo-900" [] [Whitespace(" ")],
+                    value_token: TW_VALUE@52..62 "indigo-900" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@62..63 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -102,8 +107,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@69..70 "\n" [] [],
     ],
-    eof_token: EOF@69..70 "" [Newline("\n")] [],
+    eof_token: EOF@70..70 "" [] [],
 }
 ```
 
@@ -112,15 +118,16 @@ TwRoot {
 ```
 0: TW_ROOT@0..70
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..69
-    0: TW_FULL_CANDIDATE@0..23
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..70
+    0: TW_FULL_CANDIDATE@0..22
       0: TW_VARIANT_LIST@0..0
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@0..23
+      3: TW_FUNCTIONAL_CANDIDATE@0..22
         0: TW_BASE@0..9 "bg-radial" [] []
         1: DASH@9..10 "-" [] []
-        2: TW_ARBITRARY_VALUE@10..23
+        2: TW_ARBITRARY_VALUE@10..22
           0: L_BRACKET@10..11 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@11..21
             0: CSS_IDENTIFIER@11..14
@@ -131,43 +138,47 @@ TwRoot {
             2: CSS_PERCENTAGE@18..21
               0: CSS_NUMBER_LITERAL@18..20 "75" [] []
               1: PERCENT@20..21 "%" [] []
-          2: R_BRACKET@21..23 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@21..22 "]" [] []
         3: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@23..36
+    1: WHITESPACE@22..23 " " [] []
+    2: TW_FULL_CANDIDATE@23..35
       0: TW_VARIANT_LIST@23..23
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@23..36
+      3: TW_FUNCTIONAL_CANDIDATE@23..35
         0: TW_BASE@23..27 "from" [] []
         1: DASH@27..28 "-" [] []
-        2: TW_NAMED_VALUE@28..36
-          0: TW_VALUE@28..36 "sky-200" [] [Whitespace(" ")]
+        2: TW_NAMED_VALUE@28..35
+          0: TW_VALUE@28..35 "sky-200" [] []
         3: (empty)
       4: (empty)
-    2: TW_FULL_CANDIDATE@36..49
+    3: WHITESPACE@35..36 " " [] []
+    4: TW_FULL_CANDIDATE@36..48
       0: TW_VARIANT_LIST@36..36
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@36..49
+      3: TW_FUNCTIONAL_CANDIDATE@36..48
         0: TW_BASE@36..39 "via" [] []
         1: DASH@39..40 "-" [] []
-        2: TW_NAMED_VALUE@40..49
-          0: TW_VALUE@40..49 "blue-400" [] [Whitespace(" ")]
+        2: TW_NAMED_VALUE@40..48
+          0: TW_VALUE@40..48 "blue-400" [] []
         3: (empty)
       4: (empty)
-    3: TW_FULL_CANDIDATE@49..63
+    5: WHITESPACE@48..49 " " [] []
+    6: TW_FULL_CANDIDATE@49..62
       0: TW_VARIANT_LIST@49..49
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@49..63
+      3: TW_FUNCTIONAL_CANDIDATE@49..62
         0: TW_BASE@49..51 "to" [] []
         1: DASH@51..52 "-" [] []
-        2: TW_NAMED_VALUE@52..63
-          0: TW_VALUE@52..63 "indigo-900" [] [Whitespace(" ")]
+        2: TW_NAMED_VALUE@52..62
+          0: TW_VALUE@52..62 "indigo-900" [] []
         3: (empty)
       4: (empty)
-    4: TW_FULL_CANDIDATE@63..69
+    7: WHITESPACE@62..63 " " [] []
+    8: TW_FULL_CANDIDATE@63..69
       0: TW_VARIANT_LIST@63..63
       1: (empty)
       2: (empty)
@@ -179,6 +190,7 @@ TwRoot {
           1: PERCENT@68..69 "%" [] []
         3: (empty)
       4: (empty)
-  2: EOF@69..70 "" [Newline("\n")] []
+    9: WHITESPACE@69..70 "\n" [] []
+  3: EOF@70..70 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/brackets/image-url.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/brackets/image-url.txt.snap
@@ -16,6 +16,7 @@ bg-[url(/img/mountains.jpg)]
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -42,8 +43,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@28..29 "\n" [] [],
     ],
-    eof_token: EOF@28..29 "" [Newline("\n")] [],
+    eof_token: EOF@29..29 "" [] [],
 }
 ```
 
@@ -52,7 +54,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..29
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..28
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..29
     0: TW_FULL_CANDIDATE@0..28
       0: TW_VARIANT_LIST@0..0
       1: (empty)
@@ -72,6 +75,7 @@ TwRoot {
           2: R_BRACKET@27..28 "]" [] []
         3: (empty)
       4: (empty)
-  2: EOF@28..29 "" [Newline("\n")] []
+    1: WHITESPACE@28..29 "\n" [] []
+  3: EOF@29..29 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/brackets/inset.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/brackets/inset.txt.snap
@@ -16,6 +16,7 @@ inset-x-[20px] inset-y-[15px]
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -32,12 +33,13 @@ TwRoot {
                             unit_token: IDENT@11..13 "px" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@13..15 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@13..14 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@14..15 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -59,8 +61,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@29..30 "\n" [] [],
     ],
-    eof_token: EOF@29..30 "" [Newline("\n")] [],
+    eof_token: EOF@30..30 "" [] [],
 }
 ```
 
@@ -69,24 +72,26 @@ TwRoot {
 ```
 0: TW_ROOT@0..30
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..29
-    0: TW_FULL_CANDIDATE@0..15
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..30
+    0: TW_FULL_CANDIDATE@0..14
       0: TW_VARIANT_LIST@0..0
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@0..15
+      3: TW_FUNCTIONAL_CANDIDATE@0..14
         0: TW_BASE@0..7 "inset-x" [] []
         1: DASH@7..8 "-" [] []
-        2: TW_ARBITRARY_VALUE@8..15
+        2: TW_ARBITRARY_VALUE@8..14
           0: L_BRACKET@8..9 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@9..13
             0: CSS_REGULAR_DIMENSION@9..13
               0: CSS_NUMBER_LITERAL@9..11 "20" [] []
               1: IDENT@11..13 "px" [] []
-          2: R_BRACKET@13..15 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@13..14 "]" [] []
         3: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@15..29
+    1: WHITESPACE@14..15 " " [] []
+    2: TW_FULL_CANDIDATE@15..29
       0: TW_VARIANT_LIST@15..15
       1: (empty)
       2: (empty)
@@ -102,6 +107,7 @@ TwRoot {
           2: R_BRACKET@28..29 "]" [] []
         3: (empty)
       4: (empty)
-  2: EOF@29..30 "" [Newline("\n")] []
+    3: WHITESPACE@29..30 "\n" [] []
+  3: EOF@30..30 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/brackets/misc-xy.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/brackets/misc-xy.txt.snap
@@ -16,6 +16,7 @@ space-x-[14px] space-y-[10px] divide-x-[2px] divide-y-[3px]
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -32,12 +33,13 @@ TwRoot {
                             unit_token: IDENT@11..13 "px" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@13..15 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@13..14 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@14..15 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -53,12 +55,13 @@ TwRoot {
                             unit_token: IDENT@26..28 "px" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@28..30 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@28..29 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@29..30 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -74,12 +77,13 @@ TwRoot {
                             unit_token: IDENT@41..43 "px" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@43..45 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@43..44 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@44..45 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -101,8 +105,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@59..60 "\n" [] [],
     ],
-    eof_token: EOF@59..60 "" [Newline("\n")] [],
+    eof_token: EOF@60..60 "" [] [],
 }
 ```
 
@@ -111,56 +116,60 @@ TwRoot {
 ```
 0: TW_ROOT@0..60
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..59
-    0: TW_FULL_CANDIDATE@0..15
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..60
+    0: TW_FULL_CANDIDATE@0..14
       0: TW_VARIANT_LIST@0..0
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@0..15
+      3: TW_FUNCTIONAL_CANDIDATE@0..14
         0: TW_BASE@0..7 "space-x" [] []
         1: DASH@7..8 "-" [] []
-        2: TW_ARBITRARY_VALUE@8..15
+        2: TW_ARBITRARY_VALUE@8..14
           0: L_BRACKET@8..9 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@9..13
             0: CSS_REGULAR_DIMENSION@9..13
               0: CSS_NUMBER_LITERAL@9..11 "14" [] []
               1: IDENT@11..13 "px" [] []
-          2: R_BRACKET@13..15 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@13..14 "]" [] []
         3: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@15..30
+    1: WHITESPACE@14..15 " " [] []
+    2: TW_FULL_CANDIDATE@15..29
       0: TW_VARIANT_LIST@15..15
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@15..30
+      3: TW_FUNCTIONAL_CANDIDATE@15..29
         0: TW_BASE@15..22 "space-y" [] []
         1: DASH@22..23 "-" [] []
-        2: TW_ARBITRARY_VALUE@23..30
+        2: TW_ARBITRARY_VALUE@23..29
           0: L_BRACKET@23..24 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@24..28
             0: CSS_REGULAR_DIMENSION@24..28
               0: CSS_NUMBER_LITERAL@24..26 "10" [] []
               1: IDENT@26..28 "px" [] []
-          2: R_BRACKET@28..30 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@28..29 "]" [] []
         3: (empty)
       4: (empty)
-    2: TW_FULL_CANDIDATE@30..45
+    3: WHITESPACE@29..30 " " [] []
+    4: TW_FULL_CANDIDATE@30..44
       0: TW_VARIANT_LIST@30..30
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@30..45
+      3: TW_FUNCTIONAL_CANDIDATE@30..44
         0: TW_BASE@30..38 "divide-x" [] []
         1: DASH@38..39 "-" [] []
-        2: TW_ARBITRARY_VALUE@39..45
+        2: TW_ARBITRARY_VALUE@39..44
           0: L_BRACKET@39..40 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@40..43
             0: CSS_REGULAR_DIMENSION@40..43
               0: CSS_NUMBER_LITERAL@40..41 "2" [] []
               1: IDENT@41..43 "px" [] []
-          2: R_BRACKET@43..45 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@43..44 "]" [] []
         3: (empty)
       4: (empty)
-    3: TW_FULL_CANDIDATE@45..59
+    5: WHITESPACE@44..45 " " [] []
+    6: TW_FULL_CANDIDATE@45..59
       0: TW_VARIANT_LIST@45..45
       1: (empty)
       2: (empty)
@@ -176,6 +185,7 @@ TwRoot {
           2: R_BRACKET@58..59 "]" [] []
         3: (empty)
       4: (empty)
-  2: EOF@59..60 "" [Newline("\n")] []
+    7: WHITESPACE@59..60 "\n" [] []
+  3: EOF@60..60 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/brackets/shadow.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/brackets/shadow.txt.snap
@@ -16,6 +16,7 @@ shadow-[0px_2px_4px]
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -46,8 +47,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@20..21 "\n" [] [],
     ],
-    eof_token: EOF@20..21 "" [Newline("\n")] [],
+    eof_token: EOF@21..21 "" [] [],
 }
 ```
 
@@ -56,7 +58,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..21
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..20
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..21
     0: TW_FULL_CANDIDATE@0..20
       0: TW_VARIANT_LIST@0..0
       1: (empty)
@@ -79,6 +82,7 @@ TwRoot {
           2: R_BRACKET@19..20 "]" [] []
         3: (empty)
       4: (empty)
-  2: EOF@20..21 "" [Newline("\n")] []
+    1: WHITESPACE@20..21 "\n" [] []
+  3: EOF@21..21 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/candidates/arbitrary-candidate-0.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/candidates/arbitrary-candidate-0.txt.snap
@@ -16,6 +16,7 @@ expression: snapshot
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -40,8 +41,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@14..15 "\n" [] [],
     ],
-    eof_token: EOF@14..15 "" [Newline("\n")] [],
+    eof_token: EOF@15..15 "" [] [],
 }
 ```
 
@@ -50,7 +52,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..15
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..14
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..15
     0: TW_FULL_CANDIDATE@0..14
       0: TW_VARIANT_LIST@0..0
       1: (empty)
@@ -68,6 +71,7 @@ TwRoot {
           1: TW_NUMBER_VALUE@12..14
             0: TW_NUMBER@12..14 "50" [] []
       4: (empty)
-  2: EOF@14..15 "" [Newline("\n")] []
+    1: WHITESPACE@14..15 "\n" [] []
+  3: EOF@15..15 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/candidates/arbitrary-candidate-1.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/candidates/arbitrary-candidate-1.txt.snap
@@ -16,6 +16,7 @@ expression: snapshot
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -53,8 +54,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@38..39 "\n" [] [],
     ],
-    eof_token: EOF@38..39 "" [Newline("\n")] [],
+    eof_token: EOF@39..39 "" [] [],
 }
 ```
 
@@ -63,7 +65,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..39
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..38
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..39
     0: TW_FULL_CANDIDATE@0..38
       0: TW_VARIANT_LIST@0..0
       1: (empty)
@@ -89,6 +92,7 @@ TwRoot {
           1: TW_NUMBER_VALUE@37..38
             0: TW_NUMBER@37..38 "5" [] []
       4: (empty)
-  2: EOF@38..39 "" [Newline("\n")] []
+    1: WHITESPACE@38..39 "\n" [] []
+  3: EOF@39..39 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/candidates/arbitrary-candidate-2.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/candidates/arbitrary-candidate-2.txt.snap
@@ -16,6 +16,7 @@ dark:[--pattern-fg:var(--color-white)]/10
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [
@@ -64,8 +65,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@41..42 "\n" [] [],
     ],
-    eof_token: EOF@41..42 "" [Newline("\n")] [],
+    eof_token: EOF@42..42 "" [] [],
 }
 ```
 
@@ -74,7 +76,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..42
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..41
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..42
     0: TW_FULL_CANDIDATE@0..41
       0: TW_VARIANT_LIST@0..5
         0: TW_VARIANT_EXPRESSION@0..4
@@ -107,6 +110,7 @@ TwRoot {
           1: TW_NUMBER_VALUE@39..41
             0: TW_NUMBER@39..41 "10" [] []
       4: (empty)
-  2: EOF@41..42 "" [Newline("\n")] []
+    1: WHITESPACE@41..42 "\n" [] []
+  3: EOF@42..42 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/candidates/arbitrary-candidate-3.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/candidates/arbitrary-candidate-3.txt.snap
@@ -16,6 +16,7 @@ expression: snapshot
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -35,8 +36,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@17..18 "\n" [] [],
     ],
-    eof_token: EOF@17..18 "" [Newline("\n")] [],
+    eof_token: EOF@18..18 "" [] [],
 }
 ```
 
@@ -45,7 +47,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..18
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..17
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..18
     0: TW_FULL_CANDIDATE@0..17
       0: TW_VARIANT_LIST@0..0
       1: (empty)
@@ -60,6 +63,7 @@ TwRoot {
         4: R_BRACKET@16..17 "]" [] []
         5: (empty)
       4: (empty)
-  2: EOF@17..18 "" [Newline("\n")] []
+    1: WHITESPACE@17..18 "\n" [] []
+  3: EOF@18..18 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/candidates/arbitrary-candidate-css-function.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/candidates/arbitrary-candidate-css-function.txt.snap
@@ -16,6 +16,7 @@ focus:[mask:radial-gradient()]
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [
@@ -51,8 +52,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@30..31 "\n" [] [],
     ],
-    eof_token: EOF@30..31 "" [Newline("\n")] [],
+    eof_token: EOF@31..31 "" [] [],
 }
 ```
 
@@ -61,7 +63,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..31
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..30
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..31
     0: TW_FULL_CANDIDATE@0..30
       0: TW_VARIANT_LIST@0..6
         0: TW_VARIANT_EXPRESSION@0..5
@@ -87,6 +90,7 @@ TwRoot {
         4: R_BRACKET@29..30 "]" [] []
         5: (empty)
       4: (empty)
-  2: EOF@30..31 "" [Newline("\n")] []
+    1: WHITESPACE@30..31 "\n" [] []
+  3: EOF@31..31 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/candidates/arbitrary-modifier-colon.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/candidates/arbitrary-modifier-colon.txt.snap
@@ -16,6 +16,7 @@ bg-red-500/[color:var(--alpha)] group-hover/[a:b]:flex @[400px]/[n:m]:flex
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -55,12 +56,13 @@ TwRoot {
                                 r_paren_token: R_PAREN@29..30 ")" [] [],
                             },
                         ],
-                        r_brack_token: R_BRACKET@30..32 "]" [] [Whitespace(" ")],
+                        r_brack_token: R_BRACKET@30..31 "]" [] [],
                     },
                 },
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@31..32 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -98,11 +100,12 @@ TwRoot {
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@50..55 "flex" [] [Whitespace(" ")],
+                base_token: TW_BASE@50..54 "flex" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@54..55 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -145,8 +148,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@74..75 "\n" [] [],
     ],
-    eof_token: EOF@74..75 "" [Newline("\n")] [],
+    eof_token: EOF@75..75 "" [] [],
 }
 ```
 
@@ -155,19 +159,20 @@ TwRoot {
 ```
 0: TW_ROOT@0..75
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..74
-    0: TW_FULL_CANDIDATE@0..32
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..75
+    0: TW_FULL_CANDIDATE@0..31
       0: TW_VARIANT_LIST@0..0
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@0..32
+      3: TW_FUNCTIONAL_CANDIDATE@0..31
         0: TW_BASE@0..2 "bg" [] []
         1: DASH@2..3 "-" [] []
         2: TW_NAMED_VALUE@3..10
           0: TW_VALUE@3..10 "red-500" [] []
-        3: TW_MODIFIER@10..32
+        3: TW_MODIFIER@10..31
           0: SLASH@10..11 "/" [] []
-          1: TW_ARBITRARY_VALUE@11..32
+          1: TW_ARBITRARY_VALUE@11..31
             0: L_BRACKET@11..12 "[" [] []
             1: CSS_GENERIC_COMPONENT_VALUE_LIST@12..30
               0: CSS_IDENTIFIER@12..17
@@ -184,9 +189,10 @@ TwRoot {
                       0: CSS_DASHED_IDENTIFIER@22..29
                         0: IDENT@22..29 "--alpha" [] []
                 3: R_PAREN@29..30 ")" [] []
-            2: R_BRACKET@30..32 "]" [] [Whitespace(" ")]
+            2: R_BRACKET@30..31 "]" [] []
       4: (empty)
-    1: TW_FULL_CANDIDATE@32..55
+    1: WHITESPACE@31..32 " " [] []
+    2: TW_FULL_CANDIDATE@32..54
       0: TW_VARIANT_LIST@32..50
         0: TW_VARIANT_EXPRESSION@32..49
           0: TW_VARIANT_SEGMENT_LIST@32..43
@@ -211,11 +217,12 @@ TwRoot {
         1: COLON@49..50 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@50..55
-        0: TW_BASE@50..55 "flex" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@50..54
+        0: TW_BASE@50..54 "flex" [] []
         1: (empty)
       4: (empty)
-    2: TW_FULL_CANDIDATE@55..74
+    3: WHITESPACE@54..55 " " [] []
+    4: TW_FULL_CANDIDATE@55..74
       0: TW_VARIANT_LIST@55..70
         0: TW_VARIANT_EXPRESSION@55..69
           0: TW_VARIANT_SEGMENT_LIST@55..56
@@ -244,6 +251,7 @@ TwRoot {
         0: TW_BASE@70..74 "flex" [] []
         1: (empty)
       4: (empty)
-  2: EOF@74..75 "" [Newline("\n")] []
+    5: WHITESPACE@74..75 "\n" [] []
+  3: EOF@75..75 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/candidates/bare-modifier.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/candidates/bare-modifier.txt.snap
@@ -15,17 +15,19 @@ expression: snapshot
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@0..11 "@container" [] [Whitespace(" ")],
+                base_token: TW_BASE@0..10 "@container" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@10..11 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -35,12 +37,13 @@ TwRoot {
                 modifier: TwModifier {
                     slash_token: SLASH@21..22 "/" [] [],
                     value: TwNamedValue {
-                        value_token: TW_VALUE@22..30 "sidebar" [] [Whitespace(" ")],
+                        value_token: TW_VALUE@22..29 "sidebar" [] [],
                     },
                 },
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@29..30 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -50,12 +53,13 @@ TwRoot {
                 modifier: TwModifier {
                     slash_token: SLASH@36..37 "/" [] [],
                     value: TwNumberValue {
-                        value_token: TW_NUMBER@37..40 "50" [] [Whitespace(" ")],
+                        value_token: TW_NUMBER@37..39 "50" [] [],
                     },
                 },
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@39..40 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -65,12 +69,13 @@ TwRoot {
                 modifier: TwModifier {
                     slash_token: SLASH@44..45 "/" [] [],
                     value: TwNumberValue {
-                        value_token: TW_NUMBER@45..48 "50" [] [Whitespace(" ")],
+                        value_token: TW_NUMBER@45..47 "50" [] [],
                     },
                 },
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@47..48 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -80,12 +85,13 @@ TwRoot {
                 modifier: TwModifier {
                     slash_token: SLASH@59..60 "/" [] [],
                     value: TwNumberValue {
-                        value_token: TW_NUMBER@60..63 "50" [] [Whitespace(" ")],
+                        value_token: TW_NUMBER@60..62 "50" [] [],
                     },
                 },
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@62..63 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -102,11 +108,12 @@ TwRoot {
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@74..79 "flex" [] [Whitespace(" ")],
+                base_token: TW_BASE@74..78 "flex" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@78..79 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -143,60 +150,66 @@ TwRoot {
 ```
 0: TW_ROOT@0..98
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..98
-    0: TW_FULL_CANDIDATE@0..11
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..98
+    0: TW_FULL_CANDIDATE@0..10
       0: TW_VARIANT_LIST@0..0
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@0..11
-        0: TW_BASE@0..11 "@container" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@0..10
+        0: TW_BASE@0..10 "@container" [] []
         1: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@11..30
+    1: WHITESPACE@10..11 " " [] []
+    2: TW_FULL_CANDIDATE@11..29
       0: TW_VARIANT_LIST@11..11
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@11..30
+      3: TW_STATIC_CANDIDATE@11..29
         0: TW_BASE@11..21 "@container" [] []
-        1: TW_MODIFIER@21..30
+        1: TW_MODIFIER@21..29
           0: SLASH@21..22 "/" [] []
-          1: TW_NAMED_VALUE@22..30
-            0: TW_VALUE@22..30 "sidebar" [] [Whitespace(" ")]
+          1: TW_NAMED_VALUE@22..29
+            0: TW_VALUE@22..29 "sidebar" [] []
       4: (empty)
-    2: TW_FULL_CANDIDATE@30..40
+    3: WHITESPACE@29..30 " " [] []
+    4: TW_FULL_CANDIDATE@30..39
       0: TW_VARIANT_LIST@30..30
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@30..40
+      3: TW_STATIC_CANDIDATE@30..39
         0: TW_BASE@30..36 "shadow" [] []
-        1: TW_MODIFIER@36..40
+        1: TW_MODIFIER@36..39
           0: SLASH@36..37 "/" [] []
-          1: TW_NUMBER_VALUE@37..40
-            0: TW_NUMBER@37..40 "50" [] [Whitespace(" ")]
+          1: TW_NUMBER_VALUE@37..39
+            0: TW_NUMBER@37..39 "50" [] []
       4: (empty)
-    3: TW_FULL_CANDIDATE@40..48
+    5: WHITESPACE@39..40 " " [] []
+    6: TW_FULL_CANDIDATE@40..47
       0: TW_VARIANT_LIST@40..40
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@40..48
+      3: TW_STATIC_CANDIDATE@40..47
         0: TW_BASE@40..44 "flex" [] []
-        1: TW_MODIFIER@44..48
+        1: TW_MODIFIER@44..47
           0: SLASH@44..45 "/" [] []
-          1: TW_NUMBER_VALUE@45..48
-            0: TW_NUMBER@45..48 "50" [] [Whitespace(" ")]
+          1: TW_NUMBER_VALUE@45..47
+            0: TW_NUMBER@45..47 "50" [] []
       4: (empty)
-    4: TW_FULL_CANDIDATE@48..63
+    7: WHITESPACE@47..48 " " [] []
+    8: TW_FULL_CANDIDATE@48..62
       0: TW_VARIANT_LIST@48..48
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@48..63
+      3: TW_STATIC_CANDIDATE@48..62
         0: TW_BASE@48..59 "drop-shadow" [] []
-        1: TW_MODIFIER@59..63
+        1: TW_MODIFIER@59..62
           0: SLASH@59..60 "/" [] []
-          1: TW_NUMBER_VALUE@60..63
-            0: TW_NUMBER@60..63 "50" [] [Whitespace(" ")]
+          1: TW_NUMBER_VALUE@60..62
+            0: TW_NUMBER@60..62 "50" [] []
       4: (empty)
-    5: TW_FULL_CANDIDATE@63..79
+    9: WHITESPACE@62..63 " " [] []
+    10: TW_FULL_CANDIDATE@63..78
       0: TW_VARIANT_LIST@63..74
         0: TW_VARIANT_EXPRESSION@63..73
           0: TW_VARIANT_SEGMENT_LIST@63..73
@@ -207,11 +220,12 @@ TwRoot {
         1: COLON@73..74 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@74..79
-        0: TW_BASE@74..79 "flex" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@74..78
+        0: TW_BASE@74..78 "flex" [] []
         1: (empty)
       4: (empty)
-    6: TW_FULL_CANDIDATE@79..98
+    11: WHITESPACE@78..79 " " [] []
+    12: TW_FULL_CANDIDATE@79..98
       0: TW_VARIANT_LIST@79..83
         0: TW_VARIANT_EXPRESSION@79..82
           0: TW_VARIANT_SEGMENT_LIST@79..82
@@ -229,6 +243,6 @@ TwRoot {
           1: TW_NAMED_VALUE@94..98
             0: TW_VALUE@94..98 "main" [] []
       4: (empty)
-  2: EOF@98..98 "" [] []
+  3: EOF@98..98 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/candidates/css-arbitrary-candidates.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/candidates/css-arbitrary-candidates.txt.snap
@@ -16,6 +16,7 @@ expression: snapshot
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -55,11 +56,12 @@ TwRoot {
                         r_paren_token: R_PAREN@23..24 ")" [] [],
                     },
                 ],
-                r_brack_token: R_BRACKET@24..26 "]" [] [Whitespace(" ")],
+                r_brack_token: R_BRACKET@24..25 "]" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@25..26 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -78,11 +80,12 @@ TwRoot {
                         r_paren_token: R_PAREN@66..67 ")" [] [],
                     },
                 ],
-                r_brack_token: R_BRACKET@67..69 "]" [] [Whitespace(" ")],
+                r_brack_token: R_BRACKET@67..68 "]" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@68..69 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -121,11 +124,12 @@ TwRoot {
                         r_paren_token: R_PAREN@89..90 ")" [] [],
                     },
                 ],
-                r_brack_token: R_BRACKET@90..92 "]" [] [Whitespace(" ")],
+                r_brack_token: R_BRACKET@90..91 "]" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@91..92 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -187,8 +191,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@141..142 "\n" [] [],
     ],
-    eof_token: EOF@141..142 "" [Newline("\n")] [],
+    eof_token: EOF@142..142 "" [] [],
 }
 ```
 
@@ -197,12 +202,13 @@ TwRoot {
 ```
 0: TW_ROOT@0..142
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..141
-    0: TW_FULL_CANDIDATE@0..26
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..142
+    0: TW_FULL_CANDIDATE@0..25
       0: TW_VARIANT_LIST@0..0
       1: (empty)
       2: (empty)
-      3: TW_ARBITRARY_CANDIDATE@0..26
+      3: TW_ARBITRARY_CANDIDATE@0..25
         0: L_BRACKET@0..1 "[" [] []
         1: TW_PROPERTY@1..6 "width" [] []
         2: COLON@6..7 ":" [] []
@@ -225,14 +231,15 @@ TwRoot {
                       0: CSS_NUMBER_LITERAL@19..20 "1" [] []
                       1: IDENT@20..23 "rem" [] []
             3: R_PAREN@23..24 ")" [] []
-        4: R_BRACKET@24..26 "]" [] [Whitespace(" ")]
+        4: R_BRACKET@24..25 "]" [] []
         5: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@26..69
+    1: WHITESPACE@25..26 " " [] []
+    2: TW_FULL_CANDIDATE@26..68
       0: TW_VARIANT_LIST@26..26
       1: (empty)
       2: (empty)
-      3: TW_ARBITRARY_CANDIDATE@26..69
+      3: TW_ARBITRARY_CANDIDATE@26..68
         0: L_BRACKET@26..27 "[" [] []
         1: TW_PROPERTY@27..43 "background-image" [] []
         2: COLON@43..44 ":" [] []
@@ -243,14 +250,15 @@ TwRoot {
             2: CSS_URL_VALUE_RAW@48..66
               0: CSS_URL_VALUE_RAW_LITERAL@48..66 "/img/mountains.jpg" [] []
             3: R_PAREN@66..67 ")" [] []
-        4: R_BRACKET@67..69 "]" [] [Whitespace(" ")]
+        4: R_BRACKET@67..68 "]" [] []
         5: (empty)
       4: (empty)
-    2: TW_FULL_CANDIDATE@69..92
+    3: WHITESPACE@68..69 " " [] []
+    4: TW_FULL_CANDIDATE@69..91
       0: TW_VARIANT_LIST@69..69
       1: (empty)
       2: (empty)
-      3: TW_ARBITRARY_CANDIDATE@69..92
+      3: TW_ARBITRARY_CANDIDATE@69..91
         0: L_BRACKET@69..70 "[" [] []
         1: TW_PROPERTY@70..75 "color" [] []
         2: COLON@75..76 ":" [] []
@@ -273,10 +281,11 @@ TwRoot {
                     2: CSS_NUMBER@86..89
                       0: CSS_NUMBER_LITERAL@86..89 "0.5" [] []
             3: R_PAREN@89..90 ")" [] []
-        4: R_BRACKET@90..92 "]" [] [Whitespace(" ")]
+        4: R_BRACKET@90..91 "]" [] []
         5: (empty)
       4: (empty)
-    3: TW_FULL_CANDIDATE@92..141
+    5: WHITESPACE@91..92 " " [] []
+    6: TW_FULL_CANDIDATE@92..141
       0: TW_VARIANT_LIST@92..92
       1: (empty)
       2: (empty)
@@ -317,6 +326,7 @@ TwRoot {
         4: R_BRACKET@140..141 "]" [] []
         5: (empty)
       4: (empty)
-  2: EOF@141..142 "" [Newline("\n")] []
+    7: WHITESPACE@141..142 "\n" [] []
+  3: EOF@142..142 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/data-attribute.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/data-attribute.txt.snap
@@ -16,6 +16,7 @@ data-active:text-red-500
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [
@@ -46,8 +47,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@24..25 "\n" [] [],
     ],
-    eof_token: EOF@24..25 "" [Newline("\n")] [],
+    eof_token: EOF@25..25 "" [] [],
 }
 ```
 
@@ -56,7 +58,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..25
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..24
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..25
     0: TW_FULL_CANDIDATE@0..24
       0: TW_VARIANT_LIST@0..12
         0: TW_VARIANT_EXPRESSION@0..11
@@ -78,6 +81,7 @@ TwRoot {
           0: TW_VALUE@17..24 "red-500" [] []
         3: (empty)
       4: (empty)
-  2: EOF@24..25 "" [Newline("\n")] []
+    1: WHITESPACE@24..25 "\n" [] []
+  3: EOF@25..25 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/gradients/precise-control.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/gradients/precise-control.txt.snap
@@ -16,6 +16,7 @@ bg-gradient-to-r from-indigo-500 from-10% via-sky-500 via-30% to-emerald-500 to-
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -25,12 +26,13 @@ TwRoot {
                 base_token: TW_BASE@0..2 "bg" [] [],
                 minus_token: DASH@2..3 "-" [] [],
                 value: TwNamedValue {
-                    value_token: TW_VALUE@3..17 "gradient-to-r" [] [Whitespace(" ")],
+                    value_token: TW_VALUE@3..16 "gradient-to-r" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@16..17 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -39,12 +41,13 @@ TwRoot {
                 base_token: TW_BASE@17..21 "from" [] [],
                 minus_token: DASH@21..22 "-" [] [],
                 value: TwNamedValue {
-                    value_token: TW_VALUE@22..33 "indigo-500" [] [Whitespace(" ")],
+                    value_token: TW_VALUE@22..32 "indigo-500" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@32..33 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -54,12 +57,13 @@ TwRoot {
                 minus_token: DASH@37..38 "-" [] [],
                 value: TwPercentageValue {
                     value_token: TW_NUMBER@38..40 "10" [] [],
-                    remainder_token: PERCENT@40..42 "%" [] [Whitespace(" ")],
+                    remainder_token: PERCENT@40..41 "%" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@41..42 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -68,12 +72,13 @@ TwRoot {
                 base_token: TW_BASE@42..45 "via" [] [],
                 minus_token: DASH@45..46 "-" [] [],
                 value: TwNamedValue {
-                    value_token: TW_VALUE@46..54 "sky-500" [] [Whitespace(" ")],
+                    value_token: TW_VALUE@46..53 "sky-500" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@53..54 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -83,12 +88,13 @@ TwRoot {
                 minus_token: DASH@57..58 "-" [] [],
                 value: TwPercentageValue {
                     value_token: TW_NUMBER@58..60 "30" [] [],
-                    remainder_token: PERCENT@60..62 "%" [] [Whitespace(" ")],
+                    remainder_token: PERCENT@60..61 "%" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@61..62 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -97,12 +103,13 @@ TwRoot {
                 base_token: TW_BASE@62..64 "to" [] [],
                 minus_token: DASH@64..65 "-" [] [],
                 value: TwNamedValue {
-                    value_token: TW_VALUE@65..77 "emerald-500" [] [Whitespace(" ")],
+                    value_token: TW_VALUE@65..76 "emerald-500" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@76..77 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -118,8 +125,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@83..84 "\n" [] [],
     ],
-    eof_token: EOF@83..84 "" [Newline("\n")] [],
+    eof_token: EOF@84..84 "" [] [],
 }
 ```
 
@@ -128,76 +136,83 @@ TwRoot {
 ```
 0: TW_ROOT@0..84
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..83
-    0: TW_FULL_CANDIDATE@0..17
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..84
+    0: TW_FULL_CANDIDATE@0..16
       0: TW_VARIANT_LIST@0..0
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@0..17
+      3: TW_FUNCTIONAL_CANDIDATE@0..16
         0: TW_BASE@0..2 "bg" [] []
         1: DASH@2..3 "-" [] []
-        2: TW_NAMED_VALUE@3..17
-          0: TW_VALUE@3..17 "gradient-to-r" [] [Whitespace(" ")]
+        2: TW_NAMED_VALUE@3..16
+          0: TW_VALUE@3..16 "gradient-to-r" [] []
         3: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@17..33
+    1: WHITESPACE@16..17 " " [] []
+    2: TW_FULL_CANDIDATE@17..32
       0: TW_VARIANT_LIST@17..17
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@17..33
+      3: TW_FUNCTIONAL_CANDIDATE@17..32
         0: TW_BASE@17..21 "from" [] []
         1: DASH@21..22 "-" [] []
-        2: TW_NAMED_VALUE@22..33
-          0: TW_VALUE@22..33 "indigo-500" [] [Whitespace(" ")]
+        2: TW_NAMED_VALUE@22..32
+          0: TW_VALUE@22..32 "indigo-500" [] []
         3: (empty)
       4: (empty)
-    2: TW_FULL_CANDIDATE@33..42
+    3: WHITESPACE@32..33 " " [] []
+    4: TW_FULL_CANDIDATE@33..41
       0: TW_VARIANT_LIST@33..33
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@33..42
+      3: TW_FUNCTIONAL_CANDIDATE@33..41
         0: TW_BASE@33..37 "from" [] []
         1: DASH@37..38 "-" [] []
-        2: TW_PERCENTAGE_VALUE@38..42
+        2: TW_PERCENTAGE_VALUE@38..41
           0: TW_NUMBER@38..40 "10" [] []
-          1: PERCENT@40..42 "%" [] [Whitespace(" ")]
+          1: PERCENT@40..41 "%" [] []
         3: (empty)
       4: (empty)
-    3: TW_FULL_CANDIDATE@42..54
+    5: WHITESPACE@41..42 " " [] []
+    6: TW_FULL_CANDIDATE@42..53
       0: TW_VARIANT_LIST@42..42
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@42..54
+      3: TW_FUNCTIONAL_CANDIDATE@42..53
         0: TW_BASE@42..45 "via" [] []
         1: DASH@45..46 "-" [] []
-        2: TW_NAMED_VALUE@46..54
-          0: TW_VALUE@46..54 "sky-500" [] [Whitespace(" ")]
+        2: TW_NAMED_VALUE@46..53
+          0: TW_VALUE@46..53 "sky-500" [] []
         3: (empty)
       4: (empty)
-    4: TW_FULL_CANDIDATE@54..62
+    7: WHITESPACE@53..54 " " [] []
+    8: TW_FULL_CANDIDATE@54..61
       0: TW_VARIANT_LIST@54..54
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@54..62
+      3: TW_FUNCTIONAL_CANDIDATE@54..61
         0: TW_BASE@54..57 "via" [] []
         1: DASH@57..58 "-" [] []
-        2: TW_PERCENTAGE_VALUE@58..62
+        2: TW_PERCENTAGE_VALUE@58..61
           0: TW_NUMBER@58..60 "30" [] []
-          1: PERCENT@60..62 "%" [] [Whitespace(" ")]
+          1: PERCENT@60..61 "%" [] []
         3: (empty)
       4: (empty)
-    5: TW_FULL_CANDIDATE@62..77
+    9: WHITESPACE@61..62 " " [] []
+    10: TW_FULL_CANDIDATE@62..76
       0: TW_VARIANT_LIST@62..62
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@62..77
+      3: TW_FUNCTIONAL_CANDIDATE@62..76
         0: TW_BASE@62..64 "to" [] []
         1: DASH@64..65 "-" [] []
-        2: TW_NAMED_VALUE@65..77
-          0: TW_VALUE@65..77 "emerald-500" [] [Whitespace(" ")]
+        2: TW_NAMED_VALUE@65..76
+          0: TW_VALUE@65..76 "emerald-500" [] []
         3: (empty)
       4: (empty)
-    6: TW_FULL_CANDIDATE@77..83
+    11: WHITESPACE@76..77 " " [] []
+    12: TW_FULL_CANDIDATE@77..83
       0: TW_VARIANT_LIST@77..77
       1: (empty)
       2: (empty)
@@ -209,6 +224,7 @@ TwRoot {
           1: PERCENT@82..83 "%" [] []
         3: (empty)
       4: (empty)
-  2: EOF@83..84 "" [Newline("\n")] []
+    13: WHITESPACE@83..84 "\n" [] []
+  3: EOF@84..84 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/gradients/simple.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/gradients/simple.txt.snap
@@ -16,6 +16,7 @@ bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -25,12 +26,13 @@ TwRoot {
                 base_token: TW_BASE@0..2 "bg" [] [],
                 minus_token: DASH@2..3 "-" [] [],
                 value: TwNamedValue {
-                    value_token: TW_VALUE@3..17 "gradient-to-r" [] [Whitespace(" ")],
+                    value_token: TW_VALUE@3..16 "gradient-to-r" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@16..17 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -39,12 +41,13 @@ TwRoot {
                 base_token: TW_BASE@17..21 "from" [] [],
                 minus_token: DASH@21..22 "-" [] [],
                 value: TwNamedValue {
-                    value_token: TW_VALUE@22..33 "indigo-500" [] [Whitespace(" ")],
+                    value_token: TW_VALUE@22..32 "indigo-500" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@32..33 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -53,12 +56,13 @@ TwRoot {
                 base_token: TW_BASE@33..36 "via" [] [],
                 minus_token: DASH@36..37 "-" [] [],
                 value: TwNamedValue {
-                    value_token: TW_VALUE@37..48 "purple-500" [] [Whitespace(" ")],
+                    value_token: TW_VALUE@37..47 "purple-500" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@47..48 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -73,8 +77,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@59..60 "\n" [] [],
     ],
-    eof_token: EOF@59..60 "" [Newline("\n")] [],
+    eof_token: EOF@60..60 "" [] [],
 }
 ```
 
@@ -83,41 +88,45 @@ TwRoot {
 ```
 0: TW_ROOT@0..60
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..59
-    0: TW_FULL_CANDIDATE@0..17
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..60
+    0: TW_FULL_CANDIDATE@0..16
       0: TW_VARIANT_LIST@0..0
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@0..17
+      3: TW_FUNCTIONAL_CANDIDATE@0..16
         0: TW_BASE@0..2 "bg" [] []
         1: DASH@2..3 "-" [] []
-        2: TW_NAMED_VALUE@3..17
-          0: TW_VALUE@3..17 "gradient-to-r" [] [Whitespace(" ")]
+        2: TW_NAMED_VALUE@3..16
+          0: TW_VALUE@3..16 "gradient-to-r" [] []
         3: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@17..33
+    1: WHITESPACE@16..17 " " [] []
+    2: TW_FULL_CANDIDATE@17..32
       0: TW_VARIANT_LIST@17..17
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@17..33
+      3: TW_FUNCTIONAL_CANDIDATE@17..32
         0: TW_BASE@17..21 "from" [] []
         1: DASH@21..22 "-" [] []
-        2: TW_NAMED_VALUE@22..33
-          0: TW_VALUE@22..33 "indigo-500" [] [Whitespace(" ")]
+        2: TW_NAMED_VALUE@22..32
+          0: TW_VALUE@22..32 "indigo-500" [] []
         3: (empty)
       4: (empty)
-    2: TW_FULL_CANDIDATE@33..48
+    3: WHITESPACE@32..33 " " [] []
+    4: TW_FULL_CANDIDATE@33..47
       0: TW_VARIANT_LIST@33..33
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@33..48
+      3: TW_FUNCTIONAL_CANDIDATE@33..47
         0: TW_BASE@33..36 "via" [] []
         1: DASH@36..37 "-" [] []
-        2: TW_NAMED_VALUE@37..48
-          0: TW_VALUE@37..48 "purple-500" [] [Whitespace(" ")]
+        2: TW_NAMED_VALUE@37..47
+          0: TW_VALUE@37..47 "purple-500" [] []
         3: (empty)
       4: (empty)
-    3: TW_FULL_CANDIDATE@48..59
+    5: WHITESPACE@47..48 " " [] []
+    6: TW_FULL_CANDIDATE@48..59
       0: TW_VARIANT_LIST@48..48
       1: (empty)
       2: (empty)
@@ -128,6 +137,7 @@ TwRoot {
           0: TW_VALUE@51..59 "pink-500" [] []
         3: (empty)
       4: (empty)
-  2: EOF@59..60 "" [Newline("\n")] []
+    7: WHITESPACE@59..60 "\n" [] []
+  3: EOF@60..60 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/group-data.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/group-data.txt.snap
@@ -16,6 +16,7 @@ group-data-[collapsible=icon]:hidden
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [
@@ -48,8 +49,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@36..37 "\n" [] [],
     ],
-    eof_token: EOF@36..37 "" [Newline("\n")] [],
+    eof_token: EOF@37..37 "" [] [],
 }
 ```
 
@@ -58,7 +60,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..37
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..36
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..37
     0: TW_FULL_CANDIDATE@0..36
       0: TW_VARIANT_LIST@0..30
         0: TW_VARIANT_EXPRESSION@0..29
@@ -82,6 +85,7 @@ TwRoot {
         0: TW_BASE@30..36 "hidden" [] []
         1: (empty)
       4: (empty)
-  2: EOF@36..37 "" [Newline("\n")] []
+    1: WHITESPACE@36..37 "\n" [] []
+  3: EOF@37..37 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/2-classes.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/2-classes.txt.snap
@@ -16,17 +16,19 @@ border -top-2
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@0..7 "border" [] [Whitespace(" ")],
+                base_token: TW_BASE@0..6 "border" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@6..7 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -41,8 +43,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@13..14 "\n" [] [],
     ],
-    eof_token: EOF@13..14 "" [Newline("\n")] [],
+    eof_token: EOF@14..14 "" [] [],
 }
 ```
 
@@ -51,16 +54,18 @@ TwRoot {
 ```
 0: TW_ROOT@0..14
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..13
-    0: TW_FULL_CANDIDATE@0..7
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..14
+    0: TW_FULL_CANDIDATE@0..6
       0: TW_VARIANT_LIST@0..0
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@0..7
-        0: TW_BASE@0..7 "border" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@0..6
+        0: TW_BASE@0..6 "border" [] []
         1: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@7..13
+    1: WHITESPACE@6..7 " " [] []
+    2: TW_FULL_CANDIDATE@7..13
       0: TW_VARIANT_LIST@7..7
       1: (empty)
       2: DASH@7..8 "-" [] []
@@ -71,6 +76,7 @@ TwRoot {
           0: TW_NUMBER@12..13 "2" [] []
         3: (empty)
       4: (empty)
-  2: EOF@13..14 "" [Newline("\n")] []
+    3: WHITESPACE@13..14 "\n" [] []
+  3: EOF@14..14 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/arbitrary-value-0.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/arbitrary-value-0.txt.snap
@@ -16,6 +16,7 @@ bg-[#ff0000]
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -37,8 +38,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@12..13 "\n" [] [],
     ],
-    eof_token: EOF@12..13 "" [Newline("\n")] [],
+    eof_token: EOF@13..13 "" [] [],
 }
 ```
 
@@ -47,7 +49,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..13
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..12
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..13
     0: TW_FULL_CANDIDATE@0..12
       0: TW_VARIANT_LIST@0..0
       1: (empty)
@@ -63,6 +66,7 @@ TwRoot {
           2: R_BRACKET@11..12 "]" [] []
         3: (empty)
       4: (empty)
-  2: EOF@12..13 "" [Newline("\n")] []
+    1: WHITESPACE@12..13 "\n" [] []
+  3: EOF@13..13 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/arbitrary-value-1.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/arbitrary-value-1.txt.snap
@@ -16,6 +16,7 @@ px-[16px]
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -38,8 +39,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@9..10 "\n" [] [],
     ],
-    eof_token: EOF@9..10 "" [Newline("\n")] [],
+    eof_token: EOF@10..10 "" [] [],
 }
 ```
 
@@ -48,7 +50,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..10
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..9
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..10
     0: TW_FULL_CANDIDATE@0..9
       0: TW_VARIANT_LIST@0..0
       1: (empty)
@@ -65,6 +68,7 @@ TwRoot {
           2: R_BRACKET@8..9 "]" [] []
         3: (empty)
       4: (empty)
-  2: EOF@9..10 "" [Newline("\n")] []
+    1: WHITESPACE@9..10 "\n" [] []
+  3: EOF@10..10 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/base-has-dash-0.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/base-has-dash-0.txt.snap
@@ -16,6 +16,7 @@ drop-shadow-red-500
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -31,8 +32,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@19..20 "\n" [] [],
     ],
-    eof_token: EOF@19..20 "" [Newline("\n")] [],
+    eof_token: EOF@20..20 "" [] [],
 }
 ```
 
@@ -41,7 +43,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..20
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..19
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..20
     0: TW_FULL_CANDIDATE@0..19
       0: TW_VARIANT_LIST@0..0
       1: (empty)
@@ -53,6 +56,7 @@ TwRoot {
           0: TW_VALUE@12..19 "red-500" [] []
         3: (empty)
       4: (empty)
-  2: EOF@19..20 "" [Newline("\n")] []
+    1: WHITESPACE@19..20 "\n" [] []
+  3: EOF@20..20 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/base-has-dash-1.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/base-has-dash-1.txt.snap
@@ -16,6 +16,7 @@ drop-shadow-[#000000]
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -37,8 +38,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@21..22 "\n" [] [],
     ],
-    eof_token: EOF@21..22 "" [Newline("\n")] [],
+    eof_token: EOF@22..22 "" [] [],
 }
 ```
 
@@ -47,7 +49,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..22
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..21
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..22
     0: TW_FULL_CANDIDATE@0..21
       0: TW_VARIANT_LIST@0..0
       1: (empty)
@@ -63,6 +66,7 @@ TwRoot {
           2: R_BRACKET@20..21 "]" [] []
         3: (empty)
       4: (empty)
-  2: EOF@21..22 "" [Newline("\n")] []
+    1: WHITESPACE@21..22 "\n" [] []
+  3: EOF@22..22 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/base-has-dash-2.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/base-has-dash-2.txt.snap
@@ -16,6 +16,7 @@ border-spacing-y-[2px]
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -38,8 +39,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@22..23 "\n" [] [],
     ],
-    eof_token: EOF@22..23 "" [Newline("\n")] [],
+    eof_token: EOF@23..23 "" [] [],
 }
 ```
 
@@ -48,7 +50,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..23
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..22
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..23
     0: TW_FULL_CANDIDATE@0..22
       0: TW_VARIANT_LIST@0..0
       1: (empty)
@@ -65,6 +68,7 @@ TwRoot {
           2: R_BRACKET@21..22 "]" [] []
         3: (empty)
       4: (empty)
-  2: EOF@22..23 "" [Newline("\n")] []
+    1: WHITESPACE@22..23 "\n" [] []
+  3: EOF@23..23 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/basic-0.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/basic-0.txt.snap
@@ -16,6 +16,7 @@ text-md
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -31,8 +32,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@7..8 "\n" [] [],
     ],
-    eof_token: EOF@7..8 "" [Newline("\n")] [],
+    eof_token: EOF@8..8 "" [] [],
 }
 ```
 
@@ -41,7 +43,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..8
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..7
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..8
     0: TW_FULL_CANDIDATE@0..7
       0: TW_VARIANT_LIST@0..0
       1: (empty)
@@ -53,6 +56,7 @@ TwRoot {
           0: TW_VALUE@5..7 "md" [] []
         3: (empty)
       4: (empty)
-  2: EOF@7..8 "" [Newline("\n")] []
+    1: WHITESPACE@7..8 "\n" [] []
+  3: EOF@8..8 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/basic-1.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/basic-1.txt.snap
@@ -16,6 +16,7 @@ bg-red-500
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -31,8 +32,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@10..11 "\n" [] [],
     ],
-    eof_token: EOF@10..11 "" [Newline("\n")] [],
+    eof_token: EOF@11..11 "" [] [],
 }
 ```
 
@@ -41,7 +43,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..11
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..10
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..11
     0: TW_FULL_CANDIDATE@0..10
       0: TW_VARIANT_LIST@0..0
       1: (empty)
@@ -53,6 +56,7 @@ TwRoot {
           0: TW_VALUE@3..10 "red-500" [] []
         3: (empty)
       4: (empty)
-  2: EOF@10..11 "" [Newline("\n")] []
+    1: WHITESPACE@10..11 "\n" [] []
+  3: EOF@11..11 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/basic-2.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/basic-2.txt.snap
@@ -16,6 +16,7 @@ break-before-auto break-after-page mix-blend-normal
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -25,12 +26,13 @@ TwRoot {
                 base_token: TW_BASE@0..12 "break-before" [] [],
                 minus_token: DASH@12..13 "-" [] [],
                 value: TwNamedValue {
-                    value_token: TW_VALUE@13..18 "auto" [] [Whitespace(" ")],
+                    value_token: TW_VALUE@13..17 "auto" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@17..18 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -39,12 +41,13 @@ TwRoot {
                 base_token: TW_BASE@18..29 "break-after" [] [],
                 minus_token: DASH@29..30 "-" [] [],
                 value: TwNamedValue {
-                    value_token: TW_VALUE@30..35 "page" [] [Whitespace(" ")],
+                    value_token: TW_VALUE@30..34 "page" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@34..35 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -59,8 +62,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@51..52 "\n" [] [],
     ],
-    eof_token: EOF@51..52 "" [Newline("\n")] [],
+    eof_token: EOF@52..52 "" [] [],
 }
 ```
 
@@ -69,30 +73,33 @@ TwRoot {
 ```
 0: TW_ROOT@0..52
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..51
-    0: TW_FULL_CANDIDATE@0..18
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..52
+    0: TW_FULL_CANDIDATE@0..17
       0: TW_VARIANT_LIST@0..0
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@0..18
+      3: TW_FUNCTIONAL_CANDIDATE@0..17
         0: TW_BASE@0..12 "break-before" [] []
         1: DASH@12..13 "-" [] []
-        2: TW_NAMED_VALUE@13..18
-          0: TW_VALUE@13..18 "auto" [] [Whitespace(" ")]
+        2: TW_NAMED_VALUE@13..17
+          0: TW_VALUE@13..17 "auto" [] []
         3: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@18..35
+    1: WHITESPACE@17..18 " " [] []
+    2: TW_FULL_CANDIDATE@18..34
       0: TW_VARIANT_LIST@18..18
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@18..35
+      3: TW_FUNCTIONAL_CANDIDATE@18..34
         0: TW_BASE@18..29 "break-after" [] []
         1: DASH@29..30 "-" [] []
-        2: TW_NAMED_VALUE@30..35
-          0: TW_VALUE@30..35 "page" [] [Whitespace(" ")]
+        2: TW_NAMED_VALUE@30..34
+          0: TW_VALUE@30..34 "page" [] []
         3: (empty)
       4: (empty)
-    2: TW_FULL_CANDIDATE@35..51
+    3: WHITESPACE@34..35 " " [] []
+    4: TW_FULL_CANDIDATE@35..51
       0: TW_VARIANT_LIST@35..35
       1: (empty)
       2: (empty)
@@ -103,6 +110,7 @@ TwRoot {
           0: TW_VALUE@45..51 "normal" [] []
         3: (empty)
       4: (empty)
-  2: EOF@51..52 "" [Newline("\n")] []
+    5: WHITESPACE@51..52 "\n" [] []
+  3: EOF@52..52 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/border.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/border.txt.snap
@@ -16,6 +16,7 @@ border-slate-500 border-teal-600 border-solid
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -25,12 +26,13 @@ TwRoot {
                 base_token: TW_BASE@0..6 "border" [] [],
                 minus_token: DASH@6..7 "-" [] [],
                 value: TwNamedValue {
-                    value_token: TW_VALUE@7..17 "slate-500" [] [Whitespace(" ")],
+                    value_token: TW_VALUE@7..16 "slate-500" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@16..17 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -39,12 +41,13 @@ TwRoot {
                 base_token: TW_BASE@17..23 "border" [] [],
                 minus_token: DASH@23..24 "-" [] [],
                 value: TwNamedValue {
-                    value_token: TW_VALUE@24..33 "teal-600" [] [Whitespace(" ")],
+                    value_token: TW_VALUE@24..32 "teal-600" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@32..33 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -59,8 +62,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@45..46 "\n" [] [],
     ],
-    eof_token: EOF@45..46 "" [Newline("\n")] [],
+    eof_token: EOF@46..46 "" [] [],
 }
 ```
 
@@ -69,30 +73,33 @@ TwRoot {
 ```
 0: TW_ROOT@0..46
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..45
-    0: TW_FULL_CANDIDATE@0..17
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..46
+    0: TW_FULL_CANDIDATE@0..16
       0: TW_VARIANT_LIST@0..0
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@0..17
+      3: TW_FUNCTIONAL_CANDIDATE@0..16
         0: TW_BASE@0..6 "border" [] []
         1: DASH@6..7 "-" [] []
-        2: TW_NAMED_VALUE@7..17
-          0: TW_VALUE@7..17 "slate-500" [] [Whitespace(" ")]
+        2: TW_NAMED_VALUE@7..16
+          0: TW_VALUE@7..16 "slate-500" [] []
         3: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@17..33
+    1: WHITESPACE@16..17 " " [] []
+    2: TW_FULL_CANDIDATE@17..32
       0: TW_VARIANT_LIST@17..17
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@17..33
+      3: TW_FUNCTIONAL_CANDIDATE@17..32
         0: TW_BASE@17..23 "border" [] []
         1: DASH@23..24 "-" [] []
-        2: TW_NAMED_VALUE@24..33
-          0: TW_VALUE@24..33 "teal-600" [] [Whitespace(" ")]
+        2: TW_NAMED_VALUE@24..32
+          0: TW_VALUE@24..32 "teal-600" [] []
         3: (empty)
       4: (empty)
-    2: TW_FULL_CANDIDATE@33..45
+    3: WHITESPACE@32..33 " " [] []
+    4: TW_FULL_CANDIDATE@33..45
       0: TW_VARIANT_LIST@33..33
       1: (empty)
       2: (empty)
@@ -103,6 +110,7 @@ TwRoot {
           0: TW_VALUE@40..45 "solid" [] []
         3: (empty)
       4: (empty)
-  2: EOF@45..46 "" [Newline("\n")] []
+    5: WHITESPACE@45..46 "\n" [] []
+  3: EOF@46..46 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/css-value.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/css-value.txt.snap
@@ -16,6 +16,7 @@ text-(--my-color)
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -33,8 +34,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@17..18 "\n" [] [],
     ],
-    eof_token: EOF@17..18 "" [Newline("\n")] [],
+    eof_token: EOF@18..18 "" [] [],
 }
 ```
 
@@ -43,7 +45,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..18
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..17
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..18
     0: TW_FULL_CANDIDATE@0..17
       0: TW_VARIANT_LIST@0..0
       1: (empty)
@@ -57,6 +60,7 @@ TwRoot {
           2: R_PAREN@16..17 ")" [] []
         3: (empty)
       4: (empty)
-  2: EOF@17..18 "" [Newline("\n")] []
+    1: WHITESPACE@17..18 "\n" [] []
+  3: EOF@18..18 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/empty.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/empty.txt.snap
@@ -15,6 +15,7 @@ expression: snapshot
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [],
     eof_token: EOF@0..0 "" [] [],
 }
@@ -25,7 +26,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..0
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..0
-  2: EOF@0..0 "" [] []
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..0
+  3: EOF@0..0 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/important.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/important.txt.snap
@@ -16,6 +16,7 @@ text-lg!
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -31,8 +32,9 @@ TwRoot {
             },
             excl_token: BANG@7..8 "!" [] [],
         },
+        WHITESPACE@8..9 "\n" [] [],
     ],
-    eof_token: EOF@8..9 "" [Newline("\n")] [],
+    eof_token: EOF@9..9 "" [] [],
 }
 ```
 
@@ -41,7 +43,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..9
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..8
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..9
     0: TW_FULL_CANDIDATE@0..8
       0: TW_VARIANT_LIST@0..0
       1: (empty)
@@ -53,6 +56,7 @@ TwRoot {
           0: TW_VALUE@5..7 "lg" [] []
         3: (empty)
       4: BANG@7..8 "!" [] []
-  2: EOF@8..9 "" [Newline("\n")] []
+    1: WHITESPACE@8..9 "\n" [] []
+  3: EOF@9..9 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/legacy-important.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/legacy-important.txt.snap
@@ -15,17 +15,19 @@ expression: snapshot
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: BANG@0..1 "!" [] [],
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@1..6 "flex" [] [Whitespace(" ")],
+                base_token: TW_BASE@1..5 "flex" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@5..6 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -45,12 +47,13 @@ TwRoot {
                 base_token: TW_BASE@13..14 "p" [] [],
                 minus_token: DASH@14..15 "-" [] [],
                 value: TwNumberValue {
-                    value_token: TW_NUMBER@15..17 "4" [] [Whitespace(" ")],
+                    value_token: TW_NUMBER@15..16 "4" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@16..17 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: BANG@17..18 "!" [] [],
@@ -59,12 +62,13 @@ TwRoot {
                 base_token: TW_BASE@19..20 "m" [] [],
                 minus_token: DASH@20..21 "-" [] [],
                 value: TwNumberValue {
-                    value_token: TW_NUMBER@21..23 "4" [] [Whitespace(" ")],
+                    value_token: TW_NUMBER@21..22 "4" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@22..23 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: BANG@23..24 "!" [] [],
@@ -78,11 +82,12 @@ TwRoot {
                         ident_token: IDENT@31..34 "red" [] [],
                     },
                 ],
-                r_brack_token: R_BRACKET@34..36 "]" [] [Whitespace(" ")],
+                r_brack_token: R_BRACKET@34..35 "]" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@35..36 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: BANG@36..37 "!" [] [],
@@ -96,12 +101,13 @@ TwRoot {
                 modifier: TwModifier {
                     slash_token: SLASH@47..48 "/" [] [],
                     value: TwNumberValue {
-                        value_token: TW_NUMBER@48..51 "50" [] [Whitespace(" ")],
+                        value_token: TW_NUMBER@48..50 "50" [] [],
                     },
                 },
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@50..51 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: BANG@51..52 "!" [] [],
@@ -111,12 +117,13 @@ TwRoot {
                 modifier: TwModifier {
                     slash_token: SLASH@62..63 "/" [] [],
                     value: TwNamedValue {
-                        value_token: TW_VALUE@63..68 "main" [] [Whitespace(" ")],
+                        value_token: TW_VALUE@63..67 "main" [] [],
                     },
                 },
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@67..68 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: BANG@68..69 "!" [] [],
@@ -125,12 +132,13 @@ TwRoot {
                 base_token: TW_BASE@69..70 "w" [] [],
                 minus_token: DASH@70..71 "-" [] [],
                 value: TwNamedValue {
-                    value_token: TW_VALUE@71..76 "full" [] [Whitespace(" ")],
+                    value_token: TW_VALUE@71..75 "full" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@75..76 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -139,8 +147,9 @@ TwRoot {
                 base_token: TW_BASE@76..80 "flex" [] [],
                 modifier: missing (optional),
             },
-            excl_token: BANG@80..82 "!" [] [Whitespace(" ")],
+            excl_token: BANG@80..81 "!" [] [],
         },
+        WHITESPACE@81..82 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: BANG@82..83 "!" [] [],
@@ -161,16 +170,18 @@ TwRoot {
 ```
 0: TW_ROOT@0..87
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..87
-    0: TW_FULL_CANDIDATE@0..6
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..87
+    0: TW_FULL_CANDIDATE@0..5
       0: TW_VARIANT_LIST@0..0
       1: BANG@0..1 "!" [] []
       2: (empty)
-      3: TW_STATIC_CANDIDATE@1..6
-        0: TW_BASE@1..6 "flex" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@1..5
+        0: TW_BASE@1..5 "flex" [] []
         1: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@6..17
+    1: WHITESPACE@5..6 " " [] []
+    2: TW_FULL_CANDIDATE@6..16
       0: TW_VARIANT_LIST@6..12
         0: TW_VARIANT_EXPRESSION@6..11
           0: TW_VARIANT_SEGMENT_LIST@6..11
@@ -181,83 +192,90 @@ TwRoot {
         1: COLON@11..12 ":" [] []
       1: BANG@12..13 "!" [] []
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@13..17
+      3: TW_FUNCTIONAL_CANDIDATE@13..16
         0: TW_BASE@13..14 "p" [] []
         1: DASH@14..15 "-" [] []
-        2: TW_NUMBER_VALUE@15..17
-          0: TW_NUMBER@15..17 "4" [] [Whitespace(" ")]
+        2: TW_NUMBER_VALUE@15..16
+          0: TW_NUMBER@15..16 "4" [] []
         3: (empty)
       4: (empty)
-    2: TW_FULL_CANDIDATE@17..23
+    3: WHITESPACE@16..17 " " [] []
+    4: TW_FULL_CANDIDATE@17..22
       0: TW_VARIANT_LIST@17..17
       1: BANG@17..18 "!" [] []
       2: DASH@18..19 "-" [] []
-      3: TW_FUNCTIONAL_CANDIDATE@19..23
+      3: TW_FUNCTIONAL_CANDIDATE@19..22
         0: TW_BASE@19..20 "m" [] []
         1: DASH@20..21 "-" [] []
-        2: TW_NUMBER_VALUE@21..23
-          0: TW_NUMBER@21..23 "4" [] [Whitespace(" ")]
+        2: TW_NUMBER_VALUE@21..22
+          0: TW_NUMBER@21..22 "4" [] []
         3: (empty)
       4: (empty)
-    3: TW_FULL_CANDIDATE@23..36
+    5: WHITESPACE@22..23 " " [] []
+    6: TW_FULL_CANDIDATE@23..35
       0: TW_VARIANT_LIST@23..23
       1: BANG@23..24 "!" [] []
       2: (empty)
-      3: TW_ARBITRARY_CANDIDATE@24..36
+      3: TW_ARBITRARY_CANDIDATE@24..35
         0: L_BRACKET@24..25 "[" [] []
         1: TW_PROPERTY@25..30 "color" [] []
         2: COLON@30..31 ":" [] []
         3: CSS_GENERIC_COMPONENT_VALUE_LIST@31..34
           0: CSS_IDENTIFIER@31..34
             0: IDENT@31..34 "red" [] []
-        4: R_BRACKET@34..36 "]" [] [Whitespace(" ")]
+        4: R_BRACKET@34..35 "]" [] []
         5: (empty)
       4: (empty)
-    4: TW_FULL_CANDIDATE@36..51
+    7: WHITESPACE@35..36 " " [] []
+    8: TW_FULL_CANDIDATE@36..50
       0: TW_VARIANT_LIST@36..36
       1: BANG@36..37 "!" [] []
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@37..51
+      3: TW_FUNCTIONAL_CANDIDATE@37..50
         0: TW_BASE@37..39 "bg" [] []
         1: DASH@39..40 "-" [] []
         2: TW_NAMED_VALUE@40..47
           0: TW_VALUE@40..47 "red-500" [] []
-        3: TW_MODIFIER@47..51
+        3: TW_MODIFIER@47..50
           0: SLASH@47..48 "/" [] []
-          1: TW_NUMBER_VALUE@48..51
-            0: TW_NUMBER@48..51 "50" [] [Whitespace(" ")]
+          1: TW_NUMBER_VALUE@48..50
+            0: TW_NUMBER@48..50 "50" [] []
       4: (empty)
-    5: TW_FULL_CANDIDATE@51..68
+    9: WHITESPACE@50..51 " " [] []
+    10: TW_FULL_CANDIDATE@51..67
       0: TW_VARIANT_LIST@51..51
       1: BANG@51..52 "!" [] []
       2: (empty)
-      3: TW_STATIC_CANDIDATE@52..68
+      3: TW_STATIC_CANDIDATE@52..67
         0: TW_BASE@52..62 "@container" [] []
-        1: TW_MODIFIER@62..68
+        1: TW_MODIFIER@62..67
           0: SLASH@62..63 "/" [] []
-          1: TW_NAMED_VALUE@63..68
-            0: TW_VALUE@63..68 "main" [] [Whitespace(" ")]
+          1: TW_NAMED_VALUE@63..67
+            0: TW_VALUE@63..67 "main" [] []
       4: (empty)
-    6: TW_FULL_CANDIDATE@68..76
+    11: WHITESPACE@67..68 " " [] []
+    12: TW_FULL_CANDIDATE@68..75
       0: TW_VARIANT_LIST@68..68
       1: BANG@68..69 "!" [] []
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@69..76
+      3: TW_FUNCTIONAL_CANDIDATE@69..75
         0: TW_BASE@69..70 "w" [] []
         1: DASH@70..71 "-" [] []
-        2: TW_NAMED_VALUE@71..76
-          0: TW_VALUE@71..76 "full" [] [Whitespace(" ")]
+        2: TW_NAMED_VALUE@71..75
+          0: TW_VALUE@71..75 "full" [] []
         3: (empty)
       4: (empty)
-    7: TW_FULL_CANDIDATE@76..82
+    13: WHITESPACE@75..76 " " [] []
+    14: TW_FULL_CANDIDATE@76..81
       0: TW_VARIANT_LIST@76..76
       1: (empty)
       2: (empty)
       3: TW_STATIC_CANDIDATE@76..80
         0: TW_BASE@76..80 "flex" [] []
         1: (empty)
-      4: BANG@80..82 "!" [] [Whitespace(" ")]
-    8: TW_FULL_CANDIDATE@82..87
+      4: BANG@80..81 "!" [] []
+    15: WHITESPACE@81..82 " " [] []
+    16: TW_FULL_CANDIDATE@82..87
       0: TW_VARIANT_LIST@82..82
       1: BANG@82..83 "!" [] []
       2: (empty)
@@ -265,6 +283,6 @@ TwRoot {
         0: TW_BASE@83..87 "flex" [] []
         1: (empty)
       4: (empty)
-  2: EOF@87..87 "" [] []
+  3: EOF@87..87 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/modifier.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/modifier.txt.snap
@@ -16,6 +16,7 @@ bg-primary/10
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -36,8 +37,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@13..14 "\n" [] [],
     ],
-    eof_token: EOF@13..14 "" [Newline("\n")] [],
+    eof_token: EOF@14..14 "" [] [],
 }
 ```
 
@@ -46,7 +48,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..14
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..13
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..14
     0: TW_FULL_CANDIDATE@0..13
       0: TW_VARIANT_LIST@0..0
       1: (empty)
@@ -61,6 +64,7 @@ TwRoot {
           1: TW_NUMBER_VALUE@11..13
             0: TW_NUMBER@11..13 "10" [] []
       4: (empty)
-  2: EOF@13..14 "" [Newline("\n")] []
+    1: WHITESPACE@13..14 "\n" [] []
+  3: EOF@14..14 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/multiple-spaces.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/multiple-spaces.txt.snap
@@ -16,17 +16,19 @@ border              focus:outline-none
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@0..20 "border" [] [Whitespace("              ")],
+                base_token: TW_BASE@0..6 "border" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@6..20 "              " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -52,8 +54,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@38..39 "\n" [] [],
     ],
-    eof_token: EOF@38..39 "" [Newline("\n")] [],
+    eof_token: EOF@39..39 "" [] [],
 }
 ```
 
@@ -62,16 +65,18 @@ TwRoot {
 ```
 0: TW_ROOT@0..39
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..38
-    0: TW_FULL_CANDIDATE@0..20
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..39
+    0: TW_FULL_CANDIDATE@0..6
       0: TW_VARIANT_LIST@0..0
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@0..20
-        0: TW_BASE@0..20 "border" [] [Whitespace("              ")]
+      3: TW_STATIC_CANDIDATE@0..6
+        0: TW_BASE@0..6 "border" [] []
         1: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@20..38
+    1: WHITESPACE@6..20 "              " [] []
+    2: TW_FULL_CANDIDATE@20..38
       0: TW_VARIANT_LIST@20..26
         0: TW_VARIANT_EXPRESSION@20..25
           0: TW_VARIANT_SEGMENT_LIST@20..25
@@ -89,6 +94,7 @@ TwRoot {
           0: TW_VALUE@34..38 "none" [] []
         3: (empty)
       4: (empty)
-  2: EOF@38..39 "" [Newline("\n")] []
+    3: WHITESPACE@38..39 "\n" [] []
+  3: EOF@39..39 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/multiple.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/multiple.txt.snap
@@ -16,17 +16,19 @@ border focus:outline-none
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@0..7 "border" [] [Whitespace(" ")],
+                base_token: TW_BASE@0..6 "border" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@6..7 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -52,8 +54,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@25..26 "\n" [] [],
     ],
-    eof_token: EOF@25..26 "" [Newline("\n")] [],
+    eof_token: EOF@26..26 "" [] [],
 }
 ```
 
@@ -62,16 +65,18 @@ TwRoot {
 ```
 0: TW_ROOT@0..26
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..25
-    0: TW_FULL_CANDIDATE@0..7
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..26
+    0: TW_FULL_CANDIDATE@0..6
       0: TW_VARIANT_LIST@0..0
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@0..7
-        0: TW_BASE@0..7 "border" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@0..6
+        0: TW_BASE@0..6 "border" [] []
         1: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@7..25
+    1: WHITESPACE@6..7 " " [] []
+    2: TW_FULL_CANDIDATE@7..25
       0: TW_VARIANT_LIST@7..13
         0: TW_VARIANT_EXPRESSION@7..12
           0: TW_VARIANT_SEGMENT_LIST@7..12
@@ -89,6 +94,7 @@ TwRoot {
           0: TW_VALUE@21..25 "none" [] []
         3: (empty)
       4: (empty)
-  2: EOF@25..26 "" [Newline("\n")] []
+    3: WHITESPACE@25..26 "\n" [] []
+  3: EOF@26..26 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/negative.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/negative.txt.snap
@@ -16,6 +16,7 @@ expression: snapshot
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -25,12 +26,13 @@ TwRoot {
                 base_token: TW_BASE@1..4 "top" [] [],
                 minus_token: DASH@4..5 "-" [] [],
                 value: TwNumberValue {
-                    value_token: TW_NUMBER@5..7 "4" [] [Whitespace(" ")],
+                    value_token: TW_NUMBER@5..6 "4" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@6..7 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -39,12 +41,13 @@ TwRoot {
                 base_token: TW_BASE@8..10 "mb" [] [],
                 minus_token: DASH@10..11 "-" [] [],
                 value: TwNumberValue {
-                    value_token: TW_NUMBER@11..13 "2" [] [Whitespace(" ")],
+                    value_token: TW_NUMBER@11..12 "2" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@12..13 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -70,8 +73,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@24..25 "\n" [] [],
     ],
-    eof_token: EOF@24..25 "" [Newline("\n")] [],
+    eof_token: EOF@25..25 "" [] [],
 }
 ```
 
@@ -80,30 +84,33 @@ TwRoot {
 ```
 0: TW_ROOT@0..25
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..24
-    0: TW_FULL_CANDIDATE@0..7
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..25
+    0: TW_FULL_CANDIDATE@0..6
       0: TW_VARIANT_LIST@0..0
       1: (empty)
       2: DASH@0..1 "-" [] []
-      3: TW_FUNCTIONAL_CANDIDATE@1..7
+      3: TW_FUNCTIONAL_CANDIDATE@1..6
         0: TW_BASE@1..4 "top" [] []
         1: DASH@4..5 "-" [] []
-        2: TW_NUMBER_VALUE@5..7
-          0: TW_NUMBER@5..7 "4" [] [Whitespace(" ")]
+        2: TW_NUMBER_VALUE@5..6
+          0: TW_NUMBER@5..6 "4" [] []
         3: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@7..13
+    1: WHITESPACE@6..7 " " [] []
+    2: TW_FULL_CANDIDATE@7..12
       0: TW_VARIANT_LIST@7..7
       1: (empty)
       2: DASH@7..8 "-" [] []
-      3: TW_FUNCTIONAL_CANDIDATE@8..13
+      3: TW_FUNCTIONAL_CANDIDATE@8..12
         0: TW_BASE@8..10 "mb" [] []
         1: DASH@10..11 "-" [] []
-        2: TW_NUMBER_VALUE@11..13
-          0: TW_NUMBER@11..13 "2" [] [Whitespace(" ")]
+        2: TW_NUMBER_VALUE@11..12
+          0: TW_NUMBER@11..12 "2" [] []
         3: (empty)
       4: (empty)
-    2: TW_FULL_CANDIDATE@13..24
+    3: WHITESPACE@12..13 " " [] []
+    4: TW_FULL_CANDIDATE@13..24
       0: TW_VARIANT_LIST@13..19
         0: TW_VARIANT_EXPRESSION@13..18
           0: TW_VARIANT_SEGMENT_LIST@13..18
@@ -121,6 +128,7 @@ TwRoot {
           0: TW_NUMBER@23..24 "2" [] []
         3: (empty)
       4: (empty)
-  2: EOF@24..25 "" [Newline("\n")] []
+    5: WHITESPACE@24..25 "\n" [] []
+  3: EOF@25..25 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/newlines.txt
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/newlines.txt
@@ -1,0 +1,4 @@
+  border
+focus:outline-none
+
+uppercase

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/newlines.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/newlines.txt.snap
@@ -1,0 +1,123 @@
+---
+source: crates/biome_tailwind_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```text
+  border
+focus:outline-none
+
+uppercase
+
+```
+
+
+## AST
+
+```
+TwRoot {
+    bom_token: missing (optional),
+    leading_whitespace_token: WHITESPACE@0..2 "  " [] [],
+    candidates: TwCandidateList [
+        TwFullCandidate {
+            variants: TwVariantList [],
+            legacy_important_token: missing (optional),
+            negative_token: missing (optional),
+            candidate: TwStaticCandidate {
+                base_token: TW_BASE@2..8 "border" [] [],
+                modifier: missing (optional),
+            },
+            excl_token: missing (optional),
+        },
+        WHITESPACE@8..9 "\n" [] [],
+        TwFullCandidate {
+            variants: TwVariantList [
+                TwVariantExpression {
+                    segments: TwVariantSegmentList [
+                        TwNamedVariantSegment {
+                            value_token: TW_VARIANT_SEGMENT@9..14 "focus" [] [],
+                        },
+                    ],
+                    glued_value: missing (optional),
+                    modifier: missing (optional),
+                },
+                COLON@14..15 ":" [] [],
+            ],
+            legacy_important_token: missing (optional),
+            negative_token: missing (optional),
+            candidate: TwFunctionalCandidate {
+                base_token: TW_BASE@15..22 "outline" [] [],
+                minus_token: DASH@22..23 "-" [] [],
+                value: TwNamedValue {
+                    value_token: TW_VALUE@23..27 "none" [] [],
+                },
+                modifier: missing (optional),
+            },
+            excl_token: missing (optional),
+        },
+        WHITESPACE@27..29 "\n\n" [] [],
+        TwFullCandidate {
+            variants: TwVariantList [],
+            legacy_important_token: missing (optional),
+            negative_token: missing (optional),
+            candidate: TwStaticCandidate {
+                base_token: TW_BASE@29..38 "uppercase" [] [],
+                modifier: missing (optional),
+            },
+            excl_token: missing (optional),
+        },
+        WHITESPACE@38..39 "\n" [] [],
+    ],
+    eof_token: EOF@39..39 "" [] [],
+}
+```
+
+## CST
+
+```
+0: TW_ROOT@0..39
+  0: (empty)
+  1: WHITESPACE@0..2 "  " [] []
+  2: TW_CANDIDATE_LIST@2..39
+    0: TW_FULL_CANDIDATE@2..8
+      0: TW_VARIANT_LIST@2..2
+      1: (empty)
+      2: (empty)
+      3: TW_STATIC_CANDIDATE@2..8
+        0: TW_BASE@2..8 "border" [] []
+        1: (empty)
+      4: (empty)
+    1: WHITESPACE@8..9 "\n" [] []
+    2: TW_FULL_CANDIDATE@9..27
+      0: TW_VARIANT_LIST@9..15
+        0: TW_VARIANT_EXPRESSION@9..14
+          0: TW_VARIANT_SEGMENT_LIST@9..14
+            0: TW_NAMED_VARIANT_SEGMENT@9..14
+              0: TW_VARIANT_SEGMENT@9..14 "focus" [] []
+          1: (empty)
+          2: (empty)
+        1: COLON@14..15 ":" [] []
+      1: (empty)
+      2: (empty)
+      3: TW_FUNCTIONAL_CANDIDATE@15..27
+        0: TW_BASE@15..22 "outline" [] []
+        1: DASH@22..23 "-" [] []
+        2: TW_NAMED_VALUE@23..27
+          0: TW_VALUE@23..27 "none" [] []
+        3: (empty)
+      4: (empty)
+    3: WHITESPACE@27..29 "\n\n" [] []
+    4: TW_FULL_CANDIDATE@29..38
+      0: TW_VARIANT_LIST@29..29
+      1: (empty)
+      2: (empty)
+      3: TW_STATIC_CANDIDATE@29..38
+        0: TW_BASE@29..38 "uppercase" [] []
+        1: (empty)
+      4: (empty)
+    5: WHITESPACE@38..39 "\n" [] []
+  3: EOF@39..39 "" [] []
+
+```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/number-value.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/number-value.txt.snap
@@ -16,6 +16,7 @@ w-3
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -31,8 +32,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@3..4 "\n" [] [],
     ],
-    eof_token: EOF@3..4 "" [Newline("\n")] [],
+    eof_token: EOF@4..4 "" [] [],
 }
 ```
 
@@ -41,7 +43,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..4
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..3
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..4
     0: TW_FULL_CANDIDATE@0..3
       0: TW_VARIANT_LIST@0..0
       1: (empty)
@@ -53,6 +56,7 @@ TwRoot {
           0: TW_NUMBER@2..3 "3" [] []
         3: (empty)
       4: (empty)
-  2: EOF@3..4 "" [Newline("\n")] []
+    1: WHITESPACE@3..4 "\n" [] []
+  3: EOF@4..4 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/percentage-value.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/percentage-value.txt.snap
@@ -16,6 +16,7 @@ progress-50%
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -32,8 +33,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@12..13 "\n" [] [],
     ],
-    eof_token: EOF@12..13 "" [Newline("\n")] [],
+    eof_token: EOF@13..13 "" [] [],
 }
 ```
 
@@ -42,7 +44,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..13
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..12
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..13
     0: TW_FULL_CANDIDATE@0..12
       0: TW_VARIANT_LIST@0..0
       1: (empty)
@@ -55,6 +58,7 @@ TwRoot {
           1: PERCENT@11..12 "%" [] []
         3: (empty)
       4: (empty)
-  2: EOF@12..13 "" [Newline("\n")] []
+    1: WHITESPACE@12..13 "\n" [] []
+  3: EOF@13..13 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/ratio-value.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/ratio-value.txt.snap
@@ -16,6 +16,7 @@ w-3/4
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -36,8 +37,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@5..6 "\n" [] [],
     ],
-    eof_token: EOF@5..6 "" [Newline("\n")] [],
+    eof_token: EOF@6..6 "" [] [],
 }
 ```
 
@@ -46,7 +48,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..6
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..5
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..6
     0: TW_FULL_CANDIDATE@0..5
       0: TW_VARIANT_LIST@0..0
       1: (empty)
@@ -61,6 +64,7 @@ TwRoot {
           1: TW_NUMBER_VALUE@4..5
             0: TW_NUMBER@4..5 "4" [] []
       4: (empty)
-  2: EOF@5..6 "" [Newline("\n")] []
+    1: WHITESPACE@5..6 "\n" [] []
+  3: EOF@6..6 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/static.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/simple/static.txt.snap
@@ -16,6 +16,7 @@ underline
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -27,8 +28,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@9..10 "\n" [] [],
     ],
-    eof_token: EOF@9..10 "" [Newline("\n")] [],
+    eof_token: EOF@10..10 "" [] [],
 }
 ```
 
@@ -37,7 +39,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..10
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..9
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..10
     0: TW_FULL_CANDIDATE@0..9
       0: TW_VARIANT_LIST@0..0
       1: (empty)
@@ -46,6 +49,7 @@ TwRoot {
         0: TW_BASE@0..9 "underline" [] []
         1: (empty)
       4: (empty)
-  2: EOF@9..10 "" [Newline("\n")] []
+    1: WHITESPACE@9..10 "\n" [] []
+  3: EOF@10..10 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/stress/stress-1.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/stress/stress-1.txt.snap
@@ -16,6 +16,7 @@ text-sm leading-[10px] hover:text-xl/[100px] hover:focus:aria-[checked]:text-red
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -25,12 +26,13 @@ TwRoot {
                 base_token: TW_BASE@0..4 "text" [] [],
                 minus_token: DASH@4..5 "-" [] [],
                 value: TwNamedValue {
-                    value_token: TW_VALUE@5..8 "sm" [] [Whitespace(" ")],
+                    value_token: TW_VALUE@5..7 "sm" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@7..8 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -46,12 +48,13 @@ TwRoot {
                             unit_token: IDENT@19..21 "px" [] [],
                         },
                     ],
-                    r_brack_token: R_BRACKET@21..23 "]" [] [Whitespace(" ")],
+                    r_brack_token: R_BRACKET@21..22 "]" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@22..23 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -83,12 +86,13 @@ TwRoot {
                                 unit_token: IDENT@41..43 "px" [] [],
                             },
                         ],
-                        r_brack_token: R_BRACKET@43..45 "]" [] [Whitespace(" ")],
+                        r_brack_token: R_BRACKET@43..44 "]" [] [],
                     },
                 },
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@44..45 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -134,22 +138,24 @@ TwRoot {
                 base_token: TW_BASE@72..76 "text" [] [],
                 minus_token: DASH@76..77 "-" [] [],
                 value: TwNamedValue {
-                    value_token: TW_VALUE@77..85 "red-500" [] [Whitespace(" ")],
+                    value_token: TW_VALUE@77..84 "red-500" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@84..85 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@85..90 "flex" [] [Whitespace(" ")],
+                base_token: TW_BASE@85..89 "flex" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@89..90 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -158,12 +164,13 @@ TwRoot {
                 base_token: TW_BASE@90..95 "items" [] [],
                 minus_token: DASH@95..96 "-" [] [],
                 value: TwNamedValue {
-                    value_token: TW_VALUE@96..103 "center" [] [Whitespace(" ")],
+                    value_token: TW_VALUE@96..102 "center" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@102..103 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -172,12 +179,13 @@ TwRoot {
                 base_token: TW_BASE@103..106 "gap" [] [],
                 minus_token: DASH@106..107 "-" [] [],
                 value: TwNumberValue {
-                    value_token: TW_NUMBER@107..109 "2" [] [Whitespace(" ")],
+                    value_token: TW_NUMBER@107..108 "2" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@108..109 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -203,12 +211,13 @@ TwRoot {
                 base_token: TW_BASE@125..132 "opacity" [] [],
                 minus_token: DASH@132..133 "-" [] [],
                 value: TwNumberValue {
-                    value_token: TW_NUMBER@133..136 "50" [] [Whitespace(" ")],
+                    value_token: TW_NUMBER@133..135 "50" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@135..136 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwArbitraryVariant {
@@ -240,8 +249,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@173..174 "\n" [] [],
     ],
-    eof_token: EOF@173..174 "" [Newline("\n")] [],
+    eof_token: EOF@174..174 "" [] [],
 }
 ```
 
@@ -250,35 +260,38 @@ TwRoot {
 ```
 0: TW_ROOT@0..174
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..173
-    0: TW_FULL_CANDIDATE@0..8
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..174
+    0: TW_FULL_CANDIDATE@0..7
       0: TW_VARIANT_LIST@0..0
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@0..8
+      3: TW_FUNCTIONAL_CANDIDATE@0..7
         0: TW_BASE@0..4 "text" [] []
         1: DASH@4..5 "-" [] []
-        2: TW_NAMED_VALUE@5..8
-          0: TW_VALUE@5..8 "sm" [] [Whitespace(" ")]
+        2: TW_NAMED_VALUE@5..7
+          0: TW_VALUE@5..7 "sm" [] []
         3: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@8..23
+    1: WHITESPACE@7..8 " " [] []
+    2: TW_FULL_CANDIDATE@8..22
       0: TW_VARIANT_LIST@8..8
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@8..23
+      3: TW_FUNCTIONAL_CANDIDATE@8..22
         0: TW_BASE@8..15 "leading" [] []
         1: DASH@15..16 "-" [] []
-        2: TW_ARBITRARY_VALUE@16..23
+        2: TW_ARBITRARY_VALUE@16..22
           0: L_BRACKET@16..17 "[" [] []
           1: CSS_GENERIC_COMPONENT_VALUE_LIST@17..21
             0: CSS_REGULAR_DIMENSION@17..21
               0: CSS_NUMBER_LITERAL@17..19 "10" [] []
               1: IDENT@19..21 "px" [] []
-          2: R_BRACKET@21..23 "]" [] [Whitespace(" ")]
+          2: R_BRACKET@21..22 "]" [] []
         3: (empty)
       4: (empty)
-    2: TW_FULL_CANDIDATE@23..45
+    3: WHITESPACE@22..23 " " [] []
+    4: TW_FULL_CANDIDATE@23..44
       0: TW_VARIANT_LIST@23..29
         0: TW_VARIANT_EXPRESSION@23..28
           0: TW_VARIANT_SEGMENT_LIST@23..28
@@ -289,22 +302,23 @@ TwRoot {
         1: COLON@28..29 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@29..45
+      3: TW_FUNCTIONAL_CANDIDATE@29..44
         0: TW_BASE@29..33 "text" [] []
         1: DASH@33..34 "-" [] []
         2: TW_NAMED_VALUE@34..36
           0: TW_VALUE@34..36 "xl" [] []
-        3: TW_MODIFIER@36..45
+        3: TW_MODIFIER@36..44
           0: SLASH@36..37 "/" [] []
-          1: TW_ARBITRARY_VALUE@37..45
+          1: TW_ARBITRARY_VALUE@37..44
             0: L_BRACKET@37..38 "[" [] []
             1: CSS_GENERIC_COMPONENT_VALUE_LIST@38..43
               0: CSS_REGULAR_DIMENSION@38..43
                 0: CSS_NUMBER_LITERAL@38..41 "100" [] []
                 1: IDENT@41..43 "px" [] []
-            2: R_BRACKET@43..45 "]" [] [Whitespace(" ")]
+            2: R_BRACKET@43..44 "]" [] []
       4: (empty)
-    3: TW_FULL_CANDIDATE@45..85
+    5: WHITESPACE@44..45 " " [] []
+    6: TW_FULL_CANDIDATE@45..84
       0: TW_VARIANT_LIST@45..72
         0: TW_VARIANT_EXPRESSION@45..50
           0: TW_VARIANT_SEGMENT_LIST@45..50
@@ -334,44 +348,48 @@ TwRoot {
         5: COLON@71..72 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@72..85
+      3: TW_FUNCTIONAL_CANDIDATE@72..84
         0: TW_BASE@72..76 "text" [] []
         1: DASH@76..77 "-" [] []
-        2: TW_NAMED_VALUE@77..85
-          0: TW_VALUE@77..85 "red-500" [] [Whitespace(" ")]
+        2: TW_NAMED_VALUE@77..84
+          0: TW_VALUE@77..84 "red-500" [] []
         3: (empty)
       4: (empty)
-    4: TW_FULL_CANDIDATE@85..90
+    7: WHITESPACE@84..85 " " [] []
+    8: TW_FULL_CANDIDATE@85..89
       0: TW_VARIANT_LIST@85..85
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@85..90
-        0: TW_BASE@85..90 "flex" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@85..89
+        0: TW_BASE@85..89 "flex" [] []
         1: (empty)
       4: (empty)
-    5: TW_FULL_CANDIDATE@90..103
+    9: WHITESPACE@89..90 " " [] []
+    10: TW_FULL_CANDIDATE@90..102
       0: TW_VARIANT_LIST@90..90
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@90..103
+      3: TW_FUNCTIONAL_CANDIDATE@90..102
         0: TW_BASE@90..95 "items" [] []
         1: DASH@95..96 "-" [] []
-        2: TW_NAMED_VALUE@96..103
-          0: TW_VALUE@96..103 "center" [] [Whitespace(" ")]
+        2: TW_NAMED_VALUE@96..102
+          0: TW_VALUE@96..102 "center" [] []
         3: (empty)
       4: (empty)
-    6: TW_FULL_CANDIDATE@103..109
+    11: WHITESPACE@102..103 " " [] []
+    12: TW_FULL_CANDIDATE@103..108
       0: TW_VARIANT_LIST@103..103
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@103..109
+      3: TW_FUNCTIONAL_CANDIDATE@103..108
         0: TW_BASE@103..106 "gap" [] []
         1: DASH@106..107 "-" [] []
-        2: TW_NUMBER_VALUE@107..109
-          0: TW_NUMBER@107..109 "2" [] [Whitespace(" ")]
+        2: TW_NUMBER_VALUE@107..108
+          0: TW_NUMBER@107..108 "2" [] []
         3: (empty)
       4: (empty)
-    7: TW_FULL_CANDIDATE@109..136
+    13: WHITESPACE@108..109 " " [] []
+    14: TW_FULL_CANDIDATE@109..135
       0: TW_VARIANT_LIST@109..125
         0: TW_VARIANT_EXPRESSION@109..124
           0: TW_VARIANT_SEGMENT_LIST@109..124
@@ -387,14 +405,15 @@ TwRoot {
         1: COLON@124..125 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@125..136
+      3: TW_FUNCTIONAL_CANDIDATE@125..135
         0: TW_BASE@125..132 "opacity" [] []
         1: DASH@132..133 "-" [] []
-        2: TW_NUMBER_VALUE@133..136
-          0: TW_NUMBER@133..136 "50" [] [Whitespace(" ")]
+        2: TW_NUMBER_VALUE@133..135
+          0: TW_NUMBER@133..135 "50" [] []
         3: (empty)
       4: (empty)
-    8: TW_FULL_CANDIDATE@136..173
+    15: WHITESPACE@135..136 " " [] []
+    16: TW_FULL_CANDIDATE@136..173
       0: TW_VARIANT_LIST@136..155
         0: TW_ARBITRARY_VARIANT@136..145
           0: L_BRACKET@136..137 "[" [] []
@@ -417,6 +436,7 @@ TwRoot {
           0: TW_VALUE@162..173 "not-allowed" [] []
         3: (empty)
       4: (empty)
-  2: EOF@173..174 "" [Newline("\n")] []
+    17: WHITESPACE@173..174 "\n" [] []
+  3: EOF@174..174 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/stress/stress-2.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/stress/stress-2.txt.snap
@@ -16,6 +16,7 @@ border-foreground text-foreground ring-offset-background focus-visible:ring-ring
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [],
@@ -25,12 +26,13 @@ TwRoot {
                 base_token: TW_BASE@0..6 "border" [] [],
                 minus_token: DASH@6..7 "-" [] [],
                 value: TwNamedValue {
-                    value_token: TW_VALUE@7..18 "foreground" [] [Whitespace(" ")],
+                    value_token: TW_VALUE@7..17 "foreground" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@17..18 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -39,12 +41,13 @@ TwRoot {
                 base_token: TW_BASE@18..22 "text" [] [],
                 minus_token: DASH@22..23 "-" [] [],
                 value: TwNamedValue {
-                    value_token: TW_VALUE@23..34 "foreground" [] [Whitespace(" ")],
+                    value_token: TW_VALUE@23..33 "foreground" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@33..34 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -53,12 +56,13 @@ TwRoot {
                 base_token: TW_BASE@34..45 "ring-offset" [] [],
                 minus_token: DASH@45..46 "-" [] [],
                 value: TwNamedValue {
-                    value_token: TW_VALUE@46..57 "background" [] [Whitespace(" ")],
+                    value_token: TW_VALUE@46..56 "background" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@56..57 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -82,12 +86,13 @@ TwRoot {
                 base_token: TW_BASE@71..75 "ring" [] [],
                 minus_token: DASH@75..76 "-" [] [],
                 value: TwNamedValue {
-                    value_token: TW_VALUE@76..81 "ring" [] [Whitespace(" ")],
+                    value_token: TW_VALUE@76..80 "ring" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@80..81 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -96,12 +101,13 @@ TwRoot {
                 base_token: TW_BASE@81..87 "aspect" [] [],
                 minus_token: DASH@87..88 "-" [] [],
                 value: TwNamedValue {
-                    value_token: TW_VALUE@88..95 "square" [] [Whitespace(" ")],
+                    value_token: TW_VALUE@88..94 "square" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@94..95 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -110,12 +116,13 @@ TwRoot {
                 base_token: TW_BASE@95..99 "size" [] [],
                 minus_token: DASH@99..100 "-" [] [],
                 value: TwNumberValue {
-                    value_token: TW_NUMBER@100..102 "4" [] [Whitespace(" ")],
+                    value_token: TW_NUMBER@100..101 "4" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@101..102 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -124,22 +131,24 @@ TwRoot {
                 base_token: TW_BASE@102..109 "rounded" [] [],
                 minus_token: DASH@109..110 "-" [] [],
                 value: TwNamedValue {
-                    value_token: TW_VALUE@110..115 "full" [] [Whitespace(" ")],
+                    value_token: TW_VALUE@110..114 "full" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@114..115 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@115..122 "border" [] [Whitespace(" ")],
+                base_token: TW_BASE@115..121 "border" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@121..122 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -159,12 +168,13 @@ TwRoot {
                 base_token: TW_BASE@128..135 "outline" [] [],
                 minus_token: DASH@135..136 "-" [] [],
                 value: TwNamedValue {
-                    value_token: TW_VALUE@136..141 "none" [] [Whitespace(" ")],
+                    value_token: TW_VALUE@136..140 "none" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@140..141 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -188,12 +198,13 @@ TwRoot {
                 base_token: TW_BASE@155..159 "ring" [] [],
                 minus_token: DASH@159..160 "-" [] [],
                 value: TwNumberValue {
-                    value_token: TW_NUMBER@160..162 "2" [] [Whitespace(" ")],
+                    value_token: TW_NUMBER@160..161 "2" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@161..162 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -217,12 +228,13 @@ TwRoot {
                 base_token: TW_BASE@176..187 "ring-offset" [] [],
                 minus_token: DASH@187..188 "-" [] [],
                 value: TwNumberValue {
-                    value_token: TW_NUMBER@188..190 "2" [] [Whitespace(" ")],
+                    value_token: TW_NUMBER@188..189 "2" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@189..190 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -242,12 +254,13 @@ TwRoot {
                 base_token: TW_BASE@199..205 "cursor" [] [],
                 minus_token: DASH@205..206 "-" [] [],
                 value: TwNamedValue {
-                    value_token: TW_VALUE@206..218 "not-allowed" [] [Whitespace(" ")],
+                    value_token: TW_VALUE@206..217 "not-allowed" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@217..218 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -273,8 +286,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@237..238 "\n" [] [],
     ],
-    eof_token: EOF@237..238 "" [Newline("\n")] [],
+    eof_token: EOF@238..238 "" [] [],
 }
 ```
 
@@ -283,41 +297,45 @@ TwRoot {
 ```
 0: TW_ROOT@0..238
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..237
-    0: TW_FULL_CANDIDATE@0..18
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..238
+    0: TW_FULL_CANDIDATE@0..17
       0: TW_VARIANT_LIST@0..0
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@0..18
+      3: TW_FUNCTIONAL_CANDIDATE@0..17
         0: TW_BASE@0..6 "border" [] []
         1: DASH@6..7 "-" [] []
-        2: TW_NAMED_VALUE@7..18
-          0: TW_VALUE@7..18 "foreground" [] [Whitespace(" ")]
+        2: TW_NAMED_VALUE@7..17
+          0: TW_VALUE@7..17 "foreground" [] []
         3: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@18..34
+    1: WHITESPACE@17..18 " " [] []
+    2: TW_FULL_CANDIDATE@18..33
       0: TW_VARIANT_LIST@18..18
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@18..34
+      3: TW_FUNCTIONAL_CANDIDATE@18..33
         0: TW_BASE@18..22 "text" [] []
         1: DASH@22..23 "-" [] []
-        2: TW_NAMED_VALUE@23..34
-          0: TW_VALUE@23..34 "foreground" [] [Whitespace(" ")]
+        2: TW_NAMED_VALUE@23..33
+          0: TW_VALUE@23..33 "foreground" [] []
         3: (empty)
       4: (empty)
-    2: TW_FULL_CANDIDATE@34..57
+    3: WHITESPACE@33..34 " " [] []
+    4: TW_FULL_CANDIDATE@34..56
       0: TW_VARIANT_LIST@34..34
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@34..57
+      3: TW_FUNCTIONAL_CANDIDATE@34..56
         0: TW_BASE@34..45 "ring-offset" [] []
         1: DASH@45..46 "-" [] []
-        2: TW_NAMED_VALUE@46..57
-          0: TW_VALUE@46..57 "background" [] [Whitespace(" ")]
+        2: TW_NAMED_VALUE@46..56
+          0: TW_VALUE@46..56 "background" [] []
         3: (empty)
       4: (empty)
-    3: TW_FULL_CANDIDATE@57..81
+    5: WHITESPACE@56..57 " " [] []
+    6: TW_FULL_CANDIDATE@57..80
       0: TW_VARIANT_LIST@57..71
         0: TW_VARIANT_EXPRESSION@57..70
           0: TW_VARIANT_SEGMENT_LIST@57..70
@@ -331,55 +349,60 @@ TwRoot {
         1: COLON@70..71 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@71..81
+      3: TW_FUNCTIONAL_CANDIDATE@71..80
         0: TW_BASE@71..75 "ring" [] []
         1: DASH@75..76 "-" [] []
-        2: TW_NAMED_VALUE@76..81
-          0: TW_VALUE@76..81 "ring" [] [Whitespace(" ")]
+        2: TW_NAMED_VALUE@76..80
+          0: TW_VALUE@76..80 "ring" [] []
         3: (empty)
       4: (empty)
-    4: TW_FULL_CANDIDATE@81..95
+    7: WHITESPACE@80..81 " " [] []
+    8: TW_FULL_CANDIDATE@81..94
       0: TW_VARIANT_LIST@81..81
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@81..95
+      3: TW_FUNCTIONAL_CANDIDATE@81..94
         0: TW_BASE@81..87 "aspect" [] []
         1: DASH@87..88 "-" [] []
-        2: TW_NAMED_VALUE@88..95
-          0: TW_VALUE@88..95 "square" [] [Whitespace(" ")]
+        2: TW_NAMED_VALUE@88..94
+          0: TW_VALUE@88..94 "square" [] []
         3: (empty)
       4: (empty)
-    5: TW_FULL_CANDIDATE@95..102
+    9: WHITESPACE@94..95 " " [] []
+    10: TW_FULL_CANDIDATE@95..101
       0: TW_VARIANT_LIST@95..95
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@95..102
+      3: TW_FUNCTIONAL_CANDIDATE@95..101
         0: TW_BASE@95..99 "size" [] []
         1: DASH@99..100 "-" [] []
-        2: TW_NUMBER_VALUE@100..102
-          0: TW_NUMBER@100..102 "4" [] [Whitespace(" ")]
+        2: TW_NUMBER_VALUE@100..101
+          0: TW_NUMBER@100..101 "4" [] []
         3: (empty)
       4: (empty)
-    6: TW_FULL_CANDIDATE@102..115
+    11: WHITESPACE@101..102 " " [] []
+    12: TW_FULL_CANDIDATE@102..114
       0: TW_VARIANT_LIST@102..102
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@102..115
+      3: TW_FUNCTIONAL_CANDIDATE@102..114
         0: TW_BASE@102..109 "rounded" [] []
         1: DASH@109..110 "-" [] []
-        2: TW_NAMED_VALUE@110..115
-          0: TW_VALUE@110..115 "full" [] [Whitespace(" ")]
+        2: TW_NAMED_VALUE@110..114
+          0: TW_VALUE@110..114 "full" [] []
         3: (empty)
       4: (empty)
-    7: TW_FULL_CANDIDATE@115..122
+    13: WHITESPACE@114..115 " " [] []
+    14: TW_FULL_CANDIDATE@115..121
       0: TW_VARIANT_LIST@115..115
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@115..122
-        0: TW_BASE@115..122 "border" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@115..121
+        0: TW_BASE@115..121 "border" [] []
         1: (empty)
       4: (empty)
-    8: TW_FULL_CANDIDATE@122..141
+    15: WHITESPACE@121..122 " " [] []
+    16: TW_FULL_CANDIDATE@122..140
       0: TW_VARIANT_LIST@122..128
         0: TW_VARIANT_EXPRESSION@122..127
           0: TW_VARIANT_SEGMENT_LIST@122..127
@@ -390,14 +413,15 @@ TwRoot {
         1: COLON@127..128 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@128..141
+      3: TW_FUNCTIONAL_CANDIDATE@128..140
         0: TW_BASE@128..135 "outline" [] []
         1: DASH@135..136 "-" [] []
-        2: TW_NAMED_VALUE@136..141
-          0: TW_VALUE@136..141 "none" [] [Whitespace(" ")]
+        2: TW_NAMED_VALUE@136..140
+          0: TW_VALUE@136..140 "none" [] []
         3: (empty)
       4: (empty)
-    9: TW_FULL_CANDIDATE@141..162
+    17: WHITESPACE@140..141 " " [] []
+    18: TW_FULL_CANDIDATE@141..161
       0: TW_VARIANT_LIST@141..155
         0: TW_VARIANT_EXPRESSION@141..154
           0: TW_VARIANT_SEGMENT_LIST@141..154
@@ -411,14 +435,15 @@ TwRoot {
         1: COLON@154..155 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@155..162
+      3: TW_FUNCTIONAL_CANDIDATE@155..161
         0: TW_BASE@155..159 "ring" [] []
         1: DASH@159..160 "-" [] []
-        2: TW_NUMBER_VALUE@160..162
-          0: TW_NUMBER@160..162 "2" [] [Whitespace(" ")]
+        2: TW_NUMBER_VALUE@160..161
+          0: TW_NUMBER@160..161 "2" [] []
         3: (empty)
       4: (empty)
-    10: TW_FULL_CANDIDATE@162..190
+    19: WHITESPACE@161..162 " " [] []
+    20: TW_FULL_CANDIDATE@162..189
       0: TW_VARIANT_LIST@162..176
         0: TW_VARIANT_EXPRESSION@162..175
           0: TW_VARIANT_SEGMENT_LIST@162..175
@@ -432,14 +457,15 @@ TwRoot {
         1: COLON@175..176 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@176..190
+      3: TW_FUNCTIONAL_CANDIDATE@176..189
         0: TW_BASE@176..187 "ring-offset" [] []
         1: DASH@187..188 "-" [] []
-        2: TW_NUMBER_VALUE@188..190
-          0: TW_NUMBER@188..190 "2" [] [Whitespace(" ")]
+        2: TW_NUMBER_VALUE@188..189
+          0: TW_NUMBER@188..189 "2" [] []
         3: (empty)
       4: (empty)
-    11: TW_FULL_CANDIDATE@190..218
+    21: WHITESPACE@189..190 " " [] []
+    22: TW_FULL_CANDIDATE@190..217
       0: TW_VARIANT_LIST@190..199
         0: TW_VARIANT_EXPRESSION@190..198
           0: TW_VARIANT_SEGMENT_LIST@190..198
@@ -450,14 +476,15 @@ TwRoot {
         1: COLON@198..199 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@199..218
+      3: TW_FUNCTIONAL_CANDIDATE@199..217
         0: TW_BASE@199..205 "cursor" [] []
         1: DASH@205..206 "-" [] []
-        2: TW_NAMED_VALUE@206..218
-          0: TW_VALUE@206..218 "not-allowed" [] [Whitespace(" ")]
+        2: TW_NAMED_VALUE@206..217
+          0: TW_VALUE@206..217 "not-allowed" [] []
         3: (empty)
       4: (empty)
-    12: TW_FULL_CANDIDATE@218..237
+    23: WHITESPACE@217..218 " " [] []
+    24: TW_FULL_CANDIDATE@218..237
       0: TW_VARIANT_LIST@218..227
         0: TW_VARIANT_EXPRESSION@218..226
           0: TW_VARIANT_SEGMENT_LIST@218..226
@@ -475,6 +502,7 @@ TwRoot {
           0: TW_NUMBER@235..237 "50" [] []
         3: (empty)
       4: (empty)
-  2: EOF@237..238 "" [Newline("\n")] []
+    25: WHITESPACE@237..238 "\n" [] []
+  3: EOF@238..238 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/arbitrary-selector-functional-candidate.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/arbitrary-selector-functional-candidate.txt.snap
@@ -16,6 +16,7 @@ hover:[&_p]:underline
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [
@@ -44,8 +45,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@21..22 "\n" [] [],
     ],
-    eof_token: EOF@21..22 "" [Newline("\n")] [],
+    eof_token: EOF@22..22 "" [] [],
 }
 ```
 
@@ -54,7 +56,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..22
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..21
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..22
     0: TW_FULL_CANDIDATE@0..21
       0: TW_VARIANT_LIST@0..12
         0: TW_VARIANT_EXPRESSION@0..5
@@ -75,6 +78,7 @@ TwRoot {
         0: TW_BASE@12..21 "underline" [] []
         1: (empty)
       4: (empty)
-  2: EOF@21..22 "" [Newline("\n")] []
+    1: WHITESPACE@21..22 "\n" [] []
+  3: EOF@22..22 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/arbitrary-variant.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/arbitrary-variant.txt.snap
@@ -16,6 +16,7 @@ expression: snapshot
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [
@@ -38,8 +39,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@18..19 "\n" [] [],
     ],
-    eof_token: EOF@18..19 "" [Newline("\n")] [],
+    eof_token: EOF@19..19 "" [] [],
 }
 ```
 
@@ -48,7 +50,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..19
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..18
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..19
     0: TW_FULL_CANDIDATE@0..18
       0: TW_VARIANT_LIST@0..6
         0: TW_ARBITRARY_VARIANT@0..5
@@ -65,6 +68,7 @@ TwRoot {
           0: TW_VALUE@11..18 "red-500" [] []
         3: (empty)
       4: (empty)
-  2: EOF@18..19 "" [Newline("\n")] []
+    1: WHITESPACE@18..19 "\n" [] []
+  3: EOF@19..19 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/child-descendant.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/child-descendant.txt.snap
@@ -15,6 +15,7 @@ expression: snapshot
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [
@@ -32,11 +33,12 @@ TwRoot {
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@2..7 "flex" [] [Whitespace(" ")],
+                base_token: TW_BASE@2..6 "flex" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@6..7 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -68,8 +70,9 @@ TwRoot {
 ```
 0: TW_ROOT@0..14
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..14
-    0: TW_FULL_CANDIDATE@0..7
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..14
+    0: TW_FULL_CANDIDATE@0..6
       0: TW_VARIANT_LIST@0..2
         0: TW_VARIANT_EXPRESSION@0..1
           0: TW_VARIANT_SEGMENT_LIST@0..1
@@ -80,11 +83,12 @@ TwRoot {
         1: COLON@1..2 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@2..7
-        0: TW_BASE@2..7 "flex" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@2..6
+        0: TW_BASE@2..6 "flex" [] []
         1: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@7..14
+    1: WHITESPACE@6..7 " " [] []
+    2: TW_FULL_CANDIDATE@7..14
       0: TW_VARIANT_LIST@7..10
         0: TW_VARIANT_EXPRESSION@7..9
           0: TW_VARIANT_SEGMENT_LIST@7..9
@@ -99,6 +103,6 @@ TwRoot {
         0: TW_BASE@10..14 "flex" [] []
         1: (empty)
       4: (empty)
-  2: EOF@14..14 "" [] []
+  3: EOF@14..14 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/combinator-selectors.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/combinator-selectors.txt.snap
@@ -15,6 +15,7 @@ has-[>svg]:flex has-[+p]:flex has-[~span]:flex group-has-[>svg]:flex
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [
@@ -38,11 +39,12 @@ TwRoot {
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@11..16 "flex" [] [Whitespace(" ")],
+                base_token: TW_BASE@11..15 "flex" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@15..16 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -65,11 +67,12 @@ TwRoot {
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@25..30 "flex" [] [Whitespace(" ")],
+                base_token: TW_BASE@25..29 "flex" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@29..30 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -92,11 +95,12 @@ TwRoot {
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@42..47 "flex" [] [Whitespace(" ")],
+                base_token: TW_BASE@42..46 "flex" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@46..47 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -138,8 +142,9 @@ TwRoot {
 ```
 0: TW_ROOT@0..68
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..68
-    0: TW_FULL_CANDIDATE@0..16
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..68
+    0: TW_FULL_CANDIDATE@0..15
       0: TW_VARIANT_LIST@0..11
         0: TW_VARIANT_EXPRESSION@0..10
           0: TW_VARIANT_SEGMENT_LIST@0..10
@@ -155,11 +160,12 @@ TwRoot {
         1: COLON@10..11 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@11..16
-        0: TW_BASE@11..16 "flex" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@11..15
+        0: TW_BASE@11..15 "flex" [] []
         1: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@16..30
+    1: WHITESPACE@15..16 " " [] []
+    2: TW_FULL_CANDIDATE@16..29
       0: TW_VARIANT_LIST@16..25
         0: TW_VARIANT_EXPRESSION@16..24
           0: TW_VARIANT_SEGMENT_LIST@16..24
@@ -175,11 +181,12 @@ TwRoot {
         1: COLON@24..25 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@25..30
-        0: TW_BASE@25..30 "flex" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@25..29
+        0: TW_BASE@25..29 "flex" [] []
         1: (empty)
       4: (empty)
-    2: TW_FULL_CANDIDATE@30..47
+    3: WHITESPACE@29..30 " " [] []
+    4: TW_FULL_CANDIDATE@30..46
       0: TW_VARIANT_LIST@30..42
         0: TW_VARIANT_EXPRESSION@30..41
           0: TW_VARIANT_SEGMENT_LIST@30..41
@@ -195,11 +202,12 @@ TwRoot {
         1: COLON@41..42 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@42..47
-        0: TW_BASE@42..47 "flex" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@42..46
+        0: TW_BASE@42..46 "flex" [] []
         1: (empty)
       4: (empty)
-    3: TW_FULL_CANDIDATE@47..68
+    5: WHITESPACE@46..47 " " [] []
+    6: TW_FULL_CANDIDATE@47..68
       0: TW_VARIANT_LIST@47..64
         0: TW_VARIANT_EXPRESSION@47..63
           0: TW_VARIANT_SEGMENT_LIST@47..63
@@ -222,6 +230,6 @@ TwRoot {
         0: TW_BASE@64..68 "flex" [] []
         1: (empty)
       4: (empty)
-  2: EOF@68..68 "" [] []
+  3: EOF@68..68 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/consecutive-arbitrary-variants.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/consecutive-arbitrary-variants.txt.snap
@@ -16,6 +16,7 @@ expression: snapshot
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [
@@ -29,11 +30,12 @@ TwRoot {
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@26..31 "grid" [] [Whitespace(" ")],
+                base_token: TW_BASE@26..30 "grid" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@30..31 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwArbitraryVariant {
@@ -49,12 +51,13 @@ TwRoot {
                 base_token: TW_BASE@53..55 "mt" [] [],
                 minus_token: DASH@55..56 "-" [] [],
                 value: TwNumberValue {
-                    value_token: TW_NUMBER@56..58 "4" [] [Whitespace(" ")],
+                    value_token: TW_NUMBER@56..57 "4" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@57..58 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwArbitraryVariant {
@@ -70,12 +73,13 @@ TwRoot {
                 base_token: TW_BASE@75..77 "bg" [] [],
                 minus_token: DASH@77..78 "-" [] [],
                 value: TwNamedValue {
-                    value_token: TW_VALUE@78..87 "blue-500" [] [Whitespace(" ")],
+                    value_token: TW_VALUE@78..86 "blue-500" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@86..87 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -103,8 +107,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@108..109 "\n" [] [],
     ],
-    eof_token: EOF@108..109 "" [Newline("\n")] [],
+    eof_token: EOF@109..109 "" [] [],
 }
 ```
 
@@ -113,8 +118,9 @@ TwRoot {
 ```
 0: TW_ROOT@0..109
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..108
-    0: TW_FULL_CANDIDATE@0..31
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..109
+    0: TW_FULL_CANDIDATE@0..30
       0: TW_VARIANT_LIST@0..26
         0: TW_ARBITRARY_VARIANT@0..25
           0: L_BRACKET@0..1 "[" [] []
@@ -123,11 +129,12 @@ TwRoot {
         1: COLON@25..26 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@26..31
-        0: TW_BASE@26..31 "grid" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@26..30
+        0: TW_BASE@26..30 "grid" [] []
         1: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@31..58
+    1: WHITESPACE@30..31 " " [] []
+    2: TW_FULL_CANDIDATE@31..57
       0: TW_VARIANT_LIST@31..53
         0: TW_ARBITRARY_VARIANT@31..52
           0: L_BRACKET@31..32 "[" [] []
@@ -136,14 +143,15 @@ TwRoot {
         1: COLON@52..53 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@53..58
+      3: TW_FUNCTIONAL_CANDIDATE@53..57
         0: TW_BASE@53..55 "mt" [] []
         1: DASH@55..56 "-" [] []
-        2: TW_NUMBER_VALUE@56..58
-          0: TW_NUMBER@56..58 "4" [] [Whitespace(" ")]
+        2: TW_NUMBER_VALUE@56..57
+          0: TW_NUMBER@56..57 "4" [] []
         3: (empty)
       4: (empty)
-    2: TW_FULL_CANDIDATE@58..87
+    3: WHITESPACE@57..58 " " [] []
+    4: TW_FULL_CANDIDATE@58..86
       0: TW_VARIANT_LIST@58..75
         0: TW_ARBITRARY_VARIANT@58..74
           0: L_BRACKET@58..59 "[" [] []
@@ -152,14 +160,15 @@ TwRoot {
         1: COLON@74..75 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@75..87
+      3: TW_FUNCTIONAL_CANDIDATE@75..86
         0: TW_BASE@75..77 "bg" [] []
         1: DASH@77..78 "-" [] []
-        2: TW_NAMED_VALUE@78..87
-          0: TW_VALUE@78..87 "blue-500" [] [Whitespace(" ")]
+        2: TW_NAMED_VALUE@78..86
+          0: TW_VALUE@78..86 "blue-500" [] []
         3: (empty)
       4: (empty)
-    3: TW_FULL_CANDIDATE@87..108
+    5: WHITESPACE@86..87 " " [] []
+    6: TW_FULL_CANDIDATE@87..108
       0: TW_VARIANT_LIST@87..99
         0: TW_VARIANT_EXPRESSION@87..92
           0: TW_VARIANT_SEGMENT_LIST@87..92
@@ -179,6 +188,7 @@ TwRoot {
         0: TW_BASE@99..108 "underline" [] []
         1: (empty)
       4: (empty)
-  2: EOF@108..109 "" [Newline("\n")] []
+    7: WHITESPACE@108..109 "\n" [] []
+  3: EOF@109..109 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/container-query.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/container-query.txt.snap
@@ -15,6 +15,7 @@ expression: snapshot
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [
@@ -32,11 +33,12 @@ TwRoot {
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@4..9 "flex" [] [Whitespace(" ")],
+                base_token: TW_BASE@4..8 "flex" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@8..9 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -53,11 +55,12 @@ TwRoot {
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@13..18 "flex" [] [Whitespace(" ")],
+                base_token: TW_BASE@13..17 "flex" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@17..18 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -74,11 +77,12 @@ TwRoot {
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@22..27 "flex" [] [Whitespace(" ")],
+                base_token: TW_BASE@22..26 "flex" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@26..27 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -99,11 +103,12 @@ TwRoot {
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@35..40 "flex" [] [Whitespace(" ")],
+                base_token: TW_BASE@35..39 "flex" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@39..40 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -126,11 +131,12 @@ TwRoot {
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@53..58 "flex" [] [Whitespace(" ")],
+                base_token: TW_BASE@53..57 "flex" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@57..58 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -162,8 +168,9 @@ TwRoot {
 ```
 0: TW_ROOT@0..73
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..73
-    0: TW_FULL_CANDIDATE@0..9
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..73
+    0: TW_FULL_CANDIDATE@0..8
       0: TW_VARIANT_LIST@0..4
         0: TW_VARIANT_EXPRESSION@0..3
           0: TW_VARIANT_SEGMENT_LIST@0..3
@@ -174,11 +181,12 @@ TwRoot {
         1: COLON@3..4 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@4..9
-        0: TW_BASE@4..9 "flex" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@4..8
+        0: TW_BASE@4..8 "flex" [] []
         1: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@9..18
+    1: WHITESPACE@8..9 " " [] []
+    2: TW_FULL_CANDIDATE@9..17
       0: TW_VARIANT_LIST@9..13
         0: TW_VARIANT_EXPRESSION@9..12
           0: TW_VARIANT_SEGMENT_LIST@9..12
@@ -189,11 +197,12 @@ TwRoot {
         1: COLON@12..13 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@13..18
-        0: TW_BASE@13..18 "flex" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@13..17
+        0: TW_BASE@13..17 "flex" [] []
         1: (empty)
       4: (empty)
-    2: TW_FULL_CANDIDATE@18..27
+    3: WHITESPACE@17..18 " " [] []
+    4: TW_FULL_CANDIDATE@18..26
       0: TW_VARIANT_LIST@18..22
         0: TW_VARIANT_EXPRESSION@18..21
           0: TW_VARIANT_SEGMENT_LIST@18..21
@@ -204,11 +213,12 @@ TwRoot {
         1: COLON@21..22 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@22..27
-        0: TW_BASE@22..27 "flex" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@22..26
+        0: TW_BASE@22..26 "flex" [] []
         1: (empty)
       4: (empty)
-    3: TW_FULL_CANDIDATE@27..40
+    5: WHITESPACE@26..27 " " [] []
+    6: TW_FULL_CANDIDATE@27..39
       0: TW_VARIANT_LIST@27..35
         0: TW_VARIANT_EXPRESSION@27..34
           0: TW_VARIANT_SEGMENT_LIST@27..34
@@ -222,11 +232,12 @@ TwRoot {
         1: COLON@34..35 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@35..40
-        0: TW_BASE@35..40 "flex" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@35..39
+        0: TW_BASE@35..39 "flex" [] []
         1: (empty)
       4: (empty)
-    4: TW_FULL_CANDIDATE@40..58
+    7: WHITESPACE@39..40 " " [] []
+    8: TW_FULL_CANDIDATE@40..57
       0: TW_VARIANT_LIST@40..53
         0: TW_VARIANT_EXPRESSION@40..52
           0: TW_VARIANT_SEGMENT_LIST@40..52
@@ -242,11 +253,12 @@ TwRoot {
         1: COLON@52..53 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@53..58
-        0: TW_BASE@53..58 "flex" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@53..57
+        0: TW_BASE@53..57 "flex" [] []
         1: (empty)
       4: (empty)
-    5: TW_FULL_CANDIDATE@58..73
+    9: WHITESPACE@57..58 " " [] []
+    10: TW_FULL_CANDIDATE@58..73
       0: TW_VARIANT_LIST@58..69
         0: TW_VARIANT_EXPRESSION@58..68
           0: TW_VARIANT_SEGMENT_LIST@58..68
@@ -261,6 +273,6 @@ TwRoot {
         0: TW_BASE@69..73 "flex" [] []
         1: (empty)
       4: (empty)
-  2: EOF@73..73 "" [] []
+  3: EOF@73..73 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/functional-arbirary-param.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/functional-arbirary-param.txt.snap
@@ -16,6 +16,7 @@ aria-[disabled]:text-red-500
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [
@@ -48,8 +49,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@28..29 "\n" [] [],
     ],
-    eof_token: EOF@28..29 "" [Newline("\n")] [],
+    eof_token: EOF@29..29 "" [] [],
 }
 ```
 
@@ -58,7 +60,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..29
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..28
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..29
     0: TW_FULL_CANDIDATE@0..28
       0: TW_VARIANT_LIST@0..16
         0: TW_VARIANT_EXPRESSION@0..15
@@ -82,6 +85,7 @@ TwRoot {
           0: TW_VALUE@21..28 "red-500" [] []
         3: (empty)
       4: (empty)
-  2: EOF@28..29 "" [Newline("\n")] []
+    1: WHITESPACE@28..29 "\n" [] []
+  3: EOF@29..29 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/functional-named-param.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/functional-named-param.txt.snap
@@ -16,6 +16,7 @@ aria-disabled:text-red-500
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [
@@ -46,8 +47,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@26..27 "\n" [] [],
     ],
-    eof_token: EOF@26..27 "" [Newline("\n")] [],
+    eof_token: EOF@27..27 "" [] [],
 }
 ```
 
@@ -56,7 +58,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..27
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..26
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..27
     0: TW_FULL_CANDIDATE@0..26
       0: TW_VARIANT_LIST@0..14
         0: TW_VARIANT_EXPRESSION@0..13
@@ -78,6 +81,7 @@ TwRoot {
           0: TW_VALUE@19..26 "red-500" [] []
         3: (empty)
       4: (empty)
-  2: EOF@26..27 "" [Newline("\n")] []
+    1: WHITESPACE@26..27 "\n" [] []
+  3: EOF@27..27 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/hover.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/hover.txt.snap
@@ -16,6 +16,7 @@ hover:text-red-500
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [
@@ -42,8 +43,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@18..19 "\n" [] [],
     ],
-    eof_token: EOF@18..19 "" [Newline("\n")] [],
+    eof_token: EOF@19..19 "" [] [],
 }
 ```
 
@@ -52,7 +54,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..19
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..18
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..19
     0: TW_FULL_CANDIDATE@0..18
       0: TW_VARIANT_LIST@0..6
         0: TW_VARIANT_EXPRESSION@0..5
@@ -71,6 +74,7 @@ TwRoot {
           0: TW_VALUE@11..18 "red-500" [] []
         3: (empty)
       4: (empty)
-  2: EOF@18..19 "" [Newline("\n")] []
+    1: WHITESPACE@18..19 "\n" [] []
+  3: EOF@19..19 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/hover_focus.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/hover_focus.txt.snap
@@ -16,6 +16,7 @@ hover:focus:text-red-500
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [
@@ -52,8 +53,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@24..25 "\n" [] [],
     ],
-    eof_token: EOF@24..25 "" [Newline("\n")] [],
+    eof_token: EOF@25..25 "" [] [],
 }
 ```
 
@@ -62,7 +64,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..25
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..24
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..25
     0: TW_FULL_CANDIDATE@0..24
       0: TW_VARIANT_LIST@0..12
         0: TW_VARIANT_EXPRESSION@0..5
@@ -88,6 +91,7 @@ TwRoot {
           0: TW_VALUE@17..24 "red-500" [] []
         3: (empty)
       4: (empty)
-  2: EOF@24..25 "" [Newline("\n")] []
+    1: WHITESPACE@24..25 "\n" [] []
+  3: EOF@25..25 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/starts-with-number.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/starts-with-number.txt.snap
@@ -16,6 +16,7 @@ expression: snapshot
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [
@@ -38,8 +39,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@9..10 "\n" [] [],
     ],
-    eof_token: EOF@9..10 "" [Newline("\n")] [],
+    eof_token: EOF@10..10 "" [] [],
 }
 ```
 
@@ -48,7 +50,8 @@ TwRoot {
 ```
 0: TW_ROOT@0..10
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..9
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..10
     0: TW_FULL_CANDIDATE@0..9
       0: TW_VARIANT_LIST@0..4
         0: TW_VARIANT_EXPRESSION@0..3
@@ -64,6 +67,7 @@ TwRoot {
         0: TW_BASE@4..9 "table" [] []
         1: (empty)
       4: (empty)
-  2: EOF@9..10 "" [Newline("\n")] []
+    1: WHITESPACE@9..10 "\n" [] []
+  3: EOF@10..10 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/variant-expression-data.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/variant-expression-data.txt.snap
@@ -16,6 +16,7 @@ data-active:flex data-[state=open]:block group-data-[state=open]:block group-has
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [
@@ -37,11 +38,12 @@ TwRoot {
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@12..17 "flex" [] [Whitespace(" ")],
+                base_token: TW_BASE@12..16 "flex" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@16..17 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -64,11 +66,12 @@ TwRoot {
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@35..41 "block" [] [Whitespace(" ")],
+                base_token: TW_BASE@35..40 "block" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@40..41 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -95,11 +98,12 @@ TwRoot {
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@65..71 "block" [] [Whitespace(" ")],
+                base_token: TW_BASE@65..70 "block" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@70..71 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -126,11 +130,12 @@ TwRoot {
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@85..91 "block" [] [Whitespace(" ")],
+                base_token: TW_BASE@85..90 "block" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@90..91 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -156,12 +161,13 @@ TwRoot {
                 base_token: TW_BASE@106..110 "text" [] [],
                 minus_token: DASH@110..111 "-" [] [],
                 value: TwNamedValue {
-                    value_token: TW_VALUE@111..119 "red-500" [] [Whitespace(" ")],
+                    value_token: TW_VALUE@111..118 "red-500" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@118..119 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -182,11 +188,12 @@ TwRoot {
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@126..131 "flex" [] [Whitespace(" ")],
+                base_token: TW_BASE@126..130 "flex" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@130..131 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -212,8 +219,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@142..143 "\n" [] [],
     ],
-    eof_token: EOF@142..143 "" [Newline("\n")] [],
+    eof_token: EOF@143..143 "" [] [],
 }
 ```
 
@@ -222,8 +230,9 @@ TwRoot {
 ```
 0: TW_ROOT@0..143
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..142
-    0: TW_FULL_CANDIDATE@0..17
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..143
+    0: TW_FULL_CANDIDATE@0..16
       0: TW_VARIANT_LIST@0..12
         0: TW_VARIANT_EXPRESSION@0..11
           0: TW_VARIANT_SEGMENT_LIST@0..11
@@ -237,11 +246,12 @@ TwRoot {
         1: COLON@11..12 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@12..17
-        0: TW_BASE@12..17 "flex" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@12..16
+        0: TW_BASE@12..16 "flex" [] []
         1: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@17..41
+    1: WHITESPACE@16..17 " " [] []
+    2: TW_FULL_CANDIDATE@17..40
       0: TW_VARIANT_LIST@17..35
         0: TW_VARIANT_EXPRESSION@17..34
           0: TW_VARIANT_SEGMENT_LIST@17..34
@@ -257,11 +267,12 @@ TwRoot {
         1: COLON@34..35 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@35..41
-        0: TW_BASE@35..41 "block" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@35..40
+        0: TW_BASE@35..40 "block" [] []
         1: (empty)
       4: (empty)
-    2: TW_FULL_CANDIDATE@41..71
+    3: WHITESPACE@40..41 " " [] []
+    4: TW_FULL_CANDIDATE@41..70
       0: TW_VARIANT_LIST@41..65
         0: TW_VARIANT_EXPRESSION@41..64
           0: TW_VARIANT_SEGMENT_LIST@41..64
@@ -280,11 +291,12 @@ TwRoot {
         1: COLON@64..65 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@65..71
-        0: TW_BASE@65..71 "block" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@65..70
+        0: TW_BASE@65..70 "block" [] []
         1: (empty)
       4: (empty)
-    3: TW_FULL_CANDIDATE@71..91
+    5: WHITESPACE@70..71 " " [] []
+    6: TW_FULL_CANDIDATE@71..90
       0: TW_VARIANT_LIST@71..85
         0: TW_VARIANT_EXPRESSION@71..84
           0: TW_VARIANT_SEGMENT_LIST@71..84
@@ -303,11 +315,12 @@ TwRoot {
         1: COLON@84..85 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@85..91
-        0: TW_BASE@85..91 "block" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@85..90
+        0: TW_BASE@85..90 "block" [] []
         1: (empty)
       4: (empty)
-    4: TW_FULL_CANDIDATE@91..119
+    7: WHITESPACE@90..91 " " [] []
+    8: TW_FULL_CANDIDATE@91..118
       0: TW_VARIANT_LIST@91..106
         0: TW_VARIANT_EXPRESSION@91..105
           0: TW_VARIANT_SEGMENT_LIST@91..105
@@ -323,14 +336,15 @@ TwRoot {
         1: COLON@105..106 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@106..119
+      3: TW_FUNCTIONAL_CANDIDATE@106..118
         0: TW_BASE@106..110 "text" [] []
         1: DASH@110..111 "-" [] []
-        2: TW_NAMED_VALUE@111..119
-          0: TW_VALUE@111..119 "red-500" [] [Whitespace(" ")]
+        2: TW_NAMED_VALUE@111..118
+          0: TW_VALUE@111..118 "red-500" [] []
         3: (empty)
       4: (empty)
-    5: TW_FULL_CANDIDATE@119..131
+    9: WHITESPACE@118..119 " " [] []
+    10: TW_FULL_CANDIDATE@119..130
       0: TW_VARIANT_LIST@119..126
         0: TW_VARIANT_EXPRESSION@119..125
           0: TW_VARIANT_SEGMENT_LIST@119..125
@@ -344,11 +358,12 @@ TwRoot {
         1: COLON@125..126 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@126..131
-        0: TW_BASE@126..131 "flex" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@126..130
+        0: TW_BASE@126..130 "flex" [] []
         1: (empty)
       4: (empty)
-    6: TW_FULL_CANDIDATE@131..142
+    11: WHITESPACE@130..131 " " [] []
+    12: TW_FULL_CANDIDATE@131..142
       0: TW_VARIANT_LIST@131..138
         0: TW_VARIANT_EXPRESSION@131..137
           0: TW_VARIANT_SEGMENT_LIST@131..137
@@ -366,6 +381,7 @@ TwRoot {
         0: TW_BASE@138..142 "grid" [] []
         1: (empty)
       4: (empty)
-  2: EOF@142..143 "" [Newline("\n")] []
+    13: WHITESPACE@142..143 "\n" [] []
+  3: EOF@143..143 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/variant-expression.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/variant-expression.txt.snap
@@ -16,6 +16,7 @@ hover:flex group-hover:flex group-peer-hover:flex group-hover:peer-focus:flex fo
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [
@@ -33,11 +34,12 @@ TwRoot {
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@6..11 "flex" [] [Whitespace(" ")],
+                base_token: TW_BASE@6..10 "flex" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@10..11 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -58,11 +60,12 @@ TwRoot {
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@23..28 "flex" [] [Whitespace(" ")],
+                base_token: TW_BASE@23..27 "flex" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@27..28 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -87,11 +90,12 @@ TwRoot {
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@45..50 "flex" [] [Whitespace(" ")],
+                base_token: TW_BASE@45..49 "flex" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@49..50 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -126,11 +130,12 @@ TwRoot {
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@73..78 "flex" [] [Whitespace(" ")],
+                base_token: TW_BASE@73..77 "flex" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@77..78 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -154,12 +159,13 @@ TwRoot {
                 base_token: TW_BASE@92..96 "ring" [] [],
                 minus_token: DASH@96..97 "-" [] [],
                 value: TwNamedValue {
-                    value_token: TW_VALUE@97..102 "ring" [] [Whitespace(" ")],
+                    value_token: TW_VALUE@97..101 "ring" [] [],
                 },
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@101..102 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -180,11 +186,12 @@ TwRoot {
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@112..117 "flex" [] [Whitespace(" ")],
+                base_token: TW_BASE@112..116 "flex" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@116..117 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -216,8 +223,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@143..144 "\n" [] [],
     ],
-    eof_token: EOF@143..144 "" [Newline("\n")] [],
+    eof_token: EOF@144..144 "" [] [],
 }
 ```
 
@@ -226,8 +234,9 @@ TwRoot {
 ```
 0: TW_ROOT@0..144
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..143
-    0: TW_FULL_CANDIDATE@0..11
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..144
+    0: TW_FULL_CANDIDATE@0..10
       0: TW_VARIANT_LIST@0..6
         0: TW_VARIANT_EXPRESSION@0..5
           0: TW_VARIANT_SEGMENT_LIST@0..5
@@ -238,11 +247,12 @@ TwRoot {
         1: COLON@5..6 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@6..11
-        0: TW_BASE@6..11 "flex" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@6..10
+        0: TW_BASE@6..10 "flex" [] []
         1: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@11..28
+    1: WHITESPACE@10..11 " " [] []
+    2: TW_FULL_CANDIDATE@11..27
       0: TW_VARIANT_LIST@11..23
         0: TW_VARIANT_EXPRESSION@11..22
           0: TW_VARIANT_SEGMENT_LIST@11..22
@@ -256,11 +266,12 @@ TwRoot {
         1: COLON@22..23 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@23..28
-        0: TW_BASE@23..28 "flex" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@23..27
+        0: TW_BASE@23..27 "flex" [] []
         1: (empty)
       4: (empty)
-    2: TW_FULL_CANDIDATE@28..50
+    3: WHITESPACE@27..28 " " [] []
+    4: TW_FULL_CANDIDATE@28..49
       0: TW_VARIANT_LIST@28..45
         0: TW_VARIANT_EXPRESSION@28..44
           0: TW_VARIANT_SEGMENT_LIST@28..44
@@ -277,11 +288,12 @@ TwRoot {
         1: COLON@44..45 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@45..50
-        0: TW_BASE@45..50 "flex" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@45..49
+        0: TW_BASE@45..49 "flex" [] []
         1: (empty)
       4: (empty)
-    3: TW_FULL_CANDIDATE@50..78
+    5: WHITESPACE@49..50 " " [] []
+    6: TW_FULL_CANDIDATE@50..77
       0: TW_VARIANT_LIST@50..73
         0: TW_VARIANT_EXPRESSION@50..61
           0: TW_VARIANT_SEGMENT_LIST@50..61
@@ -305,11 +317,12 @@ TwRoot {
         3: COLON@72..73 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@73..78
-        0: TW_BASE@73..78 "flex" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@73..77
+        0: TW_BASE@73..77 "flex" [] []
         1: (empty)
       4: (empty)
-    4: TW_FULL_CANDIDATE@78..102
+    7: WHITESPACE@77..78 " " [] []
+    8: TW_FULL_CANDIDATE@78..101
       0: TW_VARIANT_LIST@78..92
         0: TW_VARIANT_EXPRESSION@78..91
           0: TW_VARIANT_SEGMENT_LIST@78..91
@@ -323,14 +336,15 @@ TwRoot {
         1: COLON@91..92 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@92..102
+      3: TW_FUNCTIONAL_CANDIDATE@92..101
         0: TW_BASE@92..96 "ring" [] []
         1: DASH@96..97 "-" [] []
-        2: TW_NAMED_VALUE@97..102
-          0: TW_VALUE@97..102 "ring" [] [Whitespace(" ")]
+        2: TW_NAMED_VALUE@97..101
+          0: TW_VALUE@97..101 "ring" [] []
         3: (empty)
       4: (empty)
-    5: TW_FULL_CANDIDATE@102..117
+    9: WHITESPACE@101..102 " " [] []
+    10: TW_FULL_CANDIDATE@102..116
       0: TW_VARIANT_LIST@102..112
         0: TW_VARIANT_EXPRESSION@102..111
           0: TW_VARIANT_SEGMENT_LIST@102..111
@@ -344,11 +358,12 @@ TwRoot {
         1: COLON@111..112 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@112..117
-        0: TW_BASE@112..117 "flex" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@112..116
+        0: TW_BASE@112..116 "flex" [] []
         1: (empty)
       4: (empty)
-    6: TW_FULL_CANDIDATE@117..143
+    11: WHITESPACE@116..117 " " [] []
+    12: TW_FULL_CANDIDATE@117..143
       0: TW_VARIANT_LIST@117..133
         0: TW_VARIANT_EXPRESSION@117..132
           0: TW_VARIANT_SEGMENT_LIST@117..132
@@ -371,6 +386,7 @@ TwRoot {
           0: TW_NUMBER@141..143 "50" [] []
         3: (empty)
       4: (empty)
-  2: EOF@143..144 "" [Newline("\n")] []
+    13: WHITESPACE@143..144 "\n" [] []
+  3: EOF@144..144 "" [] []
 
 ```

--- a/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/variant-modifier.txt.snap
+++ b/crates/biome_tailwind_parser/tests/tailwind_specs/ok/variants/variant-modifier.txt.snap
@@ -16,6 +16,7 @@ group-hover/menu:flex peer-checked/foo:flex @sm/main:flex @[400px]:flex @[400px]
 ```
 TwRoot {
     bom_token: missing (optional),
+    leading_whitespace_token: missing (optional),
     candidates: TwCandidateList [
         TwFullCandidate {
             variants: TwVariantList [
@@ -42,11 +43,12 @@ TwRoot {
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@17..22 "flex" [] [Whitespace(" ")],
+                base_token: TW_BASE@17..21 "flex" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@21..22 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -72,11 +74,12 @@ TwRoot {
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@39..44 "flex" [] [Whitespace(" ")],
+                base_token: TW_BASE@39..43 "flex" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@43..44 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -98,11 +101,12 @@ TwRoot {
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@53..58 "flex" [] [Whitespace(" ")],
+                base_token: TW_BASE@53..57 "flex" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@57..58 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -123,11 +127,12 @@ TwRoot {
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@67..72 "flex" [] [Whitespace(" ")],
+                base_token: TW_BASE@67..71 "flex" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@71..72 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -153,11 +158,12 @@ TwRoot {
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@86..91 "flex" [] [Whitespace(" ")],
+                base_token: TW_BASE@86..90 "flex" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@90..91 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [
                 TwVariantExpression {
@@ -189,11 +195,12 @@ TwRoot {
             legacy_important_token: missing (optional),
             negative_token: missing (optional),
             candidate: TwStaticCandidate {
-                base_token: TW_BASE@108..113 "flex" [] [Whitespace(" ")],
+                base_token: TW_BASE@108..112 "flex" [] [],
                 modifier: missing (optional),
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@112..113 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -207,12 +214,13 @@ TwRoot {
                 modifier: TwModifier {
                     slash_token: SLASH@123..124 "/" [] [],
                     value: TwNumberValue {
-                        value_token: TW_NUMBER@124..127 "50" [] [Whitespace(" ")],
+                        value_token: TW_NUMBER@124..126 "50" [] [],
                     },
                 },
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@126..127 " " [] [],
         TwFullCandidate {
             variants: TwVariantList [],
             legacy_important_token: missing (optional),
@@ -232,8 +240,9 @@ TwRoot {
             },
             excl_token: missing (optional),
         },
+        WHITESPACE@132..133 "\n" [] [],
     ],
-    eof_token: EOF@132..133 "" [Newline("\n")] [],
+    eof_token: EOF@133..133 "" [] [],
 }
 ```
 
@@ -242,8 +251,9 @@ TwRoot {
 ```
 0: TW_ROOT@0..133
   0: (empty)
-  1: TW_CANDIDATE_LIST@0..132
-    0: TW_FULL_CANDIDATE@0..22
+  1: (empty)
+  2: TW_CANDIDATE_LIST@0..133
+    0: TW_FULL_CANDIDATE@0..21
       0: TW_VARIANT_LIST@0..17
         0: TW_VARIANT_EXPRESSION@0..16
           0: TW_VARIANT_SEGMENT_LIST@0..11
@@ -260,11 +270,12 @@ TwRoot {
         1: COLON@16..17 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@17..22
-        0: TW_BASE@17..22 "flex" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@17..21
+        0: TW_BASE@17..21 "flex" [] []
         1: (empty)
       4: (empty)
-    1: TW_FULL_CANDIDATE@22..44
+    1: WHITESPACE@21..22 " " [] []
+    2: TW_FULL_CANDIDATE@22..43
       0: TW_VARIANT_LIST@22..39
         0: TW_VARIANT_EXPRESSION@22..38
           0: TW_VARIANT_SEGMENT_LIST@22..34
@@ -281,11 +292,12 @@ TwRoot {
         1: COLON@38..39 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@39..44
-        0: TW_BASE@39..44 "flex" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@39..43
+        0: TW_BASE@39..43 "flex" [] []
         1: (empty)
       4: (empty)
-    2: TW_FULL_CANDIDATE@44..58
+    3: WHITESPACE@43..44 " " [] []
+    4: TW_FULL_CANDIDATE@44..57
       0: TW_VARIANT_LIST@44..53
         0: TW_VARIANT_EXPRESSION@44..52
           0: TW_VARIANT_SEGMENT_LIST@44..47
@@ -299,11 +311,12 @@ TwRoot {
         1: COLON@52..53 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@53..58
-        0: TW_BASE@53..58 "flex" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@53..57
+        0: TW_BASE@53..57 "flex" [] []
         1: (empty)
       4: (empty)
-    3: TW_FULL_CANDIDATE@58..72
+    5: WHITESPACE@57..58 " " [] []
+    6: TW_FULL_CANDIDATE@58..71
       0: TW_VARIANT_LIST@58..67
         0: TW_VARIANT_EXPRESSION@58..66
           0: TW_VARIANT_SEGMENT_LIST@58..59
@@ -317,11 +330,12 @@ TwRoot {
         1: COLON@66..67 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@67..72
-        0: TW_BASE@67..72 "flex" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@67..71
+        0: TW_BASE@67..71 "flex" [] []
         1: (empty)
       4: (empty)
-    4: TW_FULL_CANDIDATE@72..91
+    7: WHITESPACE@71..72 " " [] []
+    8: TW_FULL_CANDIDATE@72..90
       0: TW_VARIANT_LIST@72..86
         0: TW_VARIANT_EXPRESSION@72..85
           0: TW_VARIANT_SEGMENT_LIST@72..73
@@ -338,11 +352,12 @@ TwRoot {
         1: COLON@85..86 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@86..91
-        0: TW_BASE@86..91 "flex" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@86..90
+        0: TW_BASE@86..90 "flex" [] []
         1: (empty)
       4: (empty)
-    5: TW_FULL_CANDIDATE@91..113
+    9: WHITESPACE@90..91 " " [] []
+    10: TW_FULL_CANDIDATE@91..112
       0: TW_VARIANT_LIST@91..108
         0: TW_VARIANT_EXPRESSION@91..107
           0: TW_VARIANT_SEGMENT_LIST@91..102
@@ -363,25 +378,27 @@ TwRoot {
         1: COLON@107..108 ":" [] []
       1: (empty)
       2: (empty)
-      3: TW_STATIC_CANDIDATE@108..113
-        0: TW_BASE@108..113 "flex" [] [Whitespace(" ")]
+      3: TW_STATIC_CANDIDATE@108..112
+        0: TW_BASE@108..112 "flex" [] []
         1: (empty)
       4: (empty)
-    6: TW_FULL_CANDIDATE@113..127
+    11: WHITESPACE@112..113 " " [] []
+    12: TW_FULL_CANDIDATE@113..126
       0: TW_VARIANT_LIST@113..113
       1: (empty)
       2: (empty)
-      3: TW_FUNCTIONAL_CANDIDATE@113..127
+      3: TW_FUNCTIONAL_CANDIDATE@113..126
         0: TW_BASE@113..115 "bg" [] []
         1: DASH@115..116 "-" [] []
         2: TW_NAMED_VALUE@116..123
           0: TW_VALUE@116..123 "red-500" [] []
-        3: TW_MODIFIER@123..127
+        3: TW_MODIFIER@123..126
           0: SLASH@123..124 "/" [] []
-          1: TW_NUMBER_VALUE@124..127
-            0: TW_NUMBER@124..127 "50" [] [Whitespace(" ")]
+          1: TW_NUMBER_VALUE@124..126
+            0: TW_NUMBER@124..126 "50" [] []
       4: (empty)
-    7: TW_FULL_CANDIDATE@127..132
+    13: WHITESPACE@126..127 " " [] []
+    14: TW_FULL_CANDIDATE@127..132
       0: TW_VARIANT_LIST@127..127
       1: (empty)
       2: (empty)
@@ -395,6 +412,7 @@ TwRoot {
           1: TW_NUMBER_VALUE@131..132
             0: TW_NUMBER@131..132 "2" [] []
       4: (empty)
-  2: EOF@132..133 "" [Newline("\n")] []
+    15: WHITESPACE@132..133 "\n" [] []
+  3: EOF@133..133 "" [] []
 
 ```

--- a/crates/biome_tailwind_syntax/src/generated/kind.rs
+++ b/crates/biome_tailwind_syntax/src/generated/kind.rs
@@ -109,7 +109,7 @@ pub enum TailwindSyntaxKind {
     CSS_URL_VALUE_RAW_LITERAL,
     ERROR_TOKEN,
     IDENT,
-    NEWLINE,
+    CSS_WHITESPACE,
     TW_ROOT,
     TW_CANDIDATE_LIST,
     TW_FULL_CANDIDATE,

--- a/crates/biome_tailwind_syntax/src/generated/nodes.rs
+++ b/crates/biome_tailwind_syntax/src/generated/nodes.rs
@@ -1287,6 +1287,7 @@ impl TwRoot {
     pub fn as_fields(&self) -> TwRootFields {
         TwRootFields {
             bom_token: self.bom_token(),
+            leading_whitespace_token: self.leading_whitespace_token(),
             candidates: self.candidates(),
             eof_token: self.eof_token(),
         }
@@ -1294,11 +1295,14 @@ impl TwRoot {
     pub fn bom_token(&self) -> Option<SyntaxToken> {
         support::token(&self.syntax, 0usize)
     }
+    pub fn leading_whitespace_token(&self) -> Option<SyntaxToken> {
+        support::token(&self.syntax, 1usize)
+    }
     pub fn candidates(&self) -> TwCandidateList {
-        support::list(&self.syntax, 1usize)
+        support::list(&self.syntax, 2usize)
     }
     pub fn eof_token(&self) -> SyntaxResult<SyntaxToken> {
-        support::required_token(&self.syntax, 2usize)
+        support::required_token(&self.syntax, 3usize)
     }
 }
 impl Serialize for TwRoot {
@@ -1312,6 +1316,7 @@ impl Serialize for TwRoot {
 #[derive(Serialize)]
 pub struct TwRootFields {
     pub bom_token: Option<SyntaxToken>,
+    pub leading_whitespace_token: Option<SyntaxToken>,
     pub candidates: TwCandidateList,
     pub eof_token: SyntaxResult<SyntaxToken>,
 }
@@ -3410,6 +3415,10 @@ impl std::fmt::Debug for TwRoot {
                     "bom_token",
                     &support::DebugOptionalElement(self.bom_token()),
                 )
+                .field(
+                    "leading_whitespace_token",
+                    &support::DebugOptionalElement(self.leading_whitespace_token()),
+                )
                 .field("candidates", &self.candidates())
                 .field("eof_token", &support::DebugSyntaxResult(self.eof_token()))
                 .finish()
@@ -5483,7 +5492,7 @@ impl Serialize for TwCandidateList {
         seq.end()
     }
 }
-impl AstNodeList for TwCandidateList {
+impl AstSeparatedList for TwCandidateList {
     type Language = Language;
     type Node = AnyTwFullCandidate;
     fn syntax_list(&self) -> &SyntaxList {
@@ -5496,19 +5505,19 @@ impl AstNodeList for TwCandidateList {
 impl Debug for TwCandidateList {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.write_str("TwCandidateList ")?;
-        f.debug_list().entries(self.iter()).finish()
+        f.debug_list().entries(self.elements()).finish()
     }
 }
-impl IntoIterator for &TwCandidateList {
-    type Item = AnyTwFullCandidate;
-    type IntoIter = AstNodeListIterator<Language, AnyTwFullCandidate>;
+impl IntoIterator for TwCandidateList {
+    type Item = SyntaxResult<AnyTwFullCandidate>;
+    type IntoIter = AstSeparatedListNodesIterator<Language, AnyTwFullCandidate>;
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
 }
-impl IntoIterator for TwCandidateList {
-    type Item = AnyTwFullCandidate;
-    type IntoIter = AstNodeListIterator<Language, AnyTwFullCandidate>;
+impl IntoIterator for &TwCandidateList {
+    type Item = SyntaxResult<AnyTwFullCandidate>;
+    type IntoIter = AstSeparatedListNodesIterator<Language, AnyTwFullCandidate>;
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }

--- a/crates/biome_tailwind_syntax/src/generated/nodes_mut.rs
+++ b/crates/biome_tailwind_syntax/src/generated/nodes_mut.rs
@@ -490,16 +490,22 @@ impl TwRoot {
                 .splice_slots(0usize..=0usize, once(element.map(|element| element.into()))),
         )
     }
+    pub fn with_leading_whitespace_token(self, element: Option<SyntaxToken>) -> Self {
+        Self::unwrap_cast(
+            self.syntax
+                .splice_slots(1usize..=1usize, once(element.map(|element| element.into()))),
+        )
+    }
     pub fn with_candidates(self, element: TwCandidateList) -> Self {
         Self::unwrap_cast(
             self.syntax
-                .splice_slots(1usize..=1usize, once(Some(element.into_syntax().into()))),
+                .splice_slots(2usize..=2usize, once(Some(element.into_syntax().into()))),
         )
     }
     pub fn with_eof_token(self, element: SyntaxToken) -> Self {
         Self::unwrap_cast(
             self.syntax
-                .splice_slots(2usize..=2usize, once(Some(element.into()))),
+                .splice_slots(3usize..=3usize, once(Some(element.into()))),
         )
     }
 }

--- a/crates/biome_tailwind_syntax/src/lib.rs
+++ b/crates/biome_tailwind_syntax/src/lib.rs
@@ -15,7 +15,7 @@ pub use util::*;
 use crate::TailwindSyntaxKind::{
     TW_BOGUS, TW_BOGUS_CANDIDATE, TW_BOGUS_MODIFIER, TW_BOGUS_VALUE, TW_BOGUS_VARIANT,
 };
-use biome_rowan::{AstNode, RawSyntaxKind, SyntaxKind};
+use biome_rowan::{AstNode, RawSyntaxKind};
 
 impl From<u16> for TailwindSyntaxKind {
     fn from(d: u16) -> Self {
@@ -71,7 +71,7 @@ impl biome_rowan::SyntaxKind for TailwindSyntaxKind {
     }
 
     fn is_trivia(self) -> bool {
-        matches!(self, Self::NEWLINE | Self::WHITESPACE)
+        matches!(self, Self::CSS_WHITESPACE)
     }
 
     fn to_string(&self) -> Option<&'static str> {
@@ -83,14 +83,9 @@ impl TryFrom<TailwindSyntaxKind> for TriviaPieceKind {
     type Error = ();
 
     fn try_from(value: TailwindSyntaxKind) -> Result<Self, Self::Error> {
-        if value.is_trivia() {
-            match value {
-                TailwindSyntaxKind::NEWLINE => Ok(Self::Newline),
-                TailwindSyntaxKind::WHITESPACE => Ok(Self::Whitespace),
-                _ => unreachable!("Not Trivia"),
-            }
-        } else {
-            Err(())
+        match value {
+            TailwindSyntaxKind::CSS_WHITESPACE => Ok(Self::Whitespace),
+            _ => Err(()),
         }
     }
 }

--- a/crates/biome_tailwind_syntax/src/lint_utils.rs
+++ b/crates/biome_tailwind_syntax/src/lint_utils.rs
@@ -1,4 +1,4 @@
-use biome_rowan::{AstNode, AstNodeList, TextRange, TextSize};
+use biome_rowan::{AstNode, AstSeparatedList, TextRange, TextSize};
 
 use crate::{AnyTwCandidate, AnyTwFullCandidate, AnyTwModifier, AnyTwValue, TwCandidateList};
 
@@ -10,7 +10,7 @@ use crate::{AnyTwCandidate, AnyTwFullCandidate, AnyTwModifier, AnyTwValue, TwCan
 pub fn arbitrary_ranges(candidates: &TwCandidateList, content_start: TextSize) -> Vec<TextRange> {
     let mut results = Vec::new();
 
-    for candidate in candidates.iter() {
+    for candidate in candidates.iter().flatten() {
         let AnyTwFullCandidate::TwFullCandidate(candidate) = candidate else {
             continue;
         };

--- a/xtask/codegen/src/tailwind_kinds_src.rs
+++ b/xtask/codegen/src/tailwind_kinds_src.rs
@@ -33,7 +33,7 @@ pub const TAILWIND_KINDS_SRC: KindsSrc = KindsSrc {
         "CSS_COLOR_LITERAL",
         "CSS_URL_VALUE_RAW_LITERAL",
     ],
-    tokens: &["ERROR_TOKEN", "IDENT", "NEWLINE"],
+    tokens: &["ERROR_TOKEN", "IDENT", "CSS_WHITESPACE"],
     keywords: &[
         "data", "url", "var", // length units
         "em", "rem", "ex", "rex", "cap", "rcap", "ch", "rch", "ic", "ric", "lh", "rlh",

--- a/xtask/codegen/tailwind.ungram
+++ b/xtask/codegen/tailwind.ungram
@@ -51,10 +51,11 @@ CssBogusPropertyValue = SyntaxElement*
 
 TwRoot =
 	bom: 'UNICODE_BOM'?
+	leading_whitespace: ' '?
 	candidates: TwCandidateList
 	eof: 'EOF'
 
-TwCandidateList = AnyTwFullCandidate*
+TwCandidateList = (AnyTwFullCandidate (' ' AnyTwFullCandidate)* ' '?)
 
 AnyTwFullCandidate = TwFullCandidate | TwBogusCandidate
 


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This change may seem unusual, but it actually makes sense. whitespace in tailwind class lists physically separate the classes. Therefore, the whitespace is actually an important syntax structure, and not trivia. This makes it easier to deal with parser recovery.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
supercedes and closes #11498

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
