### PR TITLE
fix(noUnusedVariables): recognize merged interfaces

### DIFF
--- a/.changeset/fix-interface-declaration-merging.md
+++ b/.changeset/fix-interface-declaration-merging.md
@@ -1,0 +1,23 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6644](https://github.com/biomejs/biome/issues/6644): [`noUnusedVariables`](https://biomejs.dev/linter/rules/no-unused-variables/) now recognizes all interface declarations in a TypeScript declaration-merging group when the interface is referenced.
+
+The following snippet no longer triggers the rule.
+
+```ts
+interface Things {
+    foo: string;
+}
+
+interface Things {
+    bar: string;
+}
+
+export type Key = keyof Things;
+
+interface Things {
+    baz: string;
+}
+```

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_variables.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_variables.rs
@@ -475,9 +475,9 @@ fn is_implemented_overload_type_parameter(
         }
 
         signatures.iter().any(|id| {
-            model.binding_by_id(*id).is_some_and(|binding| {
-                binding.syntax().text_trimmed_range() == signature_range
-            })
+            model
+                .binding_by_id(*id)
+                .is_some_and(|binding| binding.syntax().text_trimmed_range() == signature_range)
         })
     })
 }
@@ -735,6 +735,9 @@ fn is_declaration_merged_with_used(
 ) -> Option<bool> {
     let decl = binding.declaration()?;
     match decl {
+        AnyJsBindingDeclaration::TsInterfaceDeclaration(_) => {
+            is_interface_merged_with_used(model, binding)
+        }
         AnyJsBindingDeclaration::TsModuleDeclaration(_) => {
             is_namespace_merged_with_used_value(model, binding)
         }
@@ -743,6 +746,30 @@ fn is_declaration_merged_with_used(
         }
         _ => None,
     }
+}
+
+fn is_interface_merged_with_used(
+    model: &SemanticModel,
+    binding: &AnyJsIdentifierBinding,
+) -> Option<bool> {
+    let name_token = binding.name_token().ok()?;
+    let name = name_token.text_trimmed();
+    let scope = model.scope_hoisted_to(binding.syntax())?;
+
+    Some(scope.bindings().any(|scope_binding| {
+        let other = scope_binding.tree();
+        let Some(other_declaration) = other.declaration() else {
+            return false;
+        };
+        matches!(
+            other_declaration,
+            AnyJsBindingDeclaration::TsInterfaceDeclaration(_)
+        ) && other
+            .name_token()
+            .is_ok_and(|other_name| other_name.text_trimmed() == name)
+            && (model.is_exported(&other)
+                || !is_unused_by_references(model, &other, other_declaration.syntax()))
+    }))
 }
 
 /// Returns `true` if `call` is a call to a simple identifier named `name`.
@@ -889,8 +916,7 @@ pub fn is_unused(model: &SemanticModel, binding: &AnyJsIdentifierBinding) -> boo
     let Some(declaration) = binding.declaration() else {
         return false;
     };
-    let declaration = declaration.syntax();
-    if !is_unused_by_references(model, binding, declaration) {
+    if !is_unused_by_references(model, binding, declaration.syntax()) {
         return false;
     }
     !is_declaration_merged_with_used(model, binding).unwrap_or(false)

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidInterfaceDeclarationMerging.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidInterfaceDeclarationMerging.ts
@@ -1,0 +1,26 @@
+/* should generate diagnostics */
+
+interface Unused {
+    first: string;
+}
+
+interface Unused {
+    second: string;
+}
+
+const ValueOnly = 0;
+interface ValueOnly {
+    prop: string;
+}
+console.log(ValueOnly);
+
+interface Shadowed {
+    outer: string;
+}
+export function useShadowed() {
+    interface Shadowed {
+        inner: string;
+    }
+    type Key = keyof Shadowed;
+    return null as Key;
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidInterfaceDeclarationMerging.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/invalidInterfaceDeclarationMerging.ts.snap
@@ -1,0 +1,102 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidInterfaceDeclarationMerging.ts
+---
+# Input
+```ts
+/* should generate diagnostics */
+
+interface Unused {
+    first: string;
+}
+
+interface Unused {
+    second: string;
+}
+
+const ValueOnly = 0;
+interface ValueOnly {
+    prop: string;
+}
+console.log(ValueOnly);
+
+interface Shadowed {
+    outer: string;
+}
+export function useShadowed() {
+    interface Shadowed {
+        inner: string;
+    }
+    type Key = keyof Shadowed;
+    return null as Key;
+}
+
+```
+
+# Diagnostics
+```
+invalidInterfaceDeclarationMerging.ts:3:11 lint/correctness/noUnusedVariables ━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This interface Unused is unused.
+  
+    1 │ /* should generate diagnostics */
+    2 │ 
+  > 3 │ interface Unused {
+      │           ^^^^^^
+    4 │     first: string;
+    5 │ }
+  
+  i Unused variables are often the result of typos, incomplete refactors, or other sources of bugs.
+  
+
+```
+
+```
+invalidInterfaceDeclarationMerging.ts:7:11 lint/correctness/noUnusedVariables ━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This interface Unused is unused.
+  
+    5 │ }
+    6 │ 
+  > 7 │ interface Unused {
+      │           ^^^^^^
+    8 │     second: string;
+    9 │ }
+  
+  i Unused variables are often the result of typos, incomplete refactors, or other sources of bugs.
+  
+
+```
+
+```
+invalidInterfaceDeclarationMerging.ts:12:11 lint/correctness/noUnusedVariables ━━━━━━━━━━━━━━━━━━━━━
+
+  ! This interface ValueOnly is unused.
+  
+    11 │ const ValueOnly = 0;
+  > 12 │ interface ValueOnly {
+       │           ^^^^^^^^^
+    13 │     prop: string;
+    14 │ }
+  
+  i Unused variables are often the result of typos, incomplete refactors, or other sources of bugs.
+  
+
+```
+
+```
+invalidInterfaceDeclarationMerging.ts:17:11 lint/correctness/noUnusedVariables ━━━━━━━━━━━━━━━━━━━━━
+
+  ! This interface Shadowed is unused.
+  
+    15 │ console.log(ValueOnly);
+    16 │ 
+  > 17 │ interface Shadowed {
+       │           ^^^^^^^^
+    18 │     outer: string;
+    19 │ }
+  
+  i Unused variables are often the result of typos, incomplete refactors, or other sources of bugs.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validInterfaceDeclarationMerging.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validInterfaceDeclarationMerging.ts
@@ -1,0 +1,19 @@
+/* should not generate diagnostics */
+
+interface Things {
+    foo: string;
+}
+
+interface Things {
+    bar: string;
+}
+
+type Key = keyof Things;
+
+interface Things {
+    baz: string;
+}
+
+export function doStuff(key: Key) {
+    return key;
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validInterfaceDeclarationMerging.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validInterfaceDeclarationMerging.ts.snap
@@ -1,0 +1,27 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validInterfaceDeclarationMerging.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+interface Things {
+    foo: string;
+}
+
+interface Things {
+    bar: string;
+}
+
+type Key = keyof Things;
+
+interface Things {
+    baz: string;
+}
+
+export function doStuff(key: Key) {
+    return key;
+}
+
+```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Implemented with a coding agent.

Closes #6644 

The rule now checks for "merged" interfaces. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added new tests. Green CI.

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
