### PR TITLE
perf(type_inference): build one declaration graph per cyclic lookup

### DIFF
--- a/.changeset/cyclic-imports-share-evaluator.md
+++ b/.changeset/cyclic-imports-share-evaluator.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11610](https://github.com/biomejs/biome/issues/11610), [#11611](https://github.com/biomejs/biome/issues/11611), [#11612](https://github.com/biomejs/biome/issues/11612), [#11615](https://github.com/biomejs/biome/issues/11615), and [#11616](https://github.com/biomejs/biome/issues/11616): type-aware lint rules were several times slower in Biome 2.5.12 when inferring types that come from packages with import cycles between their declaration files, such as Zod. Type inference now builds a single declaration graph per lookup instead of one for every cyclic import it encounters.

--- a/crates/biome_module_graph/src/db/queries/type_inference/lookups.rs
+++ b/crates/biome_module_graph/src/db/queries/type_inference/lookups.rs
@@ -54,8 +54,12 @@ pub fn infer_expression_type<'db>(
             }
 
             let reference = js_info.raw_expressions.get(&expression)?.clone();
-            let mut ctx = ResolutionCtx::new(db, module, &js_info, ImportResolution::on_demand());
-            Some(ctx.resolve(&reference))
+            let (_, ty) =
+                ResolutionCtx::resolve_on_demand_with_cycle_recovery(db, module, &js_info, |ctx| {
+                    ctx.resolve(&reference)
+                });
+
+            Some(ty)
         },
     )
 }

--- a/crates/biome_module_graph/src/db/type_inference/imports.rs
+++ b/crates/biome_module_graph/src/db/type_inference/imports.rs
@@ -329,8 +329,11 @@ pub(in crate::db) fn resolve_export_type_on_demand<'db>(
         return None;
     }
 
-    let ctx = ResolutionCtx::new(db, module, &js_info, super::ImportResolution::on_demand());
-    Some(ctx.resolve_export_name_on_demand(module, name))
+    let (_, ty) =
+        ResolutionCtx::resolve_on_demand_with_cycle_recovery(db, module, &js_info, |ctx| {
+            ctx.resolve_export_name_on_demand(module, name)
+        });
+    Some(ty)
 }
 
 impl<'db> ResolutionCtx<'db, '_> {
@@ -398,21 +401,7 @@ impl<'db> ResolutionCtx<'db, '_> {
                 let reference = js_info.raw_binding_types.get(range)?.clone();
                 let mut ctx = match self.import_resolution {
                     super::ImportResolution::OnDemand { remaining } => {
-                        let resolve_declarations_directly = if self.resolves_declarations_directly()
-                        {
-                            let sccs =
-                                inference_module_sccs(self.db, ModuleGraphGeneration::get(self.db));
-                            *module == self.module
-                                || sccs.contains_cycle_between(self.module, *module)
-                        } else {
-                            false
-                        };
-                        self.for_on_demand_import(
-                            *module,
-                            &js_info,
-                            remaining,
-                            resolve_declarations_directly,
-                        )
+                        self.for_on_demand_import(*module, &js_info, remaining)
                     }
                     import_resolution @ (super::ImportResolution::FromTables { .. }
                     | super::ImportResolution::CycleFallback(_)) => {
@@ -499,7 +488,13 @@ impl<'db> ResolutionCtx<'db, '_> {
                 let in_same_cycle = sccs.contains_cycle_between(self.module, module);
                 let resolve_declarations_directly = module == self.module || in_same_cycle;
                 if resolve_declarations_directly && !self.resolves_declarations_directly() {
+                    // Crossing into the active import component without a
+                    // declaration evaluator is the first pass of a lookup.
+                    // Report the cycle so the root retries with one shared
+                    // evaluator instead of building a throwaway declaration
+                    // graph for every cyclic edge reached from here.
                     self.mark_inference_cycle();
+                    return InferredTypeData::Unknown;
                 }
                 if remaining == 0 && !resolve_declarations_directly {
                     return infer_module_types_bottom_up_for_import_depth(self.db, module)
@@ -518,12 +513,7 @@ impl<'db> ResolutionCtx<'db, '_> {
                 } else {
                     remaining - 1
                 };
-                let ctx = self.for_on_demand_import(
-                    module,
-                    &js_info,
-                    remaining,
-                    resolve_declarations_directly,
-                );
+                let ctx = self.for_on_demand_import(module, &js_info, remaining);
                 ctx.resolve_import_symbol_on_demand(module, symbol)
             }
         }
