### PR TITLE
fix(noUselessConstructor): add TypeScript forwarding constructor exclion

### DIFF
--- a/.changeset/brave-waves-deny.md
+++ b/.changeset/brave-waves-deny.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#7495](https://github.com/biomejs/biome/issues/7495): [`noUselessConstructor`](https://biomejs.dev/linter/rules/no-useless-constructor/) now ignores TypeScript constructors that forward at least one argument to `super`, preserving constructors that narrow the subclass's accepted parameter types. The exemption also applies when the parent and child signatures are identical; JavaScript and zero-argument forwarding behavior are unchanged.

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_constructor.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_constructor.rs
@@ -7,6 +7,7 @@ use biome_js_syntax::{
     AnyJsCallArgument, AnyJsClass, AnyJsConstructorParameter, AnyJsFormalParameter,
     JsCallExpression, JsConstructorClassMember,
 };
+use biome_languages::JsFileSource;
 use biome_rowan::{AstNode, AstNodeList, AstSeparatedList, BatchMutationExt};
 use biome_rule_options::no_useless_constructor::NoUselessConstructorOptions;
 
@@ -22,11 +23,16 @@ declare_lint_rule! {
     ///
     /// - decorated classes;
     /// - constructors with at least one [parameter property](https://www.typescriptlang.org/docs/handbook/2/classes.html#parameter-properties);
-    /// - `private` and `protected` constructors.
+    /// - `private` and `protected` constructors;
+    /// - TypeScript constructors that forward at least one argument to `super`.
+    ///
+    /// TypeScript forwarding constructors can narrow the parameter types accepted by a subclass.
+    /// The rule does not compare parent and child signatures, so it ignores these constructors
+    /// even when the signatures are identical.
     ///
     /// ## Caveat
     ///
-    /// This rule reports on constructors whose sole purpose is to make a parent constructor public.
+    /// This rule reports on zero-argument constructors whose sole purpose is to make a parent constructor public.
     /// See the last invalid example.
     ///
     /// ## Examples
@@ -39,7 +45,7 @@ declare_lint_rule! {
     /// }
     /// ```
     ///
-    /// ```ts,expect_diagnostic
+    /// ```js,expect_diagnostic
     /// class B extends A {
     ///     constructor (a) {
     ///         super(a);
@@ -106,6 +112,18 @@ declare_lint_rule! {
     ///   constructor(arg = 4) {
     ///     super(arg)
     ///   }
+    /// }
+    /// ```
+    ///
+    /// ```ts
+    /// class Base {
+    ///     constructor(public value: string | number) {}
+    /// }
+    ///
+    /// class Narrowed extends Base {
+    ///     constructor(value: string) {
+    ///         super(value);
+    ///     }
     /// }
     /// ```
     ///
@@ -194,6 +212,12 @@ impl Rule for NoUselessConstructor {
         let js_call = js_expr.as_js_call_expression()?;
         let is_super_call = js_call.callee().ok()?.as_js_super_expression().is_some();
         if !is_super_call {
+            return None;
+        }
+        // TypeScript forwarding constructors can narrow the inherited parameter types.
+        if ctx.source_type::<JsFileSource>().is_typescript()
+            && !js_call.arguments().ok()?.args().is_empty()
+        {
             return None;
         }
         if !is_delegating_initialization(constructor, js_call) {

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessConstructor/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessConstructor/invalid.ts
@@ -1,5 +1,20 @@
+/* should generate diagnostics */
+class A {
+    constructor() {}
+}
+
 class B extends A {
-    constructor(foo: number) {
-        super(foo);
+    constructor() {
+        super();
+    }
+}
+
+class ProtectedBase {
+    protected constructor() {}
+}
+
+class Public extends ProtectedBase {
+    constructor() {
+        super();
     }
 }

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessConstructor/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessConstructor/invalid.ts.snap
@@ -4,9 +4,24 @@ expression: invalid.ts
 ---
 # Input
 ```ts
+/* should generate diagnostics */
+class A {
+    constructor() {}
+}
+
 class B extends A {
-    constructor(foo: number) {
-        super(foo);
+    constructor() {
+        super();
+    }
+}
+
+class ProtectedBase {
+    protected constructor() {}
+}
+
+class Public extends ProtectedBase {
+    constructor() {
+        super();
     }
 }
 
@@ -14,27 +29,78 @@ class B extends A {
 
 # Diagnostics
 ```
-invalid.ts:2:5 lint/complexity/noUselessConstructor  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:3:5 lint/complexity/noUselessConstructor  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i This constructor is unnecessary.
   
-    1 │ class B extends A {
-  > 2 │     constructor(foo: number) {
-      │     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  > 3 │         super(foo);
-  > 4 │     }
-      │     ^
-    5 │ }
-    6 │ 
+    1 │ /* should generate diagnostics */
+    2 │ class A {
+  > 3 │     constructor() {}
+      │     ^^^^^^^^^^^^^^^^
+    4 │ }
+    5 │ 
   
   i Unsafe fix: Remove the unnecessary constructor.
   
-    1 1 │   class B extends A {
-    2   │ - ····constructor(foo:·number)·{
-    3   │ - ········super(foo);
-    4   │ - ····}
-    5 2 │   }
-    6 3 │   
+     1  1 │   /* should generate diagnostics */
+     2  2 │   class A {
+     3    │ - ····constructor()·{}
+     4  3 │   }
+     5  4 │   
+  
+
+```
+
+```
+invalid.ts:7:5 lint/complexity/noUselessConstructor  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This constructor is unnecessary.
+  
+     6 │ class B extends A {
+   > 7 │     constructor() {
+       │     ^^^^^^^^^^^^^^^
+   > 8 │         super();
+   > 9 │     }
+       │     ^
+    10 │ }
+    11 │ 
+  
+  i Unsafe fix: Remove the unnecessary constructor.
+  
+     5  5 │   
+     6  6 │   class B extends A {
+     7    │ - ····constructor()·{
+     8    │ - ········super();
+     9    │ - ····}
+    10  7 │   }
+    11  8 │   
+  
+
+```
+
+```
+invalid.ts:17:5 lint/complexity/noUselessConstructor  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This constructor is unnecessary.
+  
+    16 │ class Public extends ProtectedBase {
+  > 17 │     constructor() {
+       │     ^^^^^^^^^^^^^^^
+  > 18 │         super();
+  > 19 │     }
+       │     ^
+    20 │ }
+    21 │ 
+  
+  i Unsafe fix: Remove the unnecessary constructor.
+  
+    15 15 │   
+    16 16 │   class Public extends ProtectedBase {
+    17    │ - ····constructor()·{
+    18    │ - ········super();
+    19    │ - ····}
+    20 17 │   }
+    21 18 │   
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessConstructor/validForwarding.ts
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessConstructor/validForwarding.ts
@@ -1,0 +1,73 @@
+/* should not generate diagnostics */
+import { ImportedBase } from "external";
+
+interface A { x: number }
+interface B { y: string }
+
+class Base {
+    constructor(public value: A | B) {}
+}
+
+class Narrowed extends Base {
+    constructor(value: A) {
+        super(value);
+    }
+}
+
+class SameSignature extends Base {
+    constructor(value: A | B) {
+        super(value);
+    }
+}
+
+class Unannotated extends Base {
+    constructor(value) {
+        super(value);
+    }
+}
+
+class OptionalBase {
+    constructor(public value?: A | B) {}
+}
+
+class Optional extends OptionalBase {
+    constructor(value?: A) {
+        super(value);
+    }
+}
+
+class RestBase {
+    constructor(...values: (A | B)[]) {
+        console.log(values);
+    }
+}
+
+class Rest extends RestBase {
+    constructor(...values: A[]) {
+        super(...values);
+    }
+}
+
+class Imported extends ImportedBase {
+    constructor(value: A) {
+        super(value);
+    }
+}
+
+class Unresolved extends UnknownBase {
+    constructor(foo: number) {
+        super(foo);
+    }
+}
+
+class ProtectedBase {
+    protected constructor(value: A) {
+        console.log(value);
+    }
+}
+
+class Public extends ProtectedBase {
+    constructor(value: A) {
+        super(value);
+    }
+}

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessConstructor/validForwarding.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessConstructor/validForwarding.ts.snap
@@ -1,0 +1,81 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validForwarding.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+import { ImportedBase } from "external";
+
+interface A { x: number }
+interface B { y: string }
+
+class Base {
+    constructor(public value: A | B) {}
+}
+
+class Narrowed extends Base {
+    constructor(value: A) {
+        super(value);
+    }
+}
+
+class SameSignature extends Base {
+    constructor(value: A | B) {
+        super(value);
+    }
+}
+
+class Unannotated extends Base {
+    constructor(value) {
+        super(value);
+    }
+}
+
+class OptionalBase {
+    constructor(public value?: A | B) {}
+}
+
+class Optional extends OptionalBase {
+    constructor(value?: A) {
+        super(value);
+    }
+}
+
+class RestBase {
+    constructor(...values: (A | B)[]) {
+        console.log(values);
+    }
+}
+
+class Rest extends RestBase {
+    constructor(...values: A[]) {
+        super(...values);
+    }
+}
+
+class Imported extends ImportedBase {
+    constructor(value: A) {
+        super(value);
+    }
+}
+
+class Unresolved extends UnknownBase {
+    constructor(foo: number) {
+        super(foo);
+    }
+}
+
+class ProtectedBase {
+    protected constructor(value: A) {
+        console.log(value);
+    }
+}
+
+class Public extends ProtectedBase {
+    constructor(value: A) {
+        super(value);
+    }
+}
+
+```

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessConstructor/validForwarding.tsx
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessConstructor/validForwarding.tsx
@@ -1,0 +1,10 @@
+/* should not generate diagnostics */
+class Base<T> {
+    constructor(public value: T) {}
+}
+
+class Narrowed extends Base<string | number> {
+    constructor(value: string) {
+        super(value);
+    }
+}

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessConstructor/validForwarding.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessConstructor/validForwarding.tsx.snap
@@ -1,0 +1,18 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validForwarding.tsx
+---
+# Input
+```tsx
+/* should not generate diagnostics */
+class Base<T> {
+    constructor(public value: T) {}
+}
+
+class Narrowed extends Base<string | number> {
+    constructor(value: string) {
+        super(value);
+    }
+}
+
+```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Used a coding agent

Closes https://github.com/biomejs/biome/issues/7495

For now, we exclude constructor argument forwarding in TypeScript files. 

Making the rule smarter would require type inference.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added new tests

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
