### PR TITLE
perf(yaml_formatter): avoid copying unchanged scalars

### DIFF
--- a/.changeset/loud-banks-see.md
+++ b/.changeset/loud-banks-see.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Improved the performance of Biome Formatter up to ~50% in some cases.

--- a/crates/biome_formatter/src/comments/builder.rs
+++ b/crates/biome_formatter/src/comments/builder.rs
@@ -62,6 +62,10 @@ where
         CommentsMap<SyntaxElementKey, SourceComment<Style::Language>>,
         FxHashSet<SyntaxElementKey>,
     ) {
+        if !root.has_comments_descendants() && !root.has_skipped_descendants() {
+            return self.builder.finish();
+        }
+
         // A root with a parent means that only a part of a document is
         // formatted (range and on-type formatting). Full documents always
         // start at a parentless root and take none of the subtree paths
@@ -778,8 +782,8 @@ mod tests {
     };
     use biome_rowan::syntax::SyntaxElementKey;
     use biome_rowan::{
-        AstNode, BatchMutation, SyntaxNode, SyntaxNodeOptionExt, SyntaxTriviaPieceComments,
-        TextRange, chain_trivia_pieces,
+        AstNode, BatchMutation, SyntaxNode, SyntaxNodeOptionExt, SyntaxToken,
+        SyntaxTriviaPieceComments, TextRange, TriviaPiece, TriviaPieceKind, chain_trivia_pieces,
     };
     use std::cell::RefCell;
 
@@ -1235,6 +1239,29 @@ b;"#;
 
         assert_eq!(decorated.len(), 1);
         assert!(comments.leading(&root.key()).is_empty());
+    }
+
+    #[test]
+    fn skipped_trivia_without_comments_is_collected() {
+        let root = JsSyntaxNode::new_detached(
+            JsSyntaxKind::JS_MODULE,
+            [Some(
+                SyntaxToken::new_detached(
+                    JsSyntaxKind::IDENT,
+                    "?value",
+                    [TriviaPiece::new(TriviaPieceKind::Skipped, 1)],
+                    [],
+                )
+                .into(),
+            )],
+        );
+        let token = root.first_token().unwrap();
+        let style = TestCommentStyle::default();
+        let builder = CommentsBuilderVisitor::new(&style, None);
+
+        let (_, skipped) = builder.visit(&root);
+
+        assert!(skipped.contains(&token.key()));
     }
 
     fn extract_comments_from_node(

--- a/crates/biome_formatter/src/printer/mod.rs
+++ b/crates/biome_formatter/src/printer/mod.rs
@@ -374,9 +374,9 @@ impl<'a> Printer<'a> {
         if !self.state.pending_indent.is_empty() {
             let indent = std::mem::take(&mut self.state.pending_indent);
 
-            let (indent_string, repeat_count) = match self.options.indent_style() {
-                IndentStyle::Tab => ("\t", 1),
-                IndentStyle::Space => (" ", self.options.indent_width().value()),
+            let (indent_char, repeat_count, indent_char_width) = match self.options.indent_style() {
+                IndentStyle::Tab => ('\t', 1, self.options.indent_width().value()),
+                IndentStyle::Space => (' ', self.options.indent_width().value(), 1),
             };
 
             let total_indent_char_count = indent.level() as usize * repeat_count as usize;
@@ -385,10 +385,12 @@ impl<'a> Printer<'a> {
                 .buffer
                 .reserve(total_indent_char_count + indent.align_len());
 
-            for _ in 0..total_indent_char_count {
-                for ch in indent_string.chars() {
-                    self.print_char(ch);
-                }
+            self.state
+                .buffer
+                .extend(std::iter::repeat_n(indent_char, total_indent_char_count));
+            self.state.line_width += total_indent_char_count * indent_char_width as usize;
+            if total_indent_char_count > 0 {
+                self.state.has_empty_line = false;
             }
 
             for ch in indent.align().chars() {
@@ -1702,6 +1704,19 @@ mod tests {
 a"#,
             formatted.as_code()
         )
+    }
+
+    #[test]
+    fn it_prints_initial_space_indentation_at_the_requested_level() {
+        let options = PrinterOptions {
+            indent_style: IndentStyle::Space,
+            indent_width: 3.try_into().unwrap(),
+            ..PrinterOptions::default()
+        };
+
+        let result = format_with_options_and_indentation(&token("content"), options, 3);
+
+        assert_eq!("         content", result.as_code());
     }
 
     #[test]

--- a/crates/biome_rowan/src/green.rs
+++ b/crates/biome_rowan/src/green.rs
@@ -11,6 +11,47 @@ pub(crate) use self::{
     trivia::GreenTrivia,
 };
 
+/// Summary of trivia that is present in a green element's subtree.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+pub(crate) struct GreenElementFlags(u8);
+
+impl GreenElementFlags {
+    pub(crate) const HAS_COMMENTS: Self = Self(1 << 0);
+    pub(crate) const HAS_SKIPPED: Self = Self(1 << 1);
+    pub(crate) const HAS_COMMENTS_AND_SKIPPED: Self =
+        Self(Self::HAS_COMMENTS.0 | Self::HAS_SKIPPED.0);
+
+    #[inline]
+    pub(crate) fn contains(self, other: Self) -> bool {
+        self.0 & other.0 != 0
+    }
+
+    #[inline]
+    pub(crate) fn contains_all(self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+
+    #[inline]
+    pub(crate) fn insert(&mut self, other: Self) {
+        self.0 |= other.0;
+    }
+
+    #[inline]
+    pub(crate) fn union(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+
+    pub(crate) fn from_trivia_kind(kind: crate::TriviaPieceKind) -> Self {
+        if kind.is_comment() {
+            Self::HAS_COMMENTS
+        } else if kind.is_skipped() {
+            Self::HAS_SKIPPED
+        } else {
+            Self::default()
+        }
+    }
+}
+
 pub use self::node_cache::NodeCache;
 pub(crate) use self::node_cache::NodeCacheNodeEntryMut;
 

--- a/crates/biome_rowan/src/green/node.rs
+++ b/crates/biome_rowan/src/green/node.rs
@@ -15,16 +15,22 @@ use crate::utility_types::static_assert;
 use crate::{
     GreenToken, NodeOrToken, TextRange, TextSize,
     arc::{Arc, HeaderSlice, ThinArc},
-    green::{GreenElement, GreenElementRef, RawSyntaxKind},
+    green::{GreenElement, GreenElementFlags, GreenElementRef, RawSyntaxKind},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(super) struct GreenNodeHead {
     kind: RawSyntaxKind,
+    flags: GreenElementFlags,
     text_len: TextSize,
     #[cfg(feature = "countme")]
     _c: countme::Count<GreenNode>,
 }
+
+#[cfg(target_pointer_width = "64")]
+static_assert!(mem::size_of::<GreenElementFlags>() == 1);
+#[cfg(target_pointer_width = "64")]
+static_assert!(mem::size_of::<GreenNodeHead>() == 8);
 
 #[cfg(feature = "countme")]
 pub(crate) fn has_live() -> bool {
@@ -181,6 +187,21 @@ impl GreenNodeData {
         self.header().text_len
     }
 
+    #[inline]
+    pub(crate) fn has_comments(&self) -> bool {
+        self.flags().contains(GreenElementFlags::HAS_COMMENTS)
+    }
+
+    #[inline]
+    pub(crate) fn has_skipped(&self) -> bool {
+        self.flags().contains(GreenElementFlags::HAS_SKIPPED)
+    }
+
+    #[inline]
+    pub(crate) fn flags(&self) -> GreenElementFlags {
+        self.header().flags
+    }
+
     /// Children of this node.
     #[inline]
     pub fn children(&self) -> Children<'_> {
@@ -257,11 +278,20 @@ impl GreenNode {
         I::IntoIter: ExactSizeIterator,
     {
         let mut text_len: TextSize = 0.into();
+        let mut flags = GreenElementFlags::default();
         let slots = slots.into_iter().map(|el| {
             let rel_offset = text_len;
             match el {
                 Some(el) => {
                     text_len += el.text_len();
+                    match &el {
+                        NodeOrToken::Node(node) => {
+                            flags.insert(node.flags());
+                        }
+                        NodeOrToken::Token(token) => {
+                            flags.insert(token.flags());
+                        }
+                    }
                     match el {
                         NodeOrToken::Node(node) => Slot::Node { rel_offset, node },
                         NodeOrToken::Token(token) => Slot::Token { rel_offset, token },
@@ -274,6 +304,7 @@ impl GreenNode {
         let data = ThinArc::from_header_and_iter(
             GreenNodeHead {
                 kind,
+                flags: GreenElementFlags::default(),
                 text_len: 0.into(),
                 #[cfg(feature = "countme")]
                 _c: countme::Count::new(),
@@ -281,11 +312,14 @@ impl GreenNode {
             slots,
         );
 
-        // XXX: fixup `text_len` after construction, because we can't iterate
-        // `slots` twice.
+        // XXX: fix up aggregate data after construction, because we can't
+        // iterate `slots` twice.
         let data = {
             let mut data = Arc::from_thin(data);
-            Arc::get_mut(&mut data).unwrap().header.text_len = text_len;
+            debug_assert!(data.is_unique());
+            let head = &mut Arc::get_mut(&mut data).unwrap().header;
+            head.text_len = text_len;
+            head.flags = flags;
             Arc::into_thin(data)
         };
 
@@ -501,8 +535,9 @@ impl FusedIterator for Children<'_> {}
 
 #[cfg(test)]
 mod tests {
-    use crate::GreenNode;
+    use crate::green::{GreenElement, GreenTrivia};
     use crate::raw_language::{RawLanguageKind, RawSyntaxTreeBuilder};
+    use crate::{GreenNode, GreenToken, RawSyntaxKind, TriviaPiece, TriviaPieceKind};
 
     fn build_test_list() -> GreenNode {
         let mut builder: RawSyntaxTreeBuilder = RawSyntaxTreeBuilder::new();
@@ -562,5 +597,40 @@ mod tests {
 
         // Has 3 slots, one is missing
         assert_eq!(root.slots().len(), 3);
+    }
+
+    #[test]
+    fn propagates_trivia_flags() {
+        let comment_token = GreenToken::with_trivia(
+            RawSyntaxKind(0),
+            "//value",
+            GreenTrivia::new([TriviaPiece::single_line_comment(2)]),
+            GreenTrivia::empty(),
+        );
+        let comment_node =
+            GreenNode::new(RawSyntaxKind(0), [Some(GreenElement::Token(comment_token))]);
+        assert!(comment_node.has_comments());
+        assert!(!comment_node.has_skipped());
+
+        let skipped_token = GreenToken::with_trivia(
+            RawSyntaxKind(0),
+            "?value",
+            GreenTrivia::new([TriviaPiece::new(TriviaPieceKind::Skipped, 1)]),
+            GreenTrivia::empty(),
+        );
+        let skipped_node =
+            GreenNode::new(RawSyntaxKind(0), [Some(GreenElement::Token(skipped_token))]);
+        assert!(!skipped_node.has_comments());
+        assert!(skipped_node.has_skipped());
+
+        let root = GreenNode::new(
+            RawSyntaxKind(0),
+            [
+                Some(GreenElement::Node(comment_node)),
+                Some(GreenElement::Node(skipped_node)),
+            ],
+        );
+        assert!(root.has_comments());
+        assert!(root.has_skipped());
     }
 }

--- a/crates/biome_rowan/src/green/node_cache.rs
+++ b/crates/biome_rowan/src/green/node_cache.rs
@@ -11,7 +11,7 @@ use crate::green::Slot;
 use crate::syntax::{TriviaPiece, TriviaPieceKind};
 use crate::{
     GreenNode, GreenNodeData, GreenToken, GreenTokenData, NodeOrToken, RawSyntaxKind,
-    green::GreenElementRef,
+    green::{GreenElementFlags, GreenElementRef},
 };
 
 use super::element::GreenElement;
@@ -306,10 +306,12 @@ impl NodeCache {
                 entry.key().0.value().to_owned()
             }
             RawEntryMut::Vacant(entry) => {
-                let leading = self.trivia.get(self.generation, leading);
-                let trailing = self.trivia.get(self.generation, trailing);
+                let (leading, leading_flags) = self.trivia.get(self.generation, leading);
+                let (trailing, trailing_flags) = self.trivia.get(self.generation, trailing);
 
-                let token = GreenToken::with_trivia(kind, text, leading, trailing);
+                let mut flags = leading_flags;
+                flags.insert(trailing_flags);
+                let token = GreenToken::with_trivia_and_flags(kind, text, leading, trailing, flags);
                 let key = CachedToken(GenerationalPointer::new(token.clone(), self.generation));
                 entry.insert_with_hasher(hash, key, (), |t| token_hash(t.0.value()));
                 token
@@ -459,18 +461,24 @@ impl Default for TriviaCache {
 impl TriviaCache {
     /// Tries to retrieve a [GreenTrivia] with the given pieces from the cache or creates a new one and caches
     /// it for further calls.
-    fn get(&mut self, generation: Generation, pieces: &[TriviaPiece]) -> GreenTrivia {
+    fn get(
+        &mut self,
+        generation: Generation,
+        pieces: &[TriviaPiece],
+    ) -> (GreenTrivia, GreenElementFlags) {
         match pieces {
-            [] => GreenTrivia::empty(),
+            [] => (GreenTrivia::empty(), GreenElementFlags::default()),
             [
                 TriviaPiece {
                     kind: TriviaPieceKind::Whitespace,
                     length,
                 },
-            ] if *length == TextSize::from(1) => self.whitespace.clone(),
+            ] if *length == TextSize::from(1) => {
+                (self.whitespace.clone(), GreenElementFlags::default())
+            }
 
             _ => {
-                let hash = Self::trivia_hash_of(pieces);
+                let (hash, flags) = Self::trivia_hash::<true>(pieces);
 
                 let entry = self
                     .cache
@@ -480,7 +488,7 @@ impl TriviaCache {
                 match entry {
                     RawEntryMut::Occupied(mut entry) => {
                         entry.key_mut().0.set_generation(generation);
-                        entry.key().0.value().to_owned()
+                        (entry.key().0.value().to_owned(), flags)
                     }
                     RawEntryMut::Vacant(entry) => {
                         let trivia = GreenTrivia::new(pieces.iter().copied());
@@ -488,25 +496,29 @@ impl TriviaCache {
                             hash,
                             CachedTrivia(GenerationalPointer::new(trivia.clone(), generation)),
                             (),
-                            |cached| Self::trivia_hash_of(cached.0.value().pieces()),
+                            |cached| Self::trivia_hash::<false>(cached.0.value().pieces()).0,
                         );
-                        trivia
+                        (trivia, flags)
                     }
                 }
             }
         }
     }
 
-    fn trivia_hash_of(pieces: &[TriviaPiece]) -> u64 {
+    fn trivia_hash<const COMPUTE_FLAGS: bool>(pieces: &[TriviaPiece]) -> (u64, GreenElementFlags) {
         let mut h = FxHasher::default();
+        let mut flags = GreenElementFlags::default();
 
         pieces.len().hash(&mut h);
 
         for piece in pieces {
             piece.hash(&mut h);
+            if COMPUTE_FLAGS && !flags.contains_all(GreenElementFlags::HAS_COMMENTS_AND_SKIPPED) {
+                flags.insert(GreenElementFlags::from_trivia_kind(piece.kind()));
+            }
         }
 
-        h.finish()
+        (h.finish(), flags)
     }
 }
 
@@ -514,9 +526,10 @@ impl TriviaCache {
 mod tests {
     use std::mem::size_of;
 
-    use crate::green::node_cache::{CachedNode, CachedToken, CachedTrivia, token_hash};
+    use crate::green::GreenElementFlags;
+    use crate::green::node_cache::{CachedNode, CachedToken, CachedTrivia, NodeCache, token_hash};
     use crate::green::trivia::GreenTrivia;
-    use crate::{GreenToken, RawSyntaxKind};
+    use crate::{GreenToken, GreenTokenData, RawSyntaxKind, TriviaPiece, TriviaPieceKind};
     use biome_text_size::TextSize;
 
     #[test]
@@ -548,6 +561,21 @@ mod tests {
             GreenTrivia::whitespace(1),
         );
         assert_ne!(token_hash(&t1), token_hash(&t4));
+    }
+
+    #[test]
+    fn cached_token_preserves_trivia_flags() {
+        let mut cache = NodeCache::default();
+        let kind = RawSyntaxKind(0);
+        let leading = [TriviaPiece::new(TriviaPieceKind::Skipped, 1)];
+        let trailing = [TriviaPiece::single_line_comment(2)];
+
+        let (_, token) = cache.token_with_trivia(kind, "?value//", &leading, &trailing);
+        let (_, cached) = cache.token_with_trivia(kind, "?value//", &leading, &trailing);
+
+        assert!(std::ptr::eq::<GreenTokenData>(&*token, &*cached));
+        assert!(cached.flags().contains(GreenElementFlags::HAS_COMMENTS));
+        assert!(cached.flags().contains(GreenElementFlags::HAS_SKIPPED));
     }
 
     #[test]

--- a/crates/biome_rowan/src/green/token.rs
+++ b/crates/biome_rowan/src/green/token.rs
@@ -9,12 +9,13 @@ use crate::green::trivia::GreenTrivia;
 use crate::{
     TextSize,
     arc::{Arc, HeaderSlice, ThinArc},
-    green::RawSyntaxKind,
+    green::{GreenElementFlags, RawSyntaxKind},
 };
 
 #[derive(PartialEq, Eq, Hash)]
 struct GreenTokenHead {
     kind: RawSyntaxKind,
+    flags: GreenElementFlags,
     leading: GreenTrivia,
     trailing: GreenTrivia,
     #[cfg(feature = "countme")]
@@ -143,6 +144,11 @@ impl GreenTokenData {
     pub fn trailing_trivia(&self) -> &GreenTrivia {
         &self.data.header.trailing
     }
+
+    #[inline]
+    pub(crate) fn flags(&self) -> GreenElementFlags {
+        self.data.header.flags
+    }
 }
 
 impl GreenToken {
@@ -161,8 +167,21 @@ impl GreenToken {
         leading: GreenTrivia,
         trailing: GreenTrivia,
     ) -> Self {
+        let flags = leading.flags().union(trailing.flags());
+        Self::with_trivia_and_flags(kind, text, leading, trailing, flags)
+    }
+
+    #[inline]
+    pub(crate) fn with_trivia_and_flags(
+        kind: RawSyntaxKind,
+        text: &str,
+        leading: GreenTrivia,
+        trailing: GreenTrivia,
+        flags: GreenElementFlags,
+    ) -> Self {
         let head = GreenTokenHead {
             kind,
+            flags,
             leading,
             trailing,
             #[cfg(feature = "countme")]

--- a/crates/biome_rowan/src/green/trivia.rs
+++ b/crates/biome_rowan/src/green/trivia.rs
@@ -1,5 +1,6 @@
 use crate::TriviaPiece;
 use crate::arc::{Arc, HeaderSlice, ThinArc};
+use crate::green::GreenElementFlags;
 use biome_text_size::TextSize;
 use std::fmt::Formatter;
 use std::mem::ManuallyDrop;
@@ -77,6 +78,18 @@ impl fmt::Debug for GreenTrivia {
 }
 
 impl GreenTrivia {
+    #[inline]
+    pub(crate) fn flags(&self) -> GreenElementFlags {
+        let mut flags = GreenElementFlags::default();
+        for piece in self.pieces() {
+            flags.insert(GreenElementFlags::from_trivia_kind(piece.kind()));
+            if flags.contains_all(GreenElementFlags::HAS_COMMENTS_AND_SKIPPED) {
+                break;
+            }
+        }
+        flags
+    }
+
     /// Creates a new trivia containing the passed in pieces
     pub fn new<I>(pieces: I) -> Self
     where

--- a/crates/biome_rowan/src/syntax.rs
+++ b/crates/biome_rowan/src/syntax.rs
@@ -129,8 +129,8 @@ mod tests {
     use biome_text_size::TextRange;
 
     use crate::Direction;
-    use crate::raw_language::{RawLanguageKind, RawSyntaxTreeBuilder};
-    use crate::syntax::TriviaPiece;
+    use crate::raw_language::{RawLanguage, RawLanguageKind, RawSyntaxTreeBuilder};
+    use crate::syntax::{SyntaxNode, SyntaxToken, TriviaPiece, TriviaPieceKind};
 
     #[test]
     fn empty_list() {
@@ -518,5 +518,36 @@ mod tests {
         assert_eq!(2, pieces_rev.len());
         assert_eq!("/**/", pieces_rev[0].text());
         assert_eq!("\n\t ", pieces_rev[1].text());
+    }
+
+    #[test]
+    fn replacing_trivia_clears_descendant_flags() {
+        let token = SyntaxToken::<RawLanguage>::new_detached(
+            RawLanguageKind::STRING_TOKEN,
+            "?value//",
+            [TriviaPiece::new(TriviaPieceKind::Skipped, 1)],
+            [TriviaPiece::single_line_comment(2)],
+        );
+        let root =
+            SyntaxNode::<RawLanguage>::new_detached(RawLanguageKind::ROOT, [Some(token.into())]);
+
+        assert!(root.has_comments_descendants());
+        assert!(root.has_skipped_descendants());
+
+        let token = root.first_token().unwrap();
+        let replacement = token.with_leading_trivia([]);
+        let root = root
+            .replace_child(token.into(), replacement.into())
+            .unwrap();
+        assert!(root.has_comments_descendants());
+        assert!(!root.has_skipped_descendants());
+
+        let token = root.first_token().unwrap();
+        let replacement = token.with_trailing_trivia([]);
+        let root = root
+            .replace_child(token.into(), replacement.into())
+            .unwrap();
+        assert!(!root.has_comments_descendants());
+        assert!(!root.has_skipped_descendants());
     }
 }

--- a/crates/biome_rowan/src/syntax/node.rs
+++ b/crates/biome_rowan/src/syntax/node.rs
@@ -706,11 +706,16 @@ impl<L: Language> SyntaxNode<L> {
         SyntaxList::new(self)
     }
 
-    /// Whether the node contains any comments. This function checks
-    /// **all the descendants** of the current node.
+    /// Whether any token in this node's subtree has leading or trailing comments.
+    #[inline]
     pub fn has_comments_descendants(&self) -> bool {
-        self.descendants_tokens(Direction::Next)
-            .any(|tok| tok.has_trailing_comments() || tok.has_leading_comments())
+        self.raw.green().has_comments()
+    }
+
+    /// Whether any token in this node's subtree has skipped trivia.
+    #[inline]
+    pub fn has_skipped_descendants(&self) -> bool {
+        self.raw.green().has_skipped()
     }
 
     /// It checks if the current node has trailing or leading trivia

--- a/crates/biome_yaml_formatter/src/flow_scalar.rs
+++ b/crates/biome_yaml_formatter/src/flow_scalar.rs
@@ -38,20 +38,21 @@ impl Format<YamlFormatContext> for FormatFlowScalar<'_> {
             self.token.text_trimmed().trim_end(),
             f.options().quote_style(),
         );
-        let value = normalized.as_ref();
-        let position = Some(self.token.text_trimmed_range().start());
+        let position = self.token.text_trimmed_range().start();
 
-        if !value.contains(['\n', '\r']) {
-            return write!(f, [format_replaced(self.token, &text(value, position))]);
+        if !normalized.contains(['\n', '\r']) {
+            let content = syntax_token_cow_slice(normalized, self.token, position);
+            return write!(f, [format_replaced(self.token, &content)]);
         }
 
+        let value = normalized.as_ref();
         let content = format_with(|f| {
             let mut lines = ContentLines::new(value);
 
             // Leading whitespace before the token is trivia rather than part
             // of its text, so the first line only has its end trimmed
             if let Some(first) = lines.next() {
-                write!(f, [text(first.trim_end(), position)])?;
+                write!(f, [text(first.trim_end(), Some(position))])?;
             }
 
             let mut prev_empty = false;

--- a/crates/biome_yaml_formatter/src/utils.rs
+++ b/crates/biome_yaml_formatter/src/utils.rs
@@ -3,8 +3,9 @@ use crate::prelude::*;
 use biome_formatter::write;
 use biome_rowan::AstNodeList;
 use biome_yaml_syntax::{
-    AnyYamlBlockHeader, AnyYamlBlockScalar, AnyYamlFlowNode, AnyYamlMappingImplicitKey,
-    AnyYamlProperty, YamlPropertyList, YamlSyntaxNode, YamlSyntaxToken,
+    AnyYamlBlockHeader, AnyYamlBlockScalar, AnyYamlFlowNode, AnyYamlJsonContent,
+    AnyYamlMappingImplicitKey, AnyYamlProperty, YamlFlowInBlockNode, YamlPropertyList,
+    YamlSyntaxNode, YamlSyntaxToken,
 };
 
 /// Whether a `:` placed directly after this key would be lexed as part of
@@ -128,6 +129,22 @@ pub(crate) fn ends_in_keep_chomped_scalar(root: &YamlSyntaxNode) -> bool {
                 .any(|header| matches!(header, AnyYamlBlockHeader::YamlBlockKeepIndicator(_)))
         })
     })
+}
+
+pub(crate) fn flow_scalar_has_line_break(node: &YamlFlowInBlockNode) -> bool {
+    let token = match node.flow() {
+        Ok(AnyYamlFlowNode::YamlFlowYamlNode(node)) => {
+            node.content().and_then(|scalar| scalar.value_token().ok())
+        }
+        Ok(AnyYamlFlowNode::YamlFlowJsonNode(node)) => match node.content() {
+            Ok(AnyYamlJsonContent::YamlDoubleQuotedScalar(scalar)) => scalar.value_token().ok(),
+            Ok(AnyYamlJsonContent::YamlSingleQuotedScalar(scalar)) => scalar.value_token().ok(),
+            _ => None,
+        },
+        _ => None,
+    };
+
+    token.is_some_and(|token| token.text_trimmed().contains(['\n', '\r']))
 }
 
 /// Returns the scalar token when `key` is an unqualified multiline plain

--- a/crates/biome_yaml_formatter/src/yaml/auxiliary/block_map_explicit_entry.rs
+++ b/crates/biome_yaml_formatter/src/yaml/auxiliary/block_map_explicit_entry.rs
@@ -1,10 +1,11 @@
 use crate::comments::{FormatCommentsSlice, SourceColumn};
 use crate::prelude::*;
+use crate::utils::flow_scalar_has_line_break;
 use crate::yaml::auxiliary::block_map_implicit_entry::FormatEntryValue;
 use crate::yaml::auxiliary::flow_map_implicit_entry::FormatCollectionKeyEntry;
 use biome_formatter::comments::SourceComment;
 use biome_formatter::{format_args, write};
-use biome_rowan::{AstNode, Direction, TextSize};
+use biome_rowan::{AstNode, TextSize};
 use biome_yaml_syntax::{
     AnyYamlBlockNode, AnyYamlFlowNode, AnyYamlMappingImplicitKey, YamlBlockMapExplicitEntry,
     YamlBlockMapExplicitEntryFields, YamlLanguage,
@@ -56,16 +57,12 @@ impl FormatNodeRule<YamlBlockMapExplicitEntry> for FormatYamlBlockMapExplicitEnt
         // the `? key` form that makes them recognizable as set members
         let keep_explicit = match &key {
             None => false,
-            Some(key_node @ AnyYamlBlockNode::YamlFlowInBlockNode(_)) => {
+            Some(key_node @ AnyYamlBlockNode::YamlFlowInBlockNode(flow_in_block)) => {
                 // Only a break inside a token keeps the key off a single
                 // line, as in a multiline scalar. The properties and the
                 // content of the key are joined onto one line, so the breaks
                 // in the trivia between them don't reach the output
-                !key_node.is_flow_collection()
-                    && key_node
-                        .syntax()
-                        .descendants_tokens(Direction::Next)
-                        .any(|token| token.text_trimmed().contains(['\n', '\r']))
+                !key_node.is_flow_collection() && flow_scalar_has_line_break(flow_in_block)
             }
             Some(_) => true,
         };

--- a/crates/biome_yaml_formatter/src/yaml/auxiliary/block_map_implicit_entry.rs
+++ b/crates/biome_yaml_formatter/src/yaml/auxiliary/block_map_implicit_entry.rs
@@ -1,10 +1,9 @@
 use super::flow_map_implicit_entry::FormatCollectionKeyEntry;
 use crate::comments::{FormatEntryDanglingComments, subtree_has_comments};
 use crate::prelude::*;
-use crate::utils::needs_space_before_colon;
+use crate::utils::{flow_scalar_has_line_break, needs_space_before_colon};
 use biome_formatter::format_args;
 use biome_formatter::write;
-use biome_rowan::Direction;
 use biome_yaml_syntax::{
     AnyYamlBlockNode, YamlBlockMapImplicitEntry, YamlBlockMapImplicitEntryFields,
 };
@@ -152,7 +151,7 @@ impl Format<YamlFormatContext> for FormatEntryValue<'_> {
                     ]))]
                 )
             }
-        } else if matches!(value, AnyYamlBlockNode::YamlFlowInBlockNode(_)) {
+        } else if let AnyYamlBlockNode::YamlFlowInBlockNode(flow_in_block) = value {
             // The continuation lines of a multiline flow scalar are
             // indented past the key:
             //
@@ -176,10 +175,7 @@ impl Format<YamlFormatContext> for FormatEntryValue<'_> {
             // is inside the scalar's own token: the properties and the
             // content of the value are joined onto one line, so the breaks
             // in the trivia between them don't reach the output
-            let is_multiline = value
-                .syntax()
-                .descendants_tokens(Direction::Next)
-                .any(|token| token.text_trimmed().contains(['\n', '\r']));
+            let is_multiline = flow_scalar_has_line_break(flow_in_block);
             if is_multiline {
                 let value = value.format().memoized();
                 write!(


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

> [!NOTE]
> Used agents to retrieve these possible perf findings

There are four commits in this PR, all of them aimed to incraese performance in some parts of the formatter. Some are directed to YAML, some are broader:

- [`13f799d` (this PR)](https://github.com/biomejs/biome/pull/11613/changes/13f799d3d4b9fe3ccec2da850b8f4a961a8ce819) uses a slice method to avoid copying values
- [`0f9e357` (this PR)](https://github.com/biomejs/biome/pull/11613/changes/0f9e357bae006761653d159388fb209e84570f7d) the indentations are emitted in bulk instead of calling `push_*` for each character
- [`f2c61d6` (this PR)](https://github.com/biomejs/biome/pull/11613/changes/f2c61d656bce538ca1dd7a34edb970207c7134bc) avoid scanning scalar subtrees
- [`32a6f5c` (this PR)](https://github.com/biomejs/biome/pull/11613/changes/32a6f5c8c0f1203f1e125b45fb6bf99af8809a7d) stores a small binary in the `GreenToken` that indicates whether the token has comments. This information is later used by the formatter comments builder to skip those tokens/nodes that don't have comments. 


The last commit shifts some workload to the parser, which is now *always* computed, from the formatter, which is workload that is done while formatting, but it's more expensive.

Formatters become way faster; the parser becomes slightly slower. It shouldn't increase the memory too much.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added new tests for Rowan

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
