### PR TITLE
fix(js/parse): avoid panic on skipped token trivia

### DIFF
--- a/.changeset/fix-delete-parser-rewrite-panic.md
+++ b/.changeset/fix-delete-parser-rewrite-panic.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#4592](https://github.com/biomejs/biome/issues/4592). Biome no longer crashes while parsing malformed `delete` expressions.

--- a/crates/biome_js_parser/Cargo.toml
+++ b/crates/biome_js_parser/Cargo.toml
@@ -40,11 +40,11 @@ smallvec            = { workspace = true }
 tracing             = { workspace = true }
 
 [dev-dependencies]
-biome_configuration = { path = "../biome_configuration" }
+biome_configuration = { path = "../biome_configuration", features = ["lang_js"] }
 biome_deserialize   = { path = "../biome_deserialize" }
 biome_fs            = { path = "../biome_fs" }
 biome_service       = { path = "../biome_service" }
-biome_test_utils    = { path = "../biome_test_utils" }
+biome_test_utils    = { path = "../biome_test_utils", features = ["lang_js"] }
 camino              = { workspace = true }
 criterion           = { package = "codspeed-criterion-compat", version = "=5.0.1" }
 insta               = { workspace = true }

--- a/crates/biome_js_parser/src/parser/rewrite_parser.rs
+++ b/crates/biome_js_parser/src/parser/rewrite_parser.rs
@@ -59,14 +59,6 @@ impl<'parser, 'source> RewriteParser<'parser, 'source> {
         // @test(--a)
         // class Test {}
 
-        // If the parser originally skipped this token as trivia, then make sure to also consume the trivia.
-        if let Some(trivia) = self.inner.source().trivia_list.get(self.trivia_offset)
-            && trivia.kind().is_skipped()
-            && trivia.offset() == self.offset
-        {
-            self.trivia_offset += 1;
-        }
-
         self.offset = token.end;
         self.skip_trivia(true);
     }
