### PR TITLE
fix(biome_html_analyze): don't report Astro headings using set:html or set:text

### DIFF
--- a/.changeset/heading-astro-set-directives.md
+++ b/.changeset/heading-astro-set-directives.md
@@ -1,0 +1,10 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11644](https://github.com/biomejs/biome/issues/11644): [`useHeadingContent`](https://biomejs.dev/linter/rules/use-heading-content/) no longer reports Astro headings that render their text with the `set:html` or `set:text` directive.
+
+```astro
+<h1 set:html={heading} />
+<h2 set:text={heading}></h2>
+```

--- a/.changeset/heading-astro-set-directives.md
+++ b/.changeset/heading-astro-set-directives.md
@@ -2,9 +2,16 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#11644](https://github.com/biomejs/biome/issues/11644): [`useHeadingContent`](https://biomejs.dev/linter/rules/use-heading-content/) no longer reports Astro headings that render their text with the `set:html` or `set:text` directive.
+Fixed [#11644](https://github.com/biomejs/biome/issues/11644): [`useHeadingContent`](https://biomejs.dev/linter/rules/use-heading-content/) no longer reports headings that render their text with a directive: `set:html` and `set:text` in Astro files, `v-html` and `v-text` in Vue files.
 
 ```astro
 <h1 set:html={heading} />
 <h2 set:text={heading}></h2>
+```
+
+```vue
+<template>
+  <h1 v-html="heading"></h1>
+  <h2 v-text="heading"></h2>
+</template>
 ```

--- a/crates/biome_html_analyze/src/lint/a11y/use_heading_content.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_heading_content.rs
@@ -2,10 +2,14 @@ use biome_analyze::context::RuleContext;
 use biome_analyze::{Ast, Rule, RuleDiagnostic, RuleSource, declare_lint_rule};
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_html_syntax::{AnyHtmlContent, AnyHtmlElement, HtmlElementList, HtmlSyntaxKind, T};
+use biome_html_syntax::element_ext::AnyHtmlTagElement;
+use biome_html_syntax::{
+    AnyAstroDirective, AnyHtmlAttribute, AnyHtmlContent, AnyHtmlElement, HtmlElementList,
+    HtmlSyntaxKind, T,
+};
 use biome_languages::HtmlFileSource;
 use biome_parser::{TokenSet, token_set};
-use biome_rowan::AstNode;
+use biome_rowan::{AstNode, AstNodeList};
 use biome_rule_options::use_heading_content::UseHeadingContentOptions;
 
 use crate::a11y::{
@@ -60,6 +64,17 @@ declare_lint_rule! {
     /// <h1><span aria-hidden="true">hidden</span> visible content</h1>
     /// ```
     ///
+    /// In Astro files, the `set:html` and `set:text` directives render the heading
+    /// text, so headings that use them are not reported.
+    ///
+    /// ```astro
+    /// <h1 set:html={heading} />
+    /// ```
+    ///
+    /// ```astro
+    /// <h1 set:text={heading}></h1>
+    /// ```
+    ///
     /// ## Accessibility guidelines
     ///
     /// - [WCAG 2.4.6](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-descriptive.html)
@@ -108,6 +123,12 @@ impl Rule for UseHeadingContent {
             return None;
         }
 
+        // Astro's `set:html` / `set:text` render the heading's text at build time,
+        // so the heading does have content even though the element looks empty.
+        if source_type.is_astro() && has_astro_set_content_directive(&tag_element) {
+            return None;
+        }
+
         match node {
             // Self-closing headings (e.g. <h1 />) can never have content
             AnyHtmlElement::HtmlSelfClosingElement(_) => Some(()),
@@ -142,6 +163,29 @@ impl Rule for UseHeadingContent {
             ),
         )
     }
+}
+
+/// Checks if the element carries Astro's `set:html` or `set:text` directive.
+///
+/// Both directives make Astro render the given expression as the element's
+/// children, so the element has content even when it is written as empty or
+/// self-closing.
+///
+/// Ref: <https://docs.astro.build/en/reference/directives-reference/#sethtml>
+fn has_astro_set_content_directive(element: &AnyHtmlTagElement) -> bool {
+    element.attributes().iter().any(|attribute| {
+        let AnyHtmlAttribute::AnyAstroDirective(AnyAstroDirective::AstroSetDirective(directive)) =
+            attribute
+        else {
+            return false;
+        };
+        directive
+            .value()
+            .ok()
+            .and_then(|value| value.name().ok())
+            .and_then(|name| name.token_text_trimmed())
+            .is_some_and(|name| matches!(name.text(), "html" | "text"))
+    })
 }
 
 /// Checks if an `HtmlElementList` contains accessible content.

--- a/crates/biome_html_analyze/src/lint/a11y/use_heading_content.rs
+++ b/crates/biome_html_analyze/src/lint/a11y/use_heading_content.rs
@@ -4,8 +4,8 @@ use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_html_syntax::element_ext::AnyHtmlTagElement;
 use biome_html_syntax::{
-    AnyAstroDirective, AnyHtmlAttribute, AnyHtmlContent, AnyHtmlElement, HtmlElementList,
-    HtmlSyntaxKind, T,
+    AnyAstroDirective, AnyHtmlAttribute, AnyHtmlContent, AnyHtmlElement, AnyVueDirective,
+    HtmlElementList, HtmlSyntaxKind, T,
 };
 use biome_languages::HtmlFileSource;
 use biome_parser::{TokenSet, token_set};
@@ -64,15 +64,16 @@ declare_lint_rule! {
     /// <h1><span aria-hidden="true">hidden</span> visible content</h1>
     /// ```
     ///
-    /// In Astro files, the `set:html` and `set:text` directives render the heading
-    /// text, so headings that use them are not reported.
+    /// Directives that render the heading text are treated as content: `set:html`
+    /// and `set:text` in Astro files, `v-html` and `v-text` in Vue files. Headings
+    /// that use them are not reported.
     ///
     /// ```astro
     /// <h1 set:html={heading} />
     /// ```
     ///
-    /// ```astro
-    /// <h1 set:text={heading}></h1>
+    /// ```vue
+    /// <template><h1 v-text="heading"></h1></template>
     /// ```
     ///
     /// ## Accessibility guidelines
@@ -123,9 +124,10 @@ impl Rule for UseHeadingContent {
             return None;
         }
 
-        // Astro's `set:html` / `set:text` render the heading's text at build time,
-        // so the heading does have content even though the element looks empty.
-        if source_type.is_astro() && has_astro_set_content_directive(&tag_element) {
+        // Astro's `set:html` / `set:text` and Vue's `v-html` / `v-text` render the
+        // heading's text, so the heading does have content even though the element
+        // looks empty.
+        if has_content_injecting_directive(&tag_element, source_type) {
             return None;
         }
 
@@ -165,26 +167,40 @@ impl Rule for UseHeadingContent {
     }
 }
 
-/// Checks if the element carries Astro's `set:html` or `set:text` directive.
+/// Checks if the element carries a directive that renders its content.
 ///
-/// Both directives make Astro render the given expression as the element's
-/// children, so the element has content even when it is written as empty or
-/// self-closing.
+/// Astro's `set:html` / `set:text` and Vue's `v-html` / `v-text` all render the
+/// bound expression as the element's children, so the element has content even
+/// when it is written as empty or self-closing.
 ///
-/// Ref: <https://docs.astro.build/en/reference/directives-reference/#sethtml>
-fn has_astro_set_content_directive(element: &AnyHtmlTagElement) -> bool {
-    element.attributes().iter().any(|attribute| {
-        let AnyHtmlAttribute::AnyAstroDirective(AnyAstroDirective::AstroSetDirective(directive)) =
-            attribute
-        else {
-            return false;
-        };
-        directive
-            .value()
-            .ok()
-            .and_then(|value| value.name().ok())
-            .and_then(|name| name.token_text_trimmed())
-            .is_some_and(|name| matches!(name.text(), "html" | "text"))
+/// Refs: <https://docs.astro.build/en/reference/directives-reference/#sethtml>,
+/// <https://vuejs.org/api/built-in-directives.html#v-html>
+fn has_content_injecting_directive(
+    element: &AnyHtmlTagElement,
+    source_type: &HtmlFileSource,
+) -> bool {
+    element.attributes().iter().any(|attribute| match attribute {
+        // set:html={expr} / set:text={expr}
+        AnyHtmlAttribute::AnyAstroDirective(AnyAstroDirective::AstroSetDirective(directive))
+            if source_type.is_astro() =>
+        {
+            directive
+                .value()
+                .ok()
+                .and_then(|value| value.name().ok())
+                .and_then(|name| name.token_text_trimmed())
+                .is_some_and(|name| matches!(name.text(), "html" | "text"))
+        }
+        // v-html="expr" / v-text="expr"
+        AnyHtmlAttribute::AnyVueDirective(AnyVueDirective::VueDirective(directive))
+            if source_type.is_vue() =>
+        {
+            directive.name_token().is_ok_and(|name| {
+                let name = name.text_trimmed();
+                name.eq_ignore_ascii_case("v-html") || name.eq_ignore_ascii_case("v-text")
+            })
+        }
+        _ => false,
     })
 }
 

--- a/crates/biome_html_analyze/tests/specs/a11y/useHeadingContent/astro/invalid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/useHeadingContent/astro/invalid.astro
@@ -6,3 +6,5 @@
 <h1 aria-hidden="true">invisible content</h1>
 <h1><span aria-hidden="true">hidden</span></h1>
 <h3></h3>
+<h1 />
+<h2 class:list={classes} />

--- a/crates/biome_html_analyze/tests/specs/a11y/useHeadingContent/astro/invalid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useHeadingContent/astro/invalid.astro.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_html_analyze/tests/spec_tests.rs
-assertion_line: 120
 expression: invalid.astro
 ---
 # Input
@@ -13,6 +12,8 @@ expression: invalid.astro
 <h1 aria-hidden="true">invisible content</h1>
 <h1><span aria-hidden="true">hidden</span></h1>
 <h3></h3>
+<h1 />
+<h2 class:list={classes} />
 
 ```
 
@@ -78,7 +79,7 @@ invalid.astro:7:1 lint/a11y/useHeadingContent ━━━━━━━━━━━�
   > 7 │ <h1><span aria-hidden="true">hidden</span></h1>
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     8 │ <h3></h3>
-    9 │ 
+    9 │ <h1 />
   
   i All headings on a page should have content that is accessible to screen readers.
   
@@ -90,11 +91,45 @@ invalid.astro:8:1 lint/a11y/useHeadingContent ━━━━━━━━━━━�
 
   × Provide screen reader accessible content when using heading elements.
   
-    6 │ <h1 aria-hidden="true">invisible content</h1>
-    7 │ <h1><span aria-hidden="true">hidden</span></h1>
-  > 8 │ <h3></h3>
-      │ ^^^^^^^^^
-    9 │ 
+     6 │ <h1 aria-hidden="true">invisible content</h1>
+     7 │ <h1><span aria-hidden="true">hidden</span></h1>
+   > 8 │ <h3></h3>
+       │ ^^^^^^^^^
+     9 │ <h1 />
+    10 │ <h2 class:list={classes} />
+  
+  i All headings on a page should have content that is accessible to screen readers.
+  
+
+```
+
+```
+invalid.astro:9:1 lint/a11y/useHeadingContent ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Provide screen reader accessible content when using heading elements.
+  
+     7 │ <h1><span aria-hidden="true">hidden</span></h1>
+     8 │ <h3></h3>
+   > 9 │ <h1 />
+       │ ^^^^^^
+    10 │ <h2 class:list={classes} />
+    11 │ 
+  
+  i All headings on a page should have content that is accessible to screen readers.
+  
+
+```
+
+```
+invalid.astro:10:1 lint/a11y/useHeadingContent ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Provide screen reader accessible content when using heading elements.
+  
+     8 │ <h3></h3>
+     9 │ <h1 />
+  > 10 │ <h2 class:list={classes} />
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    11 │ 
   
   i All headings on a page should have content that is accessible to screen readers.
   

--- a/crates/biome_html_analyze/tests/specs/a11y/useHeadingContent/astro/valid.astro
+++ b/crates/biome_html_analyze/tests/specs/a11y/useHeadingContent/astro/valid.astro
@@ -15,3 +15,9 @@
 <!-- PascalCase: custom components, should NOT trigger the rule -->
 <H1></H1>
 <MyHeading></MyHeading>
+
+<!-- Astro set:html / set:text inject the heading text at render time -->
+<h1 set:html={heading} />
+<h2 set:text={heading} />
+<h3 set:html={heading}></h3>
+<h4 set:text={heading}></h4>

--- a/crates/biome_html_analyze/tests/specs/a11y/useHeadingContent/astro/valid.astro.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useHeadingContent/astro/valid.astro.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_html_analyze/tests/spec_tests.rs
-assertion_line: 120
 expression: valid.astro
 ---
 # Input
@@ -22,5 +21,11 @@ expression: valid.astro
 <!-- PascalCase: custom components, should NOT trigger the rule -->
 <H1></H1>
 <MyHeading></MyHeading>
+
+<!-- Astro set:html / set:text inject the heading text at render time -->
+<h1 set:html={heading} />
+<h2 set:text={heading} />
+<h3 set:html={heading}></h3>
+<h4 set:text={heading}></h4>
 
 ```

--- a/crates/biome_html_analyze/tests/specs/a11y/useHeadingContent/vue/invalid.vue
+++ b/crates/biome_html_analyze/tests/specs/a11y/useHeadingContent/vue/invalid.vue
@@ -5,4 +5,5 @@
   <h1 aria-hidden="true">invisible content</h1>
   <h1><span aria-hidden="true">hidden</span></h1>
   <h3></h3>
+  <h1 v-bind:id="id"></h1>
 </template>

--- a/crates/biome_html_analyze/tests/specs/a11y/useHeadingContent/vue/invalid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useHeadingContent/vue/invalid.vue.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_html_analyze/tests/spec_tests.rs
-assertion_line: 120
 expression: invalid.vue
 ---
 # Input
@@ -12,6 +11,7 @@ expression: invalid.vue
   <h1 aria-hidden="true">invisible content</h1>
   <h1><span aria-hidden="true">hidden</span></h1>
   <h3></h3>
+  <h1 v-bind:id="id"></h1>
 </template>
 
 ```
@@ -78,7 +78,7 @@ invalid.vue:6:3 lint/a11y/useHeadingContent ━━━━━━━━━━━━
   > 6 │   <h1><span aria-hidden="true">hidden</span></h1>
       │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     7 │   <h3></h3>
-    8 │ </template>
+    8 │   <h1 v-bind:id="id"></h1>
   
   i All headings on a page should have content that is accessible to screen readers.
   
@@ -94,8 +94,25 @@ invalid.vue:7:3 lint/a11y/useHeadingContent ━━━━━━━━━━━━
     6 │   <h1><span aria-hidden="true">hidden</span></h1>
   > 7 │   <h3></h3>
       │   ^^^^^^^^^
-    8 │ </template>
-    9 │ 
+    8 │   <h1 v-bind:id="id"></h1>
+    9 │ </template>
+  
+  i All headings on a page should have content that is accessible to screen readers.
+  
+
+```
+
+```
+invalid.vue:8:3 lint/a11y/useHeadingContent ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Provide screen reader accessible content when using heading elements.
+  
+     6 │   <h1><span aria-hidden="true">hidden</span></h1>
+     7 │   <h3></h3>
+   > 8 │   <h1 v-bind:id="id"></h1>
+       │   ^^^^^^^^^^^^^^^^^^^^^^^^
+     9 │ </template>
+    10 │ 
   
   i All headings on a page should have content that is accessible to screen readers.
   

--- a/crates/biome_html_analyze/tests/specs/a11y/useHeadingContent/vue/valid.vue
+++ b/crates/biome_html_analyze/tests/specs/a11y/useHeadingContent/vue/valid.vue
@@ -20,4 +20,8 @@
 
   <!-- PascalCase self-closing: custom component, NOT native <img> -->
   <h1><Img /></h1>
+
+  <!-- v-html / v-text render the heading text at runtime -->
+  <h1 v-html="heading"></h1>
+  <h2 v-text="heading"></h2>
 </template>

--- a/crates/biome_html_analyze/tests/specs/a11y/useHeadingContent/vue/valid.vue.snap
+++ b/crates/biome_html_analyze/tests/specs/a11y/useHeadingContent/vue/valid.vue.snap
@@ -26,6 +26,10 @@ expression: valid.vue
 
   <!-- PascalCase self-closing: custom component, NOT native <img> -->
   <h1><Img /></h1>
+
+  <!-- v-html / v-text render the heading text at runtime -->
+  <h1 v-html="heading"></h1>
+  <h2 v-text="heading"></h2>
 </template>
 
 ```


### PR DESCRIPTION
## Summary

Closes #11644.

`useHeadingContent` reports a false positive on Astro headings that inject their text through the `set:html` or `set:text` directive:

```astro
<h1 set:html={heading} />
<h2 set:text={heading} />
<h3 set:html={heading}></h3>
```

Astro renders those directives as the element's children at build time, so the heading does have accessible content. The rule only saw an element with no child nodes and flagged it.

The JSX version of this rule already handles the equivalent situation for React: `has_valid_heading_content` treats the presence of `dangerouslySetInnerHTML` as content, checked on the element itself before the child-content branch and without inspecting the bound expression. This applies the same reasoning to the Astro-native equivalent, at the same point in `run()` — which matters here, because the HTML rule short-circuits `HtmlSelfClosingElement` straight to a diagnostic and would otherwise still flag `<h1 set:html={x} />`.

`set:html` is not a plain attribute in the HTML grammar — it parses to an `AstroSetDirective` node — so `find_attribute_by_name` would never match it. The check matches that node and reads its directive name, the same way the existing `noAstroSetHtmlDirective` rule does, behind the same `source_type.is_astro()` guard.

Scope is limited to `set:html` and `set:text`. Vue's `v-html`/`v-text` may have the same gap, but that is unverified and left for a separate change.

## Test Plan

`cargo test -p biome_html_analyze`: 576 spec tests and 71 unit tests pass.

The `astro` fixtures cover both directives in self-closing and paired form on the valid side. Reverting only the rule source makes `valid_astro` fail with all four headings flagged, which is the reported bug.

On the invalid side I added two cases to show the fix is not over-broad: `<h1 />` proves a genuinely empty self-closing heading still reports, and `<h2 class:list={classes} />` proves an unrelated Astro directive does not earn an exemption.

`cargo clippy -p biome_html_analyze --all-features --all-targets -- --deny warnings` and `cargo fmt --check` are clean, and `just lint-rules` passes.

One note: I wrote the changeset file by hand in the documented format rather than through `just new-changeset`, so its filename is descriptive instead of the usual generated slug. Happy to rename it if you'd prefer.
