### PR TITLE
perf(css_parser): avoid rejected nesting blocks

### DIFF
--- a/crates/biome_css_parser/src/syntax/scss/declaration/nesting.rs
+++ b/crates/biome_css_parser/src/syntax/scss/declaration/nesting.rs
@@ -43,7 +43,8 @@ pub(crate) fn parse_scss_nesting_declaration(p: &mut CssParser) -> ParsedSyntax 
         return Absent;
     }
 
-    parse_scss_nesting_declaration_candidate(p).map_or(Absent, |(syntax, _)| syntax)
+    parse_scss_nesting_declaration_candidate(p, SelectorLikeBlockPolicy::Parse)
+        .map_or(Absent, |(syntax, _)| syntax)
 }
 
 #[inline]
@@ -71,37 +72,59 @@ struct ScssNestingMarkers {
     is_custom_property: bool,
 }
 
-/// Parses a SCSS nested-property/declaration candidate and returns both the
-/// parsed syntax and whether the same prefix could still be interpreted as a
-/// selector by the caller.
+/// Controls whether a source-tight selector-like candidate may parse its
+/// following block before the caller decides its final classification.
+#[derive(Clone, Copy)]
+enum SelectorLikeBlockPolicy {
+    /// Complete the candidate as nested-property syntax when a block follows.
+    Parse,
+    /// Stop before the block so an enclosing speculative parse can rewind and
+    /// retry the construct as a nested qualified rule.
+    RejectBeforeBlock,
+}
+
+/// Parses a SCSS nested-property/declaration candidate.
 ///
-/// This keeps the real parsing shared between the committed and speculative
-/// nesting entrypoints.
+/// With `RejectBeforeBlock`, this returns `None` after abandoning a parsed
+/// source-tight selector-like prefix and value immediately before `{`. That
+/// policy must only be used inside `try_parse`, which rewinds the consumed
+/// parser context and token-source state.
 #[inline]