@@ -74,11 +66,7 @@ impl<'parser, 'source> RewriteParser<'parser, 'source> {
     fn skip_trivia(&mut self, trailing: bool) {
         let remaining_trivia = &self.inner.source().trivia_list[self.trivia_offset..];
         for trivia in remaining_trivia {
-            // Don't skip over any "skipped token trivia". These get consumed when bumping the token.
-            if trailing != trivia.trailing()
-                || self.offset != trivia.offset()
-                || trivia.kind().is_skipped()
-            {
+            if trailing != trivia.trailing() || self.offset != trivia.offset() {
                 break;
             }
 

--- a/crates/biome_js_parser/tests/js_test_suite/error/unary_delete_rewrite_skipped_trivia.js
+++ b/crates/biome_js_parser/tests/js_test_suite/error/unary_delete_rewrite_skipped_trivia.js
@@ -1,0 +1,1 @@
+delete<v l={{}i }

--- a/crates/biome_js_parser/tests/js_test_suite/error/unary_delete_rewrite_skipped_trivia.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/unary_delete_rewrite_skipped_trivia.js.snap
@@ -1,0 +1,189 @@
+---
+source: crates/biome_js_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```js
+delete<v l={{}i }
+
+```
+
+
+## AST
+
+```
+JsModule {
+    bom_token: missing (optional),
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsExpressionStatement {
+            expression: JsAssignmentExpression {
+                left: JsBogusAssignment {
+                    items: [
+                        DELETE_KW@0..6 "delete" [] [],
+                        JsBogusExpression {
+                            items: [
+                                L_ANGLE@6..7 "<" [] [],
+                                TsReferenceType {
+                                    name: JsReferenceIdentifier {
+                                        value_token: IDENT@7..9 "v" [] [Whitespace(" ")],
+                                    },
+                                    type_arguments: missing (optional),
+                                },
+                                JsIdentifierExpression {
+                                    name: JsReferenceIdentifier {
+                                        value_token: IDENT@9..10 "l" [] [],
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
+                operator_token: EQ@10..11 "=" [] [],
+                right: JsObjectExpression {
+                    l_curly_token: L_CURLY@11..12 "{" [] [],
+                    members: JsObjectMemberList [
+                        JsBogusMember {
+                            items: [
+                                L_CURLY@12..13 "{" [] [],
+                            ],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@13..14 "}" [] [],
+                },
+            },
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsIdentifierExpression {
+                name: JsReferenceIdentifier {
+                    value_token: IDENT@14..16 "i" [] [Whitespace(" ")],
+                },
+            },
+            semicolon_token: missing (optional),
+        },
+        JsBogusStatement {
+            items: [
+                R_CURLY@16..17 "}" [] [],
+            ],
+        },
+    ],
+    eof_token: EOF@17..18 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: JS_MODULE@0..18
+  0: (empty)
+  1: (empty)
+  2: JS_DIRECTIVE_LIST@0..0
+  3: JS_MODULE_ITEM_LIST@0..17
+    0: JS_EXPRESSION_STATEMENT@0..14
+      0: JS_ASSIGNMENT_EXPRESSION@0..14
+        0: JS_BOGUS_ASSIGNMENT@0..10
+          0: DELETE_KW@0..6 "delete" [] []
+          1: JS_BOGUS_EXPRESSION@6..10
+            0: L_ANGLE@6..7 "<" [] []
+            1: TS_REFERENCE_TYPE@7..9
+              0: JS_REFERENCE_IDENTIFIER@7..9
+                0: IDENT@7..9 "v" [] [Whitespace(" ")]
+              1: (empty)
+            2: JS_IDENTIFIER_EXPRESSION@9..10
+              0: JS_REFERENCE_IDENTIFIER@9..10
+                0: IDENT@9..10 "l" [] []
+        1: EQ@10..11 "=" [] []
+        2: JS_OBJECT_EXPRESSION@11..14
+          0: L_CURLY@11..12 "{" [] []
+          1: JS_OBJECT_MEMBER_LIST@12..13
+            0: JS_BOGUS_MEMBER@12..13
+              0: L_CURLY@12..13 "{" [] []
+          2: R_CURLY@13..14 "}" [] []
+      1: (empty)
+    1: JS_EXPRESSION_STATEMENT@14..16
+      0: JS_IDENTIFIER_EXPRESSION@14..16
+        0: JS_REFERENCE_IDENTIFIER@14..16
+          0: IDENT@14..16 "i" [] [Whitespace(" ")]
+      1: (empty)
+    2: JS_BOGUS_STATEMENT@16..17
+      0: R_CURLY@16..17 "}" [] []
+  4: EOF@17..18 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+unary_delete_rewrite_skipped_trivia.js:1:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × type assertion are a TypeScript only feature. Convert your file to a TypeScript file or remove the syntax.
+  
+  > 1 │ delete<v l={{}i }
+      │       ^^^^
+    2 │ 
+  
+  i TypeScript only syntax
+  
+unary_delete_rewrite_skipped_trivia.js:1:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Invalid assignment to `delete<v l`
+  
+  > 1 │ delete<v l={{}i }
+      │ ^^^^^^^^^^
+    2 │ 
+  
+  i This expression cannot be assigned to
+  
+unary_delete_rewrite_skipped_trivia.js:1:13 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a property, a shorthand property, a getter, a setter, or a method but instead found '{'.
+  
+  > 1 │ delete<v l={{}i }
+      │             ^
+    2 │ 
+  
+  i Expected a property, a shorthand property, a getter, a setter, or a method here.
+  
+  > 1 │ delete<v l={{}i }
+      │             ^
+    2 │ 
+  
+unary_delete_rewrite_skipped_trivia.js:1:15 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+  
+  > 1 │ delete<v l={{}i }
+      │               ^
+    2 │ 
+  
+  i An explicit or implicit semicolon is expected here...
+  
+  > 1 │ delete<v l={{}i }
+      │               ^
+    2 │ 
+  
+  i ...Which is required to end this statement
+  
+  > 1 │ delete<v l={{}i }
+      │ ^^^^^^^^^^^^^^^
+    2 │ 
+  
+unary_delete_rewrite_skipped_trivia.js:1:17 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a statement but instead found '}'.
+  
+  > 1 │ delete<v l={{}i }
+      │                 ^
+    2 │ 
+  
+  i Expected a statement here.
+  
+  > 1 │ delete<v l={{}i }
+      │                 ^
+    2 │ 
+  
+```

--- a/crates/biome_js_parser/tests/js_test_suite/error/unary_delete_rewrite_skipped_trivia.jsx
+++ b/crates/biome_js_parser/tests/js_test_suite/error/unary_delete_rewrite_skipped_trivia.jsx
@@ -1,0 +1,1 @@
+delete<v l={{}i }

--- a/crates/biome_js_parser/tests/js_test_suite/error/unary_delete_rewrite_skipped_trivia.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/unary_delete_rewrite_skipped_trivia.jsx.snap
@@ -1,0 +1,141 @@
+---
+source: crates/biome_js_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```jsx
+delete<v l={{}i }
+
+```
+
+
+## AST
+
+```
+JsModule {
+    bom_token: missing (optional),
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsExpressionStatement {
+            expression: JsUnaryExpression {
+                operator_token: DELETE_KW@0..6 "delete" [] [],
+                argument: JsxTagExpression {
+                    tag: JsxElement {
+                        opening_element: JsxOpeningElement {
+                            l_angle_token: L_ANGLE@6..7 "<" [] [],
+                            name: JsxName {
+                                value_token: JSX_IDENT@7..9 "v" [] [Whitespace(" ")],
+                            },
+                            type_arguments: missing (optional),
+                            attributes: JsxAttributeList [
+                                JsxAttribute {
+                                    name: JsxName {
+                                        value_token: JSX_IDENT@9..10 "l" [] [],
+                                    },
+                                    initializer: JsxAttributeInitializerClause {
+                                        eq_token: EQ@10..11 "=" [] [],
+                                        value: JsxExpressionAttributeValue {
+                                            l_curly_token: L_CURLY@11..12 "{" [] [],
+                                            expression: JsObjectExpression {
+                                                l_curly_token: L_CURLY@12..13 "{" [] [],
+                                                members: JsObjectMemberList [],
+                                                r_curly_token: R_CURLY@13..14 "}" [] [],
+                                            },
+                                            r_curly_token: R_CURLY@14..17 "}" [Skipped("i"), Whitespace(" ")] [],
+                                        },
+                                    },
+                                },
+                            ],
+                            r_angle_token: missing (required),
+                        },
+                        children: JsxChildList [],
+                        closing_element: JsxClosingElement {
+                            l_angle_token: missing (required),
+                            slash_token: missing (required),
+                            name: missing (required),
+                            r_angle_token: missing (required),
+                        },
+                    },
+                },
+            },
+            semicolon_token: missing (optional),
+        },
+    ],
+    eof_token: EOF@17..18 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: JS_MODULE@0..18
+  0: (empty)
+  1: (empty)
+  2: JS_DIRECTIVE_LIST@0..0
+  3: JS_MODULE_ITEM_LIST@0..17
+    0: JS_EXPRESSION_STATEMENT@0..17
+      0: JS_UNARY_EXPRESSION@0..17
+        0: DELETE_KW@0..6 "delete" [] []
+        1: JSX_TAG_EXPRESSION@6..17
+          0: JSX_ELEMENT@6..17
+            0: JSX_OPENING_ELEMENT@6..17
+              0: L_ANGLE@6..7 "<" [] []
+              1: JSX_NAME@7..9
+                0: JSX_IDENT@7..9 "v" [] [Whitespace(" ")]
+              2: (empty)
+              3: JSX_ATTRIBUTE_LIST@9..17
+                0: JSX_ATTRIBUTE@9..17
+                  0: JSX_NAME@9..10
+                    0: JSX_IDENT@9..10 "l" [] []
+                  1: JSX_ATTRIBUTE_INITIALIZER_CLAUSE@10..17
+                    0: EQ@10..11 "=" [] []
+                    1: JSX_EXPRESSION_ATTRIBUTE_VALUE@11..17
+                      0: L_CURLY@11..12 "{" [] []
+                      1: JS_OBJECT_EXPRESSION@12..14
+                        0: L_CURLY@12..13 "{" [] []
+                        1: JS_OBJECT_MEMBER_LIST@13..13
+                        2: R_CURLY@13..14 "}" [] []
+                      2: R_CURLY@14..17 "}" [Skipped("i"), Whitespace(" ")] []
+              4: (empty)
+            1: JSX_CHILD_LIST@17..17
+            2: JSX_CLOSING_ELEMENT@17..17
+              0: (empty)
+              1: (empty)
+              2: (empty)
+              3: (empty)
+      1: (empty)
+  4: EOF@17..18 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+unary_delete_rewrite_skipped_trivia.jsx:1:15 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `}` but instead found `i`
+  
+  > 1 │ delete<v l={{}i }
+      │               ^
+    2 │ 
+  
+  i Remove i
+  
+unary_delete_rewrite_skipped_trivia.jsx:2:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `>` but instead the file ends
+  
+    1 │ delete<v l={{}i }
+  > 2 │ 
+      │ 
+  
+  i the file ends here
+  
+    1 │ delete<v l={{}i }
+  > 2 │ 
+      │ 
+  
+```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/4592

Fixed with the help of AI.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added two tests

<!-- What demonstrates that your implementation is correct? -->

## Docs

N/A

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
