### PR TITLE
fix(lint/js): detect Astro set:html in template expressions

### DIFF
--- a/.changeset/real-crews-lead.md
+++ b/.changeset/real-crews-lead.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed `noAstroSetHtmlDirective` failing to report `set:html` inside Astro expressions, such as `{<div set:html={content} />}`.

--- a/crates/biome_js_analyze/src/lint/nursery/no_astro_set_html_directive.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_astro_set_html_directive.rs
@@ -1,0 +1,89 @@
+use biome_analyze::{
+    Ast, Rule, RuleDiagnostic, RuleDomain, RuleSource, context::RuleContext, declare_lint_rule,
+};
+use biome_console::markup;
+use biome_diagnostics::Severity;
+use biome_js_syntax::{JsxAttribute, JsxName};
+use biome_languages::JsFileSource;
+use biome_rowan::AstNode;
+use biome_rule_options::no_astro_set_html_directive::NoAstroSetHtmlDirectiveOptions;
+
+declare_lint_rule! {
+    /// Disallow the use of Astro's `set:html` directive.
+    ///
+    /// `set:html` renders HTML without escaping it. Using `set:html` can introduce cross-site scripting vulnerabilities.
+    /// When raw HTML is required, sanitize the value before passing it to `set:html`, then suppress the diagnostic with an explanation.
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```astro,expect_diagnostic
+    /// <div set:html={content} />
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```astro
+    /// <div>{content}</div>
+    /// ```
+    ///
+    /// ## References
+    ///
+    /// - [Astro `set:html` directive](https://docs.astro.build/en/reference/directives-reference/#sethtml)
+    /// - [OWASP HTML sanitization guidance](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#html-sanitization)
+    pub NoAstroSetHtmlDirective {
+        version: "2.5.11",
+        name: "noAstroSetHtmlDirective",
+        language: "jsx",
+        recommended: true,
+        severity: Severity::Error,
+        domains: &[RuleDomain::Astro],
+        sources: &[RuleSource::EslintAstro("no-set-html-directive").same()],
+    }
+}
+
+impl Rule for NoAstroSetHtmlDirective {
+    type Query = Ast<JsxName>;
+    type State = ();
+    type Signals = Option<Self::State>;
+    type Options = NoAstroSetHtmlDirectiveOptions;
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        if !ctx
+            .source_type::<JsFileSource>()
+            .as_embedding_kind()
+            .is_astro_template()
+        {
+            return None;
+        }
+
+        let name = ctx.query();
+        (name.value_token().ok()?.text_trimmed() == "set:html").then_some(())?;
+        name.syntax().parent().and_then(JsxAttribute::cast)?;
+        Some(())
+    }
+
+    fn diagnostic(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<RuleDiagnostic> {
+        let attribute = ctx
+            .query()
+            .syntax()
+            .parent()
+            .and_then(JsxAttribute::cast)?;
+        Some(
+            RuleDiagnostic::new(
+                rule_category!(),
+                attribute.range(),
+                markup! {
+                    "The "<Emphasis>"set:html"</Emphasis>" directive inserts unescaped HTML."
+                },
+            )
+            .note(markup! {
+                "Using "<Emphasis>"set:html"</Emphasis>" can introduce cross-site scripting vulnerabilities."
+            })
+            .note(markup! {
+                "Use a regular Astro expression to render text, or suppress this diagnostic with an explanation if raw HTML is required."
+            }),
+        )
+    }
+}

--- a/crates/biome_js_analyze/src/lint/nursery/no_astro_set_html_directive.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_astro_set_html_directive.rs
@@ -3,7 +3,7 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_diagnostics::Severity;
-use biome_js_syntax::{JsxAttribute, JsxName};
+use biome_js_syntax::JsxAttribute;
 use biome_languages::JsFileSource;
 use biome_rowan::AstNode;
 use biome_rule_options::no_astro_set_html_directive::NoAstroSetHtmlDirectiveOptions;