-fn parse_scss_nesting_declaration_candidate(p: &mut CssParser) -> Option<(ParsedSyntax, bool)> {
+fn parse_scss_nesting_declaration_candidate(
+    p: &mut CssParser,
+    selector_like_block_policy: SelectorLikeBlockPolicy,
+) -> Option<(ParsedSyntax, bool)> {
     if !is_at_scss_nesting_declaration(p) {
         return None;
     }
 
     let (markers, could_be_selector) = parse_scss_nesting_declaration_prefix(p)?;
-    let syntax = parse_scss_nesting_declaration_after_prefix(p, markers);
+    let syntax = parse_scss_nesting_declaration_after_prefix(
+        p,
+        markers,
+        could_be_selector,
+        selector_like_block_policy,
+    )?;
 
     Some((syntax, could_be_selector))
 }
 
-/// Parses the remainder of a SCSS nesting candidate after its `name:` prefix
-/// has already been recognized.
+/// Parses the remainder of a SCSS nesting candidate after its `name:` prefix.
 ///
-/// This decides whether the candidate becomes a nested-property block or a
-/// regular declaration once the value and following token are known.
+/// Returns `None` only when `RejectBeforeBlock` stops a source-tight
+/// selector-like candidate immediately before its block.
 #[inline]
 fn parse_scss_nesting_declaration_after_prefix(
     p: &mut CssParser,
     markers: ScssNestingMarkers,
-) -> ParsedSyntax {
+    could_be_selector: bool,
+    selector_like_block_policy: SelectorLikeBlockPolicy,
+) -> Option<ParsedSyntax> {
     if markers.is_custom_property {
         parse_custom_property_value(p, END_OF_PROPERTY_VALUE_COMPONENT_LIST_TOKEN_SET);
-        return complete_scss_nesting_regular_declaration(p, markers, false);
+        return Some(complete_scss_nesting_regular_declaration(
+            p, markers, false,
+        ));
     }
 
     let missing_value =
@@ -110,14 +133,30 @@ fn parse_scss_nesting_declaration_after_prefix(
         // handled by the caller via `missing_value`.
         parse_scss_optional_value_until(p, SCSS_NESTING_VALUE_END_SET).is_absent();
 
+    if could_be_selector
+        && p.at(T!['{'])
+        && matches!(
+            selector_like_block_policy,
+            SelectorLikeBlockPolicy::RejectBeforeBlock
+        )
+    {
+        markers.property.abandon(p);
+        markers.declaration.abandon(p);
+        return None;
+    }
+
     if p.at(T!['{']) {
         // A following `{` turns the parsed prefix into nested-property syntax.
         if missing_value {
             complete_empty_scss_expression(p);
         }
-        complete_scss_nested_property_block(p, markers)
+        Some(complete_scss_nested_property_block(p, markers))
     } else {
-        complete_scss_nesting_regular_declaration(p, markers, missing_value)
+        Some(complete_scss_nesting_regular_declaration(
+            p,
+            markers,
+            missing_value,
+        ))
     }
 }
 
@@ -230,7 +269,10 @@ pub(crate) fn try_parse_scss_nesting_declaration(
             return Err(());
         }
 
-        let Some((syntax, could_be_selector)) = parse_scss_nesting_declaration_candidate(p) else {
+        let Some((syntax, could_be_selector)) = parse_scss_nesting_declaration_candidate(
+            p,
+            SelectorLikeBlockPolicy::RejectBeforeBlock,
+        ) else {
             return Err(());
         };
 
@@ -251,7 +293,10 @@ pub(crate) fn try_parse_scss_nesting_declaration(
 #[inline]
 fn try_parse_scss_nested_property_declaration(p: &mut CssParser) -> Result<ParsedSyntax, ()> {
     try_parse(p, |p| {
-        let Some((syntax, could_be_selector)) = parse_scss_nesting_declaration_candidate(p) else {
+        let Some((syntax, could_be_selector)) = parse_scss_nesting_declaration_candidate(
+            p,
+            SelectorLikeBlockPolicy::RejectBeforeBlock,
+        ) else {
             return Err(());
         };
 

--- a/crates/biome_css_parser/src/syntax/scss/declaration/nesting.rs
+++ b/crates/biome_css_parser/src/syntax/scss/declaration/nesting.rs
@@ -122,9 +122,7 @@ fn parse_scss_nesting_declaration_after_prefix(
 ) -> Option<ParsedSyntax> {
     if markers.is_custom_property {
         parse_custom_property_value(p, END_OF_PROPERTY_VALUE_COMPONENT_LIST_TOKEN_SET);
-        return Some(complete_scss_nesting_regular_declaration(
-            p, markers, false,
-        ));
+        return Some(complete_scss_nesting_regular_declaration(p, markers, false));
     }
 
     let missing_value =
@@ -269,10 +267,9 @@ pub(crate) fn try_parse_scss_nesting_declaration(
             return Err(());
         }
 
-        let Some((syntax, could_be_selector)) = parse_scss_nesting_declaration_candidate(
-            p,
-            SelectorLikeBlockPolicy::RejectBeforeBlock,
-        ) else {
+        let Some((syntax, could_be_selector)) =
+            parse_scss_nesting_declaration_candidate(p, SelectorLikeBlockPolicy::RejectBeforeBlock)
+        else {
             return Err(());
         };
 
@@ -293,10 +290,9 @@ pub(crate) fn try_parse_scss_nesting_declaration(
 #[inline]
 fn try_parse_scss_nested_property_declaration(p: &mut CssParser) -> Result<ParsedSyntax, ()> {
     try_parse(p, |p| {
-        let Some((syntax, could_be_selector)) = parse_scss_nesting_declaration_candidate(
-            p,
-            SelectorLikeBlockPolicy::RejectBeforeBlock,
-        ) else {
+        let Some((syntax, could_be_selector)) =
+            parse_scss_nesting_declaration_candidate(p, SelectorLikeBlockPolicy::RejectBeforeBlock)
+        else {
             return Err(());
         };
 

--- a/crates/biome_css_parser/src/syntax/scss/declaration/nesting.rs
+++ b/crates/biome_css_parser/src/syntax/scss/declaration/nesting.rs
@@ -43,8 +43,13 @@ pub(crate) fn parse_scss_nesting_declaration(p: &mut CssParser) -> ParsedSyntax 
         return Absent;
     }
 
-    parse_scss_nesting_declaration_candidate(p, SelectorLikeBlockPolicy::Parse)
-        .map_or(Absent, |(syntax, _)| syntax)
+    let Some((syntax, _)) =
+        parse_scss_nesting_declaration_candidate(p, SelectorLikeBlockPolicy::Allow)
+    else {
+        return Absent;
+    };
+
+    syntax
 }
 
 #[inline]
@@ -76,19 +81,19 @@ struct ScssNestingMarkers {
 /// following block before the caller decides its final classification.
 #[derive(Clone, Copy)]
 enum SelectorLikeBlockPolicy {
-    /// Complete the candidate as nested-property syntax when a block follows.
-    Parse,
-    /// Stop before the block so an enclosing speculative parse can rewind and
-    /// retry the construct as a nested qualified rule.
-    RejectBeforeBlock,
+    /// Allow the candidate to complete as nested-property syntax when a block follows.
+    Allow,
+    /// Reject the candidate before its block so an enclosing speculative parse
+    /// can rewind and retry the construct as a nested qualified rule.
+    Reject,
 }
 
 /// Parses a SCSS nested-property/declaration candidate.
 ///
-/// With `RejectBeforeBlock`, this returns `None` after abandoning a parsed
-/// source-tight selector-like prefix and value immediately before `{`. That
-/// policy must only be used inside `try_parse`, which rewinds the consumed
-/// parser context and token-source state.
+/// With [`SelectorLikeBlockPolicy::Reject`], this returns `None` after
+/// abandoning a parsed source-tight selector-like prefix and value immediately
+/// before `{`. That policy must only be used inside `try_parse`, which rewinds
+/// the consumed parser context and token-source state.
 #[inline]
 fn parse_scss_nesting_declaration_candidate(
     p: &mut CssParser,
@@ -111,8 +116,8 @@ fn parse_scss_nesting_declaration_candidate(
 
 /// Parses the remainder of a SCSS nesting candidate after its `name:` prefix.
 ///
-/// Returns `None` only when `RejectBeforeBlock` stops a source-tight
-/// selector-like candidate immediately before its block.
+/// Returns `None` only when [`SelectorLikeBlockPolicy::Reject`] stops a
+/// source-tight selector-like candidate immediately before its block.
 #[inline]
 fn parse_scss_nesting_declaration_after_prefix(
     p: &mut CssParser,
@@ -133,10 +138,7 @@ fn parse_scss_nesting_declaration_after_prefix(
 
     if could_be_selector
         && p.at(T!['{'])
-        && matches!(
-            selector_like_block_policy,
-            SelectorLikeBlockPolicy::RejectBeforeBlock
-        )
+        && matches!(selector_like_block_policy, SelectorLikeBlockPolicy::Reject)
     {
         markers.property.abandon(p);
         markers.declaration.abandon(p);
@@ -268,7 +270,7 @@ pub(crate) fn try_parse_scss_nesting_declaration(
         }
 
         let Some((syntax, could_be_selector)) =
-            parse_scss_nesting_declaration_candidate(p, SelectorLikeBlockPolicy::RejectBeforeBlock)
+            parse_scss_nesting_declaration_candidate(p, SelectorLikeBlockPolicy::Reject)
         else {
             return Err(());
         };
@@ -291,7 +293,7 @@ pub(crate) fn try_parse_scss_nesting_declaration(
 fn try_parse_scss_nested_property_declaration(p: &mut CssParser) -> Result<ParsedSyntax, ()> {
     try_parse(p, |p| {
         let Some((syntax, could_be_selector)) =
-            parse_scss_nesting_declaration_candidate(p, SelectorLikeBlockPolicy::RejectBeforeBlock)
+            parse_scss_nesting_declaration_candidate(p, SelectorLikeBlockPolicy::Reject)
         else {
             return Err(());
         };

--- a/crates/biome_css_parser/tests/css_test_suite/error/scss/declaration/ambiguous-selector-recovery.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/error/scss/declaration/ambiguous-selector-recovery.scss
@@ -1,0 +1,12 @@
+.test {
+  label:hover {
+    color: ;
+    background: if(style(--scheme: dark): red; else: blue;);
+  }
+  width: 1px;
+
+  a:#{$pseudo} {
+    color: ;
+  }
+  height: 1px;
+}

--- a/crates/biome_css_parser/tests/css_test_suite/error/scss/declaration/ambiguous-selector-recovery.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/scss/declaration/ambiguous-selector-recovery.scss.snap
@@ -1,0 +1,480 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+.test {
+  label:hover {
+    color: ;
+    background: if(style(--scheme: dark): red; else: blue;);
+  }
+  width: 1px;
+
+  a:#{$pseudo} {
+    color: ;
+  }
+  height: 1px;
+}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@0..1 "." [] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@1..6 "test" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@6..7 "{" [] [],
+                items: CssDeclarationOrRuleList [
+                    CssNestedQualifiedRule {
+                        prelude: CssRelativeSelectorList [
+                            CssRelativeSelector {
+                                combinator: missing (optional),
+                                selector: CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: CssTypeSelector {
+                                        namespace: missing (optional),
+                                        ident: CssIdentifier {
+                                            value_token: IDENT@7..15 "label" [Newline("\n"), Whitespace("  ")] [],
+                                        },
+                                    },
+                                    sub_selectors: CssSubSelectorList [
+                                        CssPseudoClassSelector {
+                                            colon_token: COLON@15..16 ":" [] [],
+                                            class: CssPseudoClassIdentifier {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@16..22 "hover" [] [Whitespace(" ")],
+                                                },
+                                            },
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                        block: CssDeclarationOrRuleBlock {
+                            l_curly_token: L_CURLY@22..23 "{" [] [],
+                            items: CssDeclarationOrRuleList [
+                                CssDeclarationWithSemicolon {
+                                    declaration: CssDeclaration {
+                                        property: CssGenericProperty {
+                                            name: CssIdentifier {
+                                                value_token: IDENT@23..33 "color" [Newline("\n"), Whitespace("    ")] [],
+                                            },
+                                            colon_token: COLON@33..35 ":" [] [Whitespace(" ")],
+                                            value: ScssExpression {
+                                                items: ScssExpressionItemList [],
+                                            },
+                                        },
+                                        important: missing (optional),
+                                    },
+                                    semicolon_token: SEMICOLON@35..36 ";" [] [],
+                                },
+                                CssDeclarationWithSemicolon {
+                                    declaration: CssDeclaration {
+                                        property: CssGenericProperty {
+                                            name: CssIdentifier {
+                                                value_token: IDENT@36..51 "background" [Newline("\n"), Whitespace("    ")] [],
+                                            },
+                                            colon_token: COLON@51..53 ":" [] [Whitespace(" ")],
+                                            value: ScssExpression {
+                                                items: ScssExpressionItemList [
+                                                    CssIfFunction {
+                                                        if_token: IF_KW@53..55 "if" [] [],
+                                                        l_paren_token: L_PAREN@55..56 "(" [] [],
+                                                        css_if_branch_list: CssIfBranchList [
+                                                            CssIfBranch {
+                                                                condition: CssIfStyleTest {
+                                                                    style_token: STYLE_KW@56..61 "style" [] [],
+                                                                    l_paren_token: L_PAREN@61..62 "(" [] [],
+                                                                    test: CssDeclaration {
+                                                                        property: CssGenericProperty {
+                                                                            name: CssDashedIdentifier {
+                                                                                value_token: IDENT@62..70 "--scheme" [] [],
+                                                                            },
+                                                                            colon_token: COLON@70..72 ":" [] [Whitespace(" ")],
+                                                                            value: CssCustomPropertyValue {
+                                                                                components: CssCustomPropertyComponentList [
+                                                                                    CssCustomIdentifier {
+                                                                                        value_token: IDENT@72..76 "dark" [] [],
+                                                                                    },
+                                                                                ],
+                                                                            },
+                                                                        },
+                                                                        important: missing (optional),
+                                                                    },
+                                                                    r_paren_token: R_PAREN@76..77 ")" [] [],
+                                                                },
+                                                                colon_token: COLON@77..79 ":" [] [Whitespace(" ")],
+                                                                value: CssGenericComponentValueList [
+                                                                    CssIdentifier {
+                                                                        value_token: IDENT@79..82 "red" [] [],
+                                                                    },
+                                                                ],
+                                                            },
+                                                            SEMICOLON@82..84 ";" [] [Whitespace(" ")],
+                                                            CssIfBranch {
+                                                                condition: CssElseKeyword {
+                                                                    else_token: ELSE_KW@84..88 "else" [] [],
+                                                                },
+                                                                colon_token: COLON@88..90 ":" [] [Whitespace(" ")],
+                                                                value: CssGenericComponentValueList [
+                                                                    CssIdentifier {
+                                                                        value_token: IDENT@90..94 "blue" [] [],
+                                                                    },
+                                                                ],
+                                                            },
+                                                            SEMICOLON@94..95 ";" [] [],
+                                                        ],
+                                                        r_paren_token: R_PAREN@95..96 ")" [] [],
+                                                    },
+                                                ],
+                                            },
+                                        },
+                                        important: missing (optional),
+                                    },
+                                    semicolon_token: SEMICOLON@96..97 ";" [] [],
+                                },
+                            ],
+                            r_curly_token: R_CURLY@97..101 "}" [Newline("\n"), Whitespace("  ")] [],
+                        },
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@101..109 "width" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@109..111 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssRegularDimension {
+                                            value_token: CSS_NUMBER_LITERAL@111..112 "1" [] [],
+                                            unit_token: IDENT@112..114 "px" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@114..115 ";" [] [],
+                    },
+                    CssNestedQualifiedRule {
+                        prelude: CssRelativeSelectorList [
+                            CssRelativeSelector {
+                                combinator: missing (optional),
+                                selector: CssCompoundSelector {
+                                    nesting_selectors: CssNestedSelectorList [],
+                                    simple_selector: CssTypeSelector {
+                                        namespace: missing (optional),
+                                        ident: CssIdentifier {
+                                            value_token: IDENT@115..120 "a" [Newline("\n"), Newline("\n"), Whitespace("  ")] [],
+                                        },
+                                    },
+                                    sub_selectors: CssSubSelectorList [
+                                        CssPseudoClassSelector {
+                                            colon_token: COLON@120..121 ":" [] [],
+                                            class: CssPseudoClassIdentifier {
+                                                name: ScssInterpolatedIdentifier {
+                                                    items: ScssInterpolatedIdentifierPartList [
+                                                        ScssInterpolation {
+                                                            hash_token: HASH@121..122 "#" [] [],
+                                                            l_curly_token: L_CURLY@122..123 "{" [] [],
+                                                            value: ScssExpression {
+                                                                items: ScssExpressionItemList [
+                                                                    ScssVariable {
+                                                                        dollar_token: DOLLAR@123..124 "$" [] [],
+                                                                        name: CssIdentifier {
+                                                                            value_token: IDENT@124..130 "pseudo" [] [],
+                                                                        },
+                                                                    },
+                                                                ],
+                                                            },
+                                                            r_curly_token: R_CURLY@130..132 "}" [] [Whitespace(" ")],
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                        block: CssDeclarationOrRuleBlock {
+                            l_curly_token: L_CURLY@132..133 "{" [] [],
+                            items: CssDeclarationOrRuleList [
+                                CssDeclarationWithSemicolon {
+                                    declaration: CssDeclaration {
+                                        property: CssGenericProperty {
+                                            name: CssIdentifier {
+                                                value_token: IDENT@133..143 "color" [Newline("\n"), Whitespace("    ")] [],
+                                            },
+                                            colon_token: COLON@143..145 ":" [] [Whitespace(" ")],
+                                            value: ScssExpression {
+                                                items: ScssExpressionItemList [],
+                                            },
+                                        },
+                                        important: missing (optional),
+                                    },
+                                    semicolon_token: SEMICOLON@145..146 ";" [] [],
+                                },
+                            ],
+                            r_curly_token: R_CURLY@146..150 "}" [Newline("\n"), Whitespace("  ")] [],
+                        },
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@150..159 "height" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@159..161 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssRegularDimension {
+                                            value_token: CSS_NUMBER_LITERAL@161..162 "1" [] [],
+                                            unit_token: IDENT@162..164 "px" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@164..165 ";" [] [],
+                    },
+                ],
+                r_curly_token: R_CURLY@165..167 "}" [Newline("\n")] [],
+            },
+        },
+    ],
+    eof_token: EOF@167..168 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..168
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..167
+    0: CSS_QUALIFIED_RULE@0..167
+      0: CSS_SELECTOR_LIST@0..6
+        0: CSS_COMPOUND_SELECTOR@0..6
+          0: CSS_NESTED_SELECTOR_LIST@0..0
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@0..6
+            0: CSS_CLASS_SELECTOR@0..6
+              0: DOT@0..1 "." [] []
+              1: CSS_CUSTOM_IDENTIFIER@1..6
+                0: IDENT@1..6 "test" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@6..167
+        0: L_CURLY@6..7 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@7..165
+          0: CSS_NESTED_QUALIFIED_RULE@7..101
+            0: CSS_RELATIVE_SELECTOR_LIST@7..22
+              0: CSS_RELATIVE_SELECTOR@7..22
+                0: (empty)
+                1: CSS_COMPOUND_SELECTOR@7..22
+                  0: CSS_NESTED_SELECTOR_LIST@7..7
+                  1: CSS_TYPE_SELECTOR@7..15
+                    0: (empty)
+                    1: CSS_IDENTIFIER@7..15
+                      0: IDENT@7..15 "label" [Newline("\n"), Whitespace("  ")] []
+                  2: CSS_SUB_SELECTOR_LIST@15..22
+                    0: CSS_PSEUDO_CLASS_SELECTOR@15..22
+                      0: COLON@15..16 ":" [] []
+                      1: CSS_PSEUDO_CLASS_IDENTIFIER@16..22
+                        0: CSS_IDENTIFIER@16..22
+                          0: IDENT@16..22 "hover" [] [Whitespace(" ")]
+            1: CSS_DECLARATION_OR_RULE_BLOCK@22..101
+              0: L_CURLY@22..23 "{" [] []
+              1: CSS_DECLARATION_OR_RULE_LIST@23..97
+                0: CSS_DECLARATION_WITH_SEMICOLON@23..36
+                  0: CSS_DECLARATION@23..35
+                    0: CSS_GENERIC_PROPERTY@23..35
+                      0: CSS_IDENTIFIER@23..33
+                        0: IDENT@23..33 "color" [Newline("\n"), Whitespace("    ")] []
+                      1: COLON@33..35 ":" [] [Whitespace(" ")]
+                      2: SCSS_EXPRESSION@35..35
+                        0: SCSS_EXPRESSION_ITEM_LIST@35..35
+                    1: (empty)
+                  1: SEMICOLON@35..36 ";" [] []
+                1: CSS_DECLARATION_WITH_SEMICOLON@36..97
+                  0: CSS_DECLARATION@36..96
+                    0: CSS_GENERIC_PROPERTY@36..96
+                      0: CSS_IDENTIFIER@36..51
+                        0: IDENT@36..51 "background" [Newline("\n"), Whitespace("    ")] []
+                      1: COLON@51..53 ":" [] [Whitespace(" ")]
+                      2: SCSS_EXPRESSION@53..96
+                        0: SCSS_EXPRESSION_ITEM_LIST@53..96
+                          0: CSS_IF_FUNCTION@53..96
+                            0: IF_KW@53..55 "if" [] []
+                            1: L_PAREN@55..56 "(" [] []
+                            2: CSS_IF_BRANCH_LIST@56..95
+                              0: CSS_IF_BRANCH@56..82
+                                0: CSS_IF_STYLE_TEST@56..77
+                                  0: STYLE_KW@56..61 "style" [] []
+                                  1: L_PAREN@61..62 "(" [] []
+                                  2: CSS_DECLARATION@62..76
+                                    0: CSS_GENERIC_PROPERTY@62..76
+                                      0: CSS_DASHED_IDENTIFIER@62..70
+                                        0: IDENT@62..70 "--scheme" [] []
+                                      1: COLON@70..72 ":" [] [Whitespace(" ")]
+                                      2: CSS_CUSTOM_PROPERTY_VALUE@72..76
+                                        0: CSS_CUSTOM_PROPERTY_COMPONENT_LIST@72..76
+                                          0: CSS_CUSTOM_IDENTIFIER@72..76
+                                            0: IDENT@72..76 "dark" [] []
+                                    1: (empty)
+                                  3: R_PAREN@76..77 ")" [] []
+                                1: COLON@77..79 ":" [] [Whitespace(" ")]
+                                2: CSS_GENERIC_COMPONENT_VALUE_LIST@79..82
+                                  0: CSS_IDENTIFIER@79..82
+                                    0: IDENT@79..82 "red" [] []
+                              1: SEMICOLON@82..84 ";" [] [Whitespace(" ")]
+                              2: CSS_IF_BRANCH@84..94
+                                0: CSS_ELSE_KEYWORD@84..88
+                                  0: ELSE_KW@84..88 "else" [] []
+                                1: COLON@88..90 ":" [] [Whitespace(" ")]
+                                2: CSS_GENERIC_COMPONENT_VALUE_LIST@90..94
+                                  0: CSS_IDENTIFIER@90..94
+                                    0: IDENT@90..94 "blue" [] []
+                              3: SEMICOLON@94..95 ";" [] []
+                            3: R_PAREN@95..96 ")" [] []
+                    1: (empty)
+                  1: SEMICOLON@96..97 ";" [] []
+              2: R_CURLY@97..101 "}" [Newline("\n"), Whitespace("  ")] []
+          1: CSS_DECLARATION_WITH_SEMICOLON@101..115
+            0: CSS_DECLARATION@101..114
+              0: CSS_GENERIC_PROPERTY@101..114
+                0: CSS_IDENTIFIER@101..109
+                  0: IDENT@101..109 "width" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@109..111 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@111..114
+                  0: SCSS_EXPRESSION_ITEM_LIST@111..114
+                    0: CSS_REGULAR_DIMENSION@111..114
+                      0: CSS_NUMBER_LITERAL@111..112 "1" [] []
+                      1: IDENT@112..114 "px" [] []
+              1: (empty)
+            1: SEMICOLON@114..115 ";" [] []
+          2: CSS_NESTED_QUALIFIED_RULE@115..150
+            0: CSS_RELATIVE_SELECTOR_LIST@115..132
+              0: CSS_RELATIVE_SELECTOR@115..132
+                0: (empty)
+                1: CSS_COMPOUND_SELECTOR@115..132
+                  0: CSS_NESTED_SELECTOR_LIST@115..115
+                  1: CSS_TYPE_SELECTOR@115..120
+                    0: (empty)
+                    1: CSS_IDENTIFIER@115..120
+                      0: IDENT@115..120 "a" [Newline("\n"), Newline("\n"), Whitespace("  ")] []
+                  2: CSS_SUB_SELECTOR_LIST@120..132
+                    0: CSS_PSEUDO_CLASS_SELECTOR@120..132
+                      0: COLON@120..121 ":" [] []
+                      1: CSS_PSEUDO_CLASS_IDENTIFIER@121..132
+                        0: SCSS_INTERPOLATED_IDENTIFIER@121..132
+                          0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@121..132
+                            0: SCSS_INTERPOLATION@121..132
+                              0: HASH@121..122 "#" [] []
+                              1: L_CURLY@122..123 "{" [] []
+                              2: SCSS_EXPRESSION@123..130
+                                0: SCSS_EXPRESSION_ITEM_LIST@123..130
+                                  0: SCSS_VARIABLE@123..130
+                                    0: DOLLAR@123..124 "$" [] []
+                                    1: CSS_IDENTIFIER@124..130
+                                      0: IDENT@124..130 "pseudo" [] []
+                              3: R_CURLY@130..132 "}" [] [Whitespace(" ")]
+            1: CSS_DECLARATION_OR_RULE_BLOCK@132..150
+              0: L_CURLY@132..133 "{" [] []
+              1: CSS_DECLARATION_OR_RULE_LIST@133..146
+                0: CSS_DECLARATION_WITH_SEMICOLON@133..146
+                  0: CSS_DECLARATION@133..145
+                    0: CSS_GENERIC_PROPERTY@133..145
+                      0: CSS_IDENTIFIER@133..143
+                        0: IDENT@133..143 "color" [Newline("\n"), Whitespace("    ")] []
+                      1: COLON@143..145 ":" [] [Whitespace(" ")]
+                      2: SCSS_EXPRESSION@145..145
+                        0: SCSS_EXPRESSION_ITEM_LIST@145..145
+                    1: (empty)
+                  1: SEMICOLON@145..146 ";" [] []
+              2: R_CURLY@146..150 "}" [Newline("\n"), Whitespace("  ")] []
+          3: CSS_DECLARATION_WITH_SEMICOLON@150..165
+            0: CSS_DECLARATION@150..164
+              0: CSS_GENERIC_PROPERTY@150..164
+                0: CSS_IDENTIFIER@150..159
+                  0: IDENT@150..159 "height" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@159..161 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@161..164
+                  0: SCSS_EXPRESSION_ITEM_LIST@161..164
+                    0: CSS_REGULAR_DIMENSION@161..164
+                      0: CSS_NUMBER_LITERAL@161..162 "1" [] []
+                      1: IDENT@162..164 "px" [] []
+              1: (empty)
+            1: SEMICOLON@164..165 ";" [] []
+        2: R_CURLY@165..167 "}" [Newline("\n")] []
+  2: EOF@167..168 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+ambiguous-selector-recovery.scss:3:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Unexpected value or character.
+  
+    1 │ .test {
+    2 │   label:hover {
+  > 3 │     color: ;
+      │            ^
+    4 │     background: if(style(--scheme: dark): red; else: blue;);
+    5 │   }
+  
+  i Expected one of:
+  
+  - identifier
+  - string
+  - number
+  - dimension
+  - ratio
+  - custom property
+  - function
+  
+ambiguous-selector-recovery.scss:9:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Unexpected value or character.
+  
+     8 │   a:#{$pseudo} {
+   > 9 │     color: ;
+       │            ^
+    10 │   }
+    11 │   height: 1px;
+  
+  i Expected one of:
+  
+  - identifier
+  - string
+  - number
+  - dimension
+  - ratio
+  - custom property
+  - function
+  
+```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/declaration/ambiguous-selector-vs-nesting.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/declaration/ambiguous-selector-vs-nesting.scss
@@ -30,4 +30,6 @@
   font-#{$weight}::before {
     color: orange;
   }
+
+  font:bold;
 }

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/declaration/ambiguous-selector-vs-nesting.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/declaration/ambiguous-selector-vs-nesting.scss.snap
@@ -38,6 +38,8 @@ expression: snapshot
   font-#{$weight}::before {
     color: orange;
   }
+
+  font:bold;
 }
 
 ```
@@ -520,22 +522,41 @@ CssRoot {
                             r_curly_token: R_CURLY@339..343 "}" [Newline("\n"), Whitespace("  ")] [],
                         },
                     },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@343..351 "font" [Newline("\n"), Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@351..352 ":" [] [],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssIdentifier {
+                                            value_token: IDENT@352..356 "bold" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@356..357 ";" [] [],
+                    },
                 ],
-                r_curly_token: R_CURLY@343..345 "}" [Newline("\n")] [],
+                r_curly_token: R_CURLY@357..359 "}" [Newline("\n")] [],
             },
         },
     ],
-    eof_token: EOF@345..346 "" [Newline("\n")] [],
+    eof_token: EOF@359..360 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: CSS_ROOT@0..346
+0: CSS_ROOT@0..360
   0: (empty)
-  1: CSS_ROOT_ITEM_LIST@0..345
-    0: CSS_QUALIFIED_RULE@0..345
+  1: CSS_ROOT_ITEM_LIST@0..359
+    0: CSS_QUALIFIED_RULE@0..359
       0: CSS_SELECTOR_LIST@0..6
         0: CSS_COMPOUND_SELECTOR@0..6
           0: CSS_NESTED_SELECTOR_LIST@0..0
@@ -545,9 +566,9 @@ CssRoot {
               0: DOT@0..1 "." [] []
               1: CSS_CUSTOM_IDENTIFIER@1..6
                 0: IDENT@1..6 "test" [] [Whitespace(" ")]
-      1: CSS_DECLARATION_OR_RULE_BLOCK@6..345
+      1: CSS_DECLARATION_OR_RULE_BLOCK@6..359
         0: L_CURLY@6..7 "{" [] []
-        1: CSS_DECLARATION_OR_RULE_LIST@7..343
+        1: CSS_DECLARATION_OR_RULE_LIST@7..357
           0: CSS_NESTED_QUALIFIED_RULE@7..43
             0: CSS_RELATIVE_SELECTOR_LIST@7..22
               0: CSS_RELATIVE_SELECTOR@7..22
@@ -833,7 +854,19 @@ CssRoot {
                     1: (empty)
                   1: SEMICOLON@338..339 ";" [] []
               2: R_CURLY@339..343 "}" [Newline("\n"), Whitespace("  ")] []
-        2: R_CURLY@343..345 "}" [Newline("\n")] []
-  2: EOF@345..346 "" [Newline("\n")] []
+          8: CSS_DECLARATION_WITH_SEMICOLON@343..357
+            0: CSS_DECLARATION@343..356
+              0: CSS_GENERIC_PROPERTY@343..356
+                0: CSS_IDENTIFIER@343..351
+                  0: IDENT@343..351 "font" [Newline("\n"), Newline("\n"), Whitespace("  ")] []
+                1: COLON@351..352 ":" [] []
+                2: SCSS_EXPRESSION@352..356
+                  0: SCSS_EXPRESSION_ITEM_LIST@352..356
+                    0: CSS_IDENTIFIER@352..356
+                      0: IDENT@352..356 "bold" [] []
+              1: (empty)
+            1: SEMICOLON@356..357 ";" [] []
+        2: R_CURLY@357..359 "}" [Newline("\n")] []
+  2: EOF@359..360 "" [Newline("\n")] []
 
 ```


### PR DESCRIPTION
> AI assistance: Codex was used

## Summary

Avoid parsing selector-like SCSS nesting blocks during speculative attempts that will be rejected

## Test Plan

- green CI