### PR TITLE
perf(rowan): accelerate token lookup by offset

### DIFF
--- a/.changeset/silent-jeans-feel.md
+++ b/.changeset/silent-jeans-feel.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Improved linting performance for large CSS and JSON files.

--- a/crates/biome_rowan/src/cursor/node.rs
+++ b/crates/biome_rowan/src/cursor/node.rs
@@ -331,14 +331,22 @@ impl SyntaxNode {
                 return TokenAtOffset::None;
             }
 
-            let mut children = node.children_with_tokens().filter(|child| {
-                let child_range = child.text_range();
-                !child_range.is_empty() && child_range.contains_inclusive(offset)
-            });
-
-            let left = children.next().unwrap();
-            let right = children.next();
-            assert!(children.next().is_none());
+            let (left, right) = node.green().children_at_offset(offset - node.offset());
+            let (left, right) = match (left, right) {
+                (Some(left), right) => (left, right),
+                (None, Some(right)) => (right, None),
+                (None, None) => unreachable!("non-empty node must have a child at its offset"),
+            };
+            let to_syntax_element = |child: Child<'_>| {
+                SyntaxElement::new(
+                    child.element(),
+                    node.clone().into_owned(),
+                    child.slot(),
+                    node.offset() + child.rel_offset(),
+                )
+            };
+            let left = to_syntax_element(left);
+            let right = right.map(to_syntax_element);
 
             if let Some(right) = right {
                 let token_at_offset =
@@ -946,7 +954,14 @@ impl<'a> Siblings<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::raw_language::{RawLanguageKind, RawSyntaxTreeBuilder};
+    use crate::raw_language::{RawLanguage, RawLanguageKind, RawSyntaxTreeBuilder};
+    use crate::{SyntaxNode, TextRange, TextSize, TokenAtOffset, TriviaPiece};
+
+    fn token_texts_at_offset(node: &SyntaxNode<RawLanguage>, offset: u32) -> Vec<String> {
+        node.token_at_offset(TextSize::from(offset))
+            .map(|token| token.text_trimmed().to_string())
+            .collect()
+    }
 
     #[test]
     fn slots_iter() {
@@ -993,5 +1008,121 @@ mod tests {
                 .as_deref(),
             Some("3")
         );
+    }
+
+    #[test]
+    fn token_at_offset_preserves_nested_boundaries() {
+        let mut builder = RawSyntaxTreeBuilder::new();
+        builder.start_node(RawLanguageKind::ROOT);
+
+        for text in ["a", "b"] {
+            builder.start_node(RawLanguageKind::LITERAL_EXPRESSION);
+            builder.token(RawLanguageKind::STRING_TOKEN, text);
+            builder.finish_node();
+        }
+
+        builder.finish_node();
+        let root = builder.finish();
+
+        assert_eq!(token_texts_at_offset(&root, 0), ["a"]);
+        assert_eq!(token_texts_at_offset(&root, 1), ["a", "b"]);
+        assert_eq!(token_texts_at_offset(&root, 2), ["b"]);
+        assert!(matches!(
+            root.token_at_offset(TextSize::from(3)),
+            TokenAtOffset::None
+        ));
+    }
+
+    #[test]
+    fn token_at_offset_skips_zero_width_elements_and_includes_trivia() {
+        let mut builder = RawSyntaxTreeBuilder::new();
+        builder.start_node(RawLanguageKind::ROOT);
+        builder.token(RawLanguageKind::STRING_TOKEN, "");
+        builder.start_node(RawLanguageKind::LITERAL_EXPRESSION);
+        builder.finish_node();
+        builder.token_with_trivia(
+            RawLanguageKind::STRING_TOKEN,
+            "a ",
+            &[],
+            &[TriviaPiece::whitespace(1)],
+        );
+        builder.token(RawLanguageKind::STRING_TOKEN, "b");
+        builder.finish_node();
+        let root = builder.finish();
+
+        assert_eq!(token_texts_at_offset(&root, 0), ["a"]);
+        assert_eq!(token_texts_at_offset(&root, 1), ["a"]);
+        assert_eq!(token_texts_at_offset(&root, 2), ["a", "b"]);
+        assert_eq!(token_texts_at_offset(&root, 3), ["b"]);
+    }
+
+    #[test]
+    fn token_at_offset_skips_zero_width_elements_at_boundaries_and_eof() {
+        let mut builder = RawSyntaxTreeBuilder::new();
+        builder.start_node(RawLanguageKind::ROOT);
+        builder.token(RawLanguageKind::STRING_TOKEN, "a");
+        builder.token(RawLanguageKind::STRING_TOKEN, "");
+        builder.start_node(RawLanguageKind::LITERAL_EXPRESSION);
+        builder.finish_node();
+        builder.token(RawLanguageKind::STRING_TOKEN, "b");
+        builder.token(RawLanguageKind::STRING_TOKEN, "");
+        builder.start_node(RawLanguageKind::LITERAL_EXPRESSION);
+        builder.finish_node();
+        builder.finish_node();
+        let root = builder.finish();
+
+        assert_eq!(token_texts_at_offset(&root, 1), ["a", "b"]);
+        assert_eq!(token_texts_at_offset(&root, 2), ["b"]);
+    }
+
+    #[test]
+    fn token_at_offset_skips_missing_slots_and_respects_subtree_ranges() {
+        let mut builder = RawSyntaxTreeBuilder::new();
+        builder.start_node(RawLanguageKind::ROOT);
+        builder.token(RawLanguageKind::STRING_TOKEN, "x");
+        builder.start_node(RawLanguageKind::CONDITION);
+        builder.token(RawLanguageKind::L_PAREN_TOKEN, "x");
+        builder.token(RawLanguageKind::R_PAREN_TOKEN, "x");
+        builder.finish_node();
+        builder.finish_node();
+        let root = builder.finish();
+        let condition = root.children().next().unwrap();
+
+        let TokenAtOffset::Between(left, right) = condition.token_at_offset(TextSize::from(2))
+        else {
+            panic!("expected tokens on both sides of the missing slot");
+        };
+
+        assert_eq!(left.text_trimmed(), "x");
+        assert_eq!(right.text_trimmed(), "x");
+        assert_ne!(left, right);
+        assert_eq!(left.parent(), Some(condition.clone()));
+        assert_eq!(right.parent(), Some(condition.clone()));
+        assert_eq!(left.index(), 0);
+        assert_eq!(right.index(), 2);
+        assert_eq!(left.text_range(), TextRange::new(1.into(), 2.into()));
+        assert_eq!(right.text_range(), TextRange::new(2.into(), 3.into()));
+        assert_eq!(token_texts_at_offset(&condition, 3), ["x"]);
+        assert!(matches!(
+            condition.token_at_offset(TextSize::from(0)),
+            TokenAtOffset::None
+        ));
+        assert!(matches!(
+            condition.token_at_offset(TextSize::from(4)),
+            TokenAtOffset::None
+        ));
+    }
+
+    #[test]
+    fn token_at_offset_returns_none_for_empty_nodes() {
+        let mut builder = RawSyntaxTreeBuilder::new();
+        builder.start_node(RawLanguageKind::ROOT);
+        builder.finish_node();
+        let root = builder.finish();
+
+        assert!(matches!(
+            root.token_at_offset(TextSize::from(0)),
+            TokenAtOffset::None
+        ));
     }
 }

