### PR TITLE
perf(css_parser): short-circuit function detection

### DIFF
--- a/crates/biome_css_parser/src/syntax/property/mod.rs
+++ b/crates/biome_css_parser/src/syntax/property/mod.rs
@@ -15,10 +15,10 @@ use crate::syntax::scss::{
     parse_scss_interpolated_property_name,
 };
 use crate::syntax::{
-    CssSyntaxFeatures, ValueParsingContext, ValueParsingMode, is_at_any_value_with_context,
-    is_at_dashed_identifier, is_at_identifier, is_at_string, is_nth_at_identifier,
-    parse_any_value_with_context, parse_custom_identifier_with_keywords, parse_dashed_identifier,
-    parse_regular_identifier, parse_string,
+    CssSyntaxFeatures, ValueParsingContext, ValueParsingMode, is_at_dashed_identifier,
+    is_at_identifier, is_at_string, is_nth_at_identifier, parse_any_value_with_context,
+    parse_custom_identifier_with_keywords, parse_dashed_identifier, parse_regular_identifier,
+    parse_string,
 };
 use biome_css_syntax::CssSyntaxKind::*;
 use biome_css_syntax::{CssSyntaxKind, T, decode_css_identifier};
@@ -534,14 +534,6 @@ pub(crate) fn parse_generic_component_value(p: &mut CssParser) -> ParsedSyntax {
     )
 }
 
-#[inline]
-pub(crate) fn is_at_generic_component_value_with_context(
-    p: &mut CssParser,
-    context: ValueParsingContext,
-) -> bool {
-    is_at_any_value_with_context(p, context) || is_at_generic_delimiter(p)
-}
-
 /// Parses a generic value while preserving the caller's recovery context.
 ///
 /// SCSS expressions reuse generic CSS values for identifiers, numbers, and
@@ -552,10 +544,6 @@ pub(crate) fn parse_generic_component_value_with_context(
     p: &mut CssParser,
     context: ValueParsingContext,
 ) -> ParsedSyntax {
-    if !is_at_generic_component_value_with_context(p, context) {
-        return Absent;
-    }
-
     if is_at_generic_delimiter(p) {
         parse_generic_delimiter(p)
     } else {

--- a/crates/biome_css_parser/src/syntax/value/function/call.rs
+++ b/crates/biome_css_parser/src/syntax/value/function/call.rs
@@ -113,12 +113,16 @@ fn is_nth_at_function_with_context(
     n: usize,
     context: ValueParsingContext,
 ) -> bool {
+    if !is_nth_at_identifier(p, n) {
+        return false;
+    }
+
     let is_function_paren = match context.function_call_context() {
         FunctionCallContext::LooseRecovery => p.nth_at(n + 1, T!['(']),
         FunctionCallContext::SourceTight => is_nth_at_source_tight_l_paren(p, n + 1),
     };
 
-    is_nth_at_identifier(p, n) && is_function_paren
+    is_function_paren
         || (context.is_scss_qualified_function_recovery_allowed()
             // Sass module calls are always source-tight: `math.pow(...)`.
             && is_nth_at_scss_module_member_access(p, n)


### PR DESCRIPTION
> This PR was created with AI assistance (Codex).

## Summary

Avoids function lookahead for non-identifiers and removes duplicate generic-value checks in CSS/SCSS parsing

## Test Plan

- green ci