### PR TITLE
chore(review): make skill behavioural

### DIFF
--- a/.claude/skills/biome-code-review/SKILL.md
+++ b/.claude/skills/biome-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: biome-code-review
-description: Use this skill only when asked to review completed Biome changes in a PR, branch, commit range, diff, or working tree. Perform a read-only static review and report findings without editing files or running project code. Do not use for triage, reproduction, or implementation.
+description: Use only for reviewing completed Biome PRs, branches, commit ranges, diffs, or working trees against business logic and requirements. Excludes broad code-quality and process audits, triage, reproduction, and implementation.
 compatibility: Designed for read-only review of the Biome codebase (github.com/biomejs/biome).
 metadata:
   repository: biomejs/biome
@@ -9,22 +9,24 @@ metadata:
 
 # Biome Code Review
 
-Review proposed changes for correctness and fit with the Biome codebase.
+Review changes read-only against business requirements and applicable behavioral, architectural, and subsystem constraints.
 
 ## Invocation
 
-When an implementation agent is orchestrating the work and subagents are available, assign the completed review to a fresh subagent. Give it only:
+Delegate completed reviews to a fresh subagent when available. Supply only:
 
 - the review scope;
-- the intended business requirements that the repository cannot establish.
+- the intended business requirements, including constraints the repository cannot establish.
 
-Do not include implementation details, suspected defects, files to prioritize, prior findings, or expected outcomes. Those pointers bias the review toward confirming the orchestrator's assumptions.
+To avoid bias, omit implementation details, suspected defects, priority files, prior findings, and expected review outcomes.
 