@@ -965,7 +955,7 @@ fn inferred_type_from_binding_on_demand<'db>(
     let input = BindingTypeInput::new(db, module, range);
     match resolution_ctx.import_resolution {
         super::ImportResolution::OnDemand { remaining } if resolve_declaration_directly => {
-            let mut ctx = resolution_ctx.for_on_demand_import(module, js_info, remaining, true);
+            let mut ctx = resolution_ctx.for_on_demand_import(module, js_info, remaining);
             ctx.resolve_local_binding(range)
         }
         super::ImportResolution::OnDemand { remaining } => {
@@ -1040,7 +1030,7 @@ fn inferred_type_from_resolved_id_on_demand<'db>(
                         if resolve_declaration_directly =>
                     {
                         let mut ctx =
-                            resolution_ctx.for_on_demand_import(module, js_info, remaining, true);
+                            resolution_ctx.for_on_demand_import(module, js_info, remaining);
                         ctx.resolve_local_declaration(resolved_id.id())
                     }
                     super::ImportResolution::OnDemand { remaining } => {

--- a/crates/biome_module_graph/src/db/type_inference/promise_classification.rs
+++ b/crates/biome_module_graph/src/db/type_inference/promise_classification.rs
@@ -254,13 +254,14 @@ fn classify_expression(
                                 let ModuleInfoKind::Js(js_info) = state.module.kind(db) else {
                                     return Indeterminate;
                                 };
-                                let mut ctx = ResolutionCtx::new(
-                                    db,
-                                    state.module,
-                                    &js_info,
-                                    ImportResolution::on_demand(),
-                                );
-                                let Some(awaited) = ctx.resolve_await_expression(*return_ty) else {
+                                let (_, awaited) =
+                                    ResolutionCtx::resolve_on_demand_with_cycle_recovery(
+                                        db,
+                                        state.module,
+                                        &js_info,
+                                        |ctx| ctx.resolve_await_expression(*return_ty),
+                                    );
+                                let Some(awaited) = awaited else {
                                     return Indeterminate;
                                 };
                                 return match is_array_of_promise_type(db, awaited) {
@@ -378,13 +379,13 @@ fn classify_expression(
                         if matches!(mode, MemberLookupMode::Constructed { .. }) {
                             return Indeterminate;
                         }
-                        let mut ctx = ResolutionCtx::new(
-                            db,
-                            state.module,
-                            &js_info,
-                            ImportResolution::on_demand(),
-                        );
-                        let mut ty = ctx.resolve_qualifier(&qualifier);
+                        let (mut ctx, mut ty) =
+                            ResolutionCtx::resolve_on_demand_with_cycle_recovery(
+                                db,
+                                state.module,
+                                &js_info,
+                                |ctx| ctx.resolve_qualifier(&qualifier),
+                            );
                         for member in &members {
                             let Some(member_ty) =
                                 find_value_member_type_on_demand(db, ty, member.text())
@@ -558,13 +559,13 @@ fn classify_expression(
                                 projection,
                             }
                         } else {
-                            let mut ctx = ResolutionCtx::new(
-                                db,
-                                state.module,
-                                &js_info,
-                                ImportResolution::on_demand(),
-                            );
-                            let ty = ctx.resolve(return_ty);
+                            let (mut ctx, ty) =
+                                ResolutionCtx::resolve_on_demand_with_cycle_recovery(
+                                    db,
+                                    state.module,
+                                    &js_info,
+                                    |ctx| ctx.resolve(return_ty),
+                                );
                             let result = match state.projection {
                                 Projection::FunctionReturn => is_promise_type(db, ty),
                                 Projection::ArrayFunctionReturn => is_array_of_promise_type(db, ty),
@@ -774,16 +775,14 @@ fn classify_expression(
                         },
                         Projection::PromiseTarget => return DoesNotReturnPromise,
                         Projection::ArrayPromise if state.members.is_empty() => {
-                            let mut ctx = ResolutionCtx::new(
+                            let (_, ty) = ResolutionCtx::resolve_on_demand_with_cycle_recovery(
                                 db,
                                 state.module,
                                 &js_info,
-                                ImportResolution::on_demand(),
+                                |ctx| ctx.resolve_raw_type_id(type_id),
                             );
-                            return match is_array_of_promise_type(
-                                db,
-                                ctx.resolve_raw_type_id(type_id),
-                            ) {
+
+                            return match is_array_of_promise_type(db, ty) {
                                 Some(true) => ReturnsPromise,
                                 Some(false) => DoesNotReturnPromise,
                                 None => Indeterminate,
@@ -797,16 +796,20 @@ fn classify_expression(
                             projection: state.projection,
                         },
                         Projection::AwaitedArrayPromise if state.members.is_empty() => {
-                            let mut ctx = ResolutionCtx::new(
+                            let (_, awaited) = ResolutionCtx::resolve_on_demand_with_cycle_recovery(
                                 db,
                                 state.module,
                                 &js_info,
-                                ImportResolution::on_demand(),
+                                |ctx| {
+                                    let ty = ctx.resolve_raw_type_id(type_id);
+                                    ctx.resolve_await_expression(ty)
+                                },
                             );
-                            let ty = ctx.resolve_raw_type_id(type_id);
-                            let Some(awaited) = ctx.resolve_await_expression(ty) else {
+
+                            let Some(awaited) = awaited else {
                                 return Indeterminate;
                             };
+
                             return match is_array_of_promise_type(db, awaited) {
                                 Some(true) => ReturnsPromise,
                                 Some(false) => DoesNotReturnPromise,
@@ -962,13 +965,12 @@ fn classify_expression(
                         if interface.name.text() != "PromiseLike" {
                             return DoesNotReturnPromise;
                         }
-                        let mut ctx = ResolutionCtx::new(
+                        let (_, target) = ResolutionCtx::resolve_on_demand_with_cycle_recovery(
                             db,
                             state.module,
                             &js_info,
-                            ImportResolution::on_demand(),
+                            |ctx| ctx.resolve_raw_type_id(type_id),
                         );
-                        let target = ctx.resolve_raw_type_id(type_id);
                         let instance = InferredTypeData::instance_of(db, target, Box::default());
                         return match is_promise_type(db, instance) {
                             Some(true) => ReturnsPromise,

--- a/crates/biome_module_graph/src/db/type_inference/promise_classification.rs
+++ b/crates/biome_module_graph/src/db/type_inference/promise_classification.rs
@@ -18,7 +18,7 @@
 //! expression forms, accessors, ambiguous exports, cycles, and an exhausted
 //! work limit are indeterminate.
 
-use super::{ImportResolution, ResolutionCtx, find_value_member_type_on_demand};
+use super::{ResolutionCtx, find_value_member_type_on_demand};
 use crate::db::queries::{
     function_returns_promise, is_array_of_promise_type, is_promise_type, resolved_export_origin,
 };

--- a/crates/biome_module_graph/src/db/type_inference/resolver.rs
+++ b/crates/biome_module_graph/src/db/type_inference/resolver.rs
@@ -211,7 +211,7 @@ pub(in crate::db) struct ResolutionCtx<'db, 'a> {
     pub(in crate::db::type_inference) resolved: FxHashMap<TypeId, InferredTypeData<'db>>,
     pub(in crate::db::type_inference) in_progress: FxHashSet<TypeId>,
     pub(in crate::db::type_inference) resolution_depth: Cell<usize>,
-    encountered_inference_cycle: Cell<bool>,
+    encountered_inference_cycle: Rc<Cell<bool>>,
     on_demand_declarations: Option<SharedOnDemandDeclarationEvaluator<'db>>,
 }
 
@@ -262,7 +262,29 @@ impl<'db, 'a> ResolutionCtx<'db, 'a> {
         js_info: &'a JsModuleInfo,
         import_resolution: ImportResolution<'a>,
     ) -> Self {
-        Self::new_with_declarations(db, module, js_info, import_resolution, None)
+        Self::new_with_declarations(db, module, js_info, import_resolution, None, None)
+    }
+
+    /// Creates a root context that resolves declarations in import cycles
+    /// through a fresh declaration evaluator.
+    ///
+    /// Use this for the retry of a lookup whose first pass reported an
+    /// inference cycle. The evaluator is shared with every context derived
+    /// from this one for the lifetime of the lookup.
+    pub(in crate::db) fn new_with_declaration_evaluator(
+        db: &'db dyn ModuleDb,
+        module: ModuleInfo,
+        js_info: &'a JsModuleInfo,
+        import_resolution: ImportResolution<'a>,
+    ) -> Self {
+        Self::new_with_declarations(
+            db,
+            module,
+            js_info,
+            import_resolution,
+            Some(Rc::default()),
+            None,
+        )
     }
 
     fn new_with_declarations(
@@ -271,6 +293,7 @@ impl<'db, 'a> ResolutionCtx<'db, 'a> {
         js_info: &'a JsModuleInfo,
         import_resolution: ImportResolution<'a>,
         on_demand_declarations: Option<SharedOnDemandDeclarationEvaluator<'db>>,
+        encountered_inference_cycle: Option<Rc<Cell<bool>>>,
     ) -> Self {
         Self {
             db,
@@ -281,32 +304,61 @@ impl<'db, 'a> ResolutionCtx<'db, 'a> {
             resolved: FxHashMap::default(),
             in_progress: FxHashSet::default(),
             resolution_depth: Cell::new(0),
-            encountered_inference_cycle: Cell::new(false),
+            encountered_inference_cycle: encountered_inference_cycle.unwrap_or_default(),
             on_demand_declarations,
         }
     }
 
+    /// Resolves with a fresh on-demand context, retrying with a declaration
+    /// evaluator when the first pass crosses an import cycle.
+    ///
+    /// The first pass stays on the cheap tracked-query path and reports
+    /// cyclic imports as `Unknown`. Only a lookup that actually crossed a
+    /// cycle pays for the declaration graph, and it builds exactly one.
+    ///
+    /// Returns the context that produced the result so callers can continue
+    /// resolving related references with the same cycle handling.
+    pub(in crate::db) fn resolve_on_demand_with_cycle_recovery<T>(
+        db: &'db dyn ModuleDb,
+        module: ModuleInfo,
+        js_info: &'a JsModuleInfo,
+        mut resolve: impl FnMut(&mut Self) -> T,
+    ) -> (Self, T) {
+        let import_resolution = ImportResolution::on_demand();
+
+        let mut ctx = ResolutionCtx::new(db, module, js_info, import_resolution);
+        let result = resolve(&mut ctx);
+        if !ctx.encountered_inference_cycle() {
+            return (ctx, result);
+        }
+
+        let mut ctx =
+            ResolutionCtx::new_with_declaration_evaluator(db, module, js_info, import_resolution);
+
+        let result = resolve(&mut ctx);
+
+        (ctx, result)
+    }
+
+    /// Creates the context for an imported module reached on demand.
+    ///
+    /// The derived context shares the declaration evaluator, when one is
+    /// active, and reports inference cycles to the same root. A context
+    /// without an evaluator never creates one here: the root lookup decides
+    /// whether a retry with a declaration graph is needed.
     pub(super) fn for_on_demand_import<'info>(
         &self,
         module: ModuleInfo,
         js_info: &'info JsModuleInfo,
         remaining: u8,
-        resolve_declarations_directly: bool,
     ) -> ResolutionCtx<'db, 'info> {
-        // Contexts inside the active import component must contribute to the
-        // same declaration graph. An ordinary imported lookup keeps its own
-        // tracked-query boundary and does not need this shared state.
-        let on_demand_declarations = resolve_declarations_directly.then(|| {
-            self.on_demand_declarations
-                .as_ref()
-                .map_or_else(Rc::default, Rc::clone)
-        });
         ResolutionCtx::new_with_declarations(
             self.db,
             module,
             js_info,
             ImportResolution::OnDemand { remaining },
-            on_demand_declarations,
+            self.on_demand_declarations.clone(),
+            Some(Rc::clone(&self.encountered_inference_cycle)),
         )
     }
 
@@ -555,7 +607,7 @@ impl<'db, 'a> ResolutionCtx<'db, 'a> {
         let ImportResolution::OnDemand { remaining } = self.import_resolution else {
             return InferredTypeData::Unknown;
         };
-        let mut ctx = self.for_on_demand_import(module, &js_info, remaining, true);
+        let mut ctx = self.for_on_demand_import(module, &js_info, remaining);
         match declaration {
             OnDemandDeclaration::Binding { range, .. } => js_info
                 .raw_binding_types

--- a/crates/biome_module_graph/tests/spec_tests/cycles.test.rs
+++ b/crates/biome_module_graph/tests/spec_tests/cycles.test.rs
@@ -1,6 +1,7 @@
 use super::*;
 use biome_module_graph::{
-    BindingTypeInput, LocalTypeInput, find_member_type, infer_binding_type, infer_local_type,
+    BindingTypeInput, ExpressionTypeInput, LocalTypeInput, find_member_type, infer_binding_type,
+    infer_expression_type, infer_local_type,
 };
 
 fn unwrap_typeof_values<'db>(
@@ -829,4 +830,106 @@ fn test_binding_query_is_invalidated_when_import_cycle_is_broken() {
     assert!(is_inferred_number(&db, unwrap_typeof_values(&db, ty)));
     let events = db.take_salsa_events();
     assert_function_query_was_run(&db, infer_binding_type, input, &events);
+}
+
+fn expression_range_by_source(
+    db: &dyn ModuleDb,
+    module: ModuleInfo,
+    source: &str,
+    expected: &str,
+) -> TextRange {
+    let ModuleInfoKind::Js(js_info) = module.kind(db) else {
+        panic!("module must contain JavaScript information");
+    };
+    js_info
+        .raw_expressions
+        .keys()
+        .find(|range| source_snippet(source, **range) == expected)
+        .copied()
+        .unwrap_or_else(|| panic!("{expected} expression must exist"))
+}
+
+#[test]
+fn test_expression_query_resolves_a_namespace_reexport_member_in_its_own_import_cycle() {
+    const CONSUMER_SOURCE: &str = r#"
+        import { values } from "./a.ts";
+        export interface Marker {}
+        values.stable;
+    "#;
+
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/a.ts".into(),
+        r#"
+            export * as values from "./b.ts";
+        "#,
+    );
+    fs.insert(
+        "/src/b.ts".into(),
+        r#"
+            import type { Marker } from "./consumer.ts";
+            export const stable = 1;
+            export type BMarker = Marker;
+        "#,
+    );
+    fs.insert("/src/consumer.ts".into(), CONSUMER_SOURCE);
+
+    let db = build_js_test_module_db(&fs, &["/src/a.ts", "/src/b.ts", "/src/consumer.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/consumer.ts"))
+        .expect("consumer module must exist");
+    let input = ExpressionTypeInput::new(
+        &db,
+        module,
+        expression_range_by_source(&db, module, CONSUMER_SOURCE, "values.stable"),
+    );
+
+    let ty = infer_expression_type(&db, input).expect("expression must be inferred");
+    let ty = unwrap_typeof_values(&db, ty);
+    assert!(
+        is_inferred_number(&db, ty),
+        "namespace member reached through the consumer's own import cycle must be numeric, got {ty:?}"
+    );
+}
+
+#[test]
+fn test_expression_query_resolves_a_namespace_reexport_member_behind_a_foreign_import_cycle() {
+    const INDEX_SOURCE: &str = r#"
+        import { values } from "./a.ts";
+        values.stable;
+    "#;
+
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/a.ts".into(),
+        r#"
+            export * as values from "./b.ts";
+        "#,
+    );
+    fs.insert(
+        "/src/b.ts".into(),
+        r#"
+            import { values } from "./a.ts";
+            export const stable = 1;
+            export const selected = values.stable;
+        "#,
+    );
+    fs.insert("/src/index.ts".into(), INDEX_SOURCE);
+
+    let db = build_js_test_module_db(&fs, &["/src/a.ts", "/src/b.ts", "/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("index module must exist");
+    let input = ExpressionTypeInput::new(
+        &db,
+        module,
+        expression_range_by_source(&db, module, INDEX_SOURCE, "values.stable"),
+    );
+
+    let ty = infer_expression_type(&db, input).expect("expression must be inferred");
+    let ty = unwrap_typeof_values(&db, ty);
+    assert!(
+        is_inferred_number(&db, ty),
+        "namespace member behind a foreign import cycle must be numeric, got {ty:?}"
+    );
 }


### PR DESCRIPTION
## Summary

> [!NOTE]
> AI Assistance Disclosure: Implemented with Claude Fable 5.1. I have reviewed the diff before submitting.

Closes #11610
Closes #11611
Closes #11612
Closes #11615
Closes #11616

Since #11555, every import into a module in the same import cycle created a new declaration evaluator, even during the first pass of a lookup that would be retried with a shared evaluator anyway.

For packages whose declaration files import each other, such as Zod, a single lookup created
hundreds of thousands of evaluators, making type-aware rules about four times slower than in 2.5.11.

## Test Plan

Added unit tests.

Measured in a Claude Code sandbox:

| Issue  | Rule                   | 2.5.10 | 2.5.12 | HEAD  | 2.5.12 / 2.5.10 | HEAD / 2.5.10 |
| ------ | ---------------------- | -----: | -----: | ----: | --------------: | --------------: |
| #11610 | `useRegexpExec`        |  1.74s |  8.29s | 2.36s |           4.75x |           1.35x |
| #11611 | `noFloatingPromises`   |  1.92s |  8.99s | 2.48s |           4.69x |           1.29x |
| #11612 | `noMisusedPromises`    |  1.98s |  8.50s | 2.25s |           4.29x |           1.14x |
| #11615 | `useNullishCoalescing` |  2.09s |  7.76s | 2.32s |           3.71x |           1.11x |
| #11616 | `noUnsafePlusOperands` |  1.91s |  7.94s | 2.13s |           4.17x |           1.12x |

## Docs

N/A
