### PR TITLE
fix(a11y): allow resource load and error handlers

### DIFF
--- a/.changeset/dull-doors-shout.md
+++ b/.changeset/dull-doors-shout.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11647](https://github.com/biomejs/biome/issues/11647): false positives in [`noNoninteractiveElementInteractions`](https://biomejs.dev/linter/rules/no-noninteractive-element-interactions/) for resource `load` and `error` handlers in HTML, Svelte, Vue, Astro, and JSX. Non-interactive elements can handle resource events without requiring an interactive role.

--- a/crates/biome_html_analyze/src/lint/a11y/no_noninteractive_element_interactions.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/no_noninteractive_element_interactions.rs
@@ -16,6 +16,7 @@ declare_lint_rule! {
     /// Non-interactive elements include `<main>`, `<h1>` (,`<h2>`, etc), `<img>`, `<li>`, `<ul>` and `<ol>`.
     ///
     /// A Non-interactive element does not support event handlers(mouse and key handlers).
+    /// Resource events such as `load` and `error` do not require user interaction and are allowed.
     ///
     /// ## Examples
     ///
@@ -127,8 +128,7 @@ impl Rule for NoNoninteractiveElementInteractions {
     }
 }
 
-// Only check the focus, image, keyboard and mouse event handler types.
-const EVENT_HANDLER_TYPES: &[&str] = &["focus", "image", "keyboard", "mouse"];
+const EVENT_HANDLER_TYPES: &[&str] = &["focus", "keyboard", "mouse"];
 
 #[test]
 fn test_order() {

--- a/crates/biome_html_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/html/invalidResourceEvents.html
+++ b/crates/biome_html_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/html/invalidResourceEvents.html
@@ -1,0 +1,4 @@
+<!-- should generate diagnostics -->
+<img src="image.png" alt="Example" onerror="handleError()" onclick="handleInteraction()" />
+<img src="image.png" alt="Example" onerror="handleError()" onkeydown="handleInteraction()" />
+<img src="image.png" alt="Example" onerror="handleError()" onfocus="handleInteraction()" />

--- a/crates/biome_html_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/html/invalidResourceEvents.html
+++ b/crates/biome_html_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/html/invalidResourceEvents.html
@@ -2,3 +2,6 @@
 <img src="image.png" alt="Example" onerror="handleError()" onclick="handleInteraction()" />
 <img src="image.png" alt="Example" onerror="handleError()" onkeydown="handleInteraction()" />
 <img src="image.png" alt="Example" onerror="handleError()" onfocus="handleInteraction()" />
+<img src="image.png" alt="Example" onload="handleLoad()" onclick="handleInteraction()" />
+<img src="image.png" alt="Example" onload="handleLoad()" onkeydown="handleInteraction()" />
+<img src="image.png" alt="Example" onload="handleLoad()" onfocus="handleInteraction()" />

--- a/crates/biome_html_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/html/invalidResourceEvents.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/html/invalidResourceEvents.html.snap
@@ -8,6 +8,9 @@ expression: invalidResourceEvents.html
 <img src="image.png" alt="Example" onerror="handleError()" onclick="handleInteraction()" />
 <img src="image.png" alt="Example" onerror="handleError()" onkeydown="handleInteraction()" />
 <img src="image.png" alt="Example" onerror="handleError()" onfocus="handleInteraction()" />
+<img src="image.png" alt="Example" onload="handleLoad()" onclick="handleInteraction()" />
+<img src="image.png" alt="Example" onload="handleLoad()" onkeydown="handleInteraction()" />
+<img src="image.png" alt="Example" onload="handleLoad()" onfocus="handleInteraction()" />
 
 ```
 
@@ -38,7 +41,7 @@ invalidResourceEvents.html:3:1 lint/a11y/noNoninteractiveElementInteractions ━
   > 3 │ <img src="image.png" alt="Example" onerror="handleError()" onkeydown="handleInteraction()" />
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     4 │ <img src="image.png" alt="Example" onerror="handleError()" onfocus="handleInteraction()" />
-    5 │ 
+    5 │ <img src="image.png" alt="Example" onload="handleLoad()" onclick="handleInteraction()" />
   
   i Non-interactive element should not have event handler. Consider replace semantically interactive element like <button/> or <a href/>.
   
@@ -54,7 +57,58 @@ invalidResourceEvents.html:4:1 lint/a11y/noNoninteractiveElementInteractions ━
     3 │ <img src="image.png" alt="Example" onerror="handleError()" onkeydown="handleInteraction()" />
   > 4 │ <img src="image.png" alt="Example" onerror="handleError()" onfocus="handleInteraction()" />
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    5 │ 
+    5 │ <img src="image.png" alt="Example" onload="handleLoad()" onclick="handleInteraction()" />
+    6 │ <img src="image.png" alt="Example" onload="handleLoad()" onkeydown="handleInteraction()" />
+  
+  i Non-interactive element should not have event handler. Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalidResourceEvents.html:5:1 lint/a11y/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Unexpected event handler on non-interactive element.
+  
+    3 │ <img src="image.png" alt="Example" onerror="handleError()" onkeydown="handleInteraction()" />
+    4 │ <img src="image.png" alt="Example" onerror="handleError()" onfocus="handleInteraction()" />
+  > 5 │ <img src="image.png" alt="Example" onload="handleLoad()" onclick="handleInteraction()" />
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │ <img src="image.png" alt="Example" onload="handleLoad()" onkeydown="handleInteraction()" />
+    7 │ <img src="image.png" alt="Example" onload="handleLoad()" onfocus="handleInteraction()" />
+  
+  i Non-interactive element should not have event handler. Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalidResourceEvents.html:6:1 lint/a11y/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Unexpected event handler on non-interactive element.
+  
+    4 │ <img src="image.png" alt="Example" onerror="handleError()" onfocus="handleInteraction()" />
+    5 │ <img src="image.png" alt="Example" onload="handleLoad()" onclick="handleInteraction()" />
+  > 6 │ <img src="image.png" alt="Example" onload="handleLoad()" onkeydown="handleInteraction()" />
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    7 │ <img src="image.png" alt="Example" onload="handleLoad()" onfocus="handleInteraction()" />
+    8 │ 
+  
+  i Non-interactive element should not have event handler. Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalidResourceEvents.html:7:1 lint/a11y/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Unexpected event handler on non-interactive element.
+  
+    5 │ <img src="image.png" alt="Example" onload="handleLoad()" onclick="handleInteraction()" />
+    6 │ <img src="image.png" alt="Example" onload="handleLoad()" onkeydown="handleInteraction()" />
+  > 7 │ <img src="image.png" alt="Example" onload="handleLoad()" onfocus="handleInteraction()" />
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    8 │ 
   
   i Non-interactive element should not have event handler. Consider replace semantically interactive element like <button/> or <a href/>.
   

--- a/crates/biome_html_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/html/invalidResourceEvents.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/html/invalidResourceEvents.html.snap
@@ -1,0 +1,62 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalidResourceEvents.html
+---
+# Input
+```html
+<!-- should generate diagnostics -->
+<img src="image.png" alt="Example" onerror="handleError()" onclick="handleInteraction()" />
+<img src="image.png" alt="Example" onerror="handleError()" onkeydown="handleInteraction()" />
+<img src="image.png" alt="Example" onerror="handleError()" onfocus="handleInteraction()" />
+
+```
+
+# Diagnostics
+```
+invalidResourceEvents.html:2:1 lint/a11y/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Unexpected event handler on non-interactive element.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <img src="image.png" alt="Example" onerror="handleError()" onclick="handleInteraction()" />
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ <img src="image.png" alt="Example" onerror="handleError()" onkeydown="handleInteraction()" />
+    4 │ <img src="image.png" alt="Example" onerror="handleError()" onfocus="handleInteraction()" />
+  
+  i Non-interactive element should not have event handler. Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalidResourceEvents.html:3:1 lint/a11y/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Unexpected event handler on non-interactive element.
+  
+    1 │ <!-- should generate diagnostics -->
+    2 │ <img src="image.png" alt="Example" onerror="handleError()" onclick="handleInteraction()" />
+  > 3 │ <img src="image.png" alt="Example" onerror="handleError()" onkeydown="handleInteraction()" />
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ <img src="image.png" alt="Example" onerror="handleError()" onfocus="handleInteraction()" />
+    5 │ 
+  
+  i Non-interactive element should not have event handler. Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalidResourceEvents.html:4:1 lint/a11y/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Unexpected event handler on non-interactive element.
+  
+    2 │ <img src="image.png" alt="Example" onerror="handleError()" onclick="handleInteraction()" />
+    3 │ <img src="image.png" alt="Example" onerror="handleError()" onkeydown="handleInteraction()" />
+  > 4 │ <img src="image.png" alt="Example" onerror="handleError()" onfocus="handleInteraction()" />
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │ 
+  
+  i Non-interactive element should not have event handler. Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/html/validResourceEvents.html
+++ b/crates/biome_html_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/html/validResourceEvents.html
@@ -1,0 +1,3 @@
+<!-- should not generate diagnostics -->
+<img src="image.png" alt="Example" onerror="handleError()" />
+<img src="image.png" alt="Example" onload="handleLoad()" />

--- a/crates/biome_html_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/html/validResourceEvents.html.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/html/validResourceEvents.html.snap
@@ -1,0 +1,11 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: validResourceEvents.html
+---
+# Input
+```html
+<!-- should not generate diagnostics -->
+<img src="image.png" alt="Example" onerror="handleError()" />
+<img src="image.png" alt="Example" onload="handleLoad()" />
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/svelte/invalidResourceEvents.svelte
+++ b/crates/biome_html_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/svelte/invalidResourceEvents.svelte
@@ -1,0 +1,4 @@
+<!-- should generate diagnostics -->
+<img src="image.png" alt="Example" onerror={() => {}} onclick={() => {}} />
+<img src="image.png" alt="Example" onerror={() => {}} onkeydown={() => {}} />
+<img src="image.png" alt="Example" onerror={() => {}} onfocus={() => {}} />

--- a/crates/biome_html_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/svelte/invalidResourceEvents.svelte
+++ b/crates/biome_html_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/svelte/invalidResourceEvents.svelte
@@ -2,3 +2,6 @@
 <img src="image.png" alt="Example" onerror={() => {}} onclick={() => {}} />
 <img src="image.png" alt="Example" onerror={() => {}} onkeydown={() => {}} />
 <img src="image.png" alt="Example" onerror={() => {}} onfocus={() => {}} />
+<img src="image.png" alt="Example" onload={() => {}} onclick={() => {}} />
+<img src="image.png" alt="Example" onload={() => {}} onkeydown={() => {}} />
+<img src="image.png" alt="Example" onload={() => {}} onfocus={() => {}} />

--- a/crates/biome_html_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/svelte/invalidResourceEvents.svelte.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/svelte/invalidResourceEvents.svelte.snap
@@ -8,6 +8,9 @@ expression: invalidResourceEvents.svelte
 <img src="image.png" alt="Example" onerror={() => {}} onclick={() => {}} />
 <img src="image.png" alt="Example" onerror={() => {}} onkeydown={() => {}} />
 <img src="image.png" alt="Example" onerror={() => {}} onfocus={() => {}} />
+<img src="image.png" alt="Example" onload={() => {}} onclick={() => {}} />
+<img src="image.png" alt="Example" onload={() => {}} onkeydown={() => {}} />
+<img src="image.png" alt="Example" onload={() => {}} onfocus={() => {}} />
 
 ```
 
@@ -38,7 +41,7 @@ invalidResourceEvents.svelte:3:1 lint/a11y/noNoninteractiveElementInteractions �
   > 3 │ <img src="image.png" alt="Example" onerror={() => {}} onkeydown={() => {}} />
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     4 │ <img src="image.png" alt="Example" onerror={() => {}} onfocus={() => {}} />
-    5 │ 
+    5 │ <img src="image.png" alt="Example" onload={() => {}} onclick={() => {}} />
   
   i Non-interactive element should not have event handler. Consider replace semantically interactive element like <button/> or <a href/>.
   
@@ -54,7 +57,58 @@ invalidResourceEvents.svelte:4:1 lint/a11y/noNoninteractiveElementInteractions �
     3 │ <img src="image.png" alt="Example" onerror={() => {}} onkeydown={() => {}} />
   > 4 │ <img src="image.png" alt="Example" onerror={() => {}} onfocus={() => {}} />
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    5 │ 
+    5 │ <img src="image.png" alt="Example" onload={() => {}} onclick={() => {}} />
+    6 │ <img src="image.png" alt="Example" onload={() => {}} onkeydown={() => {}} />
+  
+  i Non-interactive element should not have event handler. Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalidResourceEvents.svelte:5:1 lint/a11y/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━
+
+  i Unexpected event handler on non-interactive element.
+  
+    3 │ <img src="image.png" alt="Example" onerror={() => {}} onkeydown={() => {}} />
+    4 │ <img src="image.png" alt="Example" onerror={() => {}} onfocus={() => {}} />
+  > 5 │ <img src="image.png" alt="Example" onload={() => {}} onclick={() => {}} />
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │ <img src="image.png" alt="Example" onload={() => {}} onkeydown={() => {}} />
+    7 │ <img src="image.png" alt="Example" onload={() => {}} onfocus={() => {}} />
+  
+  i Non-interactive element should not have event handler. Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalidResourceEvents.svelte:6:1 lint/a11y/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━
+
+  i Unexpected event handler on non-interactive element.
+  
+    4 │ <img src="image.png" alt="Example" onerror={() => {}} onfocus={() => {}} />
+    5 │ <img src="image.png" alt="Example" onload={() => {}} onclick={() => {}} />
+  > 6 │ <img src="image.png" alt="Example" onload={() => {}} onkeydown={() => {}} />
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    7 │ <img src="image.png" alt="Example" onload={() => {}} onfocus={() => {}} />
+    8 │ 
+  
+  i Non-interactive element should not have event handler. Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalidResourceEvents.svelte:7:1 lint/a11y/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━
+
+  i Unexpected event handler on non-interactive element.
+  
+    5 │ <img src="image.png" alt="Example" onload={() => {}} onclick={() => {}} />
+    6 │ <img src="image.png" alt="Example" onload={() => {}} onkeydown={() => {}} />
+  > 7 │ <img src="image.png" alt="Example" onload={() => {}} onfocus={() => {}} />
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    8 │ 
   
   i Non-interactive element should not have event handler. Consider replace semantically interactive element like <button/> or <a href/>.
   

--- a/crates/biome_html_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/svelte/invalidResourceEvents.svelte.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/svelte/invalidResourceEvents.svelte.snap
@@ -1,0 +1,62 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: invalidResourceEvents.svelte
+---
+# Input
+```svelte
+<!-- should generate diagnostics -->
+<img src="image.png" alt="Example" onerror={() => {}} onclick={() => {}} />
+<img src="image.png" alt="Example" onerror={() => {}} onkeydown={() => {}} />
+<img src="image.png" alt="Example" onerror={() => {}} onfocus={() => {}} />
+
+```
+
+# Diagnostics
+```
+invalidResourceEvents.svelte:2:1 lint/a11y/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━
+
+  i Unexpected event handler on non-interactive element.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ <img src="image.png" alt="Example" onerror={() => {}} onclick={() => {}} />
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ <img src="image.png" alt="Example" onerror={() => {}} onkeydown={() => {}} />
+    4 │ <img src="image.png" alt="Example" onerror={() => {}} onfocus={() => {}} />
+  
+  i Non-interactive element should not have event handler. Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalidResourceEvents.svelte:3:1 lint/a11y/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━
+
+  i Unexpected event handler on non-interactive element.
+  
+    1 │ <!-- should generate diagnostics -->
+    2 │ <img src="image.png" alt="Example" onerror={() => {}} onclick={() => {}} />
+  > 3 │ <img src="image.png" alt="Example" onerror={() => {}} onkeydown={() => {}} />
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ <img src="image.png" alt="Example" onerror={() => {}} onfocus={() => {}} />
+    5 │ 
+  
+  i Non-interactive element should not have event handler. Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalidResourceEvents.svelte:4:1 lint/a11y/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━
+
+  i Unexpected event handler on non-interactive element.
+  
+    2 │ <img src="image.png" alt="Example" onerror={() => {}} onclick={() => {}} />
+    3 │ <img src="image.png" alt="Example" onerror={() => {}} onkeydown={() => {}} />
+  > 4 │ <img src="image.png" alt="Example" onerror={() => {}} onfocus={() => {}} />
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │ 
+  
+  i Non-interactive element should not have event handler. Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```

--- a/crates/biome_html_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/svelte/validResourceEvents.svelte
+++ b/crates/biome_html_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/svelte/validResourceEvents.svelte
@@ -1,0 +1,3 @@
+<!-- should not generate diagnostics -->
+<img src="image.png" alt="Example" onerror={() => {}} />
+<img src="image.png" alt="Example" onload={() => {}} />

--- a/crates/biome_html_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/svelte/validResourceEvents.svelte.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/svelte/validResourceEvents.svelte.snap
@@ -1,0 +1,11 @@
+---
+source: crates/biome_html_analyze/tests/spec_tests.rs
+expression: validResourceEvents.svelte
+---
+# Input
+```svelte
+<!-- should not generate diagnostics -->
+<img src="image.png" alt="Example" onerror={() => {}} />
+<img src="image.png" alt="Example" onload={() => {}} />
+
+```

--- a/crates/biome_js_analyze/src/lint/a11y/no_noninteractive_element_interactions.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_noninteractive_element_interactions.rs
@@ -15,6 +15,7 @@ declare_lint_rule! {
     /// Non-interactive elements include `<main>`, `<area>`, `<h1>` (,`<h2>`, etc), `<img>`, `<li>`, `<ul>` and `<ol>`.
     ///
     /// A Non-interactive element does not support event handlers(mouse and key handlers).
+    /// Resource events such as `load` and `error` do not require user interaction and are allowed.
     ///
     ///
     /// ## Examples
@@ -132,8 +133,7 @@ impl Rule for NoNoninteractiveElementInteractions {
     }
 }
 
-// Only check the focus, image, keyboard and mouse event handler types.
-const EVENT_HANDLER_TYPES: &[&str] = &["focus", "image", "keyboard", "mouse"];
+const EVENT_HANDLER_TYPES: &[&str] = &["focus", "keyboard", "mouse"];
 
 #[test]
 fn test_order() {

--- a/crates/biome_js_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/invalidResourceEvents.tsx
+++ b/crates/biome_js_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/invalidResourceEvents.tsx
@@ -1,0 +1,6 @@
+/* should generate diagnostics */
+<>
+    <img src="image.png" alt="Example" onError={() => {}} onClick={() => {}} />
+    <img src="image.png" alt="Example" onError={() => {}} onKeyDown={() => {}} />
+    <img src="image.png" alt="Example" onError={() => {}} onFocus={() => {}} />
+</>

--- a/crates/biome_js_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/invalidResourceEvents.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/invalidResourceEvents.tsx.snap
@@ -1,0 +1,66 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidResourceEvents.tsx
+---
+# Input
+```tsx
+/* should generate diagnostics */
+<>
+    <img src="image.png" alt="Example" onError={() => {}} onClick={() => {}} />
+    <img src="image.png" alt="Example" onError={() => {}} onKeyDown={() => {}} />
+    <img src="image.png" alt="Example" onError={() => {}} onFocus={() => {}} />
+</>
+
+```
+
+# Diagnostics
+```
+invalidResourceEvents.tsx:3:5 lint/a11y/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Unexpected event handler on non-interactive element.
+  
+    1 │ /* should generate diagnostics */
+    2 │ <>
+  > 3 │     <img src="image.png" alt="Example" onError={() => {}} onClick={() => {}} />
+      │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │     <img src="image.png" alt="Example" onError={() => {}} onKeyDown={() => {}} />
+    5 │     <img src="image.png" alt="Example" onError={() => {}} onFocus={() => {}} />
+  
+  i Non-interactive element should not have event handler. Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalidResourceEvents.tsx:4:5 lint/a11y/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Unexpected event handler on non-interactive element.
+  
+    2 │ <>
+    3 │     <img src="image.png" alt="Example" onError={() => {}} onClick={() => {}} />
+  > 4 │     <img src="image.png" alt="Example" onError={() => {}} onKeyDown={() => {}} />
+      │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │     <img src="image.png" alt="Example" onError={() => {}} onFocus={() => {}} />
+    6 │ </>
+  
+  i Non-interactive element should not have event handler. Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalidResourceEvents.tsx:5:5 lint/a11y/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Unexpected event handler on non-interactive element.
+  
+    3 │     <img src="image.png" alt="Example" onError={() => {}} onClick={() => {}} />
+    4 │     <img src="image.png" alt="Example" onError={() => {}} onKeyDown={() => {}} />
+  > 5 │     <img src="image.png" alt="Example" onError={() => {}} onFocus={() => {}} />
+      │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │ </>
+    7 │ 
+  
+  i Non-interactive element should not have event handler. Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/validResourceEvents.tsx
+++ b/crates/biome_js_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/validResourceEvents.tsx
@@ -1,0 +1,5 @@
+/* should not generate diagnostics */
+<>
+    <img src="image.png" alt="Example" onError={() => {}} />
+    <img src="image.png" alt="Example" onLoad={() => {}} />
+</>

--- a/crates/biome_js_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/validResourceEvents.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/noNoninteractiveElementInteractions/validResourceEvents.tsx.snap
@@ -1,0 +1,13 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validResourceEvents.tsx
+---
+# Input
+```tsx
+/* should not generate diagnostics */
+<>
+    <img src="image.png" alt="Example" onError={() => {}} />
+    <img src="image.png" alt="Example" onLoad={() => {}} />
+</>
+
+```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Fixes https://github.com/biomejs/biome/issues/11647. Allow resource load/error handlers on non-interactive elements in the HTML and JSX analyzers; retain diagnostics for mouse, keyboard, and focus handlers.

AI assistance: Codex investigated the issue, wrote the code, tests, changeset, and this description, and ran validation. A separate Codex agent performed static review.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

- New HTML/Svelte valid-resource fixtures fail on unpatched `main`.
- Svelte, HTML, and TSX fixtures cover load/error handlers and combinations with click, keydown, and focus handlers.
- `cargo test -p biome_html_analyze -p biome_js_analyze --no-fail-fast`: 3,901 passed, 4 ignored.
- `just gen-rules`, `just gen-configuration`, `just f`, and `just l`.
- Diff whitespace check passes excluding generated diagnostic snapshots, which retain the test harness output.

<!-- What demonstrates that your implementation is correct? -->

## Docs

Updated both rule descriptions and added a patch changeset.

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
