### PR TITLE
feat(cli): add `--error-on-infos` option

### DIFF
--- a/.changeset/error-on-infos.md
+++ b/.changeset/error-on-infos.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": minor
+---
+
+Added the `--error-on-infos` CLI option. Similar to `--error-on-warnings`, Biome now exits with an error status if any information diagnostics are emitted when this option is passed.

--- a/crates/biome_cli/src/cli_options.rs
+++ b/crates/biome_cli/src/cli_options.rs
@@ -51,6 +51,10 @@ pub struct CliOptions {
     #[bpaf(long("error-on-warnings"), switch)]
     pub error_on_warnings: bool,
 
+    /// Exits with an error status if any information diagnostics are emitted.
+    #[bpaf(long("error-on-infos"), switch)]
+    pub error_on_infos: bool,
+
     /// Changes how diagnostics and the run summary are written.
     #[bpaf(external, many)]
     pub cli_reporter: Vec<CliReporter>,

--- a/crates/biome_cli/src/diagnostics.rs
+++ b/crates/biome_cli/src/diagnostics.rs
@@ -424,6 +424,19 @@ impl CliDiagnostic {
         })
     }
 
+    /// Emitted when information diagnostics were emitted while running `check` command
+    pub fn check_infos(category: &'static Category) -> Self {
+        Self::CheckError(CheckError {
+            category,
+            message: MessageAndDescription::from(
+                markup! {
+                    "Some "<Emphasis>"information diagnostics"</Emphasis>" were emitted while "<Emphasis>"running checks"</Emphasis>"."
+                }
+                .to_owned(),
+            ),
+        })
+    }
+
     /// Emitted when errors were emitted while apply code fixes
     pub fn apply_error(category: &'static Category) -> Self {
         Self::CheckError(CheckError {
@@ -443,6 +456,19 @@ impl CliDiagnostic {
             message: MessageAndDescription::from(
                 markup! {
                     "Some "<Emphasis>"warnings"</Emphasis>" were emitted while "<Emphasis>"running checks"</Emphasis>"."
+                }
+                .to_owned(),
+            ),
+        })
+    }
+
+    /// Emitted when information diagnostics were emitted while applying code fixes
+    pub fn apply_infos(category: &'static Category) -> Self {
+        Self::CheckError(CheckError {
+            category,
+            message: MessageAndDescription::from(
+                markup! {
+                    "Some "<Emphasis>"information diagnostics"</Emphasis>" were emitted while "<Emphasis>"applying fixes"</Emphasis>"."
                 }
                 .to_owned(),
             ),

--- a/crates/biome_cli/src/runner/impls/finalizers/default.rs
+++ b/crates/biome_cli/src/runner/impls/finalizers/default.rs
@@ -63,6 +63,7 @@ impl Finalizer for DefaultFinalizer {
         let skipped = summary.skipped;
         let processed = summary.changed + summary.unchanged;
         let should_exit_on_warnings = summary.warnings > 0 && cli_options.error_on_warnings;
+        let should_exit_on_infos = summary.infos > 0 && cli_options.error_on_infos;
         let diagnostics_payload = DiagnosticsPayload {
             diagnostic_level: cli_options.diagnostic_level,
             diagnostics,
@@ -139,13 +140,19 @@ impl Finalizer for DefaultFinalizer {
                 execution.as_diagnostic_category(),
                 paths,
             ))
-        } else if errors > 0 || should_exit_on_warnings {
+        } else if errors > 0 || should_exit_on_warnings || should_exit_on_infos {
             let category = execution.as_diagnostic_category();
             if should_exit_on_warnings {
                 if execution.is_safe_fixes_enabled() {
                     Err(CliDiagnostic::apply_warnings(category))
                 } else {
                     Err(CliDiagnostic::check_warnings(category))
+                }
+            } else if should_exit_on_infos && errors == 0 {
+                if execution.is_safe_fixes_enabled() {
+                    Err(CliDiagnostic::apply_infos(category))
+                } else {
+                    Err(CliDiagnostic::check_infos(category))
                 }
             } else if execution.is_safe_fixes_enabled() {
                 Err(CliDiagnostic::apply_error(category))

--- a/crates/biome_cli/src/runner/impls/finalizers/default.rs
+++ b/crates/biome_cli/src/runner/impls/finalizers/default.rs
@@ -148,7 +148,7 @@ impl Finalizer for DefaultFinalizer {
                 } else {
                     Err(CliDiagnostic::check_warnings(category))
                 }
-            } else if should_exit_on_infos && errors == 0 {
+            } else if should_exit_on_infos {
                 if execution.is_safe_fixes_enabled() {
                     Err(CliDiagnostic::apply_infos(category))
                 } else {

--- a/crates/biome_cli/tests/commands/lint.rs
+++ b/crates/biome_cli/tests/commands/lint.rs
@@ -600,6 +600,36 @@ fn downgrade_severity_info() {
 }
 
 #[test]
+fn does_error_with_only_infos() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+    let file_path = Utf8Path::new("biome.json");
+    fs.insert(
+        file_path.into(),
+        CONFIG_LINTER_DOWNGRADE_DIAGNOSTIC_INFO.as_bytes(),
+    );
+
+    let file_path = Utf8Path::new("file.js");
+    fs.insert(file_path.into(), NO_DEBUGGER.as_bytes());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["lint", "--error-on-infos", file_path.as_str()].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "does_error_with_only_infos",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
 fn upgrade_severity() {
     let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();

--- a/crates/biome_cli/tests/commands/lint.rs
+++ b/crates/biome_cli/tests/commands/lint.rs
@@ -630,6 +630,36 @@ fn does_error_with_only_infos() {
 }
 
 #[test]
+fn does_not_error_with_only_infos_without_flag() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+    let file_path = Utf8Path::new("biome.json");
+    fs.insert(
+        file_path.into(),
+        CONFIG_LINTER_DOWNGRADE_DIAGNOSTIC_INFO.as_bytes(),
+    );
+
+    let file_path = Utf8Path::new("file.js");
+    fs.insert(file_path.into(), NO_DEBUGGER.as_bytes());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["lint", file_path.as_str()].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "does_not_error_with_only_infos_without_flag",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
 fn upgrade_severity() {
     let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();

--- a/crates/biome_cli/tests/snapshots/main_cases_help/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_help/check_help.snap
@@ -273,6 +273,7 @@ output.
                               diagnostic.
         --no-errors-on-unmatched  Does not emit an error when no files are processed.
         --error-on-warnings   Exits with an error status if any warning diagnostics are emitted.
+        --error-on-infos      Exits with an error status if any information diagnostics are emitted.
   [--reporter=<default|concise|summary|json|json-pretty|github|gitlab|junit|checkstyle|rdjson|sarif>
   ] [--reporter-file=PATH]
         --reporter=

--- a/crates/biome_cli/tests/snapshots/main_cases_help/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_help/ci_help.snap
@@ -263,6 +263,7 @@ output.
                               diagnostic.
         --no-errors-on-unmatched  Does not emit an error when no files are processed.
         --error-on-warnings   Exits with an error status if any warning diagnostics are emitted.
+        --error-on-infos      Exits with an error status if any information diagnostics are emitted.
   [--reporter=<default|concise|summary|json|json-pretty|github|gitlab|junit|checkstyle|rdjson|sarif>
   ] [--reporter-file=PATH]
         --reporter=

--- a/crates/biome_cli/tests/snapshots/main_cases_help/format_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_help/format_help.snap
@@ -239,6 +239,7 @@ output.
                               diagnostic.
         --no-errors-on-unmatched  Does not emit an error when no files are processed.
         --error-on-warnings   Exits with an error status if any warning diagnostics are emitted.
+        --error-on-infos      Exits with an error status if any information diagnostics are emitted.
   [--reporter=<default|concise|summary|json|json-pretty|github|gitlab|junit|checkstyle|rdjson|sarif>
   ] [--reporter-file=PATH]
         --reporter=

--- a/crates/biome_cli/tests/snapshots/main_cases_help/lint_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_help/lint_help.snap
@@ -79,6 +79,7 @@ output.
                               diagnostic.
         --no-errors-on-unmatched  Does not emit an error when no files are processed.
         --error-on-warnings   Exits with an error status if any warning diagnostics are emitted.
+        --error-on-infos      Exits with an error status if any information diagnostics are emitted.
   [--reporter=<default|concise|summary|json|json-pretty|github|gitlab|junit|checkstyle|rdjson|sarif>
   ] [--reporter-file=PATH]
         --reporter=

--- a/crates/biome_cli/tests/snapshots/main_cases_help/migrate_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_help/migrate_help.snap
@@ -30,6 +30,7 @@ output.
                               diagnostic.
         --no-errors-on-unmatched  Does not emit an error when no files are processed.
         --error-on-warnings   Exits with an error status if any warning diagnostics are emitted.
+        --error-on-infos      Exits with an error status if any information diagnostics are emitted.
   [--reporter=<default|concise|summary|json|json-pretty|github|gitlab|junit|checkstyle|rdjson|sarif>
   ] [--reporter-file=PATH]
         --reporter=

--- a/crates/biome_cli/tests/snapshots/main_cases_help/rage_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_help/rage_help.snap
@@ -28,6 +28,7 @@ output.
                               diagnostic.
         --no-errors-on-unmatched  Does not emit an error when no files are processed.
         --error-on-warnings   Exits with an error status if any warning diagnostics are emitted.
+        --error-on-infos      Exits with an error status if any information diagnostics are emitted.
   [--reporter=<default|concise|summary|json|json-pretty|github|gitlab|junit|checkstyle|rdjson|sarif>
   ] [--reporter-file=PATH]
         --reporter=

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/does_error_with_only_infos.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/does_error_with_only_infos.snap
@@ -1,0 +1,57 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+      "recommended": true,
+      "suspicious": {
+        "noDebugger": "info"
+      }
+    }
+  }
+}
+```
+
+## `file.js`
+
+```js
+debugger;
+```
+
+# Termination Message
+
+```block
+lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some information diagnostics were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+file.js:1:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This is an unexpected use of the debugger statement.
+  
+  > 1 │ debugger;
+      │ ^^^^^^^^^
+  
+  i Unsafe fix: Remove debugger statement
+  
+    1 │ debugger;
+      │ ---------
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 1 info.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/does_error_with_only_infos.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/does_error_with_only_infos.snap
@@ -37,6 +37,31 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
+biome.json:2:13 deserialize  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The use of the recommended field has been deprecated, and will removed in the next major version of Biome. Use preset instead.
+  
+     1 │ {
+   > 2 │   "linter": {
+       │             ^
+   > 3 │     "rules": {
+   > 4 │         "recommended": true,
+   > 5 │         "suspicious": {
+   > 6 │             "noDebugger": "info"
+   > 7 │         }
+   > 8 │     }
+   > 9 │   }
+       │   ^
+    10 │ }
+  
+  i Migrate the configuration with the proper command
+  
+  $ biome migrate
+  
+
+```
+
+```block
 file.js:1:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i This is an unexpected use of the debugger statement.

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/does_not_error_with_only_infos_without_flag.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/does_not_error_with_only_infos_without_flag.snap
@@ -1,0 +1,46 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+      "recommended": true,
+      "suspicious": {
+        "noDebugger": "info"
+      }
+    }
+  }
+}
+```
+
+## `file.js`
+
+```js
+debugger;
+```
+
+# Emitted Messages
+
+```block
+file.js:1:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This is an unexpected use of the debugger statement.
+  
+  > 1 │ debugger;
+      │ ^^^^^^^^^
+  
+  i Unsafe fix: Remove debugger statement
+  
+    1 │ debugger;
+      │ ---------
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 1 info.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/does_not_error_with_only_infos_without_flag.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/does_not_error_with_only_infos_without_flag.snap
@@ -26,6 +26,31 @@ debugger;
 # Emitted Messages
 
 ```block
+biome.json:2:13 deserialize  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The use of the recommended field has been deprecated, and will removed in the next major version of Biome. Use preset instead.
+  
+     1 │ {
+   > 2 │   "linter": {
+       │             ^
+   > 3 │     "rules": {
+   > 4 │         "recommended": true,
+   > 5 │         "suspicious": {
+   > 6 │             "noDebugger": "info"
+   > 7 │         }
+   > 8 │     }
+   > 9 │   }
+       │   ^
+    10 │ }
+  
+  i Migrate the configuration with the proper command
+  
+  $ biome migrate
+  
+
+```
+
+```block
 file.js:1:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i This is an unexpected use of the debugger statement.


### PR DESCRIPTION
## Summary

Adds a `--error-on-infos` CLI flag. When passed, Biome exits with an error status if any information diagnostics are emitted, mirroring the existing `--error-on-warnings`.

Fixes https://github.com/biomejs/biome/discussions/7582#discussioncomment-15393294

## Notes

- `summary.infos` was already counted symmetrically with `warnings`, so this reuses the existing counter.
- Help snapshots regenerated for all affected commands.
- `--error-on-warnings` is CLI-only and absent from the config schema, so no bindings codegen was needed.

## Heads-up

`next` currently fails to build, independent of this PR: `de1ad4c4c58` added a `lang_md`-gated `markdown` field to `OverridePattern` without a matching arm in the `apply_to_configuration` destructuring, so `biome_configuration` fails with `E0027`. Reproduces on a clean `next` checkout. CI here will be red until that's fixed.

Locally, with that patched: 961 tests pass, clippy and rustfmt clean.

## AI assistance

The implementation is mine. I used Claude Code to review the change, which led to removing a dead `errors == 0` guard and adding a negative-case test, and to perform the rebase onto `next`.