-An agent already invoked as the fresh reviewer performs the review directly and does not delegate it again. If subagents are unavailable, the orchestrator may load this skill and review the complete scope itself.
+Review subagents must not delegate again. Without subagents, review the complete scope directly.
+
+Treat delegated findings as candidates; the parent must [validate them](#parent-validation) before confirming or acting.
 
 ## Safety Boundary
 
-Preserve the working tree exactly as found.
+Reviewers and validating parents must preserve the worktree. Authorized implementation follows validation, outside this skill.
 
 - Do not create, edit, move, or delete files.
 - Do not run project code, builds, tests, formatters, linters, codegen, benchmarks, package managers, LSPs, or daemons.
@@ -52,101 +54,120 @@ One fetch of the resolved base is allowed. If it fails, continue with the local 
 
 ## Establish Scope
 
-Prefer the scope supplied by the user: a PR number, commit range, diff, files, or base branch.
+Use the supplied PR, range, diff, files, or base; exclude unrelated worktree changes.
 
 For a PR number, read its title, body, base, and files with `gh pr view`, then read `gh pr diff`. Do not check it out.
 
-Otherwise review the current branch and working tree:
+When no explicit PR, range, diff, or file scope is supplied, review the current branch and working tree:
 
 1. Read branch, upstream, and every untracked path with `git status --short --branch --untracked-files=all`.
-2. Use the tracking branch when it is `origin/main` or `origin/next`. Otherwise, compare merge bases against both branches and choose the actual ancestor. Ask only when the result is genuinely ambiguous.
+2. Use the supplied base when present. Otherwise, use the tracking branch when it is `origin/main` or `origin/next`, or compare merge bases against both branches and choose the actual ancestor. Ask only when the result is genuinely ambiguous.
 3. Fetch the selected base once.
 4. Diff the merge base through the working tree so committed, staged, and unstaged changes are included.
 5. Read every reported untracked file; untracked tests and changesets are part of the review.
 
 Never fall back to `HEAD` as the base without saying so. That would omit committed branch changes.
 
-Establish intended behavior from the user brief, PR or commit text, linked issue, tests, and surrounding code. If the brief steers toward a suspected defect, review the entire scope anyway and disclose the steer in the status.
+Infer intent from the brief, PR/commit text, linked issue, tests, and code; explicit requirements take precedence. A steered brief still requires reviewing the entire supplied scope; disclose the steer.
+
+## Behavioral Boundary
+
+Before tracing beyond the diff, record intended behavior, requirements, and applicable behavioral, architectural, and subsystem constraints with sources. Report violations or concrete avoidable costs/failures introduced, worsened, or newly exposed by the change.
+
+Read surrounding code only to verify changed behavior and constraints; full-file reads do not expand scope. Stop tracing once the question is settled.
+
+Apply guidance only to changed or directly affected code; preferences are not violations, and requirements must not be invented. Exclude unrelated cleanup, defects, process checks, and speculative optimization, even from optional suggestions or questions.
 
 ## Gather Context
 
 - Read every changed file in full.
-- Inspect callers, registrations, generated counterparts, neighboring implementations, and tests affected by the change.
+- Inspect affected callers, registrations, generated counterparts, neighbors, and tests only to verify scoped behavior and constraints.
 - Read root `AGENTS.md` and only the relevant sections of `CONTRIBUTING.md` or crate guides.
-- Load only the implementation skills and review references matching the changed area.
+- Load relevant skills and references for contracts, not additional objectives or permission to execute workflows.
 - Prefer checked-out source over documentation or memory.
-- Report pre-existing problems only when the change depends on, worsens, or newly exposes them.
 
 Use this routing table instead of loading every reference:
 
-| Diff touches | Load |
+| In-scope question concerns | Load |
 | --- | --- |
 | Grammar, lint, parser, formatter, diagnostics, types, tests, generated files | [repository-and-subsystems.md](references/repository-and-subsystems.md) and the matching implementation skill |
 | `biome_service`, workspace DB, CLI/LSP execution, cancellation | [workspace-access.md](references/workspace-access.md) |
-| Production Rust partial operations, recursion, syntax text, ranges, allocation, API shape | [rust-safety-and-syntax.md](references/rust-safety-and-syntax.md) |
-| Comments, rustdoc, user documentation, changesets, branch target, PR metadata | [documentation-and-process.md](references/documentation-and-process.md) |
+| Rust production totality, failure paths, recursion, syntax text, ranges, allocation, or API shape | [rust-safety-and-syntax.md](references/rust-safety-and-syntax.md) |
+| Documentation describing required behavior or affected contracts | [documentation-and-process.md](references/documentation-and-process.md) |
 
 ## Review Method
 
 Perform two passes:
 
-1. **Design:** understand the goal, crate ownership, execution model, and data flow.
-2. **Implementation:** inspect every human-written changed line and the relevant tests for correctness, failure behavior, allocation cost, and maintainability.
+1. **Behavior:** trace requirements, control and data flow, and relevant ownership and execution contracts.
+2. **Implementation:** inspect every human-written changed line and relevant test against those requirements and affected behavior.
 
-When the title, description, changeset, or source claims a property such as zero-copy, no behavior change, faster execution, or no new dependency, try to falsify that property first. A counterexample that defeats the stated purpose is a high-severity finding.
+Try to falsify claimed requirements such as zero-copy, unchanged behavior, faster execution, or no new dependencies. Rate counterexamples by impact.
 
-Review in this order:
-
-1. Design, crate placement, workspace execution model, and claimed properties.
-2. Functional correctness, false positives, fix safety, panics, and partial operations.
-3. Text/range correctness, allocation, API shape, recursion, and error handling.
-4. Registration, codegen, tests, snapshots, documentation, changeset, and process compliance.
-
-Focus on concrete impact. Do not report stylistic preferences or theoretical edge cases without a reachable failure, except for unjustified production partial operations as defined in the Rust review reference.
+Check required paths, callers, variants, and failure behavior before supporting artifacts. Behavioral failures require reachability; constraint violations, including [production totality](#production-totality), require evidence of an unmet constraint, not a runtime counterexample.
 
 ## Cross-Cutting Checks
 
-- A bug fix needs a test that fails without the fix.
+- Verify a bug fix's regression test reaches the changed behavior and fails without the fix.
 - Read snapshot changes as expected behavior. A snapshot can faithfully record an incorrect range, message, or output.
 - A safe fix must preserve semantics for every reachable case and stop the rule from reporting after application.
-- Verify generated artifacts required by `AGENTS.md`; do not report outputs intentionally left to CI Autofix.
-- Search for existing helpers before accepting a new abstraction.
+- Check required registration and generated artifacts against affected sources and `AGENTS.md`; honor CI Autofix exceptions.
 - Consolidate repeated symptoms under their root cause.
 
 ## Finding Threshold
 
-Report only actionable issues supported by inspected code.
+Report only actionable, in-scope issues supported by inspected code.
 
-- Explain the triggering input, call path, or maintenance condition and the resulting behavior or cost.
-- Point to the smallest relevant changed line or range.
-- Give a minimal remediation direction without writing the patch.
-- Put uncertain requirements or design choices under questions, not findings.
-- List optional improvements after required findings.
+- Cite the unmet requirement, violated contract, or concrete avoidable cost and its connection to the diff.
+- For behavioral failures, give the trigger, expected versus actual behavior, and impact. For test gaps, name the required scenario and defect to catch.
+- Check guards, types, caller invariants, and tests for counter-evidence.
+- Cite the smallest relevant changed range.
+- Give minimal remediation, not a patch.
 
-Production `unwrap`, `expect`, indexing, slicing, panic macros, and integer division are the exception: if release-mode control flow, a type, or an API contract does not establish totality, their presence is a finding even when a concrete user input was not found.
+Put unresolved in-scope requirements or correctness assumptions under questions, not findings.
+
+### Production Totality
+
+Report production `unwrap`, `expect`, indexing, slicing, panic macros, integer division/remainder, and other partial operations unless release-mode control flow, types, or API contracts establish totality. No concrete failing input is required.
+
+Limit this to added or modified operations, or existing operations whose preconditions or reachability the diff affects. Check relevant guards and callers; proofs need not be local.
+
+Cite the unmet precondition and inspected evidence without claiming a demonstrated panic. See [operation-specific checks](references/rust-safety-and-syntax.md#partial-operations).
+
+## Parent Validation
+
+Validate every candidate independently; confidence is not evidence.
+
+1. Read the cited diff, source, callers or tests, and claimed requirement, constraint, or cost; the summary is not evidence.
+2. Try to disprove claims using guards, types, call order, tests, and pre-change behavior. Behavioral failures require reachability; totality findings require checking release-mode control flow, types, and API contracts, not a failing input.
+3. Apply the same scope and finding threshold; verify applicable constraints, avoidable costs, and proportional remediation. Reject out-of-scope claims even if correct; never invent requirements.
+4. Mark each **validated**, **rejected**, or **unresolved**, citing supporting or specific missing evidence. Seek targeted clarification when needed.
+5. Only validated findings qualify for confirmation or authorized remediation outside review. Note rejected/unresolved candidates in validation status; unresolved requirements belong under questions and never justify fixes.
 
 ## Report Format
 
-Return raw, unrendered Markdown inside one fenced code block, with no prose before or after it. Findings come first and are ordered by severity.
+Return only raw Markdown in one fenced block, findings first by severity.
 
 Every finding starts with exactly one `<severity>/<area>` token.
 
 | Severity | Meaning |
 | --- | --- |
-| `high` | Regression, corruption or data loss, exploitable security/privacy failure, availability failure, broad false positive, incorrect safe fix, user-reachable panic, workspace execution violation, or a change that defeats its stated purpose |
-| `medium` | Credible edge-case failure, missing variant or registration, hot-path allocation, material test gap, or unjustified production partial operation |
-| `low` | Localized correctness, maintainability, documentation, or process issue |
-| `optional` | Non-blocking improvement with a concrete benefit |
+| `high` | Material regression, corruption or data loss, exploitable security/privacy failure, availability failure, broad false positive, incorrect safe fix, user-reachable panic, or a change that defeats its core requirement |
+| `medium` | Credible edge-case failure, missing required variant or registration, demonstrated performance regression, material test gap for required behavior, or unjustified in-scope production partial operation |
+| `low` | Localized correctness, maintainability, documentation, or implementation-constraint issue that meets the finding threshold |
 
 Areas: `design`, `correctness`, `security`, `privacy`, `availability`, `performance`, `completeness`, `error-handling`, `tests`, `maintainability`, `documentation`, `changeset`, `process`.
 
-You **must** adhere to the following format:
+Areas classify eligible findings; they do not expand scope.
+
+Use exactly this format:
 
 ````md
 ```
 ## Findings
 
-- `high/correctness` `path/to/file.rs:42` - Short title. Explain the trigger, impact, and remediation direction.
+- `high/correctness` `path/to/file.rs:42` - Short title. Cite the requirement, trigger, expected/actual behavior, impact, and minimal remediation.
+- `medium/error-handling` `path/to/file.rs:57` - Missing totality guarantee. Cite the affected operation, unmet precondition, inspected evidence, and minimal remediation; do not claim a demonstrated panic.
 
 ## Questions
 
@@ -154,13 +175,13 @@ You **must** adhere to the following format:
 
 ## Review Status
 
-Scope: `<base-sha>` through `<head or working tree>`, `<n>` files, plus listed untracked files.
-Branch target: `<base>` is correct | should target `<main|next>`.
-Changeset: present and correct | present but `<problem>` | missing | not required.
-Brief: independent | steered toward `<area>`; the full scope was reviewed.
+Scope: `<supplied diff or base-sha through head or working tree>`, `<n>` files, plus listed in-scope untracked files.
+Requirements: `<intended behavior, applicable constraints, and sources>`.
+Brief: independent | steered toward `<area>`; full supplied scope reviewed.
 Validation: Static review only; no project code was run.
+Parent validation: not delegated | pending: parent must independently check source and requirements before confirming or acting | completed: `<evidence-backed candidate dispositions>`.
 Fetch: updated `origin/<base>` | failed, local `origin/<base>` used | not needed.
 ```
 ````
 
-If there are no findings, write `No findings.` under `## Findings`. Severity reflects impact, not confidence.
+Use `No findings.` under `## Findings` when empty. Severity reflects impact, not confidence. Subagents mark parent validation pending; only the parent may mark it completed after validation.

--- a/.claude/skills/biome-code-review/references/documentation-and-process.md
+++ b/.claude/skills/biome-code-review/references/documentation-and-process.md
@@ -1,6 +1,6 @@
-# Documentation and Process Review
+# Behavioral Documentation Review
 
-Load this reference only when the diff changes comments, rustdoc, user documentation, changesets, branch targeting, or PR metadata.
+Use only for in-scope requirements and contracts, not writing-style, release-policy, or PR-process audits.
 
 ## Internal Documentation
 
@@ -8,47 +8,22 @@ Load `doc-comments` for `//`, `///`, and `//!` changes. Review only:
 
 - comments added or changed by the diff;
 - existing comments made inaccurate by the new behavior;
-- documentation removed when its invariant still exists in replacement code;
-- new vocabulary or extension points whose contract is not recoverable from names and types.
+- documentation removed when an affected caller or implementor still needs its contract.
 
-Do not request documentation merely because an item is public. Report missing prose when a caller or implementor must preserve an unstated invariant, ordering, fallback, or safety contract.
+Require prose only for an explicit requirement or a caller/implementor contract needed for correct behavior. Name the contract and resulting misuse; public visibility alone is insufficient.
 
 ## Rule and Assist Documentation
 
-Rustdoc inside `declare_lint_rule!` and `declare_assist_rule!` is end-user documentation. Load `lint-rule-development` rather than `doc-comments`.
+For end-user rustdoc in `declare_lint_rule!` or `declare_assist_rule!`, load `lint-rule-development` and `doc-comments` for contracts, not style or process checks.
 
-Check what automated validation cannot establish:
+Check agreement with the required behavior:
 
-- the first paragraph accurately summarizes behavior;
-- invalid examples precede valid examples and demonstrate the actual rule;
-- each option states its default and shows configuration plus an applied example;
-- `ignore` is not used to bypass a snippet that should be validated;
-- prose explains why the pattern is a problem.
+- descriptions and examples reflect what the rule should report;
+- documented option defaults and configuration examples match the intended behavior;
+- advice and fix descriptions do not promise semantics the implementation violates.
 
-## Feature Documentation
+## User-Facing Documentation and Changesets
 
-Non-rule user-facing features may require a website PR. Verify current policy in `CONTRIBUTING.md` and the live PR template. Do not infer documentation requirements from an old skill copy.
+Check changed documentation and changeset claims against requirements and implementation before reporting contradictions.
 
-## Changesets
-
-Load `changeset` for format and release-level policy. The reviewer additionally checks:
-
-- a user-facing change has a real `.changeset/*.md` entry, including untracked files;
-- the entry describes the behavior in the diff rather than an earlier design;
-- an issue link identifies the issue actually addressed by the test and implementation;
-- the release level agrees with the target branch and the special policy for nursery rules;
-- internal-only or documentation-only changes do not add release noise.
-
-Do not create or edit a changeset during static review.
-
-## Pull Request Process
-
-Use `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` as the current sources of truth.
-
-- The title follows the supported conventional-commit format.
-- The base branch matches the change type.
-- The template remains intact.
-- The contributor, not the reviewing agent, authored the PR description and communication.
-- AI assistance is disclosed to the extent required by `CONTRIBUTING.md`.
-
-Do not generate replacement PR prose as part of a finding. State the missing or contradictory requirement.
+Do not audit changeset presence, release levels, branch targets, or PR metadata; `AGENTS.md` and `CONTRIBUTING.md` govern these outside this review.

--- a/.claude/skills/biome-code-review/references/repository-and-subsystems.md
+++ b/.claude/skills/biome-code-review/references/repository-and-subsystems.md
@@ -2,6 +2,8 @@
 
 Read only the sections matching the diff. Load the corresponding implementation skill for implementation contracts; this reference adds reviewer-specific checks.
 
+Apply checks to changed code and affected integrations; tie findings to contracts, not heuristics. Do not expand scope or run implementation workflows.
+
 ## Repository Map
 
 | Area | Source of truth | Common counterparts |
@@ -77,6 +79,8 @@ Load `type-inference`.
 - A lint-rule change requires generated rule registration and configuration.
 - Do not report bindings or other full analyzer outputs that `AGENTS.md` explicitly leaves to CI Autofix.
 - Search parallel registration, serialization, migration, preset, and documentation sites for new enum variants, options, and manifest fields.
+
+`AGENTS.md` and `testing-codegen` define required artifacts and CI exceptions. Flag missing or stale outputs, not merely an unchanged generated diff.
 
 ## Tests and Snapshots
 

--- a/.claude/skills/biome-code-review/references/rust-safety-and-syntax.md
+++ b/.claude/skills/biome-code-review/references/rust-safety-and-syntax.md
@@ -1,28 +1,28 @@
 # Rust Safety and Syntax Review
 
-Load the relevant sections when production Rust changes introduce partial operations, recursion, text extraction, ranges, allocations, or new APIs.
+Use relevant sections for affected Rust code only; exclude unrelated audits and speculative redesign.
 
 ## Partial Operations
 
-Scan added and modified production lines for:
+Check added or modified production operations, plus existing ones whose safety preconditions or reachability the diff affects:
 
 ```text
 .unwrap()  .expect(...)  indexing  slicing  panic!  unreachable!
 todo!  unimplemented!  assert!  remove  swap  split_at  integer / or %
 ```
 
-Test code may use these freely. In production, accept a partial operation only when release-mode control flow, a type invariant, or a documented API contract proves it cannot fail.
+Apply [production totality](../SKILL.md#production-totality), including caller guarantees. No concrete failing input is required; test-only code is exempt.
 
 | Construct | Review rule |
 | --- | --- |
-| Panic macros and `assert!` | Never acceptable on a production path; `debug_assert!` may document an invariant but does not establish it |
-| `unwrap`, `expect`, index, slice | Require a proof in types, control flow, or API contract |
-| Partial collection/string methods | Identify the receiver and prove every index and UTF-8 boundary |
-| Integer division/remainder | Prove the divisor is nonzero or use checked arithmetic |
+| Panic macros and `assert!` | Establish that the panic path is unreachable or the assertion always holds |
+| `unwrap`, `expect`, index, slice | Establish success, presence, or valid bounds through guards, types, or caller contracts |
+| Partial collection/string methods | Identify the receiver and establish that every index and UTF-8 boundary is valid |
+| Integer division/remainder | Establish a nonzero divisor and absence of arithmetic overflow |
 
-Comments and debug assertions are supporting evidence only. Nearby legacy partial operations are not precedent. Consolidate repeated instances in one function into one finding.
+Comments, debug assertions, and passing tests are supporting evidence, not release-mode guards. Consolidate shared missing guarantees or failures; exclude unrelated legacy code.
 
-Name the total replacement where possible: `get`, `first`, `last`, `split_first`, `Option`/`Result` propagation, a checked lexer accessor, or a bogus CST node.
+Suggest establishing the invariant or using a total operation while preserving error/recovery behavior, not blanket fallible-API conversions.
 
 ## Syntax Text and Ranges
 
@@ -30,14 +30,14 @@ Load `syntax-text-handling` for implementation contracts.
 
 - `SyntaxNode::text_trimmed()` retains trivia between child tokens. Do not compare a multi-token node's text to a semantic literal.
 - Token comparisons and hashes use trimmed token accessors so attached trivia cannot change behavior.
-- `syntax().to_*`, `.to_string()`, `String::from`, and `format!` allocate. Require actual ownership or transformation before accepting them in a hot path.
-- Quoted contents use the language syntax crate's `inner_string_text()` helper rather than manual slicing.
+- Check language-specific quote semantics and string boundaries when slicing; helper choice alone is not a finding.
 - A token-relative range used as a diagnostic must be translated to the file range exactly once, including any quote offset.
-- A `String` or `Box<str>` in analyzer state often forces allocation on every candidate; prefer `TokenText` or token plus relative range where the source token outlives the state.
 
 Treat trivia and range mistakes as correctness issues, not merely performance issues.
 
 ## Allocation and Analyzer Phases
+
+Cite the affected path and violated requirement or avoidable cost. A possible borrowed representation alone does not justify a rewrite.
 
 - `run()` decides whether to signal; `action()` constructs a fix. Data used only by the action should not be built in `run()`.
 - Prefer borrows or `Cow` when the source buffer remains available.
@@ -45,6 +45,8 @@ Treat trivia and range mistakes as correctness issues, not merely performance is
 - Avoid caches, memoization, and hand-rolled fast paths without benchmark evidence and a correct invalidation strategy.
 
 ## API Shape
+
+For affected APIs, distinguish contracts from heuristics. Report violations or concrete impact, not preferred signatures or abstractions; keep remediation local.
 
 - Language-specific behavior belongs in its language crate.
 - Generic CST questions belong in syntax extension traits; consumer-specific policy belongs in the analyzer or formatter using it.
@@ -57,20 +59,15 @@ Treat trivia and range mistakes as correctness issues, not merely performance is
 
 ## Recursion and Worklists
 
-Recursive traversal of user-controlled CST depth, imports, module graphs, semantic references, or types can overflow or loop on cycles. Prefer repository traversal iterators or an explicit worklist with a visited set for cyclic structures.
+Check affected user-controlled traversals for reachable overflow or cycles; recursion alone is not a finding.
 
 For a hand-written worklist, verify:
 
-- each frame's purpose and ordering contract are clear;
+- frame processing follows the required traversal order;
 - every early exit restores externally owned state;
-- LIFO reversal preserves intended source or declaration order;
-- cleanup uses scope or guard types when possible;
-- names such as `Visitor` or `Policy` describe an actual abstraction rather than a one-off loop.
+- LIFO reversal preserves intended source or declaration order.
 
-## Error Handling and Rust Hygiene
+## Error Handling
 
 - Do not discard errors needed by the reporting boundary with `.ok()`, `let _ =`, or an unrelated default.
-- Match the crate's established error and diagnostic type instead of adding a one-use wrapper.
-- Internal `biome_*` dev-dependencies use local paths as required by `AGENTS.md`.
-- Reject leftover `dbg!` outside tests and unjustified lint suppression.
-- Follow surrounding Rust style only when it is consistent and enforced; do not turn preferences into findings.
+- Check required reporting through changed wrappers and fallbacks; abstraction preference alone is not a finding.

--- a/.claude/skills/biome-code-review/references/workspace-access.md
+++ b/.claude/skills/biome-code-review/references/workspace-access.md
@@ -1,6 +1,6 @@
 # Workspace Access Review
 
-Load this reference for changes to workspace methods, service execution, CLI/LSP paths, database storage, Salsa queries, or cancellation.
+Check affected workspace, service, CLI/LSP, database, Salsa, and cancellation contracts only.
 
 ## Two Execution Models
 
@@ -15,9 +15,9 @@ Verify these claims against the current constructors and call sites before citin
 
 ## CLI
 
-After scanning, per-file workers must not publish workspace state while other workers hold snapshots. A new `change_file` or equivalent state-publishing call inside a worker, crawl, or parallel iterator is a high-severity race.
+After scanning, per-file workers must not publish workspace state while others hold snapshots. Trace changed publishing calls' snapshot lifetimes and write ordering to establish reachable races or deadlocks; location alone is insufficient.
 
-Server-backed synchronization, when present, must remain deferred until parallel workers finish and then run sequentially. Do not accept a change that moves synchronization into the crawl or parallelizes the deferred commit without a new architecture that proves safety.
+For changed synchronization, check read/write and write/write overlap against current execution contracts, not scheduling preferences.
 
 ## LSP Cancellation
 
@@ -41,7 +41,7 @@ Search the current workspace implementation for the established example rather t
 
 ## Review Severity
 
-Treat these as high-severity correctness findings:
+These are candidates, not automatic findings. Establish reachability and affected behavior; grade by impact:
 
 - CLI workers publishing state during parallel processing;
 - LSP reads bypassing cancellation handling;


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

> Coding agent used.

There are a few issues I found with the current wording of the skill:
- Parent agents take those findings for granted, which might lead to long sessions. Now the parent must see if they are valid. It might use more tokens, but it would avoid false positives and scope creep.
- Scope creep: the skill doesn't set proper boundaries. In one of my local sessions, the independent found something unrelated to the changes, and the parent went with it.

This PR attempts to address them

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

N/A

<!-- What demonstrates that your implementation is correct? -->

## Docs

N/A

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
