### PR TITLE
perf(css_parser): short-circuit SCSS unary operator detection

### DIFF
--- a/crates/biome_css_parser/src/syntax/scss/expression/precedence.rs
+++ b/crates/biome_css_parser/src/syntax/scss/expression/precedence.rs
@@ -109,13 +109,13 @@ fn parse_scss_unary_expression(p: &mut CssParser, options: ScssExpressionOptions
 
 #[inline]
 fn is_at_scss_unary_operator(p: &mut CssParser) -> bool {
-    // `var(--#{$name})` starts with `-`, but the pair belongs to one
-    // custom-property identifier, not chained unary operators.
-    if is_at_scss_interpolated_dashed_identifier(p) {
-        return false;
+    match p.cur() {
+        T![+] | T![not] => true,
+        // `var(--#{$name})` starts with `-`, but the pair belongs to one
+        // custom-property identifier, not chained unary operators.
+        T![-] => !is_at_scss_interpolated_dashed_identifier(p),
+        _ => false,
     }
-
-    p.at_ts(SCSS_UNARY_OPERATOR_TOKEN_SET)
 }
 
 /// Returns the precedence level for the current SCSS binary operator token.


### PR DESCRIPTION
> This PR was created with AI assistance (OpenAI Codex).

## Summary

Short-circuits SCSS unary-operator detection before checking the interpolated dashed-identifier exception. 
This avoids unnecessary lookahead for ordinary value tokens while preserving `--#{$name}` parsing.

## Test Plan

- `cargo test -p biome_css_parser`
