### PR TITLE
perf(formatter): avoid quadratic token coverage validation

### DIFF
--- a/crates/biome_formatter/src/printed_tokens.rs
+++ b/crates/biome_formatter/src/printed_tokens.rs
@@ -79,7 +79,7 @@ impl PrintedTokens {
                 continue;
             }
 
-            if !offsets.shift_remove(&range.start()) {
+            if !offsets.swap_remove(&range.start()) {
                 panic!(
                     "token has not been seen by the formatter: {token:#?}.\
                         \nUse `format_replaced` if you want to replace a token from the formatted output.\
@@ -95,5 +95,74 @@ impl PrintedTokens {
                 "tracked offset {offset:?} doesn't match any token of {root:#?}. Have you passed a token from another tree?"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use biome_js_parser::{JsParserOptions, parse_module};
+
+    #[test]
+    fn assertion_preserves_tracking_order_and_snapshots() {
+        let root = parse_module("first; second; third;", JsParserOptions::default()).syntax();
+        let tokens: Vec<_> = root.descendants_tokens(Direction::Prev).collect();
+        let mut tracked = PrintedTokens::default();
+
+        for token in &tokens[..3] {
+            tracked.track_token(token);
+        }
+        let snapshot = tracked.snapshot();
+        let saved_offsets: Vec<_> = tracked.offsets.iter().copied().collect();
+
+        for token in &tokens[3..] {
+            tracked.track_token(token);
+        }
+        let all_offsets: Vec<_> = tracked.offsets.iter().copied().collect();
+
+        tracked.assert_all_tracked(&root);
+        tracked.assert_all_tracked(&root);
+        assert_eq!(
+            tracked.offsets.iter().copied().collect::<Vec<_>>(),
+            all_offsets
+        );
+
+        tracked.set_disabled(true);
+        tracked.restore(snapshot);
+        assert!(!tracked.is_disabled());
+        assert_eq!(
+            tracked.offsets.iter().copied().collect::<Vec<_>>(),
+            saved_offsets
+        );
+
+        for token in &tokens[3..] {
+            tracked.track_token(token);
+        }
+        tracked.assert_all_tracked(&root);
+    }
+
+    #[test]
+    #[should_panic(expected = "token has not been seen by the formatter")]
+    fn assertion_rejects_missing_token() {
+        let root = parse_module("first; second;", JsParserOptions::default()).syntax();
+        let mut tracked = PrintedTokens::default();
+        for token in root.descendants_tokens(Direction::Next).skip(1) {
+            tracked.track_token(&token);
+        }
+        tracked.assert_all_tracked(&root);
+    }
+
+    #[test]
+    #[should_panic(expected = "doesn't match any token")]
+    fn assertion_rejects_extra_offset() {
+        let root = parse_module("first;", JsParserOptions::default()).syntax();
+        let mut tracked = PrintedTokens::default();
+        for token in root.descendants_tokens(Direction::Next) {
+            tracked.track_token(&token);
+        }
+        tracked
+            .offsets
+            .insert(root.text_trimmed_range().end() + TextSize::from(1));
+        tracked.assert_all_tracked(&root);
     }
 }


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Since this only affects a debug assertion, its not user facing. But, it will affect ecosystem ci since we currently run it with debug assertions enabled.

The effect appears to be quite dramatic: https://ecosystem-ci-dashboard.biomejsdev.workers.dev/compare?base=34109041094&head=34154126181&view=ranges

found and fixed by astra

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
added tests to make sure the assertion still holds

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