@@ -44,7 +44,7 @@ declare_lint_rule! {
 }
 
 impl Rule for NoAstroSetHtmlDirective {
-    type Query = Ast<JsxName>;
+    type Query = Ast<JsxAttribute>;
     type State = ();
     type Signals = Option<Self::State>;
     type Options = NoAstroSetHtmlDirectiveOptions;
@@ -58,22 +58,15 @@ impl Rule for NoAstroSetHtmlDirective {
             return None;
         }
 
-        let name = ctx.query();
-        (name.value_token().ok()?.text_trimmed() == "set:html").then_some(())?;
-        name.syntax().parent().and_then(JsxAttribute::cast)?;
-        Some(())
+        let name = ctx.query().name().ok()?;
+        (name.to_trimmed_text().text() == "set:html").then_some(())
     }
 
     fn diagnostic(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<RuleDiagnostic> {
-        let attribute = ctx
-            .query()
-            .syntax()
-            .parent()
-            .and_then(JsxAttribute::cast)?;
         Some(
             RuleDiagnostic::new(
                 rule_category!(),
-                attribute.range(),
+                ctx.query().range(),
                 markup! {
                     "The "<Emphasis>"set:html"</Emphasis>" directive inserts unescaped HTML."
                 },

--- a/crates/biome_js_analyze/tests/specs/nursery/noAstroSetHtmlDirective/invalid.astro
+++ b/crates/biome_js_analyze/tests/specs/nursery/noAstroSetHtmlDirective/invalid.astro
@@ -1,0 +1,5 @@
+<!-- should generate diagnostics -->
+{<div set:html={content}></div>}
+{<section set:html="<p>content</p>"></section>}
+{<aside set:html={`<p>content</p>`}></aside>}
+{<article set:html></article>}

--- a/crates/biome_js_analyze/tests/specs/nursery/noAstroSetHtmlDirective/invalid.astro.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noAstroSetHtmlDirective/invalid.astro.snap
@@ -1,0 +1,96 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid.astro
+---
+# Input
+```astro
+<!-- should generate diagnostics -->
+{<div set:html={content}></div>}
+{<section set:html="<p>content</p>"></section>}
+{<aside set:html={`<p>content</p>`}></aside>}
+{<article set:html></article>}
+
+```
+
+# Diagnostics
+```
+invalid.astro:2:7 lint/nursery/noAstroSetHtmlDirective ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The set:html directive inserts unescaped HTML.
+  
+    1 │ <!-- should generate diagnostics -->
+  > 2 │ {<div set:html={content}></div>}
+      │       ^^^^^^^^^^^^^^^^^^
+    3 │ {<section set:html="<p>content</p>"></section>}
+    4 │ {<aside set:html={`<p>content</p>`}></aside>}
+  
+  i Using set:html can introduce cross-site scripting vulnerabilities.
+  
+  i Use a regular Astro expression to render text, or suppress this diagnostic with an explanation if raw HTML is required.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.astro:3:11 lint/nursery/noAstroSetHtmlDirective ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The set:html directive inserts unescaped HTML.
+  
+    1 │ <!-- should generate diagnostics -->
+    2 │ {<div set:html={content}></div>}
+  > 3 │ {<section set:html="<p>content</p>"></section>}
+      │           ^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ {<aside set:html={`<p>content</p>`}></aside>}
+    5 │ {<article set:html></article>}
+  
+  i Using set:html can introduce cross-site scripting vulnerabilities.
+  
+  i Use a regular Astro expression to render text, or suppress this diagnostic with an explanation if raw HTML is required.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.astro:4:9 lint/nursery/noAstroSetHtmlDirective ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The set:html directive inserts unescaped HTML.
+  
+    2 │ {<div set:html={content}></div>}
+    3 │ {<section set:html="<p>content</p>"></section>}
+  > 4 │ {<aside set:html={`<p>content</p>`}></aside>}
+      │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │ {<article set:html></article>}
+    6 │ 
+  
+  i Using set:html can introduce cross-site scripting vulnerabilities.
+  
+  i Use a regular Astro expression to render text, or suppress this diagnostic with an explanation if raw HTML is required.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.astro:5:11 lint/nursery/noAstroSetHtmlDirective ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The set:html directive inserts unescaped HTML.
+  
+    3 │ {<section set:html="<p>content</p>"></section>}
+    4 │ {<aside set:html={`<p>content</p>`}></aside>}
+  > 5 │ {<article set:html></article>}
+      │           ^^^^^^^^
+    6 │ 
+  
+  i Using set:html can introduce cross-site scripting vulnerabilities.
+  
+  i Use a regular Astro expression to render text, or suppress this diagnostic with an explanation if raw HTML is required.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noAstroSetHtmlDirective/valid.astro
+++ b/crates/biome_js_analyze/tests/specs/nursery/noAstroSetHtmlDirective/valid.astro
@@ -1,0 +1,4 @@
+<!-- should not generate diagnostics -->
+{<div set:text={content}></div>}
+{<div>{content}</div>}
+{<div set:HTML={content}></div>}

--- a/crates/biome_js_analyze/tests/specs/nursery/noAstroSetHtmlDirective/valid.astro.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noAstroSetHtmlDirective/valid.astro.snap
@@ -1,0 +1,12 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.astro
+---
+# Input
+```astro
+<!-- should not generate diagnostics -->
+{<div set:text={content}></div>}
+{<div>{content}</div>}
+{<div set:HTML={content}></div>}
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noAstroSetHtmlDirective/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/noAstroSetHtmlDirective/valid.jsx
@@ -1,0 +1,3 @@
+// should not generate diagnostics
+
+const element = <div set:html={content} />;

--- a/crates/biome_js_analyze/tests/specs/nursery/noAstroSetHtmlDirective/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noAstroSetHtmlDirective/valid.jsx.snap
@@ -1,0 +1,11 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.jsx
+---
+# Input
+```jsx
+// should not generate diagnostics
+
+const element = <div set:html={content} />;
+
+```

--- a/crates/biome_ruledoc_utils/src/analyzer.rs
+++ b/crates/biome_ruledoc_utils/src/analyzer.rs
@@ -346,27 +346,4 @@ mod tests {
         assert!(diagnostic.contains("has no export named missing"));
         assert!(!diagnostic.contains("module not found"));
     }
-
-    #[test]
-    fn analyzes_astro_template_expression() {
-        let mut services_builder = AnalyzerServicesBuilder::from_files(HashMap::new(), false);
-        let code_block = CodeBlock::from_str("astro expect_diagnostic").expect("valid code block");
-        let code = r#"<div set:html={content} />"#;
-        let mut writer = DiagnosticConsoleWriter::default();
-
-        RuleCodeAnalyzer {
-            group: "nursery",
-            rule: "noAstroSetHtmlDirective",
-            rule_language: "jsx",
-            code_block: &code_block,
-            code,
-            configuration: None,
-            services_builder: &mut services_builder,
-            writer: &mut writer,
-        }
-        .analyze()
-        .unwrap();
-
-        assert_eq!(writer.all_diagnostics.len(), 1);
-    }
 }

--- a/crates/biome_ruledoc_utils/src/analyzer.rs
+++ b/crates/biome_ruledoc_utils/src/analyzer.rs
@@ -80,6 +80,17 @@ pub fn analyze_rule_code(analyzer: RuleCodeAnalyzer) -> Result<()> {
     match document_file_source {
         DocumentFileSource::Js(file_source) => {
             let (analysis_code, file_source) = match file_source.as_embedding_kind() {
+                JsEmbeddingKind::Astro { .. }
+                    if biome_service::file_handlers::AstroFileHandler::start(code).is_none() =>
+                {
+                    (
+                        code,
+                        JsFileSource::tsx().with_embedding_kind(JsEmbeddingKind::Astro {
+                            frontmatter: false,
+                            is_class_attribute: false,
+                        }),
+                    )
+                }
                 JsEmbeddingKind::Astro { .. } => (
                     biome_service::file_handlers::AstroFileHandler::input(code),
                     JsFileSource::ts(),
@@ -334,5 +345,28 @@ mod tests {
         let diagnostic = biome_test_utils::diagnostic_to_string("/bar.js", code, diagnostic);
         assert!(diagnostic.contains("has no export named missing"));
         assert!(!diagnostic.contains("module not found"));
+    }
+
+    #[test]
+    fn analyzes_astro_template_expression() {
+        let mut services_builder = AnalyzerServicesBuilder::from_files(HashMap::new(), false);
+        let code_block = CodeBlock::from_str("astro expect_diagnostic").expect("valid code block");
+        let code = r#"<div set:html={content} />"#;
+        let mut writer = DiagnosticConsoleWriter::default();
+
+        RuleCodeAnalyzer {
+            group: "nursery",
+            rule: "noAstroSetHtmlDirective",
+            rule_language: "jsx",
+            code_block: &code_block,
+            code,
+            configuration: None,
+            services_builder: &mut services_builder,
+            writer: &mut writer,
+        }
+        .analyze()
+        .unwrap();
+
+        assert_eq!(writer.all_diagnostics.len(), 1);
     }
 }


### PR DESCRIPTION
Closes https://github.com/biomejs/biome/issues/11656

### Summary

Fixed `noAstroSetHtmlDirective` failing to report `set:html` inside Astro expressions, such as `{<div set:html={content} />}`.

`set:html` renders HTML without escaping it. Using `set:html` can introduce cross-site scripting vulnerabilities.

### Test Plan

Added test cases for:

* `set:html` with an expression value
* `set:html` with a quoted string value
* `set:html` with a template literal value
* `set:html` without an initializer
* `set:text`
* child expressions
* uppercase `set:HTML`
* JSX outside Astro
* rustdoc examples using `astro,expect_diagnostic`

### Docs

Rule documentation and examples are included in the rustdoc.

### AI Assistance

This PR was created with OpenAI Codex assistance.
