### PR TITLE
chore: update depot logo

### DIFF
--- a/packages/@biomejs/biome/README.md
+++ b/packages/@biomejs/biome/README.md
@@ -113,9 +113,9 @@ Biome offers [enterprise support](https://biomejs.dev/enterprise), where Core Co
       <td align="center" valign="middle">
         <a href="https://depot.dev/?utm_source=biome&utm_medium=readme" target="_blank">
           <picture>
-            <source media="(prefers-color-scheme: light)" srcset="https://depot.dev/assets/brand/1693758816/depot-logo-horizontal-on-light@3x.png" />
-            <source media="(prefers-color-scheme: dark)" srcset="https://depot.dev/assets/brand/1693758816/depot-logo-horizontal-on-dark@3x.png" />
-            <img src="https://depot.dev/assets/brand/1693758816/depot-logo-horizontal-on-light@3x.png" width="600" alt="Depot logo" />
+            <source media="(prefers-color-scheme: light)" srcset="https://depot.dev/assets/brand/horizontal/depot-logo-horizontal-on-light-x3.png" />
+            <source media="(prefers-color-scheme: dark)" srcset="https://depot.dev/assets/brand/horizontal/depot-logo-horizontal-on-dark-x3.png" />
+            <img src="https://depot.dev/assets/brand/horizontal/depot-logo-horizontal-on-light-x3.png" width="600" alt="Depot logo" />
           </picture>
         </a>
       </td>


### PR DESCRIPTION
> [!CAUTION]
> Do not merge yet, depot have mixed up their light/dark logo links. [Gave them a heads up on bsky](https://bsky.app/profile/hedger.ch/post/3mukb44hibc23).

## Summary

Updates the Depot.dev logo