--- a/crates/biome_rowan/src/cursor/node.rs
+++ b/crates/biome_rowan/src/cursor/node.rs
@@ -335,20 +335,22 @@ impl SyntaxNode {
             let (left, right) = match (left, right) {
                 (Some(left), right) => (left, right),
                 (None, Some(right)) => (right, None),
-                (None, None) => unreachable!("non-empty node must have a child at its offset"),
+                (None, None) => return TokenAtOffset::None,
             };
-            let to_syntax_element = |child: Child<'_>| {
-                SyntaxElement::new(
-                    child.element(),
-                    node.clone().into_owned(),
-                    child.slot(),
-                    node.offset() + child.rel_offset(),
-                )
-            };
-            let left = to_syntax_element(left);
-            let right = right.map(to_syntax_element);
+            let left = SyntaxElement::new(
+                left.element(),
+                node.clone().into_owned(),
+                left.slot(),
+                node.offset() + left.rel_offset(),
+            );
 
             if let Some(right) = right {
+                let right = SyntaxElement::new(
+                    right.element(),
+                    node.clone().into_owned(),
+                    right.slot(),
+                    node.offset() + right.rel_offset(),
+                );
                 let token_at_offset =
                     |node: NodeOrToken<Self, SyntaxToken>| -> TokenAtOffset<SyntaxToken> {
                         match node {

--- a/crates/biome_rowan/src/green/node.rs
+++ b/crates/biome_rowan/src/green/node.rs
@@ -215,6 +215,36 @@ impl GreenNodeData {
         Some((idx, slot.rel_offset(), slot))
     }
 
+    /// Returns the non-empty child containing `offset` on the left and, at an
+    /// inclusive boundary, the non-empty child starting at `offset` on the right.
+    /// Zero-width slots are skipped.
+    pub(crate) fn children_at_offset(
+        &self,
+        offset: TextSize,
+    ) -> (Option<Child<'_>>, Option<Child<'_>>) {
+        let slots = self.slice();
+        let offset_index = slots.partition_point(|slot| slot.rel_offset() < offset);
+        let is_at_offset = |slot: &Slot| {
+            let range = slot.rel_range();
+            !range.is_empty() && range.contains_inclusive(offset)
+        };
+
+        let left = slots[..offset_index]
+            .iter()
+            .enumerate()
+            .rev()
+            .find(|(_, slot)| is_at_offset(slot))
+            .and_then(|(index, slot)| Child::try_from((index, slot)).ok());
+        let right = slots[offset_index..]
+            .iter()
+            .enumerate()
+            .take_while(|(_, slot)| slot.rel_offset() == offset)
+            .find(|(_, slot)| is_at_offset(slot))
+            .and_then(|(index, slot)| Child::try_from((offset_index + index, slot)).ok());
+
+        (left, right)
+    }
+
     #[must_use = "syntax elements are immutable, the result of update methods must be propagated to have any effect"]
     pub(crate) fn splice_slots<R, I>(&self, range: R, replace_with: I) -> GreenNode
     where

--- a/crates/biome_rowan/src/green/node.rs
+++ b/crates/biome_rowan/src/green/node.rs
@@ -223,15 +223,15 @@ impl GreenNodeData {
     /// Missing slots and children with zero-length text ranges are skipped,
     /// including zero-length tokens and nodes with no source text.
     ///
-    /// For the JavaScript call `foo(1)`, the callee child `foo` covers `0..3`
-    /// and the arguments child `(1)` covers `3..6`:
+    /// For the JavaScript call `foo(1)`, the two children cover `foo` (`0..3`)
+    /// and `(1)` (`3..6`). The pairs below show each child's source text:
     ///
     /// ```text
-    /// offset 0 → (None, Some(callee))
-    /// offset 2 → (Some(callee), None)
-    /// offset 3 → (Some(callee), Some(arguments))
-    /// offset 4 → (Some(arguments), None)
-    /// offset 6 → (Some(arguments), None)
+    /// offset 0 → (None, Some("foo"))
+    /// offset 2 → (Some("foo"), None)
+    /// offset 3 → (Some("foo"), Some("(1)"))
+    /// offset 4 → (Some("(1)"), None)
+    /// offset 6 → (Some("(1)"), None)
     /// ```
     pub(crate) fn children_at_offset(
         &self,

--- a/crates/biome_rowan/src/green/node.rs
+++ b/crates/biome_rowan/src/green/node.rs
@@ -215,9 +215,24 @@ impl GreenNodeData {
         Some((idx, slot.rel_offset(), slot))
     }
 
-    /// Returns the non-empty child containing `offset` on the left and, at an
-    /// inclusive boundary, the non-empty child starting at `offset` on the right.
-    /// Zero-width slots are skipped.
+    /// Returns a pair of optional children around `offset`:
+    ///
+    /// - Left: starts before `offset` and ends at or after it.
+    /// - Right: starts exactly at `offset`.
+    ///
+    /// Missing slots and children with zero-length text ranges are skipped,
+    /// including zero-length tokens and nodes with no source text.
+    ///
+    /// For the JavaScript call `foo(1)`, the callee child `foo` covers `0..3`
+    /// and the arguments child `(1)` covers `3..6`:
+    ///
+    /// ```text
+    /// offset 0 → (None, Some(callee))
+    /// offset 2 → (Some(callee), None)
+    /// offset 3 → (Some(callee), Some(arguments))
+    /// offset 4 → (Some(arguments), None)
+    /// offset 6 → (Some(arguments), None)
+    /// ```
     pub(crate) fn children_at_offset(
         &self,
         offset: TextSize,


### PR DESCRIPTION
> This PR was created with AI assistance (Codex).

## Summary

Use indexed child offsets for token lookup instead of scanning and constructing every sibling. 

## Test Plan

- Green CI