### PR TITLE
fix(lint): align explicit length checks

### DIFF
--- a/.changeset/smooth-times-open.md
+++ b/.changeset/smooth-times-open.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11352](https://github.com/biomejs/biome/issues/11352): [`useExplicitLengthCheck`](https://biomejs.dev/linter/rules/use-explicit-length-check/) no longer reports `length`-like properties used as value-producing `||` fallbacks or optional chains, and it no longer offers fixes for value-producing `&&` checks or unsafe negations.

--- a/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
@@ -4590,6 +4590,10 @@ pub(crate) fn migrate_eslint_any_rule(
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "unicorn/explicit-length-check" => {
+            if !options.include_inspired {
+                results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Inspired);
+                return false;
+            }
             let group = rules.style.get_or_insert_with(Default::default);
             let rule = group
                 .unwrap_group_as_mut()

--- a/crates/biome_js_analyze/src/ast_utils.rs
+++ b/crates/biome_js_analyze/src/ast_utils.rs
@@ -1,10 +1,14 @@
 use biome_js_semantic::{BindingExtensions, SemanticModel};
 use biome_js_syntax::{
     AnyFunctionLike, AnyJsArrayElement, AnyJsExpression, AnyJsLiteralExpression,
-    AnyJsTemplateElement, JsAssignmentOperator, JsLanguage, JsLogicalOperator, JsModule,
-    JsSyntaxKind, JsSyntaxNode, JsSyntaxToken, JsUnaryOperator,
+    AnyJsTemplateElement, JsAssignmentOperator, JsAwaitExpression, JsCaseClause,
+    JsDoWhileStatement, JsElseClause, JsExportDefaultExpressionClause, JsExpressionStatement,
+    JsForInStatement, JsForOfStatement, JsInExpression, JsInstanceofExpression, JsLanguage,
+    JsLogicalOperator, JsModule, JsNewExpression, JsReturnStatement, JsSyntaxKind, JsSyntaxNode,
+    JsSyntaxToken, JsThrowStatement, JsUnaryExpression, JsUnaryOperator, JsYieldArgument,
+    JsYieldExpression,
 };
-use biome_rowan::{AstNode, AstSeparatedList, TriviaPiece};
+use biome_rowan::{AstNode, AstSeparatedList, SyntaxKindSet, TriviaPiece};
 
 /// Add any leading and trailing trivia from given source node to the token.
 ///
@@ -64,6 +68,58 @@ fn add_trailing_trivia(trivia: &mut Vec<TriviaPiece>, text: &mut String, node: &
         trivia.push(TriviaPiece::whitespace(1));
     }
 }
+
+/// Returns whether an identifier-like replacement needs leading whitespace at this expression.
+///
+/// JavaScript permits punctuation-prefixed expressions to touch a preceding keyword, as in
+/// `return!value`. If a replacement starts with an identifier-like token, omitting the whitespace
+/// would instead produce a different token such as `returnvalue`. This also applies to keyword
+/// operators and to expression positions following `yield`, `else`, `do`, or `case`.
+pub(crate) fn needs_space_before_identifier_expression_replacement(
+    expression: &AnyJsExpression,
+) -> bool {
+    let Some(parent) = expression.syntax().parent() else {
+        return false;
+    };
+
+    if EXPRESSION_REPLACEMENT_SEPARATOR_PARENT_KINDS.matches(parent.kind())
+        || JsUnaryExpression::cast_ref(&parent).is_some_and(|expression| {
+            matches!(
+                expression.operator(),
+                Ok(JsUnaryOperator::Typeof | JsUnaryOperator::Void | JsUnaryOperator::Delete)
+            )
+        })
+    {
+        return true;
+    }
+
+    if let Some(argument) = JsYieldArgument::cast_ref(&parent) {
+        return argument.star_token().is_none()
+            && parent.parent().is_some_and(|parent| {
+                EXPRESSION_REPLACEMENT_SEPARATOR_PARENT_KINDS.matches(parent.kind())
+            });
+    }
+
+    JsExpressionStatement::can_cast(parent.kind())
+        && parent.parent().is_some_and(|parent| {
+            EXPRESSION_REPLACEMENT_SEPARATOR_PARENT_KINDS.matches(parent.kind())
+        })
+}
+
+const EXPRESSION_REPLACEMENT_SEPARATOR_PARENT_KINDS: SyntaxKindSet<JsLanguage> =
+    JsExportDefaultExpressionClause::KIND_SET
+        .union(JsInstanceofExpression::KIND_SET)
+        .union(JsYieldExpression::KIND_SET)
+        .union(JsReturnStatement::KIND_SET)
+        .union(JsThrowStatement::KIND_SET)
+        .union(JsNewExpression::KIND_SET)
+        .union(JsAwaitExpression::KIND_SET)
+        .union(JsInExpression::KIND_SET)
+        .union(JsForOfStatement::KIND_SET)
+        .union(JsForInStatement::KIND_SET)
+        .union(JsDoWhileStatement::KIND_SET)
+        .union(JsElseClause::KIND_SET)
+        .union(JsCaseClause::KIND_SET);
 
 pub fn is_constant_condition(
     test: AnyJsExpression,

--- a/crates/biome_js_analyze/src/lint/complexity/use_date_now.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_date_now.rs
@@ -11,9 +11,9 @@ use biome_js_syntax::{
 use biome_rowan::{AstNode, AstSeparatedList, BatchMutationExt};
 use biome_rule_options::use_date_now::UseDateNowOptions;
 
-use crate::JsRuleAction;
-
-use crate::lint::style::use_explicit_length_check::does_node_needs_space_before_child;
+use crate::{
+    JsRuleAction, ast_utils::needs_space_before_identifier_expression_replacement,
+};
 
 declare_lint_rule! {
     /// Use `Date.now()` to get the number of milliseconds since the Unix Epoch.
@@ -121,7 +121,7 @@ impl Rule for UseDateNow {
             make::js_name(make::ident("now")).into(),
         );
 
-        if does_node_needs_space_before_child(&node.syntax().parent()?) {
+        if needs_space_before_identifier_expression_replacement(node) {
             // Make fake token to get leading trivia
             let leading_trivia = make::token_decorated_with_space(T![=])
                 .leading_trivia()

--- a/crates/biome_js_analyze/src/lint/style/use_explicit_length_check.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_explicit_length_check.rs
@@ -5,15 +5,23 @@ use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{
-    AnyJsExpression, AnyJsLiteralExpression, JsBinaryExpression, JsBinaryOperator,
-    JsCallArgumentList, JsCallArguments, JsCallExpression, JsLogicalExpression, JsLogicalOperator,
-    JsStaticMemberExpression, JsSyntaxKind, JsSyntaxNode, JsUnaryExpression, JsUnaryOperator, T,
-    is_in_boolean_context, is_negation,
+    AnyJsExpression, AnyJsLiteralExpression, JsAwaitExpression, JsBinaryExpression,
+    JsBinaryOperator, JsCallArgumentList, JsCallArguments, JsCallExpression,
+    JsComputedMemberAssignment, JsComputedMemberExpression, JsExtendsClause, JsInExpression,
+    JsInstanceofExpression, JsLanguage, JsLogicalExpression, JsLogicalOperator, JsNewExpression,
+    JsParenthesizedExpression, JsSpread, JsStaticMemberAssignment, JsStaticMemberExpression,
+    JsTemplateExpression, JsUnaryExpression, JsUnaryOperator, JsxSpreadAttribute, JsxSpreadChild,
+    T, TsAsExpression, TsNonNullAssertionExpression, TsSatisfiesExpression,
+    TsTypeAssertionExpression,
+    binary_like_expression::{AnyJsBinaryLikeExpression, BinaryLikeOperator},
+    is_in_boolean_context,
 };
-use biome_rowan::{AstNode, AstSeparatedList, BatchMutationExt, TokenText};
+use biome_rowan::{AstNode, AstSeparatedList, BatchMutationExt, SyntaxKindSet, TokenText};
 use biome_rule_options::use_explicit_length_check::UseExplicitLengthCheckOptions;
 
-use crate::JsRuleAction;
+use crate::{
+    JsRuleAction, ast_utils::needs_space_before_identifier_expression_replacement,
+};
 
 declare_lint_rule! {
     /// Enforce explicitly comparing the `length`, `size`, `byteLength` or `byteOffset` property of a value.
@@ -131,7 +139,7 @@ declare_lint_rule! {
         language: "js",
         recommended: false,
         severity: Severity::Information,
-        sources: &[RuleSource::EslintUnicorn("explicit-length-check").same()],
+        sources: &[RuleSource::EslintUnicorn("explicit-length-check").inspired()],
         fix_kind: FixKind::Unsafe,
     }
 }
@@ -155,26 +163,32 @@ impl Rule for UseExplicitLengthCheck {
             return None;
         }
 
+        if member_expr.is_optional_chain() {
+            return None;
+        }
+
         // TODO. Handle cases when `length` property is not numeric
         // That requires type inference. Example: `{ length: "not a number" }`
 
-        let member_expr_syntax = member_expr.syntax();
-        let parent_syntax = member_expr_syntax.parent()?;
+        let member_expression = AnyJsExpression::from(member_expr.clone());
+        let member_expr_syntax = member_expression.syntax();
 
         if let Some((binary_expr, mut len_check, is_possibly_valid)) =
-            is_binary_expr_length_check(&parent_syntax)
+            member_expr
+                .parent::<JsBinaryExpression>()
+                .and_then(|binary_expr| is_binary_expr_length_check(&binary_expr))
         {
-            return get_boolean_ancestor(binary_expr.syntax())
+            return get_boolean_ancestor(&AnyJsExpression::from(binary_expr.clone()))
                 .map(|(expr, is_negative)| {
                     if is_negative {
                         len_check = len_check.opposite();
                     }
 
-                    UseExplicitLengthCheckState {
-                        check: len_check,
-                        node: expr,
-                        member_name: member_name.clone(),
-                    }
+                    UseExplicitLengthCheckState::new(
+                        len_check,
+                        expr,
+                        member_name.clone(),
+                    )
                 })
                 .or_else(|| {
                     // Binary expression is valid and was not wrapped in a boolean ancestor
@@ -182,51 +196,48 @@ impl Rule for UseExplicitLengthCheck {
                         return None;
                     }
 
-                    Some(UseExplicitLengthCheckState {
-                        check: len_check,
-                        node: AnyJsExpression::from(binary_expr),
+                    Some(UseExplicitLengthCheckState::new(
+                        len_check,
+                        AnyJsExpression::from(binary_expr),
                         member_name,
-                    })
+                    ))
                 });
         }
 
-        if let Some((boolean_expr, is_negative)) = get_boolean_ancestor(member_expr_syntax) {
+        if let Some((boolean_expr, is_negative)) = get_boolean_ancestor(&member_expression) {
             let check = if is_negative {
                 LengthCheck::Zero
             } else {
                 LengthCheck::NonZero
             };
 
-            return Some(UseExplicitLengthCheckState {
+            return Some(UseExplicitLengthCheckState::new(
                 check,
-                node: boolean_expr,
+                boolean_expr,
                 member_name,
-            });
+            ));
         }
 
-        if is_in_boolean_context(member_expr_syntax).unwrap_or(false) {
-            return Some(UseExplicitLengthCheckState {
-                check: LengthCheck::NonZero,
-                node: AnyJsExpression::cast_ref(member_expr_syntax)?,
+        if is_in_boolean_context(member_expr_syntax).unwrap_or(false)
+            || has_boolean_ancestor_through_logical_expression(&member_expression)
+        {
+            return Some(UseExplicitLengthCheckState::new(
+                LengthCheck::NonZero,
+                AnyJsExpression::cast_ref(member_expr_syntax)?,
                 member_name,
-            });
+            ));
         }
 
-        if let Some(logical_expr) = is_logical_expr(parent_syntax) {
-            // `const x = foo.length || 0` is valid case
-            // TODO. This handles simple cases. To know if right side is a number, we need type inference.
-            if logical_expr.operator().ok()? == JsLogicalOperator::LogicalOr
-                && logical_expr.right().ok()?.syntax().kind()
-                    == JsSyntaxKind::JS_NUMBER_LITERAL_EXPRESSION
-            {
+        if let Some(logical_expr) = get_parent_logical_expression(&member_expression) {
+            if logical_expr.operator().ok()? != JsLogicalOperator::LogicalAnd {
                 return None;
             }
 
-            return Some(UseExplicitLengthCheckState {
-                check: LengthCheck::NonZero,
-                node: AnyJsExpression::cast_ref(member_expr_syntax)?,
+            return Some(UseExplicitLengthCheckState::without_fix(
+                LengthCheck::NonZero,
+                AnyJsExpression::cast_ref(member_expr_syntax)?,
                 member_name,
-            });
+            ));
         }
 
         None
@@ -248,28 +259,53 @@ impl Rule for UseExplicitLengthCheck {
     }
 
     fn action(ctx: &RuleContext<Self>, state: &Self::State) -> Option<JsRuleAction> {
+        if !state.can_fix {
+            return None;
+        }
+
         let member_expr = ctx.query();
         let mut mutation = ctx.root().begin();
-        let operator_kind = match state.check {
-            LengthCheck::Zero => T![===],
-            LengthCheck::NonZero => T![>],
+        let (operator_kind, operator) = match state.check {
+            LengthCheck::Zero => (T![===], JsBinaryOperator::StrictEquality),
+            LengthCheck::NonZero => (T![>], JsBinaryOperator::GreaterThan),
         };
 
-        let new_binary_expr = make::js_binary_expression(
-            member_expr.clone().trim_trailing_trivia()?.into(),
+        let member_expr = member_expr.clone().trim_trailing_trivia()?;
+        let state_starts_before_member =
+            state.node.syntax().first_token() != member_expr.syntax().first_token();
+        let new_binary_expr = AnyJsExpression::from(make::js_binary_expression(
+            member_expr.into(),
             make::token_decorated_with_space(operator_kind),
             AnyJsExpression::AnyJsLiteralExpression(
                 AnyJsLiteralExpression::JsNumberLiteralExpression(
                     make::js_number_literal_expression(make::js_number_literal("0")),
                 ),
             ),
-        );
+        ));
 
-        let mut new_node = new_binary_expr.into_syntax();
-        let parent = state.node.syntax().parent()?;
+        let mut new_node = if binary_replacement_needs_parentheses(&state.node, operator) {
+            make::js_parenthesized_expression(
+                make::token(T!['(']),
+                new_binary_expr,
+                make::token(T![')']),
+            )
+            .into_syntax()
+        } else {
+            new_binary_expr.into_syntax()
+        };
+        if state_starts_before_member {
+            new_node = new_node.prepend_trivia_pieces(
+                state
+                    .node
+                    .syntax()
+                    .first_token()?
+                    .leading_trivia()
+                    .pieces(),
+            )?;
+        }
         // In cases like `export default!foo.length` -> `export default foo.length === 0`
         // we need to add a space between keyword and expression
-        if does_node_needs_space_before_child(&parent) {
+        if needs_space_before_identifier_expression_replacement(&state.node) {
             // Make fake token to get leading trivia
             let leading_trivia = make::token_decorated_with_space(T![=])
                 .leading_trivia()
@@ -280,9 +316,9 @@ impl Rule for UseExplicitLengthCheck {
                 .prepend_trivia_pieces(leading_trivia)?;
         }
 
-        mutation.replace_element_discard_trivia(
-            state.node.clone().into_syntax().into(),
-            new_node.into(),
+        mutation.replace_node_discard_trivia(
+            state.node.clone(),
+            AnyJsExpression::cast(new_node)?,
         );
 
         let code = match state.check {
@@ -293,7 +329,7 @@ impl Rule for UseExplicitLengthCheck {
         Some(JsRuleAction::new(
             ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
-             markup! { "Replace "<Emphasis>"."{member_name}</Emphasis>" with "<Emphasis>"."{member_name}" "{code}</Emphasis> }.to_owned(),
+            markup! { "Replace "<Emphasis>"."{member_name}</Emphasis>" with "<Emphasis>"."{member_name}" "{code}</Emphasis> }.to_owned(),
             mutation,
         ))
     }
@@ -306,6 +342,27 @@ pub struct UseExplicitLengthCheckState {
     check: LengthCheck,
     node: AnyJsExpression,
     member_name: TokenText,
+    can_fix: bool,
+}
+
+impl UseExplicitLengthCheckState {
+    fn new(check: LengthCheck, node: AnyJsExpression, member_name: TokenText) -> Self {
+        Self {
+            check,
+            can_fix: !is_unsafe_negation_fix(&node),
+            node,
+            member_name,
+        }
+    }
+
+    fn without_fix(check: LengthCheck, node: AnyJsExpression, member_name: TokenText) -> Self {
+        Self {
+            check,
+            node,
+            member_name,
+            can_fix: false,
+        }
+    }
 }
 
 enum MemberPosition {
@@ -345,11 +402,9 @@ fn extract_binary_position_and_literal(
 }
 
 fn is_binary_expr_length_check(
-    node: &JsSyntaxNode,
+    binary_expr: &JsBinaryExpression,
 ) -> Option<(JsBinaryExpression, LengthCheck, bool)> {
-    let binary_expr = JsBinaryExpression::cast_ref(node)?;
-
-    let (member_position, literal) = extract_binary_position_and_literal(&binary_expr)?;
+    let (member_position, literal) = extract_binary_position_and_literal(binary_expr)?;
     let number = literal
         .as_js_number_literal_expression()?
         .as_number()?
@@ -389,7 +444,7 @@ fn is_binary_expr_length_check(
         _ => None,
     }?;
 
-    Some((binary_expr, length_check, is_valid))
+    Some((binary_expr.clone(), length_check, is_valid))
 }
 
 /// Get the boolean ancestor of the node
@@ -404,86 +459,126 @@ fn is_binary_expr_length_check(
 /// !(Boolean(!(!x)))
 /// ```
 /// Returns ancestor expression and whether it is negated
-fn get_boolean_ancestor(node: &JsSyntaxNode) -> Option<(AnyJsExpression, bool)> {
-    let mut boolean_node: Option<JsSyntaxNode> = None;
-    let mut current_node = node.parent()?;
+fn get_boolean_ancestor(node: &AnyJsExpression) -> Option<(AnyJsExpression, bool)> {
+    let mut boolean_node = None;
+    let mut current_node = node.clone();
     let mut is_negative = false;
 
     loop {
         if let Some(expr) = is_boolean_call(&current_node) {
-            let syntax = expr.into_syntax();
-            current_node = syntax.parent()?;
-            boolean_node = Some(syntax);
-        } else if let Some(expr) = is_negation(&current_node) {
-            let syntax = expr.into_syntax();
-            current_node = syntax.parent()?;
-            boolean_node = Some(syntax);
+            current_node = expr.into();
+            boolean_node = Some(current_node.clone());
+        } else if let Some(expr) = current_node
+            .parent::<JsUnaryExpression>()
+            .filter(|expr| expr.operator() == Ok(JsUnaryOperator::LogicalNot))
+        {
+            current_node = expr.into();
+            boolean_node = Some(current_node.clone());
             is_negative = !is_negative;
-        } else if current_node.kind() == JsSyntaxKind::JS_PARENTHESIZED_EXPRESSION {
-            current_node = current_node.parent()?;
+        } else if let Some(expr) = current_node.parent::<JsParenthesizedExpression>() {
+            current_node = expr.into();
         } else {
             break;
         }
     }
 
-    Some((AnyJsExpression::cast(boolean_node?)?, is_negative))
+    Some((boolean_node?, is_negative))
 }
 
-/// Check if the SyntaxNode is a `Boolean` Call Expression
+/// Returns the parent `Boolean` call when the expression is its only argument.
 /// ## Example
 /// ```js
 /// Boolean(x)
 /// ```
-pub fn is_boolean_call(node: &JsSyntaxNode) -> Option<JsCallExpression> {
-    let expr = JsCallArgumentList::cast_ref(node)?
+fn is_boolean_call(node: &AnyJsExpression) -> Option<JsCallExpression> {
+    let expr = node
+        .parent::<JsCallArgumentList>()?
         .parent::<JsCallArguments>()?
         .parent::<JsCallExpression>()?;
     (expr.has_callee("Boolean") && expr.arguments().ok()?.args().len() < 2).then_some(expr)
 }
 
-/// Checks if expression is a logical expression with `&&` or `||` operator
-fn is_logical_expr(node: JsSyntaxNode) -> Option<JsLogicalExpression> {
-    let expr: JsLogicalExpression = JsLogicalExpression::cast(node)?;
+fn get_parent_logical_expression(expression: &AnyJsExpression) -> Option<JsLogicalExpression> {
+    let logical_expression = expression
+        .syntax()
+        .ancestors()
+        .skip(1)
+        .find_map(JsLogicalExpression::cast)?;
+    let is_direct_operand = [
+        logical_expression.left().ok()?,
+        logical_expression.right().ok()?,
+    ]
+    .iter()
+    .any(|operand| operand.clone().omit_parentheses().syntax() == expression.syntax());
 
-    match expr.operator().ok()? {
-        JsLogicalOperator::LogicalAnd | JsLogicalOperator::LogicalOr => Some(expr),
-        _ => None,
+    is_direct_operand.then_some(logical_expression)
+}
+
+fn has_boolean_ancestor_through_logical_expression(node: &AnyJsExpression) -> bool {
+    let Some(logical_expression) = get_parent_logical_expression(node) else {
+        return false;
+    };
+    let mut current_expression = AnyJsExpression::from(logical_expression);
+
+    while let Some(parent) = get_parent_logical_expression(&current_expression) {
+        current_expression = parent.into();
     }
+
+    get_boolean_ancestor(&current_expression).is_some()
 }
 
-fn does_unary_expr_needs_space(node: &JsSyntaxNode) -> bool {
-    JsUnaryExpression::cast_ref(node).is_some_and(|expr| {
-        matches!(
-            expr.operator(),
-            Ok(JsUnaryOperator::Typeof | JsUnaryOperator::Void | JsUnaryOperator::Delete)
-        )
-    })
+fn is_unsafe_negation_fix(node: &AnyJsExpression) -> bool {
+    let Some(unary_expression) = JsUnaryExpression::cast_ref(node.syntax()) else {
+        return false;
+    };
+    if unary_expression.operator() != Ok(JsUnaryOperator::LogicalNot) {
+        return false;
+    }
+
+    node.syntax()
+        .parent()
+        .is_some_and(|parent| UNSAFE_NEGATION_FIX_PARENT_KINDS.matches(parent.kind()))
 }
 
-/// Checks if node needs space in case inserted child
-/// would produce syntax error without it.
-/// ## Example
-/// ```js
-/// export default!foo.length
-/// ```
-/// removing slash would produce syntax error without a space
-/// ```js
-/// export default foo.length
-/// ```
-pub(crate) fn does_node_needs_space_before_child(node: &JsSyntaxNode) -> bool {
-    matches!(
-        node.kind(),
-        JsSyntaxKind::JS_EXPORT_DEFAULT_EXPRESSION_CLAUSE
-            | JsSyntaxKind::JS_INSTANCEOF_EXPRESSION
-            | JsSyntaxKind::JS_YIELD_EXPRESSION
-            | JsSyntaxKind::JS_RETURN_STATEMENT
-            | JsSyntaxKind::JS_THROW_STATEMENT
-            | JsSyntaxKind::JS_NEW_EXPRESSION
-            | JsSyntaxKind::JS_AWAIT_EXPRESSION
-            | JsSyntaxKind::JS_IN_EXPRESSION
-            | JsSyntaxKind::JS_FOR_OF_STATEMENT
-            | JsSyntaxKind::JS_FOR_IN_STATEMENT
-            | JsSyntaxKind::JS_DO_WHILE_STATEMENT
-            | JsSyntaxKind::JS_CASE_CLAUSE
-    ) || does_unary_expr_needs_space(node)
+fn binary_replacement_needs_parentheses(
+    node: &AnyJsExpression,
+    replacement_operator: JsBinaryOperator,
+) -> bool {
+    let Some(parent) = node.syntax().parent() else {
+        return false;
+    };
+
+    if BINARY_REPLACEMENT_PARENTHESES_PARENT_KINDS.matches(parent.kind()) {
+        return true;
+    }
+
+    AnyJsBinaryLikeExpression::cast(parent)
+        .and_then(|parent| parent.operator().ok())
+        .is_some_and(|parent_operator| {
+            parent_operator.precedence()
+                >= BinaryLikeOperator::Binary(replacement_operator).precedence()
+        })
 }
+
+const BINARY_REPLACEMENT_PARENTHESES_PARENT_KINDS: SyntaxKindSet<JsLanguage> =
+    JsExtendsClause::KIND_SET
+        .union(TsAsExpression::KIND_SET)
+        .union(TsSatisfiesExpression::KIND_SET)
+        .union(TsTypeAssertionExpression::KIND_SET)
+        .union(JsUnaryExpression::KIND_SET)
+        .union(JsAwaitExpression::KIND_SET)
+        .union(TsNonNullAssertionExpression::KIND_SET)
+        .union(JsxSpreadChild::KIND_SET)
+        .union(JsSpread::KIND_SET)
+        .union(JsxSpreadAttribute::KIND_SET)
+        .union(JsCallExpression::KIND_SET)
+        .union(JsNewExpression::KIND_SET)
+        .union(JsTemplateExpression::KIND_SET)
+        .union(JsStaticMemberExpression::KIND_SET)
+        .union(JsStaticMemberAssignment::KIND_SET)
+        .union(JsComputedMemberExpression::KIND_SET)
+        .union(JsComputedMemberAssignment::KIND_SET);
+
+const UNSAFE_NEGATION_FIX_PARENT_KINDS: SyntaxKindSet<JsLanguage> = JsBinaryExpression::KIND_SET
+    .union(JsInExpression::KIND_SET)
+    .union(JsInstanceofExpression::KIND_SET);

--- a/crates/biome_js_analyze/tests/specs/style/useExplicitLengthCheck/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/style/useExplicitLengthCheck/invalid.js
@@ -10,8 +10,15 @@ for (let i = 0; (bar && !foo.length); i ++) {}
 const isEmpty = foo.length < 1;
 bar(foo.length >= 1)
 bar(!foo.length || foo.length)
+alert(foo.length && bar())
+const hasLength = () => foo.length && bar()
+const parenthesizedHasLength = () => (foo.length) && bar()
+if (!foo.length > 0) {}
+if (true === !foo.length) {}
 const bar = void !foo.length;
 const isNotEmpty = Boolean(foo.length)
+Boolean(foo.length).toString()
++Boolean(foo.length)
 const isNotEmpty1 = Boolean(foo.length || bar)
 const isEmpty1 = Boolean(!foo.length)
 const isEmpty2 = Boolean(/** 1 **/foo.length === 0)
@@ -19,6 +26,16 @@ const isNotEmpty2 = !Boolean(foo.length === 0)
 const isEmpty3 = !Boolean(!Boolean(foo.length === 0))
 if (foo.size) {}
 if (foo.size && bar.length) {}
+
+// Unlike ESLint Unicorn, Biome checks direct properties on `this` because they
+// can represent numeric cardinality.
+class A {
+    a() {
+        if (this.length) {};
+        while (!this.size || foo);
+    }
+}
+
 // Space after keywords
 function foo() {return!foo.length}
 function foo() {throw!foo.length}
@@ -36,10 +53,3 @@ do!foo.length;while(true) {}
 switch(foo){case!foo.length:{}}
 for(const a of!foo.length);
 for(const a in!foo.length);
-
-class A {
-    a() {
-        if (this.length) {};
-        while (!this.size || foo);
-    }
-}

--- a/crates/biome_js_analyze/tests/specs/style/useExplicitLengthCheck/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useExplicitLengthCheck/invalid.js.snap
@@ -16,8 +16,15 @@ for (let i = 0; (bar && !foo.length); i ++) {}
 const isEmpty = foo.length < 1;
 bar(foo.length >= 1)
 bar(!foo.length || foo.length)
+alert(foo.length && bar())
+const hasLength = () => foo.length && bar()
+const parenthesizedHasLength = () => (foo.length) && bar()
+if (!foo.length > 0) {}
+if (true === !foo.length) {}
 const bar = void !foo.length;
 const isNotEmpty = Boolean(foo.length)
+Boolean(foo.length).toString()
++Boolean(foo.length)
 const isNotEmpty1 = Boolean(foo.length || bar)
 const isEmpty1 = Boolean(!foo.length)
 const isEmpty2 = Boolean(/** 1 **/foo.length === 0)
@@ -25,6 +32,16 @@ const isNotEmpty2 = !Boolean(foo.length === 0)
 const isEmpty3 = !Boolean(!Boolean(foo.length === 0))
 if (foo.size) {}
 if (foo.size && bar.length) {}
+
+// Unlike ESLint Unicorn, Biome checks direct properties on `this` because they
+// can represent numeric cardinality.
+class A {
+    a() {
+        if (this.length) {};
+        while (!this.size || foo);
+    }
+}
+
 // Space after keywords
 function foo() {return!foo.length}
 function foo() {throw!foo.length}
@@ -42,13 +59,6 @@ do!foo.length;while(true) {}
 switch(foo){case!foo.length:{}}
 for(const a of!foo.length);
 for(const a in!foo.length);
-
-class A {
-    a() {
-        if (this.length) {};
-        while (!this.size || foo);
-    }
-}
 
 ```
 
@@ -285,7 +295,7 @@ invalid.js:11:5 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━�
   > 11 │ bar(foo.length >= 1)
        │     ^^^^^^^^^^^^^^^
     12 │ bar(!foo.length || foo.length)
-    13 │ const bar = void !foo.length;
+    13 │ alert(foo.length && bar())
   
   i Unsafe fix: Replace .length with .length > 0
   
@@ -294,7 +304,7 @@ invalid.js:11:5 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━�
     11    │ - bar(foo.length·>=·1)
        11 │ + bar(foo.length·>·0)
     12 12 │   bar(!foo.length || foo.length)
-    13 13 │   const bar = void !foo.length;
+    13 13 │   alert(foo.length && bar())
   
 
 ```
@@ -308,8 +318,8 @@ invalid.js:12:5 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━�
     11 │ bar(foo.length >= 1)
   > 12 │ bar(!foo.length || foo.length)
        │     ^^^^^^^^^^^
-    13 │ const bar = void !foo.length;
-    14 │ const isNotEmpty = Boolean(foo.length)
+    13 │ alert(foo.length && bar())
+    14 │ const hasLength = () => foo.length && bar()
   
   i Unsafe fix: Replace .length with .length === 0
   
@@ -317,664 +327,747 @@ invalid.js:12:5 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━�
     11 11 │   bar(foo.length >= 1)
     12    │ - bar(!foo.length·||·foo.length)
        12 │ + bar(foo.length·===·0||·foo.length)
-    13 13 │   const bar = void !foo.length;
-    14 14 │   const isNotEmpty = Boolean(foo.length)
+    13 13 │   alert(foo.length && bar())
+    14 14 │   const hasLength = () => foo.length && bar()
   
 
 ```
 
 ```
-invalid.js:12:20 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:13:7 lint/style/useExplicitLengthCheck ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Use .length > 0 when checking .length is not zero.
   
-    10 │ const isEmpty = foo.length < 1;
     11 │ bar(foo.length >= 1)
-  > 12 │ bar(!foo.length || foo.length)
-       │                    ^^^^^^^^^^
-    13 │ const bar = void !foo.length;
-    14 │ const isNotEmpty = Boolean(foo.length)
+    12 │ bar(!foo.length || foo.length)
+  > 13 │ alert(foo.length && bar())
+       │       ^^^^^^^^^^
+    14 │ const hasLength = () => foo.length && bar()
+    15 │ const parenthesizedHasLength = () => (foo.length) && bar()
   
-  i Unsafe fix: Replace .length with .length > 0
-  
-    12 │ bar(!foo.length·||·foo.length·>·0)
-       │                              ++++ 
 
 ```
 
 ```
-invalid.js:13:18 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:14:25 lint/style/useExplicitLengthCheck ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use .length > 0 when checking .length is not zero.
+  
+    12 │ bar(!foo.length || foo.length)
+    13 │ alert(foo.length && bar())
+  > 14 │ const hasLength = () => foo.length && bar()
+       │                         ^^^^^^^^^^
+    15 │ const parenthesizedHasLength = () => (foo.length) && bar()
+    16 │ if (!foo.length > 0) {}
+  
+
+```
+
+```
+invalid.js:15:39 lint/style/useExplicitLengthCheck ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use .length > 0 when checking .length is not zero.
+  
+    13 │ alert(foo.length && bar())
+    14 │ const hasLength = () => foo.length && bar()
+  > 15 │ const parenthesizedHasLength = () => (foo.length) && bar()
+       │                                       ^^^^^^^^^^
+    16 │ if (!foo.length > 0) {}
+    17 │ if (true === !foo.length) {}
+  
+
+```
+
+```
+invalid.js:16:5 lint/style/useExplicitLengthCheck ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Use .length === 0 when checking .length is zero.
   
-    11 │ bar(foo.length >= 1)
-    12 │ bar(!foo.length || foo.length)
-  > 13 │ const bar = void !foo.length;
+    14 │ const hasLength = () => foo.length && bar()
+    15 │ const parenthesizedHasLength = () => (foo.length) && bar()
+  > 16 │ if (!foo.length > 0) {}
+       │     ^^^^^^^^^^^
+    17 │ if (true === !foo.length) {}
+    18 │ const bar = void !foo.length;
+  
+
+```
+
+```
+invalid.js:17:14 lint/style/useExplicitLengthCheck ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use .length === 0 when checking .length is zero.
+  
+    15 │ const parenthesizedHasLength = () => (foo.length) && bar()
+    16 │ if (!foo.length > 0) {}
+  > 17 │ if (true === !foo.length) {}
+       │              ^^^^^^^^^^^
+    18 │ const bar = void !foo.length;
+    19 │ const isNotEmpty = Boolean(foo.length)
+  
+
+```
+
+```
+invalid.js:18:18 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use .length === 0 when checking .length is zero.
+  
+    16 │ if (!foo.length > 0) {}
+    17 │ if (true === !foo.length) {}
+  > 18 │ const bar = void !foo.length;
        │                  ^^^^^^^^^^^
-    14 │ const isNotEmpty = Boolean(foo.length)
-    15 │ const isNotEmpty1 = Boolean(foo.length || bar)
+    19 │ const isNotEmpty = Boolean(foo.length)
+    20 │ Boolean(foo.length).toString()
   
   i Unsafe fix: Replace .length with .length === 0
   
-    11 11 │   bar(foo.length >= 1)
-    12 12 │   bar(!foo.length || foo.length)
-    13    │ - const·bar·=·void·!foo.length;
-       13 │ + const·bar·=·void··foo.length·===·0;
-    14 14 │   const isNotEmpty = Boolean(foo.length)
-    15 15 │   const isNotEmpty1 = Boolean(foo.length || bar)
+    16 16 │   if (!foo.length > 0) {}
+    17 17 │   if (true === !foo.length) {}
+    18    │ - const·bar·=·void·!foo.length;
+       18 │ + const·bar·=·void··(foo.length·===·0);
+    19 19 │   const isNotEmpty = Boolean(foo.length)
+    20 20 │   Boolean(foo.length).toString()
   
 
 ```
 
 ```
-invalid.js:14:20 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:19:20 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Use .length > 0 when checking .length is not zero.
   
-    12 │ bar(!foo.length || foo.length)
-    13 │ const bar = void !foo.length;
-  > 14 │ const isNotEmpty = Boolean(foo.length)
+    17 │ if (true === !foo.length) {}
+    18 │ const bar = void !foo.length;
+  > 19 │ const isNotEmpty = Boolean(foo.length)
        │                    ^^^^^^^^^^^^^^^^^^^
-    15 │ const isNotEmpty1 = Boolean(foo.length || bar)
-    16 │ const isEmpty1 = Boolean(!foo.length)
+    20 │ Boolean(foo.length).toString()
+    21 │ +Boolean(foo.length)
   
   i Unsafe fix: Replace .length with .length > 0
   
-    12 12 │   bar(!foo.length || foo.length)
-    13 13 │   const bar = void !foo.length;
-    14    │ - const·isNotEmpty·=·Boolean(foo.length)
-       14 │ + const·isNotEmpty·=·foo.length·>·0
-    15 15 │   const isNotEmpty1 = Boolean(foo.length || bar)
-    16 16 │   const isEmpty1 = Boolean(!foo.length)
+    17 17 │   if (true === !foo.length) {}
+    18 18 │   const bar = void !foo.length;
+    19    │ - const·isNotEmpty·=·Boolean(foo.length)
+       19 │ + const·isNotEmpty·=·foo.length·>·0
+    20 20 │   Boolean(foo.length).toString()
+    21 21 │   +Boolean(foo.length)
   
 
 ```
 
 ```
-invalid.js:15:29 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:20:1 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Use .length > 0 when checking .length is not zero.
   
-    13 │ const bar = void !foo.length;
-    14 │ const isNotEmpty = Boolean(foo.length)
-  > 15 │ const isNotEmpty1 = Boolean(foo.length || bar)
-       │                             ^^^^^^^^^^
-    16 │ const isEmpty1 = Boolean(!foo.length)
-    17 │ const isEmpty2 = Boolean(/** 1 **/foo.length === 0)
+    18 │ const bar = void !foo.length;
+    19 │ const isNotEmpty = Boolean(foo.length)
+  > 20 │ Boolean(foo.length).toString()
+       │ ^^^^^^^^^^^^^^^^^^^
+    21 │ +Boolean(foo.length)
+    22 │ const isNotEmpty1 = Boolean(foo.length || bar)
   
   i Unsafe fix: Replace .length with .length > 0
   
-    15 │ const·isNotEmpty1·=·Boolean(foo.length·>·0||·bar)
+    18 18 │   const bar = void !foo.length;
+    19 19 │   const isNotEmpty = Boolean(foo.length)
+    20    │ - Boolean(foo.length).toString()
+       20 │ + (foo.length·>·0).toString()
+    21 21 │   +Boolean(foo.length)
+    22 22 │   const isNotEmpty1 = Boolean(foo.length || bar)
+  
+
+```
+
+```
+invalid.js:21:2 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use .length > 0 when checking .length is not zero.
+  
+    19 │ const isNotEmpty = Boolean(foo.length)
+    20 │ Boolean(foo.length).toString()
+  > 21 │ +Boolean(foo.length)
+       │  ^^^^^^^^^^^^^^^^^^^
+    22 │ const isNotEmpty1 = Boolean(foo.length || bar)
+    23 │ const isEmpty1 = Boolean(!foo.length)
+  
+  i Unsafe fix: Replace .length with .length > 0
+  
+    19 19 │   const isNotEmpty = Boolean(foo.length)
+    20 20 │   Boolean(foo.length).toString()
+    21    │ - +Boolean(foo.length)
+       21 │ + +(foo.length·>·0)
+    22 22 │   const isNotEmpty1 = Boolean(foo.length || bar)
+    23 23 │   const isEmpty1 = Boolean(!foo.length)
+  
+
+```
+
+```
+invalid.js:22:29 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use .length > 0 when checking .length is not zero.
+  
+    20 │ Boolean(foo.length).toString()
+    21 │ +Boolean(foo.length)
+  > 22 │ const isNotEmpty1 = Boolean(foo.length || bar)
+       │                             ^^^^^^^^^^
+    23 │ const isEmpty1 = Boolean(!foo.length)
+    24 │ const isEmpty2 = Boolean(/** 1 **/foo.length === 0)
+  
+  i Unsafe fix: Replace .length with .length > 0
+  
+    22 │ const·isNotEmpty1·=·Boolean(foo.length·>·0||·bar)
        │                                        +++       
 
 ```
 
 ```
-invalid.js:16:18 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:23:18 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Use .length === 0 when checking .length is zero.
   
-    14 │ const isNotEmpty = Boolean(foo.length)
-    15 │ const isNotEmpty1 = Boolean(foo.length || bar)
-  > 16 │ const isEmpty1 = Boolean(!foo.length)
+    21 │ +Boolean(foo.length)
+    22 │ const isNotEmpty1 = Boolean(foo.length || bar)
+  > 23 │ const isEmpty1 = Boolean(!foo.length)
        │                  ^^^^^^^^^^^^^^^^^^^^
-    17 │ const isEmpty2 = Boolean(/** 1 **/foo.length === 0)
-    18 │ const isNotEmpty2 = !Boolean(foo.length === 0)
+    24 │ const isEmpty2 = Boolean(/** 1 **/foo.length === 0)
+    25 │ const isNotEmpty2 = !Boolean(foo.length === 0)
   
   i Unsafe fix: Replace .length with .length === 0
   
-    14 14 │   const isNotEmpty = Boolean(foo.length)
-    15 15 │   const isNotEmpty1 = Boolean(foo.length || bar)
-    16    │ - const·isEmpty1·=·Boolean(!foo.length)
-       16 │ + const·isEmpty1·=·foo.length·===·0
-    17 17 │   const isEmpty2 = Boolean(/** 1 **/foo.length === 0)
-    18 18 │   const isNotEmpty2 = !Boolean(foo.length === 0)
+    21 21 │   +Boolean(foo.length)
+    22 22 │   const isNotEmpty1 = Boolean(foo.length || bar)
+    23    │ - const·isEmpty1·=·Boolean(!foo.length)
+       23 │ + const·isEmpty1·=·foo.length·===·0
+    24 24 │   const isEmpty2 = Boolean(/** 1 **/foo.length === 0)
+    25 25 │   const isNotEmpty2 = !Boolean(foo.length === 0)
   
 
 ```
 
 ```
-invalid.js:17:18 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:24:18 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Use .length === 0 when checking .length is zero.
   
-    15 │ const isNotEmpty1 = Boolean(foo.length || bar)
-    16 │ const isEmpty1 = Boolean(!foo.length)
-  > 17 │ const isEmpty2 = Boolean(/** 1 **/foo.length === 0)
+    22 │ const isNotEmpty1 = Boolean(foo.length || bar)
+    23 │ const isEmpty1 = Boolean(!foo.length)
+  > 24 │ const isEmpty2 = Boolean(/** 1 **/foo.length === 0)
        │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    18 │ const isNotEmpty2 = !Boolean(foo.length === 0)
-    19 │ const isEmpty3 = !Boolean(!Boolean(foo.length === 0))
+    25 │ const isNotEmpty2 = !Boolean(foo.length === 0)
+    26 │ const isEmpty3 = !Boolean(!Boolean(foo.length === 0))
   
   i Unsafe fix: Replace .length with .length === 0
   
-    17 │ const·isEmpty2·=·Boolean(/**·1·**/foo.length·===·0)
+    24 │ const·isEmpty2·=·Boolean(/**·1·**/foo.length·===·0)
        │                  -----------------                -
 
 ```
 
 ```
-invalid.js:18:21 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:25:21 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Use .length > 0 when checking .length is not zero.
   
-    16 │ const isEmpty1 = Boolean(!foo.length)
-    17 │ const isEmpty2 = Boolean(/** 1 **/foo.length === 0)
-  > 18 │ const isNotEmpty2 = !Boolean(foo.length === 0)
+    23 │ const isEmpty1 = Boolean(!foo.length)
+    24 │ const isEmpty2 = Boolean(/** 1 **/foo.length === 0)
+  > 25 │ const isNotEmpty2 = !Boolean(foo.length === 0)
        │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-    19 │ const isEmpty3 = !Boolean(!Boolean(foo.length === 0))
-    20 │ if (foo.size) {}
+    26 │ const isEmpty3 = !Boolean(!Boolean(foo.length === 0))
+    27 │ if (foo.size) {}
   
   i Unsafe fix: Replace .length with .length > 0
   
-    16 16 │   const isEmpty1 = Boolean(!foo.length)
-    17 17 │   const isEmpty2 = Boolean(/** 1 **/foo.length === 0)
-    18    │ - const·isNotEmpty2·=·!Boolean(foo.length·===·0)
-       18 │ + const·isNotEmpty2·=·foo.length·>·0
-    19 19 │   const isEmpty3 = !Boolean(!Boolean(foo.length === 0))
-    20 20 │   if (foo.size) {}
+    23 23 │   const isEmpty1 = Boolean(!foo.length)
+    24 24 │   const isEmpty2 = Boolean(/** 1 **/foo.length === 0)
+    25    │ - const·isNotEmpty2·=·!Boolean(foo.length·===·0)
+       25 │ + const·isNotEmpty2·=·foo.length·>·0
+    26 26 │   const isEmpty3 = !Boolean(!Boolean(foo.length === 0))
+    27 27 │   if (foo.size) {}
   
 
 ```
 
 ```
-invalid.js:19:18 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:26:18 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Use .length === 0 when checking .length is zero.
   
-    17 │ const isEmpty2 = Boolean(/** 1 **/foo.length === 0)
-    18 │ const isNotEmpty2 = !Boolean(foo.length === 0)
-  > 19 │ const isEmpty3 = !Boolean(!Boolean(foo.length === 0))
+    24 │ const isEmpty2 = Boolean(/** 1 **/foo.length === 0)
+    25 │ const isNotEmpty2 = !Boolean(foo.length === 0)
+  > 26 │ const isEmpty3 = !Boolean(!Boolean(foo.length === 0))
        │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    20 │ if (foo.size) {}
-    21 │ if (foo.size && bar.length) {}
+    27 │ if (foo.size) {}
+    28 │ if (foo.size && bar.length) {}
   
   i Unsafe fix: Replace .length with .length === 0
   
-    19 │ const·isEmpty3·=·!Boolean(!Boolean(foo.length·===·0))
+    26 │ const·isEmpty3·=·!Boolean(!Boolean(foo.length·===·0))
        │                  ------------------                --
 
 ```
 
 ```
-invalid.js:20:5 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:27:5 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Use .size > 0 when checking .size is not zero.
   
-    18 │ const isNotEmpty2 = !Boolean(foo.length === 0)
-    19 │ const isEmpty3 = !Boolean(!Boolean(foo.length === 0))
-  > 20 │ if (foo.size) {}
+    25 │ const isNotEmpty2 = !Boolean(foo.length === 0)
+    26 │ const isEmpty3 = !Boolean(!Boolean(foo.length === 0))
+  > 27 │ if (foo.size) {}
        │     ^^^^^^^^
-    21 │ if (foo.size && bar.length) {}
-    22 │ // Space after keywords
+    28 │ if (foo.size && bar.length) {}
+    29 │ 
   
   i Unsafe fix: Replace .size with .size > 0
   
-    20 │ if·(foo.size·>·0)·{}
+    27 │ if·(foo.size·>·0)·{}
        │             ++++    
 
 ```
 
 ```
-invalid.js:21:5 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:28:5 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Use .size > 0 when checking .size is not zero.
   
-    19 │ const isEmpty3 = !Boolean(!Boolean(foo.length === 0))
-    20 │ if (foo.size) {}
-  > 21 │ if (foo.size && bar.length) {}
+    26 │ const isEmpty3 = !Boolean(!Boolean(foo.length === 0))
+    27 │ if (foo.size) {}
+  > 28 │ if (foo.size && bar.length) {}
        │     ^^^^^^^^
-    22 │ // Space after keywords
-    23 │ function foo() {return!foo.length}
+    29 │ 
+    30 │ // Unlike ESLint Unicorn, Biome checks direct properties on `this` because they
   
   i Unsafe fix: Replace .size with .size > 0
   
-    21 │ if·(foo.size·>·0&&·bar.length)·{}
+    28 │ if·(foo.size·>·0&&·bar.length)·{}
        │              +++                 
 
 ```
 
 ```
-invalid.js:21:17 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:28:17 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Use .length > 0 when checking .length is not zero.
   
-    19 │ const isEmpty3 = !Boolean(!Boolean(foo.length === 0))
-    20 │ if (foo.size) {}
-  > 21 │ if (foo.size && bar.length) {}
+    26 │ const isEmpty3 = !Boolean(!Boolean(foo.length === 0))
+    27 │ if (foo.size) {}
+  > 28 │ if (foo.size && bar.length) {}
        │                 ^^^^^^^^^^
-    22 │ // Space after keywords
-    23 │ function foo() {return!foo.length}
+    29 │ 
+    30 │ // Unlike ESLint Unicorn, Biome checks direct properties on `this` because they
   
   i Unsafe fix: Replace .length with .length > 0
   
-    21 │ if·(foo.size·&&·bar.length·>·0)·{}
+    28 │ if·(foo.size·&&·bar.length·>·0)·{}
        │                           ++++    
 
 ```
 
 ```
-invalid.js:23:23 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i Use .length === 0 when checking .length is zero.
-  
-    21 │ if (foo.size && bar.length) {}
-    22 │ // Space after keywords
-  > 23 │ function foo() {return!foo.length}
-       │                       ^^^^^^^^^^^
-    24 │ function foo() {throw!foo.length}
-    25 │ async function foo() {await!foo.length}
-  
-  i Unsafe fix: Replace .length with .length === 0
-  
-    21 21 │   if (foo.size && bar.length) {}
-    22 22 │   // Space after keywords
-    23    │ - function·foo()·{return!foo.length}
-       23 │ + function·foo()·{return·foo.length·===·0}
-    24 24 │   function foo() {throw!foo.length}
-    25 25 │   async function foo() {await!foo.length}
-  
-
-```
-
-```
-invalid.js:24:22 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i Use .length === 0 when checking .length is zero.
-  
-    22 │ // Space after keywords
-    23 │ function foo() {return!foo.length}
-  > 24 │ function foo() {throw!foo.length}
-       │                      ^^^^^^^^^^^
-    25 │ async function foo() {await!foo.length}
-    26 │ function * foo() {yield!foo.length}
-  
-  i Unsafe fix: Replace .length with .length === 0
-  
-    22 22 │   // Space after keywords
-    23 23 │   function foo() {return!foo.length}
-    24    │ - function·foo()·{throw!foo.length}
-       24 │ + function·foo()·{throw·foo.length·===·0}
-    25 25 │   async function foo() {await!foo.length}
-    26 26 │   function * foo() {yield!foo.length}
-  
-
-```
-
-```
-invalid.js:25:28 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i Use .length === 0 when checking .length is zero.
-  
-    23 │ function foo() {return!foo.length}
-    24 │ function foo() {throw!foo.length}
-  > 25 │ async function foo() {await!foo.length}
-       │                            ^^^^^^^^^^^
-    26 │ function * foo() {yield!foo.length}
-    27 │ function * foo() {yield*!foo.length}
-  
-  i Unsafe fix: Replace .length with .length === 0
-  
-    23 23 │   function foo() {return!foo.length}
-    24 24 │   function foo() {throw!foo.length}
-    25    │ - async·function·foo()·{await!foo.length}
-       25 │ + async·function·foo()·{await·foo.length·===·0}
-    26 26 │   function * foo() {yield!foo.length}
-    27 27 │   function * foo() {yield*!foo.length}
-  
-
-```
-
-```
-invalid.js:26:24 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i Use .length === 0 when checking .length is zero.
-  
-    24 │ function foo() {throw!foo.length}
-    25 │ async function foo() {await!foo.length}
-  > 26 │ function * foo() {yield!foo.length}
-       │                        ^^^^^^^^^^^
-    27 │ function * foo() {yield*!foo.length}
-    28 │ delete!foo.length
-  
-  i Unsafe fix: Replace .length with .length === 0
-  
-    24 24 │   function foo() {throw!foo.length}
-    25 25 │   async function foo() {await!foo.length}
-    26    │ - function·*·foo()·{yield!foo.length}
-       26 │ + function·*·foo()·{yieldfoo.length·===·0}
-    27 27 │   function * foo() {yield*!foo.length}
-    28 28 │   delete!foo.length
-  
-
-```
-
-```
-invalid.js:27:25 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i Use .length === 0 when checking .length is zero.
-  
-    25 │ async function foo() {await!foo.length}
-    26 │ function * foo() {yield!foo.length}
-  > 27 │ function * foo() {yield*!foo.length}
-       │                         ^^^^^^^^^^^
-    28 │ delete!foo.length
-    29 │ typeof!foo.length
-  
-  i Unsafe fix: Replace .length with .length === 0
-  
-    25 25 │   async function foo() {await!foo.length}
-    26 26 │   function * foo() {yield!foo.length}
-    27    │ - function·*·foo()·{yield*!foo.length}
-       27 │ + function·*·foo()·{yield*foo.length·===·0}
-    28 28 │   delete!foo.length
-    29 29 │   typeof!foo.length
-  
-
-```
-
-```
-invalid.js:28:7 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i Use .length === 0 when checking .length is zero.
-  
-    26 │ function * foo() {yield!foo.length}
-    27 │ function * foo() {yield*!foo.length}
-  > 28 │ delete!foo.length
-       │       ^^^^^^^^^^^
-    29 │ typeof!foo.length
-    30 │ void!foo.length
-  
-  i Unsafe fix: Replace .length with .length === 0
-  
-    26 26 │   function * foo() {yield!foo.length}
-    27 27 │   function * foo() {yield*!foo.length}
-    28    │ - delete!foo.length
-       28 │ + delete·foo.length·===·0
-    29 29 │   typeof!foo.length
-    30 30 │   void!foo.length
-  
-
-```
-
-```
-invalid.js:29:7 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i Use .length === 0 when checking .length is zero.
-  
-    27 │ function * foo() {yield*!foo.length}
-    28 │ delete!foo.length
-  > 29 │ typeof!foo.length
-       │       ^^^^^^^^^^^
-    30 │ void!foo.length
-    31 │ a instanceof!foo.length
-  
-  i Unsafe fix: Replace .length with .length === 0
-  
-    27 27 │   function * foo() {yield*!foo.length}
-    28 28 │   delete!foo.length
-    29    │ - typeof!foo.length
-       29 │ + typeof·foo.length·===·0
-    30 30 │   void!foo.length
-    31 31 │   a instanceof!foo.length
-  
-
-```
-
-```
-invalid.js:30:5 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i Use .length === 0 when checking .length is zero.
-  
-    28 │ delete!foo.length
-    29 │ typeof!foo.length
-  > 30 │ void!foo.length
-       │     ^^^^^^^^^^^
-    31 │ a instanceof!foo.length
-    32 │ a in!foo.length
-  
-  i Unsafe fix: Replace .length with .length === 0
-  
-    28 28 │   delete!foo.length
-    29 29 │   typeof!foo.length
-    30    │ - void!foo.length
-       30 │ + void·foo.length·===·0
-    31 31 │   a instanceof!foo.length
-    32 32 │   a in!foo.length
-  
-
-```
-
-```
-invalid.js:31:13 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i Use .length === 0 when checking .length is zero.
-  
-    29 │ typeof!foo.length
-    30 │ void!foo.length
-  > 31 │ a instanceof!foo.length
-       │             ^^^^^^^^^^^
-    32 │ a in!foo.length
-    33 │ export default!foo.length
-  
-  i Unsafe fix: Replace .length with .length === 0
-  
-    29 29 │   typeof!foo.length
-    30 30 │   void!foo.length
-    31    │ - a·instanceof!foo.length
-       31 │ + a·instanceof·foo.length·===·0
-    32 32 │   a in!foo.length
-    33 33 │   export default!foo.length
-  
-
-```
-
-```
-invalid.js:32:5 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i Use .length === 0 when checking .length is zero.
-  
-    30 │ void!foo.length
-    31 │ a instanceof!foo.length
-  > 32 │ a in!foo.length
-       │     ^^^^^^^^^^^
-    33 │ export default!foo.length
-    34 │ if(true){}else!foo.length
-  
-  i Unsafe fix: Replace .length with .length === 0
-  
-    30 30 │   void!foo.length
-    31 31 │   a instanceof!foo.length
-    32    │ - a·in!foo.length
-       32 │ + a·in·foo.length·===·0
-    33 33 │   export default!foo.length
-    34 34 │   if(true){}else!foo.length
-  
-
-```
-
-```
-invalid.js:33:15 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i Use .length === 0 when checking .length is zero.
-  
-    31 │ a instanceof!foo.length
-    32 │ a in!foo.length
-  > 33 │ export default!foo.length
-       │               ^^^^^^^^^^^
-    34 │ if(true){}else!foo.length
-    35 │ do!foo.length;while(true) {}
-  
-  i Unsafe fix: Replace .length with .length === 0
-  
-    31 31 │   a instanceof!foo.length
-    32 32 │   a in!foo.length
-    33    │ - export·default!foo.length
-       33 │ + export·default·foo.length·===·0
-    34 34 │   if(true){}else!foo.length
-    35 35 │   do!foo.length;while(true) {}
-  
-
-```
-
-```
-invalid.js:34:15 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i Use .length === 0 when checking .length is zero.
-  
-    32 │ a in!foo.length
-    33 │ export default!foo.length
-  > 34 │ if(true){}else!foo.length
-       │               ^^^^^^^^^^^
-    35 │ do!foo.length;while(true) {}
-    36 │ switch(foo){case!foo.length:{}}
-  
-  i Unsafe fix: Replace .length with .length === 0
-  
-    32 32 │   a in!foo.length
-    33 33 │   export default!foo.length
-    34    │ - if(true){}else!foo.length
-       34 │ + if(true){}elsefoo.length·===·0
-    35 35 │   do!foo.length;while(true) {}
-    36 36 │   switch(foo){case!foo.length:{}}
-  
-
-```
-
-```
-invalid.js:35:3 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i Use .length === 0 when checking .length is zero.
-  
-    33 │ export default!foo.length
-    34 │ if(true){}else!foo.length
-  > 35 │ do!foo.length;while(true) {}
-       │   ^^^^^^^^^^^
-    36 │ switch(foo){case!foo.length:{}}
-    37 │ for(const a of!foo.length);
-  
-  i Unsafe fix: Replace .length with .length === 0
-  
-    33 33 │   export default!foo.length
-    34 34 │   if(true){}else!foo.length
-    35    │ - do!foo.length;while(true)·{}
-       35 │ + dofoo.length·===·0;while(true)·{}
-    36 36 │   switch(foo){case!foo.length:{}}
-    37 37 │   for(const a of!foo.length);
-  
-
-```
-
-```
-invalid.js:36:17 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i Use .length === 0 when checking .length is zero.
-  
-    34 │ if(true){}else!foo.length
-    35 │ do!foo.length;while(true) {}
-  > 36 │ switch(foo){case!foo.length:{}}
-       │                 ^^^^^^^^^^^
-    37 │ for(const a of!foo.length);
-    38 │ for(const a in!foo.length);
-  
-  i Unsafe fix: Replace .length with .length === 0
-  
-    34 34 │   if(true){}else!foo.length
-    35 35 │   do!foo.length;while(true) {}
-    36    │ - switch(foo){case!foo.length:{}}
-       36 │ + switch(foo){case·foo.length·===·0:{}}
-    37 37 │   for(const a of!foo.length);
-    38 38 │   for(const a in!foo.length);
-  
-
-```
-
-```
-invalid.js:37:15 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i Use .length === 0 when checking .length is zero.
-  
-    35 │ do!foo.length;while(true) {}
-    36 │ switch(foo){case!foo.length:{}}
-  > 37 │ for(const a of!foo.length);
-       │               ^^^^^^^^^^^
-    38 │ for(const a in!foo.length);
-    39 │ 
-  
-  i Unsafe fix: Replace .length with .length === 0
-  
-    35 35 │   do!foo.length;while(true) {}
-    36 36 │   switch(foo){case!foo.length:{}}
-    37    │ - for(const·a·of!foo.length);
-       37 │ + for(const·a·of·foo.length·===·0);
-    38 38 │   for(const a in!foo.length);
-    39 39 │   
-  
-
-```
-
-```
-invalid.js:38:15 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i Use .length === 0 when checking .length is zero.
-  
-    36 │ switch(foo){case!foo.length:{}}
-    37 │ for(const a of!foo.length);
-  > 38 │ for(const a in!foo.length);
-       │               ^^^^^^^^^^^
-    39 │ 
-    40 │ class A {
-  
-  i Unsafe fix: Replace .length with .length === 0
-  
-    36 36 │   switch(foo){case!foo.length:{}}
-    37 37 │   for(const a of!foo.length);
-    38    │ - for(const·a·in!foo.length);
-       38 │ + for(const·a·in·foo.length·===·0);
-    39 39 │   
-    40 40 │   class A {
-  
-
-```
-
-```
-invalid.js:42:13 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:34:13 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Use .length > 0 when checking .length is not zero.
   
-    40 │ class A {
-    41 │     a() {
-  > 42 │         if (this.length) {};
+    32 │ class A {
+    33 │     a() {
+  > 34 │         if (this.length) {};
        │             ^^^^^^^^^^^
-    43 │         while (!this.size || foo);
-    44 │     }
+    35 │         while (!this.size || foo);
+    36 │     }
   
   i Unsafe fix: Replace .length with .length > 0
   
-    42 │ ········if·(this.length·>·0)·{};
+    34 │ ········if·(this.length·>·0)·{};
        │                        ++++     
 
 ```
 
 ```
-invalid.js:43:16 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:35:16 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Use .size === 0 when checking .size is zero.
   
-    41 │     a() {
-    42 │         if (this.length) {};
-  > 43 │         while (!this.size || foo);
+    33 │     a() {
+    34 │         if (this.length) {};
+  > 35 │         while (!this.size || foo);
        │                ^^^^^^^^^^
-    44 │     }
-    45 │ }
+    36 │     }
+    37 │ }
   
   i Unsafe fix: Replace .size with .size === 0
   
-    41 41 │       a() {
-    42 42 │           if (this.length) {};
-    43    │ - ········while·(!this.size·||·foo);
-       43 │ + ········while·(this.size·===·0||·foo);
-    44 44 │       }
-    45 45 │   }
+    33 33 │       a() {
+    34 34 │           if (this.length) {};
+    35    │ - ········while·(!this.size·||·foo);
+       35 │ + ········while·(this.size·===·0||·foo);
+    36 36 │       }
+    37 37 │   }
+  
+
+```
+
+```
+invalid.js:40:23 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use .length === 0 when checking .length is zero.
+  
+    39 │ // Space after keywords
+  > 40 │ function foo() {return!foo.length}
+       │                       ^^^^^^^^^^^
+    41 │ function foo() {throw!foo.length}
+    42 │ async function foo() {await!foo.length}
+  
+  i Unsafe fix: Replace .length with .length === 0
+  
+    38 38 │   
+    39 39 │   // Space after keywords
+    40    │ - function·foo()·{return!foo.length}
+       40 │ + function·foo()·{return·foo.length·===·0}
+    41 41 │   function foo() {throw!foo.length}
+    42 42 │   async function foo() {await!foo.length}
+  
+
+```
+
+```
+invalid.js:41:22 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use .length === 0 when checking .length is zero.
+  
+    39 │ // Space after keywords
+    40 │ function foo() {return!foo.length}
+  > 41 │ function foo() {throw!foo.length}
+       │                      ^^^^^^^^^^^
+    42 │ async function foo() {await!foo.length}
+    43 │ function * foo() {yield!foo.length}
+  
+  i Unsafe fix: Replace .length with .length === 0
+  
+    39 39 │   // Space after keywords
+    40 40 │   function foo() {return!foo.length}
+    41    │ - function·foo()·{throw!foo.length}
+       41 │ + function·foo()·{throw·foo.length·===·0}
+    42 42 │   async function foo() {await!foo.length}
+    43 43 │   function * foo() {yield!foo.length}
+  
+
+```
+
+```
+invalid.js:42:28 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use .length === 0 when checking .length is zero.
+  
+    40 │ function foo() {return!foo.length}
+    41 │ function foo() {throw!foo.length}
+  > 42 │ async function foo() {await!foo.length}
+       │                            ^^^^^^^^^^^
+    43 │ function * foo() {yield!foo.length}
+    44 │ function * foo() {yield*!foo.length}
+  
+  i Unsafe fix: Replace .length with .length === 0
+  
+    40 40 │   function foo() {return!foo.length}
+    41 41 │   function foo() {throw!foo.length}
+    42    │ - async·function·foo()·{await!foo.length}
+       42 │ + async·function·foo()·{await·(foo.length·===·0)}
+    43 43 │   function * foo() {yield!foo.length}
+    44 44 │   function * foo() {yield*!foo.length}
+  
+
+```
+
+```
+invalid.js:43:24 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use .length === 0 when checking .length is zero.
+  
+    41 │ function foo() {throw!foo.length}
+    42 │ async function foo() {await!foo.length}
+  > 43 │ function * foo() {yield!foo.length}
+       │                        ^^^^^^^^^^^
+    44 │ function * foo() {yield*!foo.length}
+    45 │ delete!foo.length
+  
+  i Unsafe fix: Replace .length with .length === 0
+  
+    41 41 │   function foo() {throw!foo.length}
+    42 42 │   async function foo() {await!foo.length}
+    43    │ - function·*·foo()·{yield!foo.length}
+       43 │ + function·*·foo()·{yield·foo.length·===·0}
+    44 44 │   function * foo() {yield*!foo.length}
+    45 45 │   delete!foo.length
+  
+
+```
+
+```
+invalid.js:44:25 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use .length === 0 when checking .length is zero.
+  
+    42 │ async function foo() {await!foo.length}
+    43 │ function * foo() {yield!foo.length}
+  > 44 │ function * foo() {yield*!foo.length}
+       │                         ^^^^^^^^^^^
+    45 │ delete!foo.length
+    46 │ typeof!foo.length
+  
+  i Unsafe fix: Replace .length with .length === 0
+  
+    42 42 │   async function foo() {await!foo.length}
+    43 43 │   function * foo() {yield!foo.length}
+    44    │ - function·*·foo()·{yield*!foo.length}
+       44 │ + function·*·foo()·{yield*foo.length·===·0}
+    45 45 │   delete!foo.length
+    46 46 │   typeof!foo.length
+  
+
+```
+
+```
+invalid.js:45:7 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use .length === 0 when checking .length is zero.
+  
+    43 │ function * foo() {yield!foo.length}
+    44 │ function * foo() {yield*!foo.length}
+  > 45 │ delete!foo.length
+       │       ^^^^^^^^^^^
+    46 │ typeof!foo.length
+    47 │ void!foo.length
+  
+  i Unsafe fix: Replace .length with .length === 0
+  
+    43 43 │   function * foo() {yield!foo.length}
+    44 44 │   function * foo() {yield*!foo.length}
+    45    │ - delete!foo.length
+       45 │ + delete·(foo.length·===·0)
+    46 46 │   typeof!foo.length
+    47 47 │   void!foo.length
+  
+
+```
+
+```
+invalid.js:46:7 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use .length === 0 when checking .length is zero.
+  
+    44 │ function * foo() {yield*!foo.length}
+    45 │ delete!foo.length
+  > 46 │ typeof!foo.length
+       │       ^^^^^^^^^^^
+    47 │ void!foo.length
+    48 │ a instanceof!foo.length
+  
+  i Unsafe fix: Replace .length with .length === 0
+  
+    44 44 │   function * foo() {yield*!foo.length}
+    45 45 │   delete!foo.length
+    46    │ - typeof!foo.length
+       46 │ + typeof·(foo.length·===·0)
+    47 47 │   void!foo.length
+    48 48 │   a instanceof!foo.length
+  
+
+```
+
+```
+invalid.js:47:5 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use .length === 0 when checking .length is zero.
+  
+    45 │ delete!foo.length
+    46 │ typeof!foo.length
+  > 47 │ void!foo.length
+       │     ^^^^^^^^^^^
+    48 │ a instanceof!foo.length
+    49 │ a in!foo.length
+  
+  i Unsafe fix: Replace .length with .length === 0
+  
+    45 45 │   delete!foo.length
+    46 46 │   typeof!foo.length
+    47    │ - void!foo.length
+       47 │ + void·(foo.length·===·0)
+    48 48 │   a instanceof!foo.length
+    49 49 │   a in!foo.length
+  
+
+```
+
+```
+invalid.js:48:13 lint/style/useExplicitLengthCheck ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use .length === 0 when checking .length is zero.
+  
+    46 │ typeof!foo.length
+    47 │ void!foo.length
+  > 48 │ a instanceof!foo.length
+       │             ^^^^^^^^^^^
+    49 │ a in!foo.length
+    50 │ export default!foo.length
+  
+
+```
+
+```
+invalid.js:49:5 lint/style/useExplicitLengthCheck ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use .length === 0 when checking .length is zero.
+  
+    47 │ void!foo.length
+    48 │ a instanceof!foo.length
+  > 49 │ a in!foo.length
+       │     ^^^^^^^^^^^
+    50 │ export default!foo.length
+    51 │ if(true){}else!foo.length
+  
+
+```
+
+```
+invalid.js:50:15 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use .length === 0 when checking .length is zero.
+  
+    48 │ a instanceof!foo.length
+    49 │ a in!foo.length
+  > 50 │ export default!foo.length
+       │               ^^^^^^^^^^^
+    51 │ if(true){}else!foo.length
+    52 │ do!foo.length;while(true) {}
+  
+  i Unsafe fix: Replace .length with .length === 0
+  
+    48 48 │   a instanceof!foo.length
+    49 49 │   a in!foo.length
+    50    │ - export·default!foo.length
+       50 │ + export·default·foo.length·===·0
+    51 51 │   if(true){}else!foo.length
+    52 52 │   do!foo.length;while(true) {}
+  
+
+```
+
+```
+invalid.js:51:15 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use .length === 0 when checking .length is zero.
+  
+    49 │ a in!foo.length
+    50 │ export default!foo.length
+  > 51 │ if(true){}else!foo.length
+       │               ^^^^^^^^^^^
+    52 │ do!foo.length;while(true) {}
+    53 │ switch(foo){case!foo.length:{}}
+  
+  i Unsafe fix: Replace .length with .length === 0
+  
+    49 49 │   a in!foo.length
+    50 50 │   export default!foo.length
+    51    │ - if(true){}else!foo.length
+       51 │ + if(true){}else·foo.length·===·0
+    52 52 │   do!foo.length;while(true) {}
+    53 53 │   switch(foo){case!foo.length:{}}
+  
+
+```
+
+```
+invalid.js:52:3 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use .length === 0 when checking .length is zero.
+  
+    50 │ export default!foo.length
+    51 │ if(true){}else!foo.length
+  > 52 │ do!foo.length;while(true) {}
+       │   ^^^^^^^^^^^
+    53 │ switch(foo){case!foo.length:{}}
+    54 │ for(const a of!foo.length);
+  
+  i Unsafe fix: Replace .length with .length === 0
+  
+    50 50 │   export default!foo.length
+    51 51 │   if(true){}else!foo.length
+    52    │ - do!foo.length;while(true)·{}
+       52 │ + do·foo.length·===·0;while(true)·{}
+    53 53 │   switch(foo){case!foo.length:{}}
+    54 54 │   for(const a of!foo.length);
+  
+
+```
+
+```
+invalid.js:53:17 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use .length === 0 when checking .length is zero.
+  
+    51 │ if(true){}else!foo.length
+    52 │ do!foo.length;while(true) {}
+  > 53 │ switch(foo){case!foo.length:{}}
+       │                 ^^^^^^^^^^^
+    54 │ for(const a of!foo.length);
+    55 │ for(const a in!foo.length);
+  
+  i Unsafe fix: Replace .length with .length === 0
+  
+    51 51 │   if(true){}else!foo.length
+    52 52 │   do!foo.length;while(true) {}
+    53    │ - switch(foo){case!foo.length:{}}
+       53 │ + switch(foo){case·foo.length·===·0:{}}
+    54 54 │   for(const a of!foo.length);
+    55 55 │   for(const a in!foo.length);
+  
+
+```
+
+```
+invalid.js:54:15 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use .length === 0 when checking .length is zero.
+  
+    52 │ do!foo.length;while(true) {}
+    53 │ switch(foo){case!foo.length:{}}
+  > 54 │ for(const a of!foo.length);
+       │               ^^^^^^^^^^^
+    55 │ for(const a in!foo.length);
+    56 │ 
+  
+  i Unsafe fix: Replace .length with .length === 0
+  
+    52 52 │   do!foo.length;while(true) {}
+    53 53 │   switch(foo){case!foo.length:{}}
+    54    │ - for(const·a·of!foo.length);
+       54 │ + for(const·a·of·foo.length·===·0);
+    55 55 │   for(const a in!foo.length);
+    56 56 │   
+  
+
+```
+
+```
+invalid.js:55:15 lint/style/useExplicitLengthCheck  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use .length === 0 when checking .length is zero.
+  
+    53 │ switch(foo){case!foo.length:{}}
+    54 │ for(const a of!foo.length);
+  > 55 │ for(const a in!foo.length);
+       │               ^^^^^^^^^^^
+    56 │ 
+  
+  i Unsafe fix: Replace .length with .length === 0
+  
+    53 53 │   switch(foo){case!foo.length:{}}
+    54 54 │   for(const a of!foo.length);
+    55    │ - for(const·a·in!foo.length);
+       55 │ + for(const·a·in·foo.length·===·0);
+    56 56 │   
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/style/useExplicitLengthCheck/valid.js
+++ b/crates/biome_js_analyze/tests/specs/style/useExplicitLengthCheck/valid.js
@@ -41,5 +41,16 @@ if (foo.length === 0 || true) {}
 
 // Logical OR
 const x3 = foo.length || 2
-// TODO. Not supported yet.
-// const A_NUMBER = 2; const x = foo.length || A_NUMBER
+const A_NUMBER = 2; const x4 = foo.length || A_NUMBER
+const x5 = foo.length || "bar"
+const A_STRING = "bar"; const x6 = foo.length || A_STRING
+const x7 = foo.length || unknown
+const itemCount = result.totalCount || result.length
+
+let object = { index: 0 };
+let string = "test";
+const index = object?.index || string.length;
+
+if (foo?.length) {}
+if (!foo?.length) {}
+if (!foo?.bar.length) {}

--- a/crates/biome_js_analyze/tests/specs/style/useExplicitLengthCheck/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useExplicitLengthCheck/valid.js.snap
@@ -47,7 +47,18 @@ if (foo.length === 0 || true) {}
 
 // Logical OR
 const x3 = foo.length || 2
-// TODO. Not supported yet.
-// const A_NUMBER = 2; const x = foo.length || A_NUMBER
+const A_NUMBER = 2; const x4 = foo.length || A_NUMBER
+const x5 = foo.length || "bar"
+const A_STRING = "bar"; const x6 = foo.length || A_STRING
+const x7 = foo.length || unknown
+const itemCount = result.totalCount || result.length
+
+let object = { index: 0 };
+let string = "test";
+const index = object?.index || string.length;
+
+if (foo?.length) {}
+if (!foo?.length) {}
+if (!foo?.bar.length) {}
 
 ```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This is a bunch of refactoring and fixes to more align useExplicitLengthCheck with the source rule. We still differ a little, but not as much now.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

fixes #11352

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
