### PR TITLE
fix(format/html/svelte): preserve adjacent Svelte expressions

### DIFF
--- a/.changeset/floppy-months-fry.md
+++ b/.changeset/floppy-months-fry.md
@@ -1,0 +1,13 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed the HTML formatter inserting whitespace between adjacent Svelte expressions when their combined length exceeds the line width.
+
+```diff
+ <span>
+-  {head.median - base.median >= 0 ? "+" : "−"}
+-  {formatMs(Math.abs(head.median - base.median))}
++  {head.median - base.median >= 0 ? "+" : "−"}{formatMs(Math.abs(head.median - base.median))}
+ </span>
+```

--- a/crates/biome_html_formatter/src/html/lists/element_list.rs
+++ b/crates/biome_html_formatter/src/html/lists/element_list.rs
@@ -1075,8 +1075,18 @@ impl FormatHtmlElementList {
                             last_nontext_had_trailing_line = false;
                         }
 
-                        // Track this element's group ID if it's followed by another adjacent inline element
-                        if next_is_adjacent_inline {
+                        // A single-brace expression cannot lend its closing token to the
+                        // next child, so a sibling break would insert rendered whitespace.
+                        if next_is_adjacent_inline
+                            && !matches!(
+                                non_text,
+                                AnyHtmlElement::AnyHtmlContent(
+                                    AnyHtmlContent::AnyHtmlTextExpression(
+                                        AnyHtmlTextExpression::HtmlSingleTextExpression(_)
+                                    )
+                                )
+                            )
+                        {
                             prev_inline_group_id = Some(non_text_group_id);
                         } else {
                             prev_inline_group_id = None;

--- a/crates/biome_html_formatter/tests/specs/html/svelte/adjacent_expressions.svelte
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/adjacent_expressions.svelte
@@ -1,0 +1,22 @@
+<span>
+	{head.median - base.median >= 0 ? "+" : "−"}{formatMs(Math.abs(head.median - base.median))}
+</span>
+
+<span>{head.median - base.median >= 0 ? "+" : "−"}{formatMs(Math.abs(head.median - base.median))}</span>
+
+<div>
+	{head.median - base.median >= 0 ? "+" : "−"}{formatMs(Math.abs(head.median - base.median))}
+</div>
+
+<span>{first}{second}{third}</span>
+
+<span>
+	{head.median - base.median >= 0 ? "+" : "−"} {formatMs(Math.abs(head.median - base.median))}
+</span>
+
+<span>
+	{head.median - base.median >= 0 ? "+" : "−"}
+	{formatMs(Math.abs(head.median - base.median))}
+</span>
+
+<span><!-- before -->{first}<!-- between -->{second}<!-- after --></span>

--- a/crates/biome_html_formatter/tests/specs/html/svelte/adjacent_expressions.svelte.snap
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/adjacent_expressions.svelte.snap
@@ -1,0 +1,71 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: svelte/adjacent_expressions.svelte
+---
+
+# Input
+
+```svelte
+<span>
+	{head.median - base.median >= 0 ? "+" : "−"}{formatMs(Math.abs(head.median - base.median))}
+</span>
+
+<span>{head.median - base.median >= 0 ? "+" : "−"}{formatMs(Math.abs(head.median - base.median))}</span>
+
+<div>
+	{head.median - base.median >= 0 ? "+" : "−"}{formatMs(Math.abs(head.median - base.median))}
+</div>
+
+<span>{first}{second}{third}</span>
+
+<span>
+	{head.median - base.median >= 0 ? "+" : "−"} {formatMs(Math.abs(head.median - base.median))}
+</span>
+
+<span>
+	{head.median - base.median >= 0 ? "+" : "−"}
+	{formatMs(Math.abs(head.median - base.median))}
+</span>
+
+<span><!-- before -->{first}<!-- between -->{second}<!-- after --></span>
+
+```
+
+
+# Formatted
+
+```svelte
+<span>
+	{head.median - base.median >= 0 ? "+" : "−"}{formatMs(Math.abs(head.median - base.median))}
+</span>
+
+<span
+	>{head.median - base.median >= 0 ? "+" : "−"}{formatMs(Math.abs(head.median - base.median))}</span
+>
+
+<div>
+	{head.median - base.median >= 0 ? "+" : "−"}{formatMs(Math.abs(head.median - base.median))}
+</div>
+
+<span>{first}{second}{third}</span>
+
+<span>
+	{head.median - base.median >= 0 ? "+" : "−"}
+	{formatMs(Math.abs(head.median - base.median))}
+</span>
+
+<span>
+	{head.median - base.median >= 0 ? "+" : "−"}
+	{formatMs(Math.abs(head.median - base.median))}
+</span>
+
+<span><!-- before -->{first}<!-- between -->{second}<!-- after --></span>
+
+```
+
+# Lines exceeding max width of 80 characters
+```
+    2: 	{head.median - base.median >= 0 ? "+" : "−"}{formatMs(Math.abs(head.median - base.median))}
+    6: 	>{head.median - base.median >= 0 ? "+" : "−"}{formatMs(Math.abs(head.median - base.median))}</span
+   10: 	{head.median - base.median >= 0 ? "+" : "−"}{formatMs(Math.abs(head.median - base.median))}
+```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Another whitespace sensitivity bug.

fixed by gpt 6 astra. was impressed that it actually covered all the cases in the tests first try.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
