### PR TITLE
perf(analyze): avoid rebuilding tokens when counting lines

### DIFF
--- a/.changeset/yummy-impalas-read.md
+++ b/.changeset/yummy-impalas-read.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Improved the performance of [`noExcessiveLinesPerFile`](https://biomejs.dev/linter/rules/no-excessive-lines-per-file/) when `skipBlankLines` is `false`.

--- a/crates/biome_analyze/src/utils.rs
+++ b/crates/biome_analyze/src/utils.rs
@@ -235,8 +235,9 @@ where
 /// Counts lines in a syntax tree, used by `noExcessiveLinesPerFile`.
 ///
 /// When `skip_blank_lines` is true, counts tokens with leading newlines (excluding blank lines).
-/// When false, counts all newline characters in leading trivia (trailing trivia is trimmed
-/// to prevent double-counting). Returns total + 1 to account for the first line.
+/// When false, counts all newline trivia pieces in leading trivia.
+/// EOF tokens and newlines inside comments or token text are excluded.
+/// Returns total + 1 to account for the first line.
 pub fn count_lines_in_file<L: Language>(
     node: &SyntaxNode<L>,
     is_eof_token: impl Fn(&SyntaxToken<L>) -> bool,
@@ -252,7 +253,6 @@ pub fn count_lines_in_file<L: Language>(
                 count += token.has_leading_newline() as usize;
             } else {
                 count += token
-                    .trim_trailing_trivia()
                     .leading_trivia()
                     .pieces()
                     .filter(|piece| piece.is_newline())
@@ -261,4 +261,69 @@ pub fn count_lines_in_file<L: Language>(
         }
     }
     count + 1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::count_lines_in_file;
+    use biome_rowan::{
+        SyntaxNode, TriviaPiece,
+        raw_language::{RawLanguage, RawLanguageKind, RawSyntaxTreeBuilder},
+    };
+
+    fn assert_line_counts(node: &SyntaxNode<RawLanguage>, all: usize, non_blank: usize) {
+        for (skip_blank_lines, expected) in [(false, all), (true, non_blank)] {
+            assert_eq!(
+                count_lines_in_file(
+                    node,
+                    |token| token.kind() == RawLanguageKind::EOF,
+                    skip_blank_lines,
+                ),
+                expected,
+                "skip_blank_lines={skip_blank_lines}, tree={node:#?}",
+            );
+        }
+    }
+
+    #[test]
+    fn count_lines_in_file_empty_tree() {
+        let root = RawSyntaxTreeBuilder::wrap_with_node(RawLanguageKind::ROOT, |_| {});
+        assert_line_counts(&root, 1, 1);
+    }
+
+    #[test]
+    fn count_lines_in_file_uses_only_non_eof_leading_newline_pieces() {
+        for (newline, len) in [("\n", 1), ("\r\n", 2)] {
+            let root = RawSyntaxTreeBuilder::wrap_with_node(RawLanguageKind::ROOT, |builder| {
+                builder.token(RawLanguageKind::NUMBER_TOKEN, "0");
+                for _ in 0..2 {
+                    builder.start_node(RawLanguageKind::LITERAL_EXPRESSION);
+                    builder.token_with_trivia(
+                        RawLanguageKind::STRING_TOKEN,
+                        &format!("/*{newline}*/{newline}{newline} \"a{newline}b\" /*c*/{newline} "),
+                        &[
+                            TriviaPiece::multi_line_comment(4 + len),
+                            TriviaPiece::newline(len),
+                            TriviaPiece::newline(len),
+                            TriviaPiece::whitespace(1),
+                        ],
+                        &[
+                            TriviaPiece::whitespace(1),
+                            TriviaPiece::multi_line_comment(5),
+                            TriviaPiece::newline(len),
+                            TriviaPiece::whitespace(1),
+                        ],
+                    );
+                    builder.finish_node();
+                }
+                builder.token_with_trivia(
+                    RawLanguageKind::EOF,
+                    newline,
+                    &[TriviaPiece::newline(len)],
+                    &[],
+                );
+            });
+            assert_line_counts(&root, 5, 3);
+        }
+    }
 }

--- a/crates/biome_css_analyze/tests/specs/style/noExcessiveLinesPerFile/invalidSkipBlankLines.css
+++ b/crates/biome_css_analyze/tests/specs/style/noExcessiveLinesPerFile/invalidSkipBlankLines.css
@@ -1,0 +1,6 @@
+/* should generate diagnostics */
+.a { color: red; }
+
+
+.b { color: blue; }
+

--- a/crates/biome_css_analyze/tests/specs/style/noExcessiveLinesPerFile/invalidSkipBlankLines.css.snap
+++ b/crates/biome_css_analyze/tests/specs/style/noExcessiveLinesPerFile/invalidSkipBlankLines.css.snap
@@ -1,0 +1,34 @@
+---
+source: crates/biome_css_analyze/tests/spec_tests.rs
+expression: invalidSkipBlankLines.css
+---
+# Input
+```css
+/* should generate diagnostics */
+.a { color: red; }
+
+
+.b { color: blue; }
+
+
+```
+
+# Diagnostics
+```
+invalidSkipBlankLines.css:2:1 lint/style/noExcessiveLinesPerFile ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This file has too many lines (3). Maximum allowed is 2.
+  
+    1 │ /* should generate diagnostics */
+  > 2 │ .a { color: red; }
+      │ ^^^^^^^^^^^^^^^^^^
+  > 3 │ 
+  > 4 │ 
+  > 5 │ .b { color: blue; }
+      │ ^^^^^^^^^^^^^^^^^^^
+    6 │ 
+  
+  i Consider splitting this file into smaller files.
+  
+
+```

--- a/crates/biome_css_analyze/tests/specs/style/noExcessiveLinesPerFile/invalidSkipBlankLines.options.json
+++ b/crates/biome_css_analyze/tests/specs/style/noExcessiveLinesPerFile/invalidSkipBlankLines.options.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "rules": {
+      "style": {
+        "noExcessiveLinesPerFile": {
+          "level": "error",
+          "options": {
+            "maxLines": 2,
+            "skipBlankLines": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_css_analyze/tests/specs/style/noExcessiveLinesPerFile/newlineTrivia.options.json
+++ b/crates/biome_css_analyze/tests/specs/style/noExcessiveLinesPerFile/newlineTrivia.options.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "rules": {
+      "style": {
+        "noExcessiveLinesPerFile": {
+          "level": "error",
+          "options": {
+            "maxLines": 2
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_css_analyze/tests/specs/style/noExcessiveLinesPerFile/newlineTrivia.scss
+++ b/crates/biome_css_analyze/tests/specs/style/noExcessiveLinesPerFile/newlineTrivia.scss
@@ -1,0 +1,8 @@
+/* should generate diagnostics */
+$color: red; /* theme
+color */
+
+.a { color: $color; }
+
+/* footer */
+

--- a/crates/biome_css_analyze/tests/specs/style/noExcessiveLinesPerFile/newlineTrivia.scss.snap
+++ b/crates/biome_css_analyze/tests/specs/style/noExcessiveLinesPerFile/newlineTrivia.scss.snap
@@ -1,0 +1,37 @@
+---
+source: crates/biome_css_analyze/tests/spec_tests.rs
+expression: newlineTrivia.scss
+---
+# Input
+```css
+/* should generate diagnostics */
+$color: red; /* theme
+color */
+
+.a { color: $color; }
+
+/* footer */
+
+
+```
+
+# Diagnostics
+```
+newlineTrivia.scss:2:1 lint/style/noExcessiveLinesPerFile ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This file has too many lines (4). Maximum allowed is 2.
+  
+    1 │ /* should generate diagnostics */
+  > 2 │ $color: red; /* theme
+      │ ^^^^^^^^^^^^^^^^^^^^^
+  > 3 │ color */
+  > 4 │ 
+  > 5 │ .a { color: $color; }
+      │ ^^^^^^^^^^^^^^^^^^^^^
+    6 │ 
+    7 │ /* footer */
+  
+  i Consider splitting this file into smaller files.
+  
+
+```

--- a/crates/biome_graphql_analyze/tests/specs/style/noExcessiveLinesPerFile/invalidSkipBlankLines.graphql
+++ b/crates/biome_graphql_analyze/tests/specs/style/noExcessiveLinesPerFile/invalidSkipBlankLines.graphql
@@ -1,0 +1,6 @@
+# should generate diagnostics
+query Foo { id }
+
+
+query Bar { id }
+

--- a/crates/biome_graphql_analyze/tests/specs/style/noExcessiveLinesPerFile/invalidSkipBlankLines.graphql.snap
+++ b/crates/biome_graphql_analyze/tests/specs/style/noExcessiveLinesPerFile/invalidSkipBlankLines.graphql.snap
@@ -1,0 +1,34 @@
+---
+source: crates/biome_graphql_analyze/tests/spec_tests.rs
+expression: invalidSkipBlankLines.graphql
+---
+# Input
+```graphql
+# should generate diagnostics
+query Foo { id }
+
+
+query Bar { id }
+
+
+```
+
+# Diagnostics
+```
+invalidSkipBlankLines.graphql:2:1 lint/style/noExcessiveLinesPerFile ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This file has too many lines (3). Maximum allowed is 2.
+  
+    1 │ # should generate diagnostics
+  > 2 │ query Foo { id }
+      │ ^^^^^^^^^^^^^^^^
+  > 3 │ 
+  > 4 │ 
+  > 5 │ query Bar { id }
+      │ ^^^^^^^^^^^^^^^^
+    6 │ 
+  
+  i Consider splitting this file into smaller files.
+  
+
+```

--- a/crates/biome_graphql_analyze/tests/specs/style/noExcessiveLinesPerFile/invalidSkipBlankLines.options.json
+++ b/crates/biome_graphql_analyze/tests/specs/style/noExcessiveLinesPerFile/invalidSkipBlankLines.options.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "rules": {
+      "style": {
+        "noExcessiveLinesPerFile": {
+          "level": "error",
+          "options": {
+            "maxLines": 2,
+            "skipBlankLines": true
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
> AI assistance: Codex 

## Summary

Avoid rebuilding tokens when `noExcessiveLinesPerFile` reads leading newline trivia. 

## Test Plan

- Green CI