### PR TITLE
fix(js/parse): recover on malformed `for...of` statements

### DIFF
--- a/.changeset/fix-parser-recovery-for-of.md
+++ b/.changeset/fix-parser-recovery-for-of.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6640](https://github.com/biomejs/biome/issues/6640). Biome no longer crashes when linting malformed `for...of` statements.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ This file contains rules that apply to every automated contribution. Detailed wo
 - Make the smallest change that satisfies the requested behavior.
 - Add tests for code changes. Bug fixes require a case that fails without the fix.
 - Run the narrowest relevant tests first, then broader checks when justified.
+- Run the tests of the current crate to check possible regressions.
 - Review generated snapshots as behavior, not disposable output.
 - Run `just f` and `just l` before committing.
 

--- a/crates/biome_js_parser/src/syntax/function.rs
+++ b/crates/biome_js_parser/src/syntax/function.rs
@@ -649,6 +649,7 @@ fn parse_parenthesized_arrow_function_expression(
     context: ExpressionContext,
 ) -> ParsedSyntax {
     let is_parenthesized = is_parenthesized_arrow_function_expression(p);
+    let is_bogus = p.at(T![=>]);
     match is_parenthesized {
         IsParenthesizedArrowFunctionExpression::True => {
             let (m, flags) =
@@ -656,7 +657,14 @@ fn parse_parenthesized_arrow_function_expression(
                     .expect("'CompletedMarker' because function should never return 'Err' if called with 'Ambiguity::Allowed'.");
             parse_arrow_body(p, flags, context)
                 .or_add_diagnostic(p, js_parse_error::expected_arrow_body);
-            Present(m.complete(p, JS_ARROW_FUNCTION_EXPRESSION))
+            Present(m.complete(
+                p,
+                if is_bogus {
+                    JS_BOGUS_EXPRESSION
+                } else {
+                    JS_ARROW_FUNCTION_EXPRESSION
+                },
+            ))
         }
         IsParenthesizedArrowFunctionExpression::Unknown => {
             parse_possible_parenthesized_arrow_function_expression(p, context)

--- a/crates/biome_js_parser/tests/js_test_suite/error/decorator_expression_class.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/decorator_expression_class.js.snap
@@ -57,18 +57,16 @@ JsModule {
                                                         },
                                                     ],
                                                 },
-                                                JsArrowFunctionExpression {
-                                                    async_token: missing (optional),
-                                                    type_parameters: missing (optional),
-                                                    parameters: missing (required),
-                                                    return_type_annotation: missing (optional),
-                                                    fat_arrow_token: FAT_ARROW@22..25 "=>" [] [Whitespace(" ")],
-                                                    body: JsFunctionBody {
-                                                        l_curly_token: L_CURLY@25..26 "{" [] [],
-                                                        directives: JsDirectiveList [],
-                                                        statements: JsStatementList [],
-                                                        r_curly_token: R_CURLY@26..27 "}" [] [],
-                                                    },
+                                                JsBogusExpression {
+                                                    items: [
+                                                        FAT_ARROW@22..25 "=>" [] [Whitespace(" ")],
+                                                        JsFunctionBody {
+                                                            l_curly_token: L_CURLY@25..26 "{" [] [],
+                                                            directives: JsDirectiveList [],
+                                                            statements: JsStatementList [],
+                                                            r_curly_token: R_CURLY@26..27 "}" [] [],
+                                                        },
+                                                    ],
                                                 },
                                             ],
                                         },
@@ -239,13 +237,9 @@ JsModule {
                       0: L_PAREN@19..20 "(" [] []
                       1: JS_CALL_ARGUMENT_LIST@20..20
                       2: R_PAREN@20..22 ")" [] [Whitespace(" ")]
-              2: JS_ARROW_FUNCTION_EXPRESSION@22..27
-                0: (empty)
-                1: (empty)
-                2: (empty)
-                3: (empty)
-                4: FAT_ARROW@22..25 "=>" [] [Whitespace(" ")]
-                5: JS_FUNCTION_BODY@25..27
+              2: JS_BOGUS_EXPRESSION@22..27
+                0: FAT_ARROW@22..25 "=>" [] [Whitespace(" ")]
+                1: JS_FUNCTION_BODY@25..27
                   0: L_CURLY@25..26 "{" [] []
                   1: JS_DIRECTIVE_LIST@26..26
                   2: JS_STATEMENT_LIST@26..26

--- a/crates/biome_js_parser/tests/js_test_suite/error/issue_6640.js
+++ b/crates/biome_js_parser/tests/js_test_suite/error/issue_6640.js
@@ -1,0 +1,1 @@
+if)for(s of=>{ for(t of break

--- a/crates/biome_js_parser/tests/js_test_suite/error/issue_6640.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/issue_6640.js.snap
@@ -1,0 +1,175 @@
+---
+source: crates/biome_js_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```js
+if)for(s of=>{ for(t of break
+
+```
+
+
+## AST
+
+```
+JsModule {
+    bom_token: missing (optional),
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsIfStatement {
+            if_token: IF_KW@0..2 "if" [] [],
+            l_paren_token: missing (required),
+            test: missing (required),
+            r_paren_token: R_PAREN@2..3 ")" [] [],
+            consequent: JsForOfStatement {
+                for_token: FOR_KW@3..6 "for" [] [],
+                await_token: missing (optional),
+                l_paren_token: L_PAREN@6..7 "(" [] [],
+                initializer: JsIdentifierAssignment {
+                    name_token: IDENT@7..9 "s" [] [Whitespace(" ")],
+                },
+                of_token: OF_KW@9..11 "of" [] [],
+                expression: JsBogusExpression {
+                    items: [
+                        FAT_ARROW@11..13 "=>" [] [],
+                        JsFunctionBody {
+                            l_curly_token: L_CURLY@13..15 "{" [] [Whitespace(" ")],
+                            directives: JsDirectiveList [],
+                            statements: JsStatementList [
+                                JsForOfStatement {
+                                    for_token: FOR_KW@15..18 "for" [] [],
+                                    await_token: missing (optional),
+                                    l_paren_token: L_PAREN@18..19 "(" [] [],
+                                    initializer: JsIdentifierAssignment {
+                                        name_token: IDENT@19..21 "t" [] [Whitespace(" ")],
+                                    },
+                                    of_token: OF_KW@21..24 "of" [] [Whitespace(" ")],
+                                    expression: missing (required),
+                                    r_paren_token: missing (required),
+                                    body: JsBreakStatement {
+                                        break_token: BREAK_KW@24..29 "break" [] [],
+                                        label: missing (optional),
+                                        semicolon_token: missing (optional),
+                                    },
+                                },
+                            ],
+                            r_curly_token: missing (required),
+                        },
+                    ],
+                },
+                r_paren_token: missing (required),
+                body: missing (required),
+            },
+            else_clause: missing (optional),
+        },
+    ],
+    eof_token: EOF@29..30 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: JS_MODULE@0..30
+  0: (empty)
+  1: (empty)
+  2: JS_DIRECTIVE_LIST@0..0
+  3: JS_MODULE_ITEM_LIST@0..29
+    0: JS_IF_STATEMENT@0..29
+      0: IF_KW@0..2 "if" [] []
+      1: (empty)
+      2: (empty)
+      3: R_PAREN@2..3 ")" [] []
+      4: JS_FOR_OF_STATEMENT@3..29
+        0: FOR_KW@3..6 "for" [] []
+        1: (empty)
+        2: L_PAREN@6..7 "(" [] []
+        3: JS_IDENTIFIER_ASSIGNMENT@7..9
+          0: IDENT@7..9 "s" [] [Whitespace(" ")]
+        4: OF_KW@9..11 "of" [] []
+        5: JS_BOGUS_EXPRESSION@11..29
+          0: FAT_ARROW@11..13 "=>" [] []
+          1: JS_FUNCTION_BODY@13..29
+            0: L_CURLY@13..15 "{" [] [Whitespace(" ")]
+            1: JS_DIRECTIVE_LIST@15..15
+            2: JS_STATEMENT_LIST@15..29
+              0: JS_FOR_OF_STATEMENT@15..29
+                0: FOR_KW@15..18 "for" [] []
+                1: (empty)
+                2: L_PAREN@18..19 "(" [] []
+                3: JS_IDENTIFIER_ASSIGNMENT@19..21
+                  0: IDENT@19..21 "t" [] [Whitespace(" ")]
+                4: OF_KW@21..24 "of" [] [Whitespace(" ")]
+                5: (empty)
+                6: (empty)
+                7: JS_BREAK_STATEMENT@24..29
+                  0: BREAK_KW@24..29 "break" [] []
+                  1: (empty)
+                  2: (empty)
+            3: (empty)
+        6: (empty)
+        7: (empty)
+      5: (empty)
+  4: EOF@29..30 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+issue_6640.js:1:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `(` but instead found `)`
+  
+  > 1 │ if)for(s of=>{ for(t of break
+      │   ^
+    2 │ 
+  
+  i Remove )
+  
+issue_6640.js:1:12 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a parenthesis '(' but instead found '=>'.
+  
+  > 1 │ if)for(s of=>{ for(t of break
+      │            ^^
+    2 │ 
+  
+  i Expected a parenthesis '(' here.
+  
+  > 1 │ if)for(s of=>{ for(t of break
+      │            ^^
+    2 │ 
+  
+issue_6640.js:1:25 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected an expression, or an assignment but instead found 'break'.
+  
+  > 1 │ if)for(s of=>{ for(t of break
+      │                         ^^^^^
+    2 │ 
+  
+  i Expected an expression, or an assignment here.
+  
+  > 1 │ if)for(s of=>{ for(t of break
+      │                         ^^^^^
+    2 │ 
+  
+issue_6640.js:2:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `}` but instead the file ends
+  
+    1 │ if)for(s of=>{ for(t of break
+  > 2 │ 
+      │ 
+  
+  i the file ends here
+  
+    1 │ if)for(s of=>{ for(t of break
+  > 2 │ 
+      │ 
+  
+```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Implemented via a coding agent.

Closes #6640 

We were not emitting a bogus node when there was an incorrect `for..of` statement.


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added a new test.

The change in the existing snapshot is correct.

Green CI.

I changed the AGENTS.md because it mistakenly skipped the testing of crates and jumped into linting.

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
