### PR TITLE
fix(noUnusedVariables): decode Unicode escapes

### DIFF
--- a/.changeset/few-gifts-give.md
+++ b/.changeset/few-gifts-give.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#7479](https://github.com/biomejs/biome/issues/7479). [`noUnusedVariables`](https://biomejs.dev/linter/rules/no-unused-variables/) now treats Unicode escapes in identifiers as the same binding as their decoded spelling.

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validIssue7479.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validIssue7479.js
@@ -1,0 +1,6 @@
+/* should not generate diagnostics */
+var \u0065 = 10;
+console.log(e);
+
+var value = 10;
+console.log(\u{76}alue);

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validIssue7479.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/validIssue7479.js.snap
@@ -1,0 +1,14 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validIssue7479.js
+---
+# Input
+```js
+/* should not generate diagnostics */
+var \u0065 = 10;
+console.log(e);
+
+var value = 10;
+console.log(\u{76}alue);
+
+```

--- a/crates/biome_js_semantic/src/events.rs
+++ b/crates/biome_js_semantic/src/events.rs
@@ -9,8 +9,7 @@ use biome_js_syntax::{
 use biome_js_syntax::{AnyJsImportClause, AnyJsNamedImportSpecifier, AnyTsType};
 
 use crate::JsDeclarationKind;
-use biome_rowan::TextSize;
-use biome_rowan::{AstNode, SyntaxNodeOptionExt, TokenText, syntax::Preorder};
+use biome_rowan::{AstNode, SyntaxNodeOptionExt, Text, TextSize, syntax::Preorder};
 use rustc_hash::FxHashMap;
 use std::collections::VecDeque;
 use std::mem;
@@ -173,8 +172,8 @@ pub struct SemanticEventExtractor {
 /// Allocating two bindings allows to for properly detecting type and value shadowing in inner scopes.
 #[derive(Debug, Hash, Eq, PartialEq, Clone)]
 enum BindingName {
-    Type(TokenText),
-    Value(TokenText),
+    Type(Text),
+    Value(Text),
 }
 impl BindingName {
     /// Turn a type into a value and a value into a type.
@@ -542,7 +541,7 @@ impl SemanticEventExtractor {
         let mut hoisted_scope_id = None;
         let mut declaration_kind = JsDeclarationKind::Unknown;
         let is_exported = if let Ok(name_token) = node.name_token() {
-            let name = name_token.token_text_trimmed();
+            let name = crate::identifier_name(name_token.token_text_trimmed());
             if let Some(declaration) = node.declaration() {
                 let info = BindingInfo::new(
                     name_token.text_trimmed_range().start(),
@@ -603,8 +602,11 @@ impl SemanticEventExtractor {
                     }
                     AnyJsBindingDeclaration::TsEnumMember(_) => {
                         declaration_kind = JsDeclarationKind::Enum;
-                        // Handle quoted names.
-                        let name = inner_string_text(&name_token);
+                        let name = if name_token.kind() == JS_STRING_LITERAL {
+                            inner_string_text(&name_token).into()
+                        } else {
+                            name
+                        };
                         self.push_binding(None, BindingName::Value(name.clone()), info.clone());
                         self.push_binding(None, BindingName::Type(name), info);
                     }
@@ -814,7 +816,7 @@ impl SemanticEventExtractor {
         let Ok(name_token) = node.value_token() else {
             return;
         };
-        let name = name_token.token_text_trimmed();
+        let name = crate::identifier_name(name_token.token_text_trimmed());
         match node {
             AnyJsIdentifierReference::JsReferenceIdentifier(node) => {
                 let Some(parent) = node.syntax().parent() else {
@@ -1043,18 +1045,14 @@ impl SemanticEventExtractor {
             return None;
         }
         let store_name = self.flavor.store_reference_name(name.text())?;
-        let store_name_start = name.len() - TextSize::from(u32::try_from(store_name.len()).ok()?);
-        Some(BindingName::Value(
-            name.clone()
-                .slice(TextRange::new(store_name_start, name.len())),
-        ))
+        Some(BindingName::Value(store_name.to_string().into()))
     }
 
     fn push_infers_in_scope(&mut self) {
         let infers = mem::take(&mut self.infers);
         for infer in infers {
             if let Ok(name_token) = infer.ident_token() {
-                let name = name_token.token_text_trimmed();
+                let name = crate::identifier_name(name_token.token_text_trimmed());
                 let name_range = name_token.text_trimmed_range();
                 let binding_info =
                     BindingInfo::new(name_range.start(), JsSyntaxKind::TS_INFER_TYPE);

--- a/crates/biome_js_semantic/src/lib.rs
+++ b/crates/biome_js_semantic/src/lib.rs
@@ -8,6 +8,21 @@ mod semantic_model;
 #[cfg(test)]
 mod tests;
 
+use biome_js_syntax::unescape_js_identifier;
+use biome_rowan::{Text, TokenText};
+
 pub use db::{js_semantic_model, semantic_model_from_snippet, semantic_model_from_source};
 pub use events::*;
 pub use semantic_model::*;
+
+/// Returns the semantic name represented by parsed identifier token text.
+///
+/// Unicode escapes are decoded without applying Unicode normalization. Names
+/// without escapes retain their token-backed storage.
+fn identifier_name(text: TokenText) -> Text {
+    let decoded = match unescape_js_identifier(text.text()) {
+        std::borrow::Cow::Borrowed(_) => None,
+        std::borrow::Cow::Owned(decoded) => Some(decoded),
+    };
+    decoded.map_or_else(|| text.into(), Into::into)
+}

--- a/crates/biome_js_semantic/src/semantic_model/builder.rs
+++ b/crates/biome_js_semantic/src/semantic_model/builder.rs
@@ -1,7 +1,8 @@
 use super::*;
 use biome_js_syntax::{
-    AnyJsDeclaration, AnyJsRoot, JsExport, JsIdentifierAssignment, JsSyntaxNode, TextRange,
-    TsConditionalType, TsDeclareStatement, TsTypeParameterName,
+    AnyJsDeclaration, AnyJsIdentifierReference, AnyJsRoot, JsExport, JsIdentifierAssignment,
+    JsSyntaxNode, TextRange, TsConditionalType, TsDeclareStatement, TsTypeParameterName,
+    unescape_js_identifier,
 };
 use biome_jsdoc_comment::JsdocComment;
 use biome_rowan::SyntaxNodePtr;
@@ -152,7 +153,12 @@ impl SemanticModelBuilder {
 
     #[inline]
     pub fn push_global(&mut self, name: impl Into<String>) {
-        self.globals_by_name.insert(name.into(), None);
+        let name = name.into();
+        let decoded = match unescape_js_identifier(&name) {
+            std::borrow::Cow::Borrowed(_) => None,
+            std::borrow::Cow::Owned(decoded) => Some(decoded),
+        };
+        self.globals_by_name.insert(decoded.unwrap_or(name), None);
     }
 
     #[inline]
@@ -226,11 +232,17 @@ impl SemanticModelBuilder {
                 // Handle bindings with a bogus name
                 if let Some(node) = self.binding_node_by_start.get(&range.start()) {
                     let name = if let Some(node) = JsIdentifierBinding::cast_ref(node) {
-                        node.name_token().ok().map(|t| t.token_text_trimmed())
+                        node.name_token()
+                            .ok()
+                            .map(|t| crate::identifier_name(t.token_text_trimmed()))
                     } else if let Some(node) = TsIdentifierBinding::cast_ref(node) {
-                        node.name_token().ok().map(|t| t.token_text_trimmed())
+                        node.name_token()
+                            .ok()
+                            .map(|t| crate::identifier_name(t.token_text_trimmed()))
                     } else if let Some(node) = TsTypeParameterName::cast_ref(node) {
-                        node.ident_token().ok().map(|t| t.token_text_trimmed())
+                        node.ident_token()
+                            .ok()
+                            .map(|t| crate::identifier_name(t.token_text_trimmed()))
                     } else {
                         None
                     };
@@ -369,9 +381,14 @@ impl SemanticModelBuilder {
                 };
 
                 let node = &self.binding_node_by_start[&range.start()];
-                let unresolved_name = node.text_trimmed().to_string();
+                let unresolved_name = AnyJsIdentifierReference::cast_ref(node)
+                    .and_then(|reference| reference.value_token().ok())
+                    .map_or_else(
+                        || node.text_trimmed().to_string().into(),
+                        |token| crate::identifier_name(token.token_text_trimmed()),
+                    );
 
-                if let Some(global_name) = self.resolve_global_name(&unresolved_name) {
+                if let Some(global_name) = self.resolve_global_name(unresolved_name.text()) {
                     self.global_references_by_start.insert(range.start());
                     if let Some(index) = self.globals_by_name[global_name] {
                         self.globals[index as usize].references.push(
@@ -483,8 +500,9 @@ impl SemanticModelBuilder {
         let Ok(reference_name) = identifier_assignment.name_token() else {
             return false;
         };
+        let reference_name = crate::identifier_name(reference_name.token_text_trimmed());
         self.flavor
-            .store_reference_name(reference_name.text_trimmed())
+            .store_reference_name(reference_name.text())
             .is_some()
     }
 }

--- a/crates/biome_js_semantic/src/semantic_model/scope.rs
+++ b/crates/biome_js_semantic/src/semantic_model/scope.rs
@@ -1,6 +1,6 @@
 use super::*;
-use biome_js_syntax::TextRange;
-use biome_rowan::TokenText;
+use biome_js_syntax::{TextRange, unescape_js_identifier};
+use biome_rowan::Text;
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 use std::sync::Arc;
@@ -17,11 +17,11 @@ pub(crate) struct SemanticModelScopeData {
     pub(crate) bindings: Vec<BindingId>,
     // Map pointing to the [bindings] vec of each bindings by its name,
     // tracking the Type/Value/Namespace distinction for TypeScript declaration merging
-    pub(crate) bindings_by_name: FxHashMap<TokenText, TsBindingReference>,
+    pub(crate) bindings_by_name: FxHashMap<Text, TsBindingReference>,
     // Same-name `function` / `declare function` declarations hoisted to this scope,
     // in source order, keyed by name. Tracked separately from `bindings_by_name` so
     // overload sets survive declaration merging with a same-name type/namespace.
-    pub(crate) overloads_by_name: FxHashMap<TokenText, SmallVec<[BindingId; 2]>>,
+    pub(crate) overloads_by_name: FxHashMap<Text, SmallVec<[BindingId; 2]>>,
     // All read references of a scope
     pub(crate) read_references: Vec<ReferenceId>,
     // All write references of a scope
@@ -107,16 +107,16 @@ impl Scope {
         }
     }
 
-    /// Returns a [Binding] by its name, like it appears on code.  It **does
-    /// not** returns bindings of parent scopes.
+    /// Returns a [Binding] by its identifier name. Unicode escapes in `name`
+    /// are decoded before lookup. It **does not** return bindings of parent scopes.
     ///
     /// When a name has both a type and value binding (e.g., a class), this
     /// returns the value binding (or the type binding if only a type exists).
     pub fn get_binding(&self, name: impl AsRef<str>) -> Option<Binding> {
         let data = &self.data.scopes[self.id.index()];
 
-        let name = name.as_ref();
-        let binding_ref = data.bindings_by_name.get(name)?;
+        let name = unescape_js_identifier(name.as_ref());
+        let binding_ref = data.bindings_by_name.get(name.as_ref())?;
         let id = binding_ref.value_ty_or_ty();
 
         Some(Binding {
@@ -132,8 +132,8 @@ impl Scope {
     /// It **does not** return bindings of parent scopes.
     pub fn get_binding_reference(&self, name: impl AsRef<str>) -> Option<TsBindingReference> {
         let data = &self.data.scopes[self.id.index()];
-        let name = name.as_ref();
-        data.bindings_by_name.get(name).copied()
+        let name = unescape_js_identifier(name.as_ref());
+        data.bindings_by_name.get(name.as_ref()).copied()
     }
 
     /// Returns every set of same-name function overloads declared in this

--- a/crates/biome_js_semantic/src/tests/references.rs
+++ b/crates/biome_js_semantic/src/tests/references.rs
@@ -1,7 +1,7 @@
 use crate::assert_semantics;
-use crate::{SemanticModelOptions, semantic_model};
+use crate::{SemanticFlavor, SemanticModelOptions, semantic_model};
 use biome_js_parser::JsParserOptions;
-use biome_js_syntax::AnyJsIdentifierReference;
+use biome_js_syntax::{AnyJsIdentifierReference, JsIdentifierAssignment};
 use biome_languages::JsFileSource;
 use biome_rowan::AstNode;
 
@@ -10,6 +10,26 @@ use biome_rowan::AstNode;
 assert_semantics! {
     ok_reference_read_global,
         "let a/*#A*/ = 1; let b = a/*READ A*/ + 1;",
+
+    ok_reference_read_escaped_binding,
+        r#"let \u0065/*#E*/ = 1; e/*READ E*/;"#,
+
+    ok_reference_read_escaped_reference,
+        r#"let e/*#E*/ = 1; \u{65}/*READ E*/;"#,
+
+    ok_reference_read_equivalent_escape_forms,
+        r#"let \u0065/*#E*/ = 1; \u{65}/*READ E*/;"#,
+
+    ok_reference_does_not_normalize_unicode,
+        r#"let \u00e9/*#PRECOMPOSED*/ = 1;
+        let e\u0301/*#DECOMPOSED*/ = 2;
+        console.log(\u{e9}/*READ PRECOMPOSED*/, e\u{301}/*READ DECOMPOSED*/);"#,
+
+    ok_reference_read_astral_escape,
+        r#"let \u{10400}/*#LETTER*/ = 1; \u{010400}/*READ LETTER*/;"#,
+
+    ok_reference_read_join_control_escape,
+        r#"let a\u200c/*#JOINED*/ = 1; a\u{200c}/*READ JOINED*/;"#,
 
     ok_reference_read_inner_scope,
         r#"function f(a/*#A1*/) {
@@ -60,6 +80,133 @@ fn classifies_global_and_unresolved_references() {
     assert!(!model.is_unresolved_reference(&configured));
     assert!(model.is_unresolved_reference(&missing));
     assert!(!model.is_global_reference(&missing));
+}
+
+#[test]
+fn escaped_identifier_scope_lookup_uses_decoded_name() {
+    let parse = biome_js_parser::parse(
+        r#"let \u0065 = 1;"#,
+        JsFileSource::js_module(),
+        JsParserOptions::default(),
+    );
+    let model = semantic_model(&parse.tree(), SemanticModelOptions::default());
+    let scope = model.global_scope();
+
+    assert!(scope.get_binding("e").is_some());
+    assert!(scope.get_binding(r#"\u{65}"#).is_some());
+    assert!(scope.get_binding_reference("e").is_some());
+    assert!(scope.get_binding_reference(r#"\u0065"#).is_some());
+}
+
+#[test]
+fn escaped_identifier_resolves_configured_global() {
+    let parse = biome_js_parser::parse(
+        r#"\u0065;"#,
+        JsFileSource::js_module(),
+        JsParserOptions::default(),
+    );
+    let mut options = SemanticModelOptions::default();
+    options.globals.insert("e".into());
+    let model = semantic_model(&parse.tree(), options);
+
+    assert_eq!(model.all_unresolved_references().count(), 0);
+    assert_eq!(model.all_global_references().count(), 1);
+}
+
+#[test]
+fn escaped_configured_global_uses_decoded_name() {
+    let parse = biome_js_parser::parse("e;", JsFileSource::js_module(), JsParserOptions::default());
+    let mut options = SemanticModelOptions::default();
+    options.globals.insert(r#"\u0065"#.into());
+    let model = semantic_model(&parse.tree(), options);
+
+    assert_eq!(model.all_unresolved_references().count(), 0);
+    assert_eq!(model.all_global_references().count(), 1);
+}
+
+#[test]
+fn escaped_identifier_overloads_share_one_name() {
+    let parse = biome_js_parser::parse(
+        r#"function \u0066(value: number): number;
+        function f(value: string): string;
+        function \u{66}(value: number | string): number | string { return value; }"#,
+        JsFileSource::ts(),
+        JsParserOptions::default(),
+    );
+    let model = semantic_model(&parse.tree(), SemanticModelOptions::default());
+    let scope = model.global_scope();
+
+    assert!(scope.get_binding_reference("f").is_some());
+    let overload_sets = scope.overload_sets();
+    assert_eq!(overload_sets.len(), 1);
+    assert_eq!(overload_sets[0].len(), 3);
+}
+
+fn svelte_options() -> SemanticModelOptions {
+    SemanticModelOptions {
+        flavor: SemanticFlavor::Svelte,
+        ..SemanticModelOptions::default()
+    }
+}
+
+#[test]
+fn svelte_store_dereference_with_escape() {
+    let parse = biome_js_parser::parse(
+        r#"const store = 1; $st\u006fre;"#,
+        JsFileSource::ts(),
+        JsParserOptions::default(),
+    );
+    let model = semantic_model(&parse.tree(), svelte_options());
+
+    assert_eq!(model.all_unresolved_references().count(), 0);
+}
+
+#[test]
+fn svelte_store_binding_with_escape() {
+    let parse = biome_js_parser::parse(
+        r#"const st\u006fre = 1; $store;"#,
+        JsFileSource::ts(),
+        JsParserOptions::default(),
+    );
+    let model = semantic_model(&parse.tree(), svelte_options());
+
+    assert_eq!(model.all_unresolved_references().count(), 0);
+}
+
+#[test]
+fn escaped_svelte_rune_is_not_a_store_dereference() {
+    let parse = biome_js_parser::parse(
+        r#"const state = 1; $st\u0061te;"#,
+        JsFileSource::ts(),
+        JsParserOptions::default(),
+    );
+    let model = semantic_model(&parse.tree(), svelte_options());
+
+    assert_eq!(model.all_unresolved_references().count(), 1);
+}
+
+#[test]
+fn svelte_store_assignment_with_escaped_dollar_is_not_a_binding_write() {
+    let parse = biome_js_parser::parse(
+        r#"const store = 1; \u0024store = 2;"#,
+        JsFileSource::ts(),
+        JsParserOptions::default(),
+    );
+    let model = semantic_model(&parse.tree(), svelte_options());
+
+    let store_binding = model
+        .global_scope()
+        .get_binding("store")
+        .expect("expected store binding");
+    assert_eq!(store_binding.all_writes().count(), 0);
+    assert_eq!(store_binding.all_reads().count(), 1);
+
+    let assignment = parse
+        .syntax()
+        .descendants()
+        .find_map(JsIdentifierAssignment::cast)
+        .expect("expected an assignment");
+    assert!(model.binding(&assignment).is_none());
 }
 
 // Read Hoisting
@@ -140,6 +287,8 @@ console.log(a/*READ A2*/);",
 
 assert_semantics! {
     ok_reference_write_global, "let a/*#A*/; a/*WRITE A*/ = 1;",
+    ok_reference_write_escaped_reference,
+        r#"let e/*#E*/; \u0065/*WRITE E*/ = 1;"#,
     ok_reference_write_inner_scope, r#"function f(a/*#A1*/) {
     a/*WRITE A1*/ = 1;
     console.log(a);
@@ -274,4 +423,10 @@ assert_semantics! {
         "function f (a/*#A1*/, b: (a/*#A2*/) => any) { return b(a/*READ A1*/); };",
     ok_typescript_type_parameter_name,
         "type A = { [key/*#A1*/ in P]: key/*READ A1*/ }",
+    ok_typescript_escaped_type_name,
+        r#"type \u0054/*#T*/ = string; let value: T/*READ T*/;"#,
+    ok_typescript_escaped_infer_name,
+        r#"type Element<T> = T extends Array<infer \u0055/*#U*/> ? U/*READ U*/ : never;"#,
+    ok_typescript_escaped_enum_member_name,
+        r#"enum E { \u0041/*#A*/ = 1, B = A/*READ A*/ }"#,
 }

--- a/crates/biome_js_syntax/src/unescape.rs
+++ b/crates/biome_js_syntax/src/unescape.rs
@@ -1,4 +1,83 @@
+use std::borrow::Cow;
+
 use biome_rowan::{Text, TokenText};
+
+/// Returns the value of an identifier after decoding its Unicode escape sequences.
+///
+/// This decodes `\uXXXX` and `\u{...}` escapes without applying Unicode
+/// normalization. If an escape is malformed or represents an invalid Unicode
+/// scalar value, the original identifier is returned unchanged.
+pub fn unescape_js_identifier(identifier: &str) -> Cow<'_, str> {
+    let Some(first_escape) = identifier.find('\\') else {
+        return Cow::Borrowed(identifier);
+    };
+
+    let mut result = String::with_capacity(identifier.len());
+    let mut copied_until = 0;
+    let mut escape_start = first_escape;
+
+    loop {
+        result.push_str(&identifier[copied_until..escape_start]);
+
+        let Some((decoded, escape_end)) = decode_unicode_escape(identifier, escape_start) else {
+            return Cow::Borrowed(identifier);
+        };
+        result.push(decoded);
+        copied_until = escape_end;
+
+        let Some(next_escape) = identifier[escape_end..].find('\\') else {
+            result.push_str(&identifier[escape_end..]);
+            return Cow::Owned(result);
+        };
+        escape_start = escape_end + next_escape;
+    }
+}
+
+fn decode_unicode_escape(identifier: &str, start: usize) -> Option<(char, usize)> {
+    let bytes = identifier.as_bytes();
+    if bytes.get(start..start + 2)? != b"\\u" {
+        return None;
+    }
+
+    if bytes.get(start + 2) == Some(&b'{') {
+        let mut value = 0u32;
+        let mut index = start + 3;
+        let digits_start = index;
+
+        while let Some(&byte) = bytes.get(index) {
+            if byte == b'}' {
+                if index == digits_start {
+                    return None;
+                }
+                return char::from_u32(value).map(|decoded| (decoded, index + 1));
+            }
+
+            value = value.checked_mul(16)?.checked_add(hex_value(byte)?)?;
+            if value > 0x10_ffff {
+                return None;
+            }
+            index += 1;
+        }
+        None
+    } else {
+        let end = start + 6;
+        let digits = bytes.get(start + 2..end)?;
+        let mut value = 0u32;
+        for &digit in digits {
+            value = value * 16 + hex_value(digit)?;
+        }
+        char::from_u32(value).map(|decoded| (decoded, end))
+    }
+}
+
+fn hex_value(byte: u8) -> Option<u32> {
+    match byte {
+        b'0'..=b'9' => Some(u32::from(byte - b'0')),
+        b'a'..=b'f' => Some(u32::from(byte - b'a' + 10)),
+        b'A'..=b'F' => Some(u32::from(byte - b'A' + 10)),
+        _ => None,
+    }
+}
 
 /// Returns `text` with escape sequences processed.
 ///
@@ -168,6 +247,8 @@ pub fn unescape_js_string(text: TokenText) -> Text {
 
 #[cfg(test)]
 mod test {
+    use std::borrow::Cow;
+
     use biome_rowan::RawSyntaxKind;
 
     use super::*;
@@ -189,6 +270,53 @@ mod test {
             let token = TokenText::new_raw(RawSyntaxKind(1), token_text);
             let actual = unescape_js_string(token);
             assert_eq!(actual.text(), *expected, "failed test case: {token_text}");
+        }
+    }
+
+    #[test]
+    fn test_unescape_js_identifier() {
+        let test_cases: &[(&str, &str)] = &[
+            ("identifier", "identifier"),
+            ("\\u0065", "e"),
+            ("\\u{65}", "e"),
+            ("a\\u0062\\u{63}", "abc"),
+            ("\\u{10400}", "𐐀"),
+            ("a\\u200cb", "a\u{200c}b"),
+            ("a\\u200db", "a\u{200d}b"),
+        ];
+
+        for (identifier, expected) in test_cases {
+            assert_eq!(
+                unescape_js_identifier(identifier),
+                *expected,
+                "failed test case: {identifier}"
+            );
+        }
+
+        assert!(matches!(
+            unescape_js_identifier("identifier"),
+            Cow::Borrowed(_)
+        ));
+        assert!(matches!(unescape_js_identifier("\\u0065"), Cow::Owned(_)));
+    }
+
+    #[test]
+    fn test_unescape_malformed_js_identifier() {
+        let test_cases = [
+            "\\x65",
+            "\\u065",
+            "\\u006g",
+            "\\u{}",
+            "\\u{65",
+            "\\u{110000}",
+            "\\ud800",
+        ];
+
+        for identifier in test_cases {
+            assert!(matches!(
+                unescape_js_identifier(identifier),
+                Cow::Borrowed(text) if text == identifier
+            ));
         }
     }
 }


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

> Used a coding agent

Closes #7479

The problem was that bindings weren't decoded when they were escaped. We do this in the parser, but then we drop the information.

This PR adds a small function that decodes the bindings when they are stored in the semantic model. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added new tests

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
