### PR TITLE
Prevent typeMember from matching type parameters

### DIFF
--- a/.changeset/cyan-ties-send.md
+++ b/.changeset/cyan-ties-send.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-[Issue #11548](https://github.com/biomejs/biome/issues/11548): Fixed [`useNamingConvention`](https://biomejs.dev/linter/rules/use-naming-convention) so `typeMember` conventions no longer apply to TypeScript type parameters.
+Fixed [#11548](https://github.com/biomejs/biome/issues/11548): [`useNamingConvention`](https://biomejs.dev/linter/rules/use-naming-convention) so `typeMember` conventions no longer apply to TypeScript type parameters.

--- a/.changeset/cyan-ties-send.md
+++ b/.changeset/cyan-ties-send.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+[Issue #11548](https://github.com/biomejs/biome/issues/11548): Fixed [`useNamingConvention`](https://biomejs.dev/linter/rules/use-naming-convention) so `typeMember` conventions no longer apply to TypeScript type parameters.

--- a/crates/biome_js_analyze/tests/specs/style/useNamingConvention/invalidTypeMemberTypeParameter.options.json
+++ b/crates/biome_js_analyze/tests/specs/style/useNamingConvention/invalidTypeMemberTypeParameter.options.json
@@ -1,0 +1,27 @@
+{
+	"linter": {
+		"rules": {
+			"style": {
+				"useNamingConvention": {
+					"level": "error",
+					"options": {
+						"conventions": [
+							{
+								"selector": {
+									"kind": "typeMember"
+								},
+								"formats": ["camelCase"]
+							},
+							{
+								"selector": {
+									"kind": "typeParameter"
+								},
+								"formats": ["CONSTANT_CASE"]
+							}
+						]
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/style/useNamingConvention/invalidTypeMemberTypeParameter.ts
+++ b/crates/biome_js_analyze/tests/specs/style/useNamingConvention/invalidTypeMemberTypeParameter.ts
@@ -1,0 +1,4 @@
+/* should generate diagnostics */
+type Foo<TYPE_PARAMETER> = {
+	Invalid_property: string;
+};

--- a/crates/biome_js_analyze/tests/specs/style/useNamingConvention/invalidTypeMemberTypeParameter.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useNamingConvention/invalidTypeMemberTypeParameter.ts.snap
@@ -1,0 +1,28 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidTypeMemberTypeParameter.ts
+---
+# Input
+```ts
+/* should generate diagnostics */
+type Foo<TYPE_PARAMETER> = {
+	Invalid_property: string;
+};
+
+```
+
+# Diagnostics
+```
+invalidTypeMemberTypeParameter.ts:3:2 lint/style/useNamingConvention ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This type member name should be in camelCase.
+  
+    1 │ /* should generate diagnostics */
+    2 │ type Foo<TYPE_PARAMETER> = {
+  > 3 │ 	Invalid_property: string;
+      │ 	^^^^^^^^^^^^^^^^
+    4 │ };
+    5 │ 
+  
+
+```

--- a/crates/biome_rule_options/src/use_naming_convention.rs
+++ b/crates/biome_rule_options/src/use_naming_convention.rs
@@ -384,11 +384,7 @@ impl Kind {
                     )
                     | (
                         Self::TypeMember,
-                        Self::TypeGetter
-                            | Self::TypeMethod
-                            | Self::TypeParameter
-                            | Self::TypeProperty
-                            | Self::TypeSetter
+                        Self::TypeGetter | Self::TypeMethod | Self::TypeProperty | Self::TypeSetter
                     )
                     | (
                         Self::NamespaceLike,


### PR DESCRIPTION
Summary -

- Fixes #11548

- typeMember was incorrectly matching TypeScript type parameters

- The fix removes type parameters from that selector

- AI helped with implementation/testing and you reviewed the changes

Test plans Below

- Added regression coverage

- 122 focused tests passed

- 2916 crate tests passed

- just f and just l passed