### PR TITLE
feat(lint/js/vue): add useVueBaseImport

### DIFF
--- a/.changeset/rich-guests-poke.md
+++ b/.changeset/rich-guests-poke.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Added the nursery Vue-domain rule [`useVueBaseImport`](https://biomejs.dev/linter/rules/use-vue-base-import/) rule, which enforces importing Vue APIs from `vue` instead of internal `@vue/*` packages.

--- a/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
@@ -5289,6 +5289,18 @@ pub(crate) fn migrate_eslint_any_rule(
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
+        "vue/prefer-import-from-vue" => {
+            if !options.include_nursery {
+                results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Nursery);
+                return false;
+            }
+            let group = rules.nursery.get_or_insert_with(Default::default);
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_vue_base_import
+                .get_or_insert(Default::default());
+            rule.set_level(rule.level().max(rule_severity.into()));
+        }
         "vue/require-v-for-key" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
             let rule = group

--- a/crates/biome_configuration/src/analyzer/linter/rules.rs
+++ b/crates/biome_configuration/src/analyzer/linter/rules.rs
@@ -598,6 +598,7 @@ pub enum RuleName {
     UseValidLang,
     UseValidTypeof,
     UseVarsOnTop,
+    UseVueBaseImport,
     UseVueConsistentDefinePropsDeclaration,
     UseVueConsistentVBindStyle,
     UseVueConsistentVOnStyle,
@@ -1138,6 +1139,7 @@ impl RuleName {
             Self::UseValidLang => "useValidLang",
             Self::UseValidTypeof => "useValidTypeof",
             Self::UseVarsOnTop => "useVarsOnTop",
+            Self::UseVueBaseImport => "useVueBaseImport",
             Self::UseVueConsistentDefinePropsDeclaration => {
                 "useVueConsistentDefinePropsDeclaration"
             }
@@ -1674,6 +1676,7 @@ impl RuleName {
             Self::UseValidLang => RuleGroup::A11y,
             Self::UseValidTypeof => RuleGroup::Correctness,
             Self::UseVarsOnTop => RuleGroup::Nursery,
+            Self::UseVueBaseImport => RuleGroup::Nursery,
             Self::UseVueConsistentDefinePropsDeclaration => RuleGroup::Nursery,
             Self::UseVueConsistentVBindStyle => RuleGroup::Style,
             Self::UseVueConsistentVOnStyle => RuleGroup::Style,
@@ -2219,6 +2222,7 @@ impl std::str::FromStr for RuleName {
             "useValidLang" => Ok(Self::UseValidLang),
             "useValidTypeof" => Ok(Self::UseValidTypeof),
             "useVarsOnTop" => Ok(Self::UseVarsOnTop),
+            "useVueBaseImport" => Ok(Self::UseVueBaseImport),
             "useVueConsistentDefinePropsDeclaration" => {
                 Ok(Self::UseVueConsistentDefinePropsDeclaration)
             }

--- a/crates/biome_configuration/src/generated/domain_selector.rs
+++ b/crates/biome_configuration/src/generated/domain_selector.rs
@@ -193,6 +193,7 @@ static VUE_FILTERS: LazyLock<Vec<RuleFilter<'static>>> = LazyLock::new(|| {
         RuleFilter::Rule("nursery", "noVueRefAsOperand"),
         RuleFilter::Rule("nursery", "noVueVOnNumberValues"),
         RuleFilter::Rule("nursery", "useScopedStyles"),
+        RuleFilter::Rule("nursery", "useVueBaseImport"),
         RuleFilter::Rule("nursery", "useVueConsistentDefinePropsDeclaration"),
         RuleFilter::Rule("nursery", "useVueNextTickPromise"),
         RuleFilter::Rule("nursery", "useVueValidVFor"),

--- a/crates/biome_configuration/src/generated/linter_options_check.rs
+++ b/crates/biome_configuration/src/generated/linter_options_check.rs
@@ -2432,6 +2432,11 @@ pub fn config_side_rule_options_types() -> Vec<(&'static str, &'static str, Type
         "useVarsOnTop",
         TypeId::of::<biome_rule_options::use_vars_on_top::UseVarsOnTopOptions>(),
     ));
+    result.push((
+        "nursery",
+        "useVueBaseImport",
+        TypeId::of::<biome_rule_options::use_vue_base_import::UseVueBaseImportOptions>(),
+    ));
     result.push(("nursery", "useVueConsistentDefinePropsDeclaration", TypeId::of::<biome_rule_options::use_vue_consistent_define_props_declaration::UseVueConsistentDefinePropsDeclarationOptions>()));
     result.push((
         "style",

--- a/crates/biome_diagnostics_categories/src/categories.rs
+++ b/crates/biome_diagnostics_categories/src/categories.rs
@@ -320,6 +320,7 @@ define_categories! {
     "lint/nursery/useUniqueInputFieldNames": "https://biomejs.dev/linter/rules/use-unique-input-field-names",
     "lint/nursery/useUniqueVariableNames": "https://biomejs.dev/linter/rules/use-unique-variable-names",
     "lint/nursery/useVarsOnTop": "https://biomejs.dev/linter/rules/use-vars-on-top",
+    "lint/nursery/useVueBaseImport": "https://biomejs.dev/linter/rules/use-vue-base-import",
     "lint/nursery/useVueConsistentDefinePropsDeclaration": "https://biomejs.dev/linter/rules/use-vue-consistent-define-props-declaration",
     "lint/nursery/useVueNextTickPromise": "https://biomejs.dev/linter/rules/use-vue-next-tick-promise",
     "lint/nursery/useVueValidVFor": "https://biomejs.dev/linter/rules/use-vue-valid-v-for",

--- a/crates/biome_js_analyze/src/lint/nursery/use_vue_base_import.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_vue_base_import.rs
@@ -1,0 +1,577 @@
+use biome_analyze::{
+    Ast, FixKind, Rule, RuleDiagnostic, RuleDomain, RuleSource, context::RuleContext,
+    declare_lint_rule,
+};
+use biome_console::markup;
+use biome_js_syntax::{
+    AnyJsImportClause, AnyJsImportLike, JsExportFromClause, JsExportNamedFromClause,
+    JsModuleSource, JsSyntaxKind, JsSyntaxToken, inner_string_text,
+};
+use biome_languages::JsFileSource;
+use biome_rowan::{AstNode, BatchMutationExt, TokenText, AstSeparatedList};
+use biome_rule_options::use_vue_base_import::UseVueBaseImportOptions;
+
+use crate::JsRuleAction;
+
+declare_lint_rule! {
+    /// Enforce importing Vue's public entry point instead of internal Vue packages.
+    ///
+    /// The `@vue/runtime-dom`, `@vue/runtime-core`, `@vue/reactivity`, and `@vue/shared` packages are internal implementation packages. Their public exports should be imported from `vue` instead.
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```js,expect_diagnostic
+    /// import { computed } from "@vue/reactivity";
+    /// ```
+    ///
+    /// ```js,expect_diagnostic
+    /// export * from "@vue/shared";
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```js
+    /// import { computed } from "vue";
+    /// import { internalOnly } from "@vue/reactivity";
+    /// ```
+    ///
+    pub UseVueBaseImport {
+        version: "next",
+        name: "useVueBaseImport",
+        language: "js",
+        sources: &[RuleSource::EslintVueJs("prefer-import-from-vue").same()],
+        recommended: true,
+        domains: &[RuleDomain::Vue],
+        fix_kind: FixKind::Safe,
+    }
+}
+
+pub struct UseVueBaseImportState {
+    fixable: bool,
+}
+
+impl Rule for UseVueBaseImport {
+    type Query = Ast<AnyJsImportLike>;
+    type State = UseVueBaseImportState;
+    type Signals = Option<Self::State>;
+    type Options = UseVueBaseImportOptions;
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let AnyJsImportLike::JsModuleSource(module_source) = ctx.query() else {
+            return None;
+        };
+
+        let module_name_text = module_source.inner_string_text().ok()?;
+        if !VUE_BASE_MODULES.contains(&module_name_text.text()) {
+            return None;
+        }
+
+        match_import_source(ctx, module_source)
+    }
+
+    fn diagnostic(ctx: &RuleContext<Self>, _: &Self::State) -> Option<RuleDiagnostic> {
+        let module_name = module_name(ctx)?;
+        let source = inner_string_text(&module_name);
+        Some(
+            RuleDiagnostic::new(
+                rule_category!(),
+                module_name.text_trimmed_range(),
+                markup! {
+                    "Don't import the internal Vue package "<Emphasis>"'"{source.text()}"'"</Emphasis>"."
+                },
+            )
+            .note(markup! {
+                "The public "<Emphasis>"'vue'"</Emphasis>" entry point re-exports Vue's supported runtime APIs."
+            }),
+        )
+    }
+
+    fn action(ctx: &RuleContext<Self>, state: &Self::State) -> Option<JsRuleAction> {
+        if !state.fixable {
+            return None;
+        }
+
+        let module_name = module_name(ctx)?;
+        let delimiter = module_name.text_trimmed().chars().next()?;
+        let replacement_text = format!("{delimiter}vue{delimiter}");
+        let replacement =
+            JsSyntaxToken::new_detached(JsSyntaxKind::JS_STRING_LITERAL, &replacement_text, [], []);
+        let mut mutation = ctx.root().begin();
+        mutation.replace_token(module_name, replacement);
+
+        Some(JsRuleAction::new(
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
+            ctx.metadata().applicability(),
+            markup! {
+                "Import "<Emphasis>"'vue'"</Emphasis>" instead."
+            }
+            .to_owned(),
+            mutation,
+        ))
+    }
+}
+
+const VUE_BASE_MODULES: &[&str] = &[
+    "@vue/runtime-dom",
+    "@vue/runtime-core",
+    "@vue/reactivity",
+    "@vue/shared",
+];
+
+const VUE_EXPORT_NAMES: &[&str] = &[
+    "AllowedAttrs",
+    "AllowedComponentProps",
+    "AnchorHTMLAttributes",
+    "App",
+    "AppConfig",
+    "AppContext",
+    "AreaHTMLAttributes",
+    "AriaAttributes",
+    "AsyncComponentLoader",
+    "AsyncComponentOptions",
+    "Attrs",
+    "AudioHTMLAttributes",
+    "BaseHTMLAttributes",
+    "BaseTransition",
+    "BaseTransitionProps",
+    "BaseTransitionPropsValidators",
+    "BlockquoteHTMLAttributes",
+    "ButtonHTMLAttributes",
+    "CSSProperties",
+    "CanvasHTMLAttributes",
+    "ClassValue",
+    "ColHTMLAttributes",
+    "ColgroupHTMLAttributes",
+    "Comment",
+    "CompatVue",
+    "Component",
+    "ComponentCustomElementInterface",
+    "ComponentCustomOptions",
+    "ComponentCustomProperties",
+    "ComponentCustomProps",
+    "ComponentInjectOptions",
+    "ComponentInstance",
+    "ComponentInternalInstance",
+    "ComponentObjectPropsOptions",
+    "ComponentOptions",
+    "ComponentOptionsBase",
+    "ComponentOptionsMixin",
+    "ComponentOptionsWithArrayProps",
+    "ComponentOptionsWithObjectProps",
+    "ComponentOptionsWithoutProps",
+    "ComponentPropsOptions",
+    "ComponentProvideOptions",
+    "ComponentPublicInstance",
+    "ComponentTypeEmits",
+    "ComputedGetter",
+    "ComputedOptions",
+    "ComputedRef",
+    "ComputedSetter",
+    "ConcreteComponent",
+    "CreateAppFunction",
+    "CreateComponentPublicInstance",
+    "CreateComponentPublicInstanceWithMixins",
+    "CustomElementOptions",
+    "CustomRefFactory",
+    "DataHTMLAttributes",
+    "DebuggerEvent",
+    "DebuggerEventExtraInfo",
+    "DebuggerOptions",
+    "DeepReadonly",
+    "DefineComponent",
+    "DefineProps",
+    "DefineSetupFnComponent",
+    "DelHTMLAttributes",
+    "DeprecationTypes",
+    "DetailsHTMLAttributes",
+    "DialogHTMLAttributes",
+    "Directive",
+    "DirectiveArguments",
+    "DirectiveBinding",
+    "DirectiveHook",
+    "DirectiveModifiers",
+    "EffectScheduler",
+    "EffectScope",
+    "ElementNamespace",
+    "EmbedHTMLAttributes",
+    "EmitFn",
+    "EmitsOptions",
+    "EmitsToProps",
+    "ErrorCodes",
+    "Events",
+    "ExtractDefaultPropTypes",
+    "ExtractPropTypes",
+    "ExtractPublicPropTypes",
+    "FieldsetHTMLAttributes",
+    "FormHTMLAttributes",
+    "Fragment",
+    "FunctionDirective",
+    "FunctionPlugin",
+    "FunctionalComponent",
+    "GlobalComponents",
+    "GlobalDirectives",
+    "HMRRuntime",
+    "HTMLAttributes",
+    "HtmlHTMLAttributes",
+    "HydrationRenderer",
+    "HydrationStrategy",
+    "HydrationStrategyFactory",
+    "IframeHTMLAttributes",
+    "ImgHTMLAttributes",
+    "InjectionKey",
+    "InputAutoCompleteAttribute",
+    "InputHTMLAttributes",
+    "InputTypeHTMLAttribute",
+    "InsHTMLAttributes",
+    "IntrinsicElementAttributes",
+    "KeepAlive",
+    "KeepAliveProps",
+    "KeygenHTMLAttributes",
+    "LabelHTMLAttributes",
+    "LegacyConfig",
+    "LiHTMLAttributes",
+    "LinkHTMLAttributes",
+    "MapHTMLAttributes",
+    "MaybeRef",
+    "MaybeRefOrGetter",
+    "MediaHTMLAttributes",
+    "MenuHTMLAttributes",
+    "MetaHTMLAttributes",
+    "MeterHTMLAttributes",
+    "MethodOptions",
+    "ModelRef",
+    "MultiWatchSources",
+    "NativeElements",
+    "ObjectDirective",
+    "ObjectEmitsOptions",
+    "ObjectHTMLAttributes",
+    "ObjectPlugin",
+    "OlHTMLAttributes",
+    "OptgroupHTMLAttributes",
+    "OptionHTMLAttributes",
+    "OptionMergeFunction",
+    "OutputHTMLAttributes",
+    "ParamHTMLAttributes",
+    "Plugin",
+    "ProgressHTMLAttributes",
+    "Prop",
+    "PropType",
+    "PublicProps",
+    "QuoteHTMLAttributes",
+    "Raw",
+    "Reactive",
+    "ReactiveEffect",
+    "ReactiveEffectOptions",
+    "ReactiveEffectRunner",
+    "ReactiveFlags",
+    "Ref",
+    "RenderFunction",
+    "Renderer",
+    "RendererElement",
+    "RendererNode",
+    "RendererOptions",
+    "ReservedProps",
+    "RootHydrateFunction",
+    "RootRenderFunction",
+    "RuntimeCompilerOptions",
+    "SVGAttributes",
+    "ScriptHTMLAttributes",
+    "SelectHTMLAttributes",
+    "SetupContext",
+    "ShallowReactive",
+    "ShallowRef",
+    "ShallowUnwrapRef",
+    "ShortEmitsToObject",
+    "Slot",
+    "Slots",
+    "SlotsType",
+    "SourceHTMLAttributes",
+    "Static",
+    "StyleHTMLAttributes",
+    "StyleValue",
+    "Suspense",
+    "SuspenseBoundary",
+    "SuspenseProps",
+    "TableHTMLAttributes",
+    "TdHTMLAttributes",
+    "Teleport",
+    "TeleportProps",
+    "TemplateRef",
+    "Text",
+    "TextareaHTMLAttributes",
+    "ThHTMLAttributes",
+    "TimeHTMLAttributes",
+    "ToRef",
+    "ToRefs",
+    "TrackHTMLAttributes",
+    "TrackOpTypes",
+    "Transition",
+    "TransitionGroup",
+    "TransitionGroupProps",
+    "TransitionHooks",
+    "TransitionProps",
+    "TransitionState",
+    "TriggerOpTypes",
+    "UnwrapNestedRefs",
+    "UnwrapRef",
+    "VNode",
+    "VNodeArrayChildren",
+    "VNodeChild",
+    "VNodeNormalizedChildren",
+    "VNodeProps",
+    "VNodeRef",
+    "VNodeTypes",
+    "VideoHTMLAttributes",
+    "VueElement",
+    "VueElementConstructor",
+    "WatchCallback",
+    "WatchEffect",
+    "WatchEffectOptions",
+    "WatchHandle",
+    "WatchOptions",
+    "WatchOptionsBase",
+    "WatchSource",
+    "WatchStopHandle",
+    "WebViewHTMLAttributes",
+    "WritableComputedOptions",
+    "WritableComputedRef",
+    "callWithAsyncErrorHandling",
+    "callWithErrorHandling",
+    "camelize",
+    "capitalize",
+    "cloneVNode",
+    "compile",
+    "compileToFunction",
+    "computed",
+    "createApp",
+    "createBaseVNode",
+    "createBlock",
+    "createCommentVNode",
+    "createElementBlock",
+    "createElementVNode",
+    "createHydrationRenderer",
+    "createRenderer",
+    "createSSRApp",
+    "createSlots",
+    "createStaticVNode",
+    "createTextVNode",
+    "createVNode",
+    "customRef",
+    "defineAsyncComponent",
+    "defineComponent",
+    "defineCustomElement",
+    "defineEmits",
+    "defineExpose",
+    "defineModel",
+    "defineOptions",
+    "defineProps",
+    "defineSSRCustomElement",
+    "defineSlots",
+    "devtools",
+    "effect",
+    "effectScope",
+    "getCurrentInstance",
+    "getCurrentScope",
+    "getCurrentWatcher",
+    "getTransitionRawChildren",
+    "guardReactiveProps",
+    "h",
+    "handleError",
+    "hasInjectionContext",
+    "hydrate",
+    "hydrateOnIdle",
+    "hydrateOnInteraction",
+    "hydrateOnMediaQuery",
+    "hydrateOnVisible",
+    "initCustomFormatter",
+    "inject",
+    "isMemoSame",
+    "isProxy",
+    "isReactive",
+    "isReadonly",
+    "isRef",
+    "isRuntimeOnly",
+    "isShallow",
+    "isVNode",
+    "markRaw",
+    "mergeProps",
+    "nextTick",
+    "nodeOps",
+    "normalizeClass",
+    "normalizeProps",
+    "normalizeStyle",
+    "onActivated",
+    "onBeforeMount",
+    "onBeforeUnmount",
+    "onBeforeUpdate",
+    "onDeactivated",
+    "onErrorCaptured",
+    "onMounted",
+    "onRenderTracked",
+    "onRenderTriggered",
+    "onScopeDispose",
+    "onServerPrefetch",
+    "onUnmounted",
+    "onUpdated",
+    "onWatcherCleanup",
+    "openBlock",
+    "patchProp",
+    "popScopeId",
+    "provide",
+    "proxyRefs",
+    "pushScopeId",
+    "queuePostFlushCb",
+    "reactive",
+    "readonly",
+    "ref",
+    "registerRuntimeCompiler",
+    "render",
+    "renderList",
+    "renderSlot",
+    "resolveComponent",
+    "resolveDirective",
+    "resolveDynamicComponent",
+    "resolveTransitionHooks",
+    "setBlockTracking",
+    "setDevtoolsHook",
+    "setTransitionHooks",
+    "shallowReactive",
+    "shallowReadonly",
+    "shallowRef",
+    "ssrContextKey",
+    "stop",
+    "toDisplayString",
+    "toHandlerKey",
+    "toHandlers",
+    "toRaw",
+    "toRef",
+    "toRefs",
+    "toValue",
+    "transformVNodeArgs",
+    "triggerRef",
+    "unref",
+    "useAttrs",
+    "useCssModule",
+    "useCssVars",
+    "useHost",
+    "useId",
+    "useModel",
+    "useSSRContext",
+    "useShadowRoot",
+    "useSlots",
+    "useTemplateRef",
+    "useTransitionState",
+    "vModelCheckbox",
+    "vModelDynamic",
+    "vModelRadio",
+    "vModelSelect",
+    "vModelText",
+    "vShow",
+    "version",
+    "warn",
+    "watch",
+    "watchEffect",
+    "watchPostEffect",
+    "watchSyncEffect",
+    "withCtx",
+    "withDefaults",
+    "withDirectives",
+    "withKeys",
+    "withMemo",
+    "withModifiers",
+    "withScopeId",
+];
+
+fn match_import_source(
+    ctx: &RuleContext<UseVueBaseImport>,
+    module_source: &JsModuleSource,
+) -> Option<UseVueBaseImportState> {
+    if let Some(import_clause) = module_source.parent::<AnyJsImportClause>() {
+        if ctx
+            .source_type::<JsFileSource>()
+            .language()
+            .is_definition_file()
+            && matches!(import_clause, AnyJsImportClause::JsImportBareClause(_))
+        {
+            return None;
+        }
+
+        return match &import_clause {
+            AnyJsImportClause::JsImportBareClause(_) => {
+                Some(UseVueBaseImportState { fixable: true })
+            }
+            AnyJsImportClause::JsImportNamedClause(_) => {
+                let names = import_clause
+                    .named_specifiers()?
+                    .specifiers()
+                    .iter()
+                    .filter_map(|specifier| {
+                        specifier
+                            .ok()?
+                            .imported_name()
+                            .map(|name| name.token_text_trimmed())
+                    });
+                state_for_named_bindings(names)
+            }
+            AnyJsImportClause::JsImportCombinedClause(_)
+            | AnyJsImportClause::JsImportDefaultClause(_)
+            | AnyJsImportClause::JsImportNamespaceClause(_) => {
+                Some(UseVueBaseImportState { fixable: false })
+            }
+        };
+    }
+
+    if let Some(export_clause) = module_source.parent::<JsExportNamedFromClause>() {
+        let names = export_clause
+            .specifiers()
+            .iter()
+            .filter_map(|specifier| specifier.ok()?.source_name().ok()?.inner_string_text().ok());
+
+        return state_for_named_bindings(names);
+    }
+
+    module_source
+        .parent::<JsExportFromClause>()
+        .map(|_| UseVueBaseImportState { fixable: false })
+}
+
+fn module_name(ctx: &RuleContext<UseVueBaseImport>) -> Option<JsSyntaxToken> {
+    let AnyJsImportLike::JsModuleSource(module_source) = ctx.query() else {
+        return None;
+    };
+
+    module_source.value_token().ok()
+}
+
+fn state_for_named_bindings(
+    names: impl IntoIterator<Item = TokenText>,
+) -> Option<UseVueBaseImportState> {
+    let mut has_names = false;
+    let mut should_report = false;
+    let mut fixable = true;
+
+    for name in names {
+        has_names = true;
+        let is_vue_export = is_vue_export_name(name.text());
+        should_report |= is_vue_export;
+        fixable &= is_vue_export;
+    }
+
+    (!has_names || should_report).then_some(UseVueBaseImportState { fixable })
+}
+
+fn is_vue_export_name(name: &str) -> bool {
+    VUE_EXPORT_NAMES.binary_search(&name).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::VUE_EXPORT_NAMES;
+
+    #[test]
+    fn vue_export_names_are_sorted() {
+        assert!(VUE_EXPORT_NAMES.windows(2).all(|pair| pair[0] < pair[1]));
+    }
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useVueBaseImport/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/useVueBaseImport/invalid.js
@@ -1,0 +1,9 @@
+/* should generate diagnostics */
+import { computed } from "@vue/reactivity";
+import { createApp } from '@vue/runtime-dom';
+import * as Vue from "@vue/runtime-core";
+import Vue from "@vue/shared";
+import "@vue/runtime-dom";
+import { computed, unknown } from "@vue/reactivity";
+export { computed as renamed } from "@vue/reactivity";
+export * from "@vue/shared";

--- a/crates/biome_js_analyze/tests/specs/nursery/useVueBaseImport/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useVueBaseImport/invalid.js.snap
@@ -1,0 +1,184 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid.js
+---
+# Input
+```js
+/* should generate diagnostics */
+import { computed } from "@vue/reactivity";
+import { createApp } from '@vue/runtime-dom';
+import * as Vue from "@vue/runtime-core";
+import Vue from "@vue/shared";
+import "@vue/runtime-dom";
+import { computed, unknown } from "@vue/reactivity";
+export { computed as renamed } from "@vue/reactivity";
+export * from "@vue/shared";
+
+```
+
+# Diagnostics
+```
+invalid.js:2:26 lint/nursery/useVueBaseImport  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Don't import the internal Vue package '@vue/reactivity'.
+  
+    1 │ /* should generate diagnostics */
+  > 2 │ import { computed } from "@vue/reactivity";
+      │                          ^^^^^^^^^^^^^^^^^
+    3 │ import { createApp } from '@vue/runtime-dom';
+    4 │ import * as Vue from "@vue/runtime-core";
+  
+  i The public 'vue' entry point re-exports Vue's supported runtime APIs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Safe fix: Import 'vue' instead.
+  
+    2 │ import·{·computed·}·from·"@vue/reactivity";
+      │                           -   -----------  
+
+```
+
+```
+invalid.js:3:27 lint/nursery/useVueBaseImport  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Don't import the internal Vue package '@vue/runtime-dom'.
+  
+    1 │ /* should generate diagnostics */
+    2 │ import { computed } from "@vue/reactivity";
+  > 3 │ import { createApp } from '@vue/runtime-dom';
+      │                           ^^^^^^^^^^^^^^^^^^
+    4 │ import * as Vue from "@vue/runtime-core";
+    5 │ import Vue from "@vue/shared";
+  
+  i The public 'vue' entry point re-exports Vue's supported runtime APIs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Safe fix: Import 'vue' instead.
+  
+    3 │ import·{·createApp·}·from·'@vue/runtime-dom';
+      │                            -   ------------  
+
+```
+
+```
+invalid.js:4:22 lint/nursery/useVueBaseImport ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Don't import the internal Vue package '@vue/runtime-core'.
+  
+    2 │ import { computed } from "@vue/reactivity";
+    3 │ import { createApp } from '@vue/runtime-dom';
+  > 4 │ import * as Vue from "@vue/runtime-core";
+      │                      ^^^^^^^^^^^^^^^^^^^
+    5 │ import Vue from "@vue/shared";
+    6 │ import "@vue/runtime-dom";
+  
+  i The public 'vue' entry point re-exports Vue's supported runtime APIs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.js:5:17 lint/nursery/useVueBaseImport ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Don't import the internal Vue package '@vue/shared'.
+  
+    3 │ import { createApp } from '@vue/runtime-dom';
+    4 │ import * as Vue from "@vue/runtime-core";
+  > 5 │ import Vue from "@vue/shared";
+      │                 ^^^^^^^^^^^^^
+    6 │ import "@vue/runtime-dom";
+    7 │ import { computed, unknown } from "@vue/reactivity";
+  
+  i The public 'vue' entry point re-exports Vue's supported runtime APIs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.js:6:8 lint/nursery/useVueBaseImport  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Don't import the internal Vue package '@vue/runtime-dom'.
+  
+    4 │ import * as Vue from "@vue/runtime-core";
+    5 │ import Vue from "@vue/shared";
+  > 6 │ import "@vue/runtime-dom";
+      │        ^^^^^^^^^^^^^^^^^^
+    7 │ import { computed, unknown } from "@vue/reactivity";
+    8 │ export { computed as renamed } from "@vue/reactivity";
+  
+  i The public 'vue' entry point re-exports Vue's supported runtime APIs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Safe fix: Import 'vue' instead.
+  
+    6 │ import·"@vue/runtime-dom";
+      │         -   ------------  
+
+```
+
+```
+invalid.js:7:35 lint/nursery/useVueBaseImport ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Don't import the internal Vue package '@vue/reactivity'.
+  
+    5 │ import Vue from "@vue/shared";
+    6 │ import "@vue/runtime-dom";
+  > 7 │ import { computed, unknown } from "@vue/reactivity";
+      │                                   ^^^^^^^^^^^^^^^^^
+    8 │ export { computed as renamed } from "@vue/reactivity";
+    9 │ export * from "@vue/shared";
+  
+  i The public 'vue' entry point re-exports Vue's supported runtime APIs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.js:8:37 lint/nursery/useVueBaseImport  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Don't import the internal Vue package '@vue/reactivity'.
+  
+     6 │ import "@vue/runtime-dom";
+     7 │ import { computed, unknown } from "@vue/reactivity";
+   > 8 │ export { computed as renamed } from "@vue/reactivity";
+       │                                     ^^^^^^^^^^^^^^^^^
+     9 │ export * from "@vue/shared";
+    10 │ 
+  
+  i The public 'vue' entry point re-exports Vue's supported runtime APIs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Safe fix: Import 'vue' instead.
+  
+    8 │ export·{·computed·as·renamed·}·from·"@vue/reactivity";
+      │                                      -   -----------  
+
+```
+
+```
+invalid.js:9:15 lint/nursery/useVueBaseImport ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Don't import the internal Vue package '@vue/shared'.
+  
+     7 │ import { computed, unknown } from "@vue/reactivity";
+     8 │ export { computed as renamed } from "@vue/reactivity";
+   > 9 │ export * from "@vue/shared";
+       │               ^^^^^^^^^^^^^
+    10 │ 
+  
+  i The public 'vue' entry point re-exports Vue's supported runtime APIs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useVueBaseImport/invalid.vue
+++ b/crates/biome_js_analyze/tests/specs/nursery/useVueBaseImport/invalid.vue
@@ -1,0 +1,4 @@
+<!-- should generate diagnostics -->
+<script setup>
+import { ref } from "@vue/reactivity";
+</script>

--- a/crates/biome_js_analyze/tests/specs/nursery/useVueBaseImport/invalid.vue.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useVueBaseImport/invalid.vue.snap
@@ -1,0 +1,36 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid.vue
+---
+# Input
+```vue
+<!-- should generate diagnostics -->
+<script setup>
+import { ref } from "@vue/reactivity";
+</script>
+
+```
+
+# Diagnostics
+```
+invalid.vue:3:21 lint/nursery/useVueBaseImport  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Don't import the internal Vue package '@vue/reactivity'.
+  
+    1 │ <!-- should generate diagnostics -->
+    2 │ <script setup>
+  > 3 │ import { ref } from "@vue/reactivity";
+      │                     ^^^^^^^^^^^^^^^^^
+    4 │ </script>
+    5 │ 
+  
+  i The public 'vue' entry point re-exports Vue's supported runtime APIs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Safe fix: Import 'vue' instead.
+  
+    2 │ import·{·ref·}·from·"@vue/reactivity";
+      │                      -   -----------  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useVueBaseImport/valid.d.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useVueBaseImport/valid.d.ts
@@ -1,0 +1,2 @@
+/* should not generate diagnostics */
+import "@vue/runtime-dom";

--- a/crates/biome_js_analyze/tests/specs/nursery/useVueBaseImport/valid.d.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useVueBaseImport/valid.d.ts.snap
@@ -1,0 +1,10 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.d.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+import "@vue/runtime-dom";
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useVueBaseImport/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/useVueBaseImport/valid.js
@@ -1,0 +1,6 @@
+/* should not generate diagnostics */
+import { computed } from "vue";
+import { internalOnly } from "@vue/reactivity";
+import { unknown } from "@vue/runtime-dom";
+export { unknown } from "@vue/shared";
+export * from "vue";

--- a/crates/biome_js_analyze/tests/specs/nursery/useVueBaseImport/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useVueBaseImport/valid.js.snap
@@ -1,0 +1,14 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.js
+---
+# Input
+```js
+/* should not generate diagnostics */
+import { computed } from "vue";
+import { internalOnly } from "@vue/reactivity";
+import { unknown } from "@vue/runtime-dom";
+export { unknown } from "@vue/shared";
+export * from "vue";
+
+```

--- a/crates/biome_rule_options/src/lib.rs
+++ b/crates/biome_rule_options/src/lib.rs
@@ -519,6 +519,7 @@ pub mod use_valid_for_direction;
 pub mod use_valid_lang;
 pub mod use_valid_typeof;
 pub mod use_vars_on_top;
+pub mod use_vue_base_import;
 pub mod use_vue_consistent_define_props_declaration;
 pub mod use_vue_consistent_v_bind_style;
 pub mod use_vue_consistent_v_on_style;

--- a/crates/biome_rule_options/src/use_vue_base_import.rs
+++ b/crates/biome_rule_options/src/use_vue_base_import.rs
@@ -1,0 +1,6 @@
+use biome_deserialize_macros::{Deserializable, Merge};
+use serde::{Deserialize, Serialize};
+#[derive(Default, Clone, Debug, Deserialize, Deserializable, Merge, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields, default)]
+pub struct UseVueBaseImportOptions {}

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -2848,6 +2848,11 @@ See https://biomejs.dev/linter/rules/use-vars-on-top
 	 */
 	useVarsOnTop?: UseVarsOnTopConfiguration;
 	/**
+	* Enforce importing Vue's public entry point instead of internal Vue packages.
+See https://biomejs.dev/linter/rules/use-vue-base-import 
+	 */
+	useVueBaseImport?: UseVueBaseImportConfiguration;
+	/**
 	* Enforce consistent defineProps declaration style.
 See https://biomejs.dev/linter/rules/use-vue-consistent-define-props-declaration 
 	 */
@@ -5009,6 +5014,9 @@ export type UseUnicodeRegexConfiguration =
 export type UseVarsOnTopConfiguration =
 	| RulePlainConfiguration
 	| RuleWithUseVarsOnTopOptions;
+export type UseVueBaseImportConfiguration =
+	| RulePlainConfiguration
+	| RuleWithUseVueBaseImportOptions;
 export type UseVueConsistentDefinePropsDeclarationConfiguration =
 	| RulePlainConfiguration
 	| RuleWithUseVueConsistentDefinePropsDeclarationOptions;
@@ -7025,6 +7033,11 @@ export interface RuleWithUseVarsOnTopOptions {
 	level: RulePlainConfiguration;
 	options?: UseVarsOnTopOptions;
 }
+export interface RuleWithUseVueBaseImportOptions {
+	fix?: FixKind;
+	level: RulePlainConfiguration;
+	options?: UseVueBaseImportOptions;
+}
 export interface RuleWithUseVueConsistentDefinePropsDeclarationOptions {
 	level: RulePlainConfiguration;
 	options?: UseVueConsistentDefinePropsDeclarationOptions;
@@ -8833,6 +8846,7 @@ Defaults to `false`.
 }
 export type UseUnicodeRegexOptions = {};
 export type UseVarsOnTopOptions = {};
+export type UseVueBaseImportOptions = {};
 export interface UseVueConsistentDefinePropsDeclarationOptions {
 	style?: DeclarationStyle;
 }
@@ -10112,6 +10126,7 @@ export type Category =
 	| "lint/nursery/useUniqueInputFieldNames"
 	| "lint/nursery/useUniqueVariableNames"
 	| "lint/nursery/useVarsOnTop"
+	| "lint/nursery/useVueBaseImport"
 	| "lint/nursery/useVueConsistentDefinePropsDeclaration"
 	| "lint/nursery/useVueNextTickPromise"
 	| "lint/nursery/useVueValidVFor"

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -7438,6 +7438,13 @@
 						{ "type": "null" }
 					]
 				},
+				"useVueBaseImport": {
+					"description": "Enforce importing Vue's public entry point instead of internal Vue packages.\nSee https://biomejs.dev/linter/rules/use-vue-base-import",
+					"anyOf": [
+						{ "$ref": "#/$defs/UseVueBaseImportConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"useVueConsistentDefinePropsDeclaration": {
 					"description": "Enforce consistent defineProps declaration style.\nSee https://biomejs.dev/linter/rules/use-vue-consistent-define-props-declaration",
 					"anyOf": [
@@ -12842,6 +12849,16 @@
 			"additionalProperties": false,
 			"required": ["level"]
 		},
+		"RuleWithUseVueBaseImportOptions": {
+			"type": "object",
+			"properties": {
+				"fix": { "anyOf": [{ "$ref": "#/$defs/FixKind" }, { "type": "null" }] },
+				"level": { "$ref": "#/$defs/RulePlainConfiguration" },
+				"options": { "$ref": "#/$defs/UseVueBaseImportOptions" }
+			},
+			"additionalProperties": false,
+			"required": ["level"]
+		},
 		"RuleWithUseVueConsistentDefinePropsDeclarationOptions": {
 			"type": "object",
 			"properties": {
@@ -17149,6 +17166,16 @@
 			]
 		},
 		"UseVarsOnTopOptions": { "type": "object", "additionalProperties": false },
+		"UseVueBaseImportConfiguration": {
+			"oneOf": [
+				{ "$ref": "#/$defs/RulePlainConfiguration" },
+				{ "$ref": "#/$defs/RuleWithUseVueBaseImportOptions" }
+			]
+		},
+		"UseVueBaseImportOptions": {
+			"type": "object",
+			"additionalProperties": false
+		},
 		"UseVueConsistentDefinePropsDeclarationConfiguration": {
 			"oneOf": [
 				{ "$ref": "#/$defs/RulePlainConfiguration" },


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This adds useVueBaseImport, which is a port of https://eslint.vuejs.org/rules/prefer-import-from-vue

implemented gpt 5.6 terra
<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
