### PR TITLE
feat(plugins): add traversal methods for JS

### DIFF
--- a/.github/workflows/pull_request_node.yml
+++ b/.github/workflows/pull_request_node.yml
@@ -57,6 +57,11 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
 
+      - name: Test plugin API declarations
+        run: |
+          pnpm --filter @biomejs/plugin-api i
+          pnpm --filter @biomejs/plugin-api run test:types
+
       - name: Build TypeScript code
         # We use the `*-dev` builds below because release builds take very long.
         # The main difference is that release builds run `wasm-opt`, which is

--- a/crates/biome_grit_patterns/src/grit_target_language/js_target_language/generated_mappings.rs
+++ b/crates/biome_grit_patterns/src/grit_target_language/js_target_language/generated_mappings.rs
@@ -613,7 +613,7 @@ pub fn kind_by_name(node_name: &str) -> Option<JsSyntaxKind> {
 /// Returns the native Biome slot mappings for a node name.
 pub fn native_slots_for_name(node_name: &str) -> &'static [(&'static str, u32)] {
     match node_name {
-        "AstroImplicitFragment" => &[("children", 0)],
+        "AstroImplicitFragment" => &[("elements", 0)],
         "JsArrayAssignmentPattern" => &[("elements", 1)],
         "JsArrayAssignmentPatternElement" => &[("pattern", 0), ("init", 1)],
         "JsArrayAssignmentPatternRestElement" => &[("pattern", 1)],
@@ -827,14 +827,14 @@ pub fn native_slots_for_name(node_name: &str) -> &'static [(&'static str, u32)] 
         "JsxClosingElement" => &[("name", 2)],
         "JsxElement" => &[
             ("opening_element", 0),
-            ("children", 1),
+            ("elements", 1),
             ("closing_element", 2),
         ],
         "JsxExpressionAttributeValue" => &[("expression", 1)],
         "JsxExpressionChild" => &[("expression", 1)],
         "JsxFragment" => &[
             ("opening_fragment", 0),
-            ("children", 1),
+            ("elements", 1),
             ("closing_fragment", 2),
         ],
         "JsxMemberName" => &[("object", 0), ("member", 2)],

--- a/crates/biome_js_analyze/src/lint/a11y/no_ambiguous_anchor_text.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_ambiguous_anchor_text.rs
@@ -172,7 +172,7 @@ fn get_accessible_child_text(node: &JsxElement) -> String {
     };
 
     let raw_child_text = node
-        .children()
+        .elements()
         .into_iter()
         .map(|child| match child {
             AnyJsxChild::JsxText(element) => {

--- a/crates/biome_js_analyze/src/lint/a11y/no_svg_without_title.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_svg_without_title.rs
@@ -142,7 +142,7 @@ impl Rule for NoSvgWithoutTitle {
         // Checks if a `svg` element has a valid `title` element is in a childlist
         let jsx_element = node.parent::<JsxElement>()?;
         if let AnyJsxElement::JsxOpeningElement(_) = node {
-            let has_valid_title = has_valid_title_element(&jsx_element.children());
+            let has_valid_title = has_valid_title_element(&jsx_element.elements());
             if has_valid_title.is_some_and(|bool| bool) {
                 return None;
             }
@@ -155,7 +155,7 @@ impl Rule for NoSvgWithoutTitle {
                 .attributes()
                 .find_by_names(["aria-label", "aria-labelledby"]);
             let is_valid_a11y_attribute = aria_label.is_some()
-                || is_valid_attribute_value(aria_labelledby, &jsx_element.children())
+                || is_valid_attribute_value(aria_labelledby, &jsx_element.elements())
                     .unwrap_or(false);
             if is_valid_a11y_attribute {
                 return None;
@@ -214,6 +214,6 @@ fn has_valid_title_element(jsx_child_list: &JsxChildList) -> Option<bool> {
     if !has_title_name {
         return Some(false);
     }
-    let is_empty_child = jsx_element.children().is_empty();
+    let is_empty_child = jsx_element.elements().is_empty();
     Some(!is_empty_child)
 }

--- a/crates/biome_js_analyze/src/lint/a11y/use_media_caption.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_media_caption.rs
@@ -70,7 +70,7 @@ impl Rule for UseMediaCaption {
             AnyJsxElement::JsxOpeningElement(_) => {
                 let jsx_element = node.parent::<JsxElement>()?;
                 let has_track = jsx_element
-                    .children()
+                    .elements()
                     .into_iter()
                     .filter_map(|child| {
                         let any_jsx = match child {

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
@@ -9,10 +9,10 @@ use biome_diagnostics::Severity;
 use biome_js_factory::make::{jsx_expression_attribute_value, jsx_tag_expression, token};
 use biome_js_semantic::SemanticModel;
 use biome_js_syntax::{
-    AnyJsExpression, AnyJsxAttributeValue, AnyJsxChild, AnyJsxElementName,
-    AnyJsxTag, JsLanguage, JsLogicalExpression, JsParenthesizedExpression, JsSyntaxKind,
-    JsxAttributeInitializerClause, JsxChildList, JsxElement, JsxExpressionAttributeValue,
-    JsxExpressionChild, JsxFragment, JsxOpeningElement, JsxTagExpression, JsxText, T,
+    AnyJsExpression, AnyJsxAttributeValue, AnyJsxChild, AnyJsxElementName, AnyJsxTag, JsLanguage,
+    JsLogicalExpression, JsParenthesizedExpression, JsSyntaxKind, JsxAttributeInitializerClause,
+    JsxChildList, JsxElement, JsxExpressionAttributeValue, JsxExpressionChild, JsxFragment,
+    JsxOpeningElement, JsxTagExpression, JsxText, T,
 };
 use biome_rowan::{AstNode, AstNodeList, BatchMutation, BatchMutationExt, declare_node_union};
 use biome_rule_options::no_useless_fragments::NoUselessFragmentsOptions;
@@ -125,8 +125,8 @@ impl NoUselessFragmentsQuery {
 
     fn children(&self) -> JsxChildList {
         match self {
-            Self::JsxFragment(element) => element.children(),
-            Self::JsxElement(element) => element.children(),
+            Self::JsxFragment(element) => element.elements(),
+            Self::JsxElement(element) => element.elements(),
         }
     }
 }
@@ -206,7 +206,7 @@ impl Rule for NoUselessFragments {
             });
 
         let child_list = match node {
-            NoUselessFragmentsQuery::JsxFragment(fragment) => fragment.children(),
+            NoUselessFragmentsQuery::JsxFragment(fragment) => fragment.elements(),
             NoUselessFragmentsQuery::JsxElement(element) => {
                 let opening_element = element.opening_element().ok()?;
                 let is_valid_react_fragment =
@@ -238,7 +238,7 @@ impl Rule for NoUselessFragments {
                     return None;
                 }
 
-                element.children()
+                element.elements()
             }
         };
 
@@ -441,9 +441,8 @@ impl Rule for NoUselessFragments {
                         // An attribute always needs a value, so `prop={<>{}</>}` can't be
                         // fixed, while `<>{}</>` on its own can simply be removed.
                         None if attribute_value.is_some() => return None,
-                        None => {
-                            mutation.remove_element(AnyJsExpression::JsxTagExpression(parent).into())
-                        }
+                        None => mutation
+                            .remove_element(AnyJsExpression::JsxTagExpression(parent).into()),
                     },
 
                     // Can't apply a code action because it would create invalid syntax.

--- a/crates/biome_js_analyze/src/lint/correctness/no_void_elements_with_children.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_void_elements_with_children.rs
@@ -104,7 +104,7 @@ impl Rule for NoVoidElementsWithChildren {
                 if let Some(element_name) = void_dom_element_name(name) {
                     let dangerous_prop =
                         opening_element.find_attribute_by_name("dangerouslySetInnerHTML");
-                    let has_children = !element.children().is_empty();
+                    let has_children = !element.elements().is_empty();
                     let children_prop = opening_element.find_attribute_by_name("children");
                     if dangerous_prop.is_some() || has_children || children_prop.is_some() {
                         let cause = NoVoidElementsWithChildrenCause::Jsx {

--- a/crates/biome_js_analyze/src/lint/correctness/use_inline_script_id.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_inline_script_id.rs
@@ -134,7 +134,7 @@ impl Rule for UseInlineScriptId {
 
         let has_children = jsx_element
             .parent::<JsxElement>()
-            .is_some_and(|parent| !parent.children().is_empty());
+            .is_some_and(|parent| !parent.elements().is_empty());
         if (has_children || attribute_names.contains("dangerouslySetInnerHTML"))
             && !attribute_names.contains("id")
         {

--- a/crates/biome_js_analyze/src/lint/nursery/use_control_label.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_control_label.rs
@@ -133,7 +133,7 @@ impl Rule for UseControlLabel {
         let has_content = match element {
             AnyJsxElement::JsxOpeningElement(opening) => opening
                 .parent::<JsxElement>()
-                .is_some_and(|parent| has_accessible_content(&parent.children())),
+                .is_some_and(|parent| has_accessible_content(&parent.elements())),
             AnyJsxElement::JsxSelfClosingElement(_) => false,
         };
         if has_content {
@@ -181,13 +181,13 @@ fn has_accessible_content(children: &JsxChildList) -> bool {
                     Some(value) => renders_content(&value),
                 })
         }
-        AnyJsxChild::JsxFragment(fragment) => has_accessible_content(&fragment.children()),
+        AnyJsxChild::JsxFragment(fragment) => has_accessible_content(&fragment.elements()),
         AnyJsxChild::JsxElement(element) => {
             let Ok(opening) = element.opening_element() else {
                 return true;
             };
             names_itself(&AnyJsxElement::from(opening))
-                .unwrap_or_else(|| has_accessible_content(&element.children()))
+                .unwrap_or_else(|| has_accessible_content(&element.elements()))
         }
         AnyJsxChild::JsxSelfClosingElement(element) => {
             names_itself(&AnyJsxElement::from(element)).unwrap_or(false)

--- a/crates/biome_js_analyze/src/lint/security/no_dangerously_set_inner_html_with_children.rs
+++ b/crates/biome_js_analyze/src/lint/security/no_dangerously_set_inner_html_with_children.rs
@@ -133,8 +133,8 @@ impl AnyJsCreateElement {
     fn has_children(&self, model: &SemanticModel) -> Option<JsSyntaxNode> {
         match self {
             Self::JsxElement(element) => {
-                if !element.children().is_empty() {
-                    Some(element.children().syntax().clone())
+                if !element.elements().is_empty() {
+                    Some(element.elements().syntax().clone())
                 } else {
                     None
                 }

--- a/crates/biome_js_analyze/src/lint/style/use_fragment_syntax.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_fragment_syntax.rs
@@ -73,7 +73,7 @@ impl Rule for UseFragmentSyntax {
     fn action(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<JsRuleAction> {
         let node = ctx.query();
         let mut mutation = ctx.root().begin();
-        let list = jsx_child_list(node.children());
+        let list = jsx_child_list(node.elements());
         let opening_element = node.opening_element().ok()?;
         let closing_element = node.closing_element().ok()?;
         let fragment = jsx_fragment(

--- a/crates/biome_js_analyze/src/lint/style/use_self_closing_elements.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_self_closing_elements.rs
@@ -103,7 +103,7 @@ impl Rule for UseSelfClosingElements {
             .opening_element()
             .is_ok_and(|node| node.name().is_ok_and(|name| name.as_jsx_name().is_some()));
 
-        if node.children().is_empty() && !(ctx.options().ignore_html_elements() && is_html_element)
+        if node.elements().is_empty() && !(ctx.options().ignore_html_elements() && is_html_element)
         {
             Some(())
         } else {

--- a/crates/biome_js_analyze/src/lint/suspicious/no_suspicious_semicolon_in_jsx.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_suspicious_semicolon_in_jsx.rs
@@ -62,8 +62,8 @@ impl Rule for NoSuspiciousSemicolonInJsx {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
         if let Some(children) = match node {
-            AnyJsxTag::JsxElement(element) => Some(element.children()),
-            AnyJsxTag::JsxFragment(fragment) => Some(fragment.children()),
+            AnyJsxTag::JsxElement(element) => Some(element.elements()),
+            AnyJsxTag::JsxFragment(fragment) => Some(fragment.elements()),
             _ => None,
         } {
             let has_semicolon = has_suspicious_semicolon(&children);
@@ -105,7 +105,7 @@ fn has_suspicious_semicolon(node: &JsxChildList) -> Option<TextRange> {
         }
 
         c.as_jsx_element()
-            .and_then(|e| has_suspicious_semicolon(&e.children()));
+            .and_then(|e| has_suspicious_semicolon(&e.elements()));
 
         None
     })

--- a/crates/biome_js_analyze/src/utils/batch.rs
+++ b/crates/biome_js_analyze/src/utils/batch.rs
@@ -100,8 +100,8 @@ pub trait JsBatchMutation {
     /// ```
     fn replace_jsx_element_with_own_children(&mut self, element: &AnyJsxChild) -> bool {
         let children = match element {
-            AnyJsxChild::JsxElement(element) => element.children(),
-            AnyJsxChild::JsxFragment(fragment) => fragment.children(),
+            AnyJsxChild::JsxElement(element) => element.elements(),
+            AnyJsxChild::JsxFragment(fragment) => fragment.elements(),
             _ => return false,
         };
         self.add_jsx_elements_replacing_element(element, children)

--- a/crates/biome_js_factory/src/generated/node_factory.rs
+++ b/crates/biome_js_factory/src/generated/node_factory.rs
@@ -5,10 +5,10 @@ use biome_js_syntax::{
     JsSyntaxElement as SyntaxElement, JsSyntaxNode as SyntaxNode, JsSyntaxToken as SyntaxToken, *,
 };
 use biome_rowan::AstNode;
-pub fn astro_implicit_fragment(children: JsxChildList) -> AstroImplicitFragment {
+pub fn astro_implicit_fragment(elements: JsxChildList) -> AstroImplicitFragment {
     AstroImplicitFragment::unwrap_cast(SyntaxNode::new_detached(
         JsSyntaxKind::ASTRO_IMPLICIT_FRAGMENT,
-        [Some(SyntaxElement::Node(children.into_syntax()))],
+        [Some(SyntaxElement::Node(elements.into_syntax()))],
     ))
 }
 pub fn js_accessor_modifier(modifier_token: SyntaxToken) -> JsAccessorModifier {
@@ -3923,14 +3923,14 @@ pub fn jsx_closing_fragment(
 }
 pub fn jsx_element(
     opening_element: JsxOpeningElement,
-    children: JsxChildList,
+    elements: JsxChildList,
     closing_element: JsxClosingElement,
 ) -> JsxElement {
     JsxElement::unwrap_cast(SyntaxNode::new_detached(
         JsSyntaxKind::JSX_ELEMENT,
         [
             Some(SyntaxElement::Node(opening_element.into_syntax())),
-            Some(SyntaxElement::Node(children.into_syntax())),
+            Some(SyntaxElement::Node(elements.into_syntax())),
             Some(SyntaxElement::Node(closing_element.into_syntax())),
         ],
     ))
@@ -3983,14 +3983,14 @@ impl JsxExpressionChildBuilder {
 }
 pub fn jsx_fragment(
     opening_fragment: JsxOpeningFragment,
-    children: JsxChildList,
+    elements: JsxChildList,
     closing_fragment: JsxClosingFragment,
 ) -> JsxFragment {
     JsxFragment::unwrap_cast(SyntaxNode::new_detached(
         JsSyntaxKind::JSX_FRAGMENT,
         [
             Some(SyntaxElement::Node(opening_fragment.into_syntax())),
-            Some(SyntaxElement::Node(children.into_syntax())),
+            Some(SyntaxElement::Node(elements.into_syntax())),
             Some(SyntaxElement::Node(closing_fragment.into_syntax())),
         ],
     ))

--- a/crates/biome_js_formatter/src/astro/auxiliary/implicit_fragment.rs
+++ b/crates/biome_js_formatter/src/astro/auxiliary/implicit_fragment.rs
@@ -5,8 +5,8 @@ use biome_js_syntax::{AstroImplicitFragment, AstroImplicitFragmentFields};
 pub(crate) struct FormatAstroImplicitFragment;
 impl FormatNodeRule<AstroImplicitFragment> for FormatAstroImplicitFragment {
     fn fmt_fields(&self, node: &AstroImplicitFragment, f: &mut JsFormatter) -> FormatResult<()> {
-        let AstroImplicitFragmentFields { children } = node.as_fields();
+        let AstroImplicitFragmentFields { elements } = node.as_fields();
 
-        write!(f, [children.format()])
+        write!(f, [elements.format()])
     }
 }

--- a/crates/biome_js_formatter/src/jsx/tag/element.rs
+++ b/crates/biome_js_formatter/src/jsx/tag/element.rs
@@ -109,8 +109,8 @@ impl AnyJsxTagWithChildren {
 
     fn children(&self) -> JsxChildList {
         match self {
-            Self::JsxElement(element) => element.children(),
-            Self::JsxFragment(fragment) => fragment.children(),
+            Self::JsxElement(element) => element.elements(),
+            Self::JsxFragment(fragment) => fragment.elements(),
         }
     }
 

--- a/crates/biome_js_parser/tests/js_test_suite/error/astro_bare_closing_brace_text.astro_expr.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/astro_bare_closing_brace_text.astro_expr.tsx.snap
@@ -33,7 +33,7 @@ JsExpressionTemplateRoot {
                     attributes: JsxAttributeList [],
                     r_angle_token: R_ANGLE@9..10 ">" [] [],
                 },
-                children: JsxChildList [
+                elements: JsxChildList [
                     JsxText {
                         value_token: JSX_TEXT_LITERAL@10..15 "a } b" [] [],
                     },

--- a/crates/biome_js_parser/tests/js_test_suite/error/astro_legacy_void_element.astro_expr.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/astro_legacy_void_element.astro_expr.tsx.snap
@@ -32,7 +32,7 @@ JsExpressionTemplateRoot {
                     attributes: JsxAttributeList [],
                     r_angle_token: R_ANGLE@15..16 ">" [] [],
                 },
-                children: JsxChildList [],
+                elements: JsxChildList [],
                 closing_element: JsxClosingElement {
                     l_angle_token: missing (required),
                     slash_token: missing (required),

--- a/crates/biome_js_parser/tests/js_test_suite/error/astro_non_void_unclosed.astro_expr.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/astro_non_void_unclosed.astro_expr.tsx.snap
@@ -25,7 +25,7 @@ JsExpressionTemplateRoot {
                 attributes: JsxAttributeList [],
                 r_angle_token: R_ANGLE@5..6 ">" [] [],
             },
-            children: JsxChildList [],
+            elements: JsxChildList [],
             closing_element: JsxClosingElement {
                 l_angle_token: missing (required),
                 slash_token: missing (required),

--- a/crates/biome_js_parser/tests/js_test_suite/error/jsx_child_expression_missing_r_curly.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/jsx_child_expression_missing_r_curly.jsx.snap
@@ -31,7 +31,7 @@ JsModule {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@5..6 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxExpressionChild {
                             l_curly_token: L_CURLY@6..8 "{" [] [Whitespace(" ")],
                             expression: JsBinaryExpression {

--- a/crates/biome_js_parser/tests/js_test_suite/error/jsx_children_expression_missing_r_curly.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/jsx_children_expression_missing_r_curly.jsx.snap
@@ -34,7 +34,7 @@ JsModule {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@5..6 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxText {
                             value_token: JSX_TEXT_LITERAL@6..9 "\n  " [] [],
                         },

--- a/crates/biome_js_parser/tests/js_test_suite/error/jsx_children_expressions_not_accepted.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/jsx_children_expressions_not_accepted.jsx.snap
@@ -36,7 +36,7 @@ JsModule {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@4..5 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxText {
                             value_token: JSX_TEXT_LITERAL@5..8 "\n  " [] [],
                         },

--- a/crates/biome_js_parser/tests/js_test_suite/error/jsx_closing_element_mismatch.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/jsx_closing_element_mismatch.jsx.snap
@@ -34,7 +34,7 @@ JsModule {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@5..6 ">" [] [],
                     },
-                    children: JsxChildList [],
+                    elements: JsxChildList [],
                     closing_element: JsxClosingElement {
                         l_angle_token: L_ANGLE@6..7 "<" [] [],
                         slash_token: SLASH@7..8 "/" [] [],
@@ -57,7 +57,7 @@ JsModule {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@16..17 ">" [] [],
                     },
-                    children: JsxChildList [],
+                    elements: JsxChildList [],
                     closing_element: JsxClosingElement {
                         l_angle_token: L_ANGLE@17..18 "<" [] [],
                         slash_token: SLASH@18..19 "/" [] [],
@@ -82,7 +82,7 @@ JsModule {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@31..32 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxElement {
                             opening_element: JsxOpeningElement {
                                 l_angle_token: L_ANGLE@32..33 "<" [] [],
@@ -93,7 +93,7 @@ JsModule {
                                 attributes: JsxAttributeList [],
                                 r_angle_token: R_ANGLE@39..40 ">" [] [],
                             },
-                            children: JsxChildList [],
+                            elements: JsxChildList [],
                             closing_element: JsxClosingElement {
                                 l_angle_token: L_ANGLE@40..41 "<" [] [],
                                 slash_token: SLASH@41..42 "/" [] [],

--- a/crates/biome_js_parser/tests/js_test_suite/error/jsx_closing_missing_r_angle.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/jsx_closing_missing_r_angle.jsx.snap
@@ -26,7 +26,7 @@ JsModule {
                         l_angle_token: L_ANGLE@0..1 "<" [] [],
                         r_angle_token: R_ANGLE@1..2 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxElement {
                             opening_element: JsxOpeningElement {
                                 l_angle_token: L_ANGLE@2..3 "<" [] [],
@@ -37,7 +37,7 @@ JsModule {
                                 attributes: JsxAttributeList [],
                                 r_angle_token: R_ANGLE@7..8 ">" [] [],
                             },
-                            children: JsxChildList [
+                            elements: JsxChildList [
                                 JsxText {
                                     value_token: JSX_TEXT_LITERAL@8..12 "abcd" [] [],
                                 },

--- a/crates/biome_js_parser/tests/js_test_suite/error/jsx_comment_only_attribute_value.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/jsx_comment_only_attribute_value.jsx.snap
@@ -45,7 +45,7 @@ JsModule {
                         ],
                         r_angle_token: R_ANGLE@37..38 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxText {
                             value_token: JSX_TEXT_LITERAL@38..39 "x" [] [],
                         },

--- a/crates/biome_js_parser/tests/js_test_suite/error/jsx_element_attribute_missing_value.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/jsx_element_attribute_missing_value.jsx.snap
@@ -62,7 +62,7 @@ JsModule {
                                     ],
                                     r_angle_token: R_ANGLE@47..48 ">" [] [],
                                 },
-                                children: JsxChildList [],
+                                elements: JsxChildList [],
                                 closing_element: JsxClosingElement {
                                     l_angle_token: L_ANGLE@48..49 "<" [] [],
                                     slash_token: SLASH@49..50 "/" [] [],

--- a/crates/biome_js_parser/tests/js_test_suite/error/jsx_fragment_closing_missing_r_angle.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/jsx_fragment_closing_missing_r_angle.jsx.snap
@@ -31,13 +31,13 @@ JsModule {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@4..5 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxFragment {
                             opening_fragment: JsxOpeningFragment {
                                 l_angle_token: L_ANGLE@5..6 "<" [] [],
                                 r_angle_token: R_ANGLE@6..7 ">" [] [],
                             },
-                            children: JsxChildList [
+                            elements: JsxChildList [
                                 JsxText {
                                     value_token: JSX_TEXT_LITERAL@7..11 "test" [] [],
                                 },

--- a/crates/biome_js_parser/tests/js_test_suite/error/jsx_invalid_text.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/jsx_invalid_text.jsx.snap
@@ -32,7 +32,7 @@ JsModule {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@2..3 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxText {
                             value_token: JSX_TEXT_LITERAL@3..10 " test >" [] [],
                         },
@@ -61,7 +61,7 @@ JsModule {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@18..19 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxText {
                             value_token: JSX_TEXT_LITERAL@19..29 " invalid }" [] [],
                         },

--- a/crates/biome_js_parser/tests/js_test_suite/error/jsx_missing_closing_fragment.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/jsx_missing_closing_fragment.jsx.snap
@@ -59,7 +59,7 @@ JsModule {
                         l_angle_token: L_ANGLE@14..16 "<" [Newline("\n")] [],
                         r_angle_token: R_ANGLE@16..17 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxText {
                             value_token: JSX_TEXT_LITERAL@17..21 "test" [] [],
                         },
@@ -73,7 +73,7 @@ JsModule {
                                 attributes: JsxAttributeList [],
                                 r_angle_token: R_ANGLE@27..28 ">" [] [],
                             },
-                            children: JsxChildList [
+                            elements: JsxChildList [
                                 JsxText {
                                     value_token: JSX_TEXT_LITERAL@28..38 " some text" [] [],
                                 },
@@ -100,7 +100,7 @@ JsModule {
                                 attributes: JsxAttributeList [],
                                 r_angle_token: R_ANGLE@50..51 ">" [] [],
                             },
-                            children: JsxChildList [
+                            elements: JsxChildList [
                                 JsxText {
                                     value_token: JSX_TEXT_LITERAL@51..52 "a" [] [],
                                 },

--- a/crates/biome_js_parser/tests/js_test_suite/error/jsx_namespace_member_element_name.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/jsx_namespace_member_element_name.jsx.snap
@@ -38,7 +38,7 @@ JsModule {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@12..13 ">" [] [],
                     },
-                    children: JsxChildList [],
+                    elements: JsxChildList [],
                     closing_element: JsxClosingElement {
                         l_angle_token: L_ANGLE@13..14 "<" [] [],
                         slash_token: SLASH@14..15 "/" [] [],

--- a/crates/biome_js_parser/tests/js_test_suite/error/jsx_opening_element_missing_r_angle.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/jsx_opening_element_missing_r_angle.jsx.snap
@@ -26,7 +26,7 @@ JsModule {
                         l_angle_token: L_ANGLE@0..1 "<" [] [],
                         r_angle_token: R_ANGLE@1..2 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxElement {
                             opening_element: JsxOpeningElement {
                                 l_angle_token: L_ANGLE@2..3 "<" [] [],
@@ -37,7 +37,7 @@ JsModule {
                                 attributes: JsxAttributeList [],
                                 r_angle_token: missing (required),
                             },
-                            children: JsxChildList [
+                            elements: JsxChildList [
                                 JsxElement {
                                     opening_element: JsxOpeningElement {
                                         l_angle_token: L_ANGLE@8..9 "<" [] [],
@@ -48,7 +48,7 @@ JsModule {
                                         attributes: JsxAttributeList [],
                                         r_angle_token: R_ANGLE@14..15 ">" [] [],
                                     },
-                                    children: JsxChildList [
+                                    elements: JsxChildList [
                                         JsxText {
                                             value_token: JSX_TEXT_LITERAL@15..28 " some content" [] [],
                                         },

--- a/crates/biome_js_parser/tests/js_test_suite/error/jsx_self_closing_element_missing_r_angle.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/jsx_self_closing_element_missing_r_angle.jsx.snap
@@ -26,7 +26,7 @@ JsModule {
                         l_angle_token: L_ANGLE@0..1 "<" [] [],
                         r_angle_token: R_ANGLE@1..2 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxSelfClosingElement {
                             l_angle_token: L_ANGLE@2..3 "<" [] [],
                             name: JsxName {

--- a/crates/biome_js_parser/tests/js_test_suite/error/jsx_spread_no_expression.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/jsx_spread_no_expression.jsx.snap
@@ -31,7 +31,7 @@ JsModule {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@5..6 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxSpreadChild {
                             l_curly_token: L_CURLY@6..7 "{" [] [],
                             dotdotdot_token: DOT3@7..10 "..." [] [],

--- a/crates/biome_js_parser/tests/js_test_suite/error/jsx_void_element_without_slash.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/jsx_void_element_without_slash.tsx.snap
@@ -49,7 +49,7 @@ JsModule {
                                             attributes: JsxAttributeList [],
                                             r_angle_token: R_ANGLE@21..22 ">" [] [],
                                         },
-                                        children: JsxChildList [
+                                        elements: JsxChildList [
                                             JsxText {
                                                 value_token: JSX_TEXT_LITERAL@22..24 ";\n" [] [],
                                             },

--- a/crates/biome_js_parser/tests/js_test_suite/error/unary_delete_rewrite_skipped_trivia.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/unary_delete_rewrite_skipped_trivia.jsx.snap
@@ -51,7 +51,7 @@ JsModule {
                             ],
                             r_angle_token: missing (required),
                         },
-                        children: JsxChildList [],
+                        elements: JsxChildList [],
                         closing_element: JsxClosingElement {
                             l_angle_token: missing (required),
                             slash_token: missing (required),

--- a/crates/biome_js_parser/tests/js_test_suite/ok/astro_attribute_name_is_raw.astro_expr.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/astro_attribute_name_is_raw.astro_expr.tsx.snap
@@ -51,7 +51,7 @@ JsExpressionTemplateRoot {
                     ],
                     r_angle_token: R_ANGLE@22..23 ">" [] [],
                 },
-                children: JsxChildList [
+                elements: JsxChildList [
                     JsxText {
                         value_token: JSX_TEXT_LITERAL@23..30 "content" [] [],
                     },

--- a/crates/biome_js_parser/tests/js_test_suite/ok/astro_attribute_names.astro_expr.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/astro_attribute_names.astro_expr.tsx.snap
@@ -86,7 +86,7 @@ JsExpressionTemplateRoot {
                     ],
                     r_angle_token: R_ANGLE@77..78 ">" [] [],
                 },
-                children: JsxChildList [
+                elements: JsxChildList [
                     JsxText {
                         value_token: JSX_TEXT_LITERAL@78..80 "go" [] [],
                     },

--- a/crates/biome_js_parser/tests/js_test_suite/ok/astro_bare_gt_text.astro_expr.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/astro_bare_gt_text.astro_expr.tsx.snap
@@ -32,7 +32,7 @@ JsExpressionTemplateRoot {
                     attributes: JsxAttributeList [],
                     r_angle_token: R_ANGLE@9..10 ">" [] [],
                 },
-                children: JsxChildList [
+                elements: JsxChildList [
                     JsxText {
                         value_token: JSX_TEXT_LITERAL@10..15 "a > b" [] [],
                     },

--- a/crates/biome_js_parser/tests/js_test_suite/ok/astro_comment_before_expression.astro_expr.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/astro_comment_before_expression.astro_expr.tsx.snap
@@ -25,7 +25,7 @@ JsExpressionTemplateRoot {
                 attributes: JsxAttributeList [],
                 r_angle_token: R_ANGLE@16..17 ">" [] [],
             },
-            children: JsxChildList [],
+            elements: JsxChildList [],
             closing_element: JsxClosingElement {
                 l_angle_token: L_ANGLE@17..18 "<" [] [],
                 slash_token: SLASH@18..19 "/" [] [],

--- a/crates/biome_js_parser/tests/js_test_suite/ok/astro_html_comment.astro_expr.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/astro_html_comment.astro_expr.tsx.snap
@@ -33,7 +33,7 @@ JsExpressionTemplateRoot {
                     attributes: JsxAttributeList [],
                     r_angle_token: R_ANGLE@9..10 ">" [] [],
                 },
-                children: JsxChildList [
+                elements: JsxChildList [
                     JsxText {
                         value_token: JSX_TEXT_LITERAL@10..21 "a" [] [Comments("<!-- c -->")],
                     },

--- a/crates/biome_js_parser/tests/js_test_suite/ok/astro_html_comment_after_expression_child.astro_expr.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/astro_html_comment_after_expression_child.astro_expr.tsx.snap
@@ -26,7 +26,7 @@ JsExpressionTemplateRoot {
                 attributes: JsxAttributeList [],
                 r_angle_token: R_ANGLE@4..5 ">" [] [],
             },
-            children: JsxChildList [
+            elements: JsxChildList [
                 JsxExpressionChild {
                     l_curly_token: L_CURLY@5..14 "{" [] [Comments("/* js */")],
                     expression: missing (optional),

--- a/crates/biome_js_parser/tests/js_test_suite/ok/astro_html_comment_between_siblings.astro_expr.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/astro_html_comment_between_siblings.astro_expr.tsx.snap
@@ -24,7 +24,7 @@ JsExpressionTemplateRoot {
         operator_token: AMP2@5..8 "&&" [] [Whitespace(" ")],
         right: JsxTagExpression {
             tag: AstroImplicitFragment {
-                children: JsxChildList [
+                elements: JsxChildList [
                     JsxElement {
                         opening_element: JsxOpeningElement {
                             l_angle_token: L_ANGLE@8..9 "<" [] [],
@@ -35,7 +35,7 @@ JsExpressionTemplateRoot {
                             attributes: JsxAttributeList [],
                             r_angle_token: R_ANGLE@10..11 ">" [] [],
                         },
-                        children: JsxChildList [],
+                        elements: JsxChildList [],
                         closing_element: JsxClosingElement {
                             l_angle_token: L_ANGLE@11..12 "<" [] [],
                             slash_token: SLASH@12..13 "/" [] [],
@@ -55,7 +55,7 @@ JsExpressionTemplateRoot {
                             attributes: JsxAttributeList [],
                             r_angle_token: R_ANGLE@27..28 ">" [] [],
                         },
-                        children: JsxChildList [],
+                        elements: JsxChildList [],
                         closing_element: JsxClosingElement {
                             l_angle_token: L_ANGLE@28..29 "<" [] [],
                             slash_token: SLASH@29..30 "/" [] [],

--- a/crates/biome_js_parser/tests/js_test_suite/ok/astro_html_comment_first_last.astro_expr.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/astro_html_comment_first_last.astro_expr.tsx.snap
@@ -33,7 +33,7 @@ JsExpressionTemplateRoot {
                     attributes: JsxAttributeList [],
                     r_angle_token: R_ANGLE@9..24 ">" [] [Comments("<!-- first -->")],
                 },
-                children: JsxChildList [
+                elements: JsxChildList [
                     JsxText {
                         value_token: JSX_TEXT_LITERAL@24..41 "text" [] [Comments("<!-- last -->")],
                     },

--- a/crates/biome_js_parser/tests/js_test_suite/ok/astro_html_comment_multiline.astro_expr.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/astro_html_comment_multiline.astro_expr.tsx.snap
@@ -34,7 +34,7 @@ JsExpressionTemplateRoot {
                     attributes: JsxAttributeList [],
                     r_angle_token: R_ANGLE@9..43 ">" [] [Comments("<!-- line one\nline tw ..."), Comments("<!---->")],
                 },
-                children: JsxChildList [],
+                elements: JsxChildList [],
                 closing_element: JsxClosingElement {
                     l_angle_token: L_ANGLE@43..44 "<" [] [],
                     slash_token: SLASH@44..45 "/" [] [],

--- a/crates/biome_js_parser/tests/js_test_suite/ok/astro_implicit_fragment.astro_expr.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/astro_implicit_fragment.astro_expr.tsx.snap
@@ -17,7 +17,7 @@ expression: snapshot
 JsExpressionTemplateRoot {
     expression: JsxTagExpression {
         tag: AstroImplicitFragment {
-            children: JsxChildList [
+            elements: JsxChildList [
                 JsxElement {
                     opening_element: JsxOpeningElement {
                         l_angle_token: L_ANGLE@0..1 "<" [] [],
@@ -28,7 +28,7 @@ JsExpressionTemplateRoot {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@2..3 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxText {
                             value_token: JSX_TEXT_LITERAL@3..4 "a" [] [],
                         },

--- a/crates/biome_js_parser/tests/js_test_suite/ok/astro_implicit_fragment_comments.astro_expr.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/astro_implicit_fragment_comments.astro_expr.tsx.snap
@@ -16,7 +16,7 @@ expression: snapshot
 JsExpressionTemplateRoot {
     expression: JsxTagExpression {
         tag: AstroImplicitFragment {
-            children: JsxChildList [
+            elements: JsxChildList [
                 JsxElement {
                     opening_element: JsxOpeningElement {
                         l_angle_token: L_ANGLE@0..1 "<" [] [],
@@ -27,7 +27,7 @@ JsExpressionTemplateRoot {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@2..3 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxText {
                             value_token: JSX_TEXT_LITERAL@3..4 "a" [] [],
                         },

--- a/crates/biome_js_parser/tests/js_test_suite/ok/astro_is_raw_children.astro_expr.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/astro_is_raw_children.astro_expr.tsx.snap
@@ -39,7 +39,7 @@ JsExpressionTemplateRoot {
                     ],
                     r_angle_token: R_ANGLE@16..17 ">" [] [],
                 },
-                children: JsxChildList [
+                elements: JsxChildList [
                     JsxText {
                         value_token: JSX_TEXT_LITERAL@17..34 "{not js} < & text" [] [],
                     },

--- a/crates/biome_js_parser/tests/js_test_suite/ok/astro_is_raw_component_case_sensitive.astro_expr.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/astro_is_raw_component_case_sensitive.astro_expr.tsx.snap
@@ -40,7 +40,7 @@ JsExpressionTemplateRoot {
                     ],
                     r_angle_token: R_ANGLE@17..18 ">" [] [],
                 },
-                children: JsxChildList [
+                elements: JsxChildList [
                     JsxText {
                         value_token: JSX_TEXT_LITERAL@18..25 "</card>" [] [],
                     },

--- a/crates/biome_js_parser/tests/js_test_suite/ok/astro_is_raw_end_tag_name_boundary.astro_expr.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/astro_is_raw_end_tag_name_boundary.astro_expr.tsx.snap
@@ -40,7 +40,7 @@ JsExpressionTemplateRoot {
                     ],
                     r_angle_token: R_ANGLE@16..17 ">" [] [],
                 },
-                children: JsxChildList [
+                elements: JsxChildList [
                     JsxText {
                         value_token: JSX_TEXT_LITERAL@17..24 "</divx>" [] [],
                     },

--- a/crates/biome_js_parser/tests/js_test_suite/ok/astro_is_raw_first_matching_end_tag.astro_expr.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/astro_is_raw_first_matching_end_tag.astro_expr.tsx.snap
@@ -40,7 +40,7 @@ JsExpressionTemplateRoot {
                     ],
                     r_angle_token: R_ANGLE@16..17 ">" [] [],
                 },
-                children: JsxChildList [
+                elements: JsxChildList [
                     JsxText {
                         value_token: JSX_TEXT_LITERAL@17..23 "<span>" [] [],
                     },

--- a/crates/biome_js_parser/tests/js_test_suite/ok/astro_quote_leading_attribute_double_quote.astro_expr.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/astro_quote_leading_attribute_double_quote.astro_expr.tsx.snap
@@ -45,7 +45,7 @@ JsExpressionTemplateRoot {
                     ],
                     r_angle_token: R_ANGLE@14..15 ">" [] [],
                 },
-                children: JsxChildList [
+                elements: JsxChildList [
                     JsxText {
                         value_token: JSX_TEXT_LITERAL@15..19 "text" [] [],
                     },

--- a/crates/biome_js_parser/tests/js_test_suite/ok/astro_quote_leading_attribute_name.astro_expr.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/astro_quote_leading_attribute_name.astro_expr.tsx.snap
@@ -45,7 +45,7 @@ JsExpressionTemplateRoot {
                     ],
                     r_angle_token: R_ANGLE@14..15 ">" [] [],
                 },
-                children: JsxChildList [
+                elements: JsxChildList [
                     JsxText {
                         value_token: JSX_TEXT_LITERAL@15..19 "text" [] [],
                     },

--- a/crates/biome_js_parser/tests/js_test_suite/ok/astro_raw_text_end_tag.astro_expr.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/astro_raw_text_end_tag.astro_expr.tsx.snap
@@ -32,7 +32,7 @@ JsExpressionTemplateRoot {
                     attributes: JsxAttributeList [],
                     r_angle_token: R_ANGLE@12..13 ">" [] [],
                 },
-                children: JsxChildList [
+                elements: JsxChildList [
                     JsxText {
                         value_token: JSX_TEXT_LITERAL@13..25 "a</scriptx>b" [] [],
                     },

--- a/crates/biome_js_parser/tests/js_test_suite/ok/astro_raw_text_end_tag_whitespace.astro_expr.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/astro_raw_text_end_tag_whitespace.astro_expr.tsx.snap
@@ -33,7 +33,7 @@ JsExpressionTemplateRoot {
                     attributes: JsxAttributeList [],
                     r_angle_token: R_ANGLE@12..13 ">" [] [],
                 },
-                children: JsxChildList [
+                elements: JsxChildList [
                     JsxText {
                         value_token: JSX_TEXT_LITERAL@13..14 "a" [] [],
                     },

--- a/crates/biome_js_parser/tests/js_test_suite/ok/astro_script_raw_text.astro_expr.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/astro_script_raw_text.astro_expr.tsx.snap
@@ -36,7 +36,7 @@ JsExpressionTemplateRoot {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@17..18 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxText {
                             value_token: JSX_TEXT_LITERAL@18..33 "let x = {a: 1};" [] [],
                         },

--- a/crates/biome_js_parser/tests/js_test_suite/ok/astro_style_raw_text.astro_expr.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/astro_style_raw_text.astro_expr.tsx.snap
@@ -36,7 +36,7 @@ JsExpressionTemplateRoot {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@16..17 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxText {
                             value_token: JSX_TEXT_LITERAL@17..33 "a { color: red }" [] [],
                         },

--- a/crates/biome_js_parser/tests/js_test_suite/ok/astro_unquoted_attribute_slash_open_tag.astro_expr.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/astro_unquoted_attribute_slash_open_tag.astro_expr.tsx.snap
@@ -45,7 +45,7 @@ JsExpressionTemplateRoot {
                     ],
                     r_angle_token: R_ANGLE@14..15 ">" [] [],
                 },
-                children: JsxChildList [],
+                elements: JsxChildList [],
                 closing_element: JsxClosingElement {
                     l_angle_token: L_ANGLE@15..16 "<" [] [],
                     slash_token: SLASH@16..17 "/" [] [],

--- a/crates/biome_js_parser/tests/js_test_suite/ok/astro_unquoted_attribute_values.astro_expr.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/astro_unquoted_attribute_values.astro_expr.tsx.snap
@@ -78,7 +78,7 @@ JsExpressionTemplateRoot {
                     ],
                     r_angle_token: R_ANGLE@57..58 ">" [] [],
                 },
-                children: JsxChildList [
+                elements: JsxChildList [
                     JsxText {
                         value_token: JSX_TEXT_LITERAL@58..60 "go" [] [],
                     },

--- a/crates/biome_js_parser/tests/js_test_suite/ok/astro_void_element_siblings.astro_expr.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/astro_void_element_siblings.astro_expr.tsx.snap
@@ -25,7 +25,7 @@ JsExpressionTemplateRoot {
                 attributes: JsxAttributeList [],
                 r_angle_token: R_ANGLE@4..5 ">" [] [],
             },
-            children: JsxChildList [
+            elements: JsxChildList [
                 JsxSelfClosingElement {
                     l_angle_token: L_ANGLE@5..6 "<" [] [],
                     name: JsxName {

--- a/crates/biome_js_parser/tests/js_test_suite/ok/jsx_any_name.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/jsx_any_name.jsx.snap
@@ -35,7 +35,7 @@ JsModule {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@10..11 ">" [] [],
                     },
-                    children: JsxChildList [],
+                    elements: JsxChildList [],
                     closing_element: JsxClosingElement {
                         l_angle_token: L_ANGLE@11..12 "<" [] [],
                         slash_token: SLASH@12..13 "/" [] [],
@@ -96,7 +96,7 @@ JsModule {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@63..64 ">" [] [],
                     },
-                    children: JsxChildList [],
+                    elements: JsxChildList [],
                     closing_element: JsxClosingElement {
                         l_angle_token: L_ANGLE@64..65 "<" [] [],
                         slash_token: SLASH@65..66 "/" [] [],

--- a/crates/biome_js_parser/tests/js_test_suite/ok/jsx_arrow_exrp_in_alternate.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/jsx_arrow_exrp_in_alternate.jsx.snap
@@ -50,7 +50,7 @@ JsModule {
                                 attributes: JsxAttributeList [],
                                 r_angle_token: R_ANGLE@17..18 ">" [] [],
                             },
-                            children: JsxChildList [
+                            elements: JsxChildList [
                                 JsxExpressionChild {
                                     l_curly_token: L_CURLY@18..19 "{" [] [],
                                     expression: JsArrowFunctionExpression {

--- a/crates/biome_js_parser/tests/js_test_suite/ok/jsx_children_expression.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/jsx_children_expression.jsx.snap
@@ -185,7 +185,7 @@ JsModule {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@52..53 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxText {
                             value_token: JSX_TEXT_LITERAL@53..56 "\n  " [] [],
                         },
@@ -915,7 +915,7 @@ JsModule {
                                     attributes: JsxAttributeList [],
                                     r_angle_token: R_ANGLE@583..584 ">" [] [],
                                 },
-                                children: JsxChildList [
+                                elements: JsxChildList [
                                     JsxText {
                                         value_token: JSX_TEXT_LITERAL@584..593 "\n        " [] [],
                                     },

--- a/crates/biome_js_parser/tests/js_test_suite/ok/jsx_children_expression_then_text.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/jsx_children_expression_then_text.jsx.snap
@@ -35,7 +35,7 @@ JsModule {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@5..6 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxText {
                             value_token: JSX_TEXT_LITERAL@6..11 "\n    " [] [],
                         },

--- a/crates/biome_js_parser/tests/js_test_suite/ok/jsx_children_spread.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/jsx_children_spread.jsx.snap
@@ -32,7 +32,7 @@ JsModule {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@4..5 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxSpreadChild {
                             l_curly_token: L_CURLY@5..6 "{" [] [],
                             dotdotdot_token: DOT3@6..9 "..." [] [],
@@ -68,7 +68,7 @@ JsModule {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@23..24 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxSpreadChild {
                             l_curly_token: L_CURLY@24..25 "{" [] [],
                             dotdotdot_token: DOT3@25..28 "..." [] [],

--- a/crates/biome_js_parser/tests/js_test_suite/ok/jsx_closing_token_trivia.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/jsx_closing_token_trivia.jsx.snap
@@ -48,7 +48,7 @@ JsModule {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@38..39 ">" [] [],
                     },
-                    children: JsxChildList [],
+                    elements: JsxChildList [],
                     closing_element: JsxClosingElement {
                         l_angle_token: L_ANGLE@39..40 "<" [] [],
                         slash_token: SLASH@40..62 "/" [Newline("\n"), Comments("/* some comment */"), Whitespace(" ")] [Whitespace(" ")],

--- a/crates/biome_js_parser/tests/js_test_suite/ok/jsx_element_attributes.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/jsx_element_attributes.jsx.snap
@@ -108,7 +108,7 @@ JsModule {
                                     ],
                                     r_angle_token: R_ANGLE@80..81 ">" [] [],
                                 },
-                                children: JsxChildList [],
+                                elements: JsxChildList [],
                                 closing_element: JsxClosingElement {
                                     l_angle_token: L_ANGLE@81..82 "<" [] [],
                                     slash_token: SLASH@82..83 "/" [] [],

--- a/crates/biome_js_parser/tests/js_test_suite/ok/jsx_element_children.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/jsx_element_children.jsx.snap
@@ -37,7 +37,7 @@ JsModule {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@2..3 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxText {
                             value_token: JSX_TEXT_LITERAL@3..8 "\n    " [] [],
                         },
@@ -51,7 +51,7 @@ JsModule {
                                 attributes: JsxAttributeList [],
                                 r_angle_token: R_ANGLE@10..11 ">" [] [],
                             },
-                            children: JsxChildList [
+                            elements: JsxChildList [
                                 JsxText {
                                     value_token: JSX_TEXT_LITERAL@11..19 "\n       " [] [],
                                 },
@@ -65,7 +65,7 @@ JsModule {
                                         attributes: JsxAttributeList [],
                                         r_angle_token: R_ANGLE@21..22 ">" [] [],
                                     },
-                                    children: JsxChildList [],
+                                    elements: JsxChildList [],
                                     closing_element: JsxClosingElement {
                                         l_angle_token: L_ANGLE@22..23 "<" [] [],
                                         slash_token: SLASH@23..24 "/" [] [],
@@ -88,7 +88,7 @@ JsModule {
                                         attributes: JsxAttributeList [],
                                         r_angle_token: R_ANGLE@36..37 ">" [] [],
                                     },
-                                    children: JsxChildList [],
+                                    elements: JsxChildList [],
                                     closing_element: JsxClosingElement {
                                         l_angle_token: L_ANGLE@37..38 "<" [] [],
                                         slash_token: SLASH@38..39 "/" [] [],
@@ -124,7 +124,7 @@ JsModule {
                                 attributes: JsxAttributeList [],
                                 r_angle_token: R_ANGLE@57..58 ">" [] [],
                             },
-                            children: JsxChildList [],
+                            elements: JsxChildList [],
                             closing_element: JsxClosingElement {
                                 l_angle_token: L_ANGLE@58..59 "<" [] [],
                                 slash_token: SLASH@59..60 "/" [] [],

--- a/crates/biome_js_parser/tests/js_test_suite/ok/jsx_element_on_arrow_function.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/jsx_element_on_arrow_function.jsx.snap
@@ -53,7 +53,7 @@ JsModule {
                                             attributes: JsxAttributeList [],
                                             r_angle_token: R_ANGLE@20..21 ">" [] [],
                                         },
-                                        children: JsxChildList [],
+                                        elements: JsxChildList [],
                                         closing_element: JsxClosingElement {
                                             l_angle_token: L_ANGLE@21..22 "<" [] [],
                                             slash_token: SLASH@22..23 "/" [] [],
@@ -106,7 +106,7 @@ JsModule {
                                                 attributes: JsxAttributeList [],
                                                 r_angle_token: R_ANGLE@50..51 ">" [] [],
                                             },
-                                            children: JsxChildList [],
+                                            elements: JsxChildList [],
                                             closing_element: JsxClosingElement {
                                                 l_angle_token: L_ANGLE@51..52 "<" [] [],
                                                 slash_token: SLASH@52..53 "/" [] [],

--- a/crates/biome_js_parser/tests/js_test_suite/ok/jsx_element_on_return.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/jsx_element_on_return.jsx.snap
@@ -52,7 +52,7 @@ JsModule {
                                     attributes: JsxAttributeList [],
                                     r_angle_token: R_ANGLE@30..31 ">" [] [],
                                 },
-                                children: JsxChildList [],
+                                elements: JsxChildList [],
                                 closing_element: JsxClosingElement {
                                     l_angle_token: L_ANGLE@31..32 "<" [] [],
                                     slash_token: SLASH@32..33 "/" [] [],

--- a/crates/biome_js_parser/tests/js_test_suite/ok/jsx_element_open_close.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/jsx_element_open_close.jsx.snap
@@ -52,7 +52,7 @@ JsModule {
                                     attributes: JsxAttributeList [],
                                     r_angle_token: R_ANGLE@30..31 ">" [] [],
                                 },
-                                children: JsxChildList [],
+                                elements: JsxChildList [],
                                 closing_element: JsxClosingElement {
                                     l_angle_token: L_ANGLE@31..32 "<" [] [],
                                     slash_token: SLASH@32..33 "/" [] [],

--- a/crates/biome_js_parser/tests/js_test_suite/ok/jsx_equal_content.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/jsx_equal_content.jsx.snap
@@ -32,7 +32,7 @@ JsModule {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@5..6 ">" [] [],
                     },
-                    children: JsxChildList [],
+                    elements: JsxChildList [],
                     closing_element: JsxClosingElement {
                         l_angle_token: L_ANGLE@6..7 "<" [] [],
                         slash_token: SLASH@7..8 "/" [] [],
@@ -57,7 +57,7 @@ JsModule {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@20..21 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxText {
                             value_token: JSX_TEXT_LITERAL@21..22 "=" [] [],
                         },

--- a/crates/biome_js_parser/tests/js_test_suite/ok/jsx_fragments.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/jsx_fragments.jsx.snap
@@ -36,7 +36,7 @@ JsModule {
                         l_angle_token: L_ANGLE@0..1 "<" [] [],
                         r_angle_token: R_ANGLE@1..2 ">" [] [],
                     },
-                    children: JsxChildList [],
+                    elements: JsxChildList [],
                     closing_fragment: JsxClosingFragment {
                         l_angle_token: L_ANGLE@2..3 "<" [] [],
                         slash_token: SLASH@3..4 "/" [] [],
@@ -53,7 +53,7 @@ JsModule {
                         l_angle_token: L_ANGLE@6..8 "<" [Newline("\n")] [],
                         r_angle_token: R_ANGLE@8..9 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxText {
                             value_token: JSX_TEXT_LITERAL@9..13 "abcd" [] [],
                         },
@@ -74,7 +74,7 @@ JsModule {
                         l_angle_token: L_ANGLE@17..19 "<" [Newline("\n")] [],
                         r_angle_token: R_ANGLE@19..20 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxText {
                             value_token: JSX_TEXT_LITERAL@20..34 "   whitespace\n" [] [],
                         },
@@ -95,7 +95,7 @@ JsModule {
                         l_angle_token: L_ANGLE@38..40 "<" [Newline("\n")] [],
                         r_angle_token: R_ANGLE@40..59 ">" [Newline("\n"), Whitespace("  "), Comments("/*comment */"), Newline("\n"), Whitespace("  ")] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxText {
                             value_token: JSX_TEXT_LITERAL@59..62 "\n  " [] [],
                         },
@@ -116,7 +116,7 @@ JsModule {
                         l_angle_token: L_ANGLE@70..72 "<" [Newline("\n")] [],
                         r_angle_token: R_ANGLE@72..73 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxElement {
                             opening_element: JsxOpeningElement {
                                 l_angle_token: L_ANGLE@73..74 "<" [] [],
@@ -127,7 +127,7 @@ JsModule {
                                 attributes: JsxAttributeList [],
                                 r_angle_token: R_ANGLE@75..76 ">" [] [],
                             },
-                            children: JsxChildList [
+                            elements: JsxChildList [
                                 JsxText {
                                     value_token: JSX_TEXT_LITERAL@76..77 "a" [] [],
                                 },

--- a/crates/biome_js_parser/tests/js_test_suite/ok/jsx_member_element_name.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/jsx_member_element_name.jsx.snap
@@ -51,7 +51,7 @@ JsModule {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@8..9 ">" [] [],
                     },
-                    children: JsxChildList [],
+                    elements: JsxChildList [],
                     closing_element: JsxClosingElement {
                         l_angle_token: L_ANGLE@9..10 "<" [] [],
                         slash_token: SLASH@10..11 "/" [] [],
@@ -100,7 +100,7 @@ JsModule {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@27..28 ">" [] [],
                     },
-                    children: JsxChildList [],
+                    elements: JsxChildList [],
                     closing_element: JsxClosingElement {
                         l_angle_token: L_ANGLE@28..29 "<" [] [],
                         slash_token: SLASH@29..30 "/" [] [],
@@ -131,7 +131,7 @@ JsModule {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@43..44 ">" [] [],
                     },
-                    children: JsxChildList [],
+                    elements: JsxChildList [],
                     closing_element: JsxClosingElement {
                         l_angle_token: L_ANGLE@44..45 "<" [] [],
                         slash_token: SLASH@45..46 "/" [] [],

--- a/crates/biome_js_parser/tests/js_test_suite/ok/jsx_primary_expression.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/jsx_primary_expression.jsx.snap
@@ -43,7 +43,7 @@ JsModule {
                                             attributes: JsxAttributeList [],
                                             r_angle_token: R_ANGLE@13..14 ">" [] [],
                                         },
-                                        children: JsxChildList [
+                                        elements: JsxChildList [
                                             JsxText {
                                                 value_token: JSX_TEXT_LITERAL@14..18 "abcd" [] [],
                                             },

--- a/crates/biome_js_parser/tests/js_test_suite/ok/jsx_style_children_are_jsx.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/jsx_style_children_are_jsx.tsx.snap
@@ -52,7 +52,7 @@ JsModule {
                                             attributes: JsxAttributeList [],
                                             r_angle_token: R_ANGLE@22..23 ">" [] [],
                                         },
-                                        children: JsxChildList [
+                                        elements: JsxChildList [
                                             JsxExpressionChild {
                                                 l_curly_token: L_CURLY@23..24 "{" [] [],
                                                 expression: JsIdentifierExpression {

--- a/crates/biome_js_parser/tests/js_test_suite/ok/jsx_text.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/jsx_text.jsx.snap
@@ -37,7 +37,7 @@ JsModule {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@2..3 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxText {
                             value_token: JSX_TEXT_LITERAL@3..7 "test" [] [],
                         },
@@ -66,7 +66,7 @@ JsModule {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@15..16 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxText {
                             value_token: JSX_TEXT_LITERAL@16..39 "   whitespace handling " [] [],
                         },
@@ -95,7 +95,7 @@ JsModule {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@47..48 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxText {
                             value_token: JSX_TEXT_LITERAL@48..77 " multi\n   line\n         node\n" [] [],
                         },
@@ -124,7 +124,7 @@ JsModule {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@88..89 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxText {
                             value_token: JSX_TEXT_LITERAL@89..95 "\\u3333" [] [],
                         },

--- a/crates/biome_js_parser/tests/js_test_suite/ok/jsx_type_arguments.jsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/jsx_type_arguments.jsx.snap
@@ -44,7 +44,7 @@ JsModule {
                         ],
                         r_angle_token: R_ANGLE@60..61 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxText {
                             value_token: JSX_TEXT_LITERAL@61..65 "() =" [] [],
                         },
@@ -85,7 +85,7 @@ JsModule {
                         ],
                         r_angle_token: R_ANGLE@85..86 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxText {
                             value_token: JSX_TEXT_LITERAL@86..90 "() =" [] [],
                         },
@@ -127,7 +127,7 @@ JsModule {
                         ],
                         r_angle_token: R_ANGLE@109..110 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxText {
                             value_token: JSX_TEXT_LITERAL@110..114 "() =" [] [],
                         },
@@ -163,7 +163,7 @@ JsModule {
                         ],
                         r_angle_token: R_ANGLE@128..129 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxText {
                             value_token: JSX_TEXT_LITERAL@129..133 "() =" [] [],
                         },

--- a/crates/biome_js_parser/tests/js_test_suite/ok/logical_expression_with_jsx.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/logical_expression_with_jsx.tsx.snap
@@ -190,7 +190,7 @@ JsModule {
                                             attributes: JsxAttributeList [],
                                             r_angle_token: R_ANGLE@119..120 ">" [] [],
                                         },
-                                        children: JsxChildList [
+                                        elements: JsxChildList [
                                             JsxText {
                                                 value_token: JSX_TEXT_LITERAL@120..126 "\n     " [] [],
                                             },
@@ -386,7 +386,7 @@ JsModule {
                                                 attributes: JsxAttributeList [],
                                                 r_angle_token: R_ANGLE@442..443 ">" [] [],
                                             },
-                                            children: JsxChildList [
+                                            elements: JsxChildList [
                                                 JsxText {
                                                     value_token: JSX_TEXT_LITERAL@443..450 "\n      " [] [],
                                                 },

--- a/crates/biome_js_parser/tests/js_test_suite/ok/metavar.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/metavar.tsx.snap
@@ -259,7 +259,7 @@ JsModule {
                         ],
                         r_angle_token: R_ANGLE@324..325 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsMetavariable {
                             value_token: GRIT_METAVARIABLE@325..328 "µ_" [] [],
                         },

--- a/crates/biome_js_parser/tests/js_test_suite/ok/ts_typeof_type2.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/ts_typeof_type2.tsx.snap
@@ -48,7 +48,7 @@ JsModule {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@26..27 ">" [] [],
                     },
-                    children: JsxChildList [
+                    elements: JsxChildList [
                         JsxText {
                             value_token: JSX_TEXT_LITERAL@27..28 "a" [] [],
                         },

--- a/crates/biome_js_parser/tests/js_test_suite/ok/tsx_element_generics_type.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/tsx_element_generics_type.tsx.snap
@@ -79,7 +79,7 @@ JsModule {
                         attributes: JsxAttributeList [],
                         r_angle_token: R_ANGLE@49..50 ">" [] [],
                     },
-                    children: JsxChildList [],
+                    elements: JsxChildList [],
                     closing_element: JsxClosingElement {
                         l_angle_token: L_ANGLE@50..51 "<" [] [],
                         slash_token: SLASH@51..52 "/" [] [],

--- a/crates/biome_js_parser/tests/js_test_suite/ok/type_parameter_modifier_tsx.tsx.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/type_parameter_modifier_tsx.tsx.snap
@@ -45,7 +45,7 @@ JsModule {
                         ],
                         r_angle_token: R_ANGLE@5..6 ">" [] [],
                     },
-                    children: JsxChildList [],
+                    elements: JsxChildList [],
                     closing_element: JsxClosingElement {
                         l_angle_token: L_ANGLE@6..7 "<" [] [],
                         slash_token: SLASH@7..8 "/" [] [],
@@ -77,7 +77,7 @@ JsModule {
                         ],
                         r_angle_token: R_ANGLE@19..20 ">" [] [],
                     },
-                    children: JsxChildList [],
+                    elements: JsxChildList [],
                     closing_element: JsxClosingElement {
                         l_angle_token: L_ANGLE@20..21 "<" [] [],
                         slash_token: SLASH@21..22 "/" [] [],
@@ -109,7 +109,7 @@ JsModule {
                         ],
                         r_angle_token: R_ANGLE@36..37 ">" [] [],
                     },
-                    children: JsxChildList [],
+                    elements: JsxChildList [],
                     closing_element: JsxClosingElement {
                         l_angle_token: L_ANGLE@37..38 "<" [] [],
                         slash_token: SLASH@38..39 "/" [] [],
@@ -147,7 +147,7 @@ JsModule {
                         ],
                         r_angle_token: R_ANGLE@56..57 ">" [] [],
                     },
-                    children: JsxChildList [],
+                    elements: JsxChildList [],
                     closing_element: JsxClosingElement {
                         l_angle_token: L_ANGLE@57..58 "<" [] [],
                         slash_token: SLASH@58..59 "/" [] [],
@@ -185,7 +185,7 @@ JsModule {
                         ],
                         r_angle_token: R_ANGLE@73..74 ">" [] [],
                     },
-                    children: JsxChildList [],
+                    elements: JsxChildList [],
                     closing_element: JsxClosingElement {
                         l_angle_token: L_ANGLE@74..75 "<" [] [],
                         slash_token: SLASH@75..76 "/" [] [],
@@ -232,7 +232,7 @@ JsModule {
                         ],
                         r_angle_token: R_ANGLE@102..103 ">" [] [],
                     },
-                    children: JsxChildList [],
+                    elements: JsxChildList [],
                     closing_element: JsxClosingElement {
                         l_angle_token: L_ANGLE@103..104 "<" [] [],
                         slash_token: SLASH@104..105 "/" [] [],
@@ -279,7 +279,7 @@ JsModule {
                         ],
                         r_angle_token: R_ANGLE@131..132 ">" [] [],
                     },
-                    children: JsxChildList [],
+                    elements: JsxChildList [],
                     closing_element: JsxClosingElement {
                         l_angle_token: L_ANGLE@132..133 "<" [] [],
                         slash_token: SLASH@133..134 "/" [] [],
@@ -332,7 +332,7 @@ JsModule {
                         ],
                         r_angle_token: R_ANGLE@164..165 ">" [] [],
                     },
-                    children: JsxChildList [],
+                    elements: JsxChildList [],
                     closing_element: JsxClosingElement {
                         l_angle_token: L_ANGLE@165..166 "<" [] [],
                         slash_token: SLASH@166..167 "/" [] [],

--- a/crates/biome_js_runtime/src/ast.rs
+++ b/crates/biome_js_runtime/src/ast.rs
@@ -101,6 +101,49 @@ impl JsAstNode {
         Ok(JsString::from(node.text_trimmed().to_string()).into())
     }
 
+    fn get_parent(this: &JsValue, _args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        let Some(node) = Self::from_this(this) else {
+            return Err(JsNativeError::typ()
+                .with_message("AST getter called with an invalid receiver")
+                .into());
+        };
+
+        Ok(node.parent().map_or_else(JsValue::undefined, |parent| {
+            Self::from_node(parent, context)
+        }))
+    }
+
+    fn ancestors(this: &JsValue, _args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        let Some(node) = Self::from_this(this) else {
+            return Err(JsNativeError::typ()
+                .with_message("AST method called with an invalid receiver")
+                .into());
+        };
+
+        let ancestors = node
+            .ancestors()
+            .skip(1)
+            .map(|ancestor| Self::from_node(ancestor, context))
+            .collect::<Vec<_>>();
+
+        Ok(JsArray::from_iter(ancestors, context).into())
+    }
+
+    fn children(this: &JsValue, _args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        let Some(node) = Self::from_this(this) else {
+            return Err(JsNativeError::typ()
+                .with_message("AST method called with an invalid receiver")
+                .into());
+        };
+
+        let children = node
+            .children()
+            .map(|child| Self::from_node(child, context))
+            .collect::<Vec<_>>();
+
+        Ok(JsArray::from_iter(children, context).into())
+    }
+
     fn wrap_optional_node<N>(node: Option<N>, context: &mut Context) -> JsValue
     where
         N: AstNode<Language = JsLanguage>,
@@ -212,10 +255,23 @@ impl Class for JsAstNode {
             NativeFunction::from_fn_ptr(Self::get_kind).to_js_function(class.context().realm());
         let text =
             NativeFunction::from_fn_ptr(Self::get_text).to_js_function(class.context().realm());
+        let parent =
+            NativeFunction::from_fn_ptr(Self::get_parent).to_js_function(class.context().realm());
 
         class
             .accessor(js_string!("kind"), Some(kind), None, Attribute::ENUMERABLE)
-            .accessor(js_string!("text"), Some(text), None, Attribute::ENUMERABLE);
+            .accessor(js_string!("text"), Some(text), None, Attribute::ENUMERABLE)
+            .accessor(js_string!("parent"), Some(parent), None, Attribute::empty())
+            .method(
+                js_string!("ancestors"),
+                0,
+                NativeFunction::from_fn_ptr(Self::ancestors),
+            )
+            .method(
+                js_string!("children"),
+                0,
+                NativeFunction::from_fn_ptr(Self::children),
+            );
 
         if !class.context().has_data::<JsAstPrototypeCache>() {
             let _ = class.context().insert_data(JsAstPrototypeCache::default());

--- a/crates/biome_js_runtime/src/generated/js_ast.rs
+++ b/crates/biome_js_runtime/src/generated/js_ast.rs
@@ -16,8 +16,8 @@ impl JsAstNode {
                     prototype,
                     JsSyntaxKind::ASTRO_IMPLICIT_FRAGMENT,
                     AstroImplicitFragment,
-                    ("children", |node, context| Self::wrap_node_list(
-                        node.children(),
+                    ("elements", |node, context| Self::wrap_node_list(
+                        node.elements(),
                         context
                     )),
                 );
@@ -3018,8 +3018,8 @@ impl JsAstNode {
                         node.opening_element().ok(),
                         context
                     )),
-                    ("children", |node, context| Self::wrap_node_list(
-                        node.children(),
+                    ("elements", |node, context| Self::wrap_node_list(
+                        node.elements(),
                         context
                     )),
                     ("closingElement", |node, context| Self::wrap_optional_node(
@@ -3071,8 +3071,8 @@ impl JsAstNode {
                         node.opening_fragment().ok(),
                         context
                     )),
-                    ("children", |node, context| Self::wrap_node_list(
-                        node.children(),
+                    ("elements", |node, context| Self::wrap_node_list(
+                        node.elements(),
                         context
                     )),
                     ("closingFragment", |node, context| Self::wrap_optional_node(
@@ -5715,6 +5715,60 @@ impl JsAstNode {
             "JS_BOGUS_STATEMENT" => JsSyntaxKind::JS_BOGUS_STATEMENT,
             "JS_BOGUS_VARIABLE_DECLARATION" => JsSyntaxKind::JS_BOGUS_VARIABLE_DECLARATION,
             "TS_BOGUS_TYPE" => JsSyntaxKind::TS_BOGUS_TYPE,
+            "JS_ARRAY_ASSIGNMENT_PATTERN_ELEMENT_LIST" => {
+                JsSyntaxKind::JS_ARRAY_ASSIGNMENT_PATTERN_ELEMENT_LIST
+            }
+            "JS_ARRAY_BINDING_PATTERN_ELEMENT_LIST" => {
+                JsSyntaxKind::JS_ARRAY_BINDING_PATTERN_ELEMENT_LIST
+            }
+            "JS_ARRAY_ELEMENT_LIST" => JsSyntaxKind::JS_ARRAY_ELEMENT_LIST,
+            "JS_CALL_ARGUMENT_LIST" => JsSyntaxKind::JS_CALL_ARGUMENT_LIST,
+            "JS_CLASS_MEMBER_LIST" => JsSyntaxKind::JS_CLASS_MEMBER_LIST,
+            "JS_CONSTRUCTOR_MODIFIER_LIST" => JsSyntaxKind::JS_CONSTRUCTOR_MODIFIER_LIST,
+            "JS_CONSTRUCTOR_PARAMETER_LIST" => JsSyntaxKind::JS_CONSTRUCTOR_PARAMETER_LIST,
+            "JS_DECORATOR_LIST" => JsSyntaxKind::JS_DECORATOR_LIST,
+            "JS_DIRECTIVE_LIST" => JsSyntaxKind::JS_DIRECTIVE_LIST,
+            "JS_EXPORT_NAMED_FROM_SPECIFIER_LIST" => {
+                JsSyntaxKind::JS_EXPORT_NAMED_FROM_SPECIFIER_LIST
+            }
+            "JS_EXPORT_NAMED_SPECIFIER_LIST" => JsSyntaxKind::JS_EXPORT_NAMED_SPECIFIER_LIST,
+            "JS_IMPORT_ASSERTION_ENTRY_LIST" => JsSyntaxKind::JS_IMPORT_ASSERTION_ENTRY_LIST,
+            "JS_METHOD_MODIFIER_LIST" => JsSyntaxKind::JS_METHOD_MODIFIER_LIST,
+            "JS_MODULE_ITEM_LIST" => JsSyntaxKind::JS_MODULE_ITEM_LIST,
+            "JS_NAMED_IMPORT_SPECIFIER_LIST" => JsSyntaxKind::JS_NAMED_IMPORT_SPECIFIER_LIST,
+            "JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY_LIST" => {
+                JsSyntaxKind::JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY_LIST
+            }
+            "JS_OBJECT_BINDING_PATTERN_PROPERTY_LIST" => {
+                JsSyntaxKind::JS_OBJECT_BINDING_PATTERN_PROPERTY_LIST
+            }
+            "JS_OBJECT_MEMBER_LIST" => JsSyntaxKind::JS_OBJECT_MEMBER_LIST,
+            "JS_PARAMETER_LIST" => JsSyntaxKind::JS_PARAMETER_LIST,
+            "JS_PROPERTY_MODIFIER_LIST" => JsSyntaxKind::JS_PROPERTY_MODIFIER_LIST,
+            "JS_STATEMENT_LIST" => JsSyntaxKind::JS_STATEMENT_LIST,
+            "JS_SWITCH_CASE_LIST" => JsSyntaxKind::JS_SWITCH_CASE_LIST,
+            "JS_TEMPLATE_ELEMENT_LIST" => JsSyntaxKind::JS_TEMPLATE_ELEMENT_LIST,
+            "JS_VARIABLE_DECLARATOR_LIST" => JsSyntaxKind::JS_VARIABLE_DECLARATOR_LIST,
+            "JSX_ATTRIBUTE_LIST" => JsSyntaxKind::JSX_ATTRIBUTE_LIST,
+            "JSX_CHILD_LIST" => JsSyntaxKind::JSX_CHILD_LIST,
+            "TS_ENUM_MEMBER_LIST" => JsSyntaxKind::TS_ENUM_MEMBER_LIST,
+            "TS_INDEX_SIGNATURE_MODIFIER_LIST" => JsSyntaxKind::TS_INDEX_SIGNATURE_MODIFIER_LIST,
+            "TS_INTERSECTION_TYPE_ELEMENT_LIST" => JsSyntaxKind::TS_INTERSECTION_TYPE_ELEMENT_LIST,
+            "TS_METHOD_SIGNATURE_MODIFIER_LIST" => JsSyntaxKind::TS_METHOD_SIGNATURE_MODIFIER_LIST,
+            "TS_PROPERTY_PARAMETER_MODIFIER_LIST" => {
+                JsSyntaxKind::TS_PROPERTY_PARAMETER_MODIFIER_LIST
+            }
+            "TS_PROPERTY_SIGNATURE_MODIFIER_LIST" => {
+                JsSyntaxKind::TS_PROPERTY_SIGNATURE_MODIFIER_LIST
+            }
+            "TS_TEMPLATE_ELEMENT_LIST" => JsSyntaxKind::TS_TEMPLATE_ELEMENT_LIST,
+            "TS_TUPLE_TYPE_ELEMENT_LIST" => JsSyntaxKind::TS_TUPLE_TYPE_ELEMENT_LIST,
+            "TS_TYPE_ARGUMENT_LIST" => JsSyntaxKind::TS_TYPE_ARGUMENT_LIST,
+            "TS_TYPE_LIST" => JsSyntaxKind::TS_TYPE_LIST,
+            "TS_TYPE_MEMBER_LIST" => JsSyntaxKind::TS_TYPE_MEMBER_LIST,
+            "TS_TYPE_PARAMETER_LIST" => JsSyntaxKind::TS_TYPE_PARAMETER_LIST,
+            "TS_TYPE_PARAMETER_MODIFIER_LIST" => JsSyntaxKind::TS_TYPE_PARAMETER_MODIFIER_LIST,
+            "TS_UNION_TYPE_VARIANT_LIST" => JsSyntaxKind::TS_UNION_TYPE_VARIANT_LIST,
             _ => return None,
         })
     }

--- a/crates/biome_js_syntax/src/generated/nodes.rs
+++ b/crates/biome_js_syntax/src/generated/nodes.rs
@@ -35,10 +35,10 @@ impl AstroImplicitFragment {
     }
     pub fn as_fields(&self) -> AstroImplicitFragmentFields {
         AstroImplicitFragmentFields {
-            children: self.children(),
+            elements: self.elements(),
         }
     }
-    pub fn children(&self) -> JsxChildList {
+    pub fn elements(&self) -> JsxChildList {
         support::list(&self.syntax, 0usize)
     }
 }
@@ -52,7 +52,7 @@ impl Serialize for AstroImplicitFragment {
 }
 #[derive(Serialize)]
 pub struct AstroImplicitFragmentFields {
-    pub children: JsxChildList,
+    pub elements: JsxChildList,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsAccessorModifier {
@@ -7565,14 +7565,14 @@ impl JsxElement {
     pub fn as_fields(&self) -> JsxElementFields {
         JsxElementFields {
             opening_element: self.opening_element(),
-            children: self.children(),
+            elements: self.elements(),
             closing_element: self.closing_element(),
         }
     }
     pub fn opening_element(&self) -> SyntaxResult<JsxOpeningElement> {
         support::required_node(&self.syntax, 0usize)
     }
-    pub fn children(&self) -> JsxChildList {
+    pub fn elements(&self) -> JsxChildList {
         support::list(&self.syntax, 1usize)
     }
     pub fn closing_element(&self) -> SyntaxResult<JsxClosingElement> {
@@ -7590,7 +7590,7 @@ impl Serialize for JsxElement {
 #[derive(Serialize)]
 pub struct JsxElementFields {
     pub opening_element: SyntaxResult<JsxOpeningElement>,
-    pub children: JsxChildList,
+    pub elements: JsxChildList,
     pub closing_element: SyntaxResult<JsxClosingElement>,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -7700,14 +7700,14 @@ impl JsxFragment {
     pub fn as_fields(&self) -> JsxFragmentFields {
         JsxFragmentFields {
             opening_fragment: self.opening_fragment(),
-            children: self.children(),
+            elements: self.elements(),
             closing_fragment: self.closing_fragment(),
         }
     }
     pub fn opening_fragment(&self) -> SyntaxResult<JsxOpeningFragment> {
         support::required_node(&self.syntax, 0usize)
     }
-    pub fn children(&self) -> JsxChildList {
+    pub fn elements(&self) -> JsxChildList {
         support::list(&self.syntax, 1usize)
     }
     pub fn closing_fragment(&self) -> SyntaxResult<JsxClosingFragment> {
@@ -7725,7 +7725,7 @@ impl Serialize for JsxFragment {
 #[derive(Serialize)]
 pub struct JsxFragmentFields {
     pub opening_fragment: SyntaxResult<JsxOpeningFragment>,
-    pub children: JsxChildList,
+    pub elements: JsxChildList,
     pub closing_fragment: SyntaxResult<JsxClosingFragment>,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -16769,7 +16769,7 @@ impl std::fmt::Debug for AstroImplicitFragment {
         let result = if current_depth < 16 {
             DEPTH.set(current_depth + 1);
             f.debug_struct("AstroImplicitFragment")
-                .field("children", &self.children())
+                .field("elements", &self.elements())
                 .finish()
         } else {
             f.debug_struct("AstroImplicitFragment").finish()
@@ -25589,7 +25589,7 @@ impl std::fmt::Debug for JsxElement {
                     "opening_element",
                     &support::DebugSyntaxResult(self.opening_element()),
                 )
-                .field("children", &self.children())
+                .field("elements", &self.elements())
                 .field(
                     "closing_element",
                     &support::DebugSyntaxResult(self.closing_element()),
@@ -25757,7 +25757,7 @@ impl std::fmt::Debug for JsxFragment {
                     "opening_fragment",
                     &support::DebugSyntaxResult(self.opening_fragment()),
                 )
-                .field("children", &self.children())
+                .field("elements", &self.elements())
                 .field(
                     "closing_fragment",
                     &support::DebugSyntaxResult(self.closing_fragment()),

--- a/crates/biome_js_syntax/src/generated/nodes_mut.rs
+++ b/crates/biome_js_syntax/src/generated/nodes_mut.rs
@@ -4,7 +4,7 @@ use crate::{JsSyntaxToken as SyntaxToken, generated::nodes::*};
 use biome_rowan::AstNode;
 use std::iter::once;
 impl AstroImplicitFragment {
-    pub fn with_children(self, element: JsxChildList) -> Self {
+    pub fn with_elements(self, element: JsxChildList) -> Self {
         Self::unwrap_cast(
             self.syntax
                 .splice_slots(0usize..=0usize, once(Some(element.into_syntax().into()))),
@@ -3577,7 +3577,7 @@ impl JsxElement {
                 .splice_slots(0usize..=0usize, once(Some(element.into_syntax().into()))),
         )
     }
-    pub fn with_children(self, element: JsxChildList) -> Self {
+    pub fn with_elements(self, element: JsxChildList) -> Self {
         Self::unwrap_cast(
             self.syntax
                 .splice_slots(1usize..=1usize, once(Some(element.into_syntax().into()))),
@@ -3637,7 +3637,7 @@ impl JsxFragment {
                 .splice_slots(0usize..=0usize, once(Some(element.into_syntax().into()))),
         )
     }
-    pub fn with_children(self, element: JsxChildList) -> Self {
+    pub fn with_elements(self, element: JsxChildList) -> Self {
         Self::unwrap_cast(
             self.syntax
                 .splice_slots(1usize..=1usize, once(Some(element.into_syntax().into()))),

--- a/crates/biome_js_syntax/src/jsx_ext.rs
+++ b/crates/biome_js_syntax/src/jsx_ext.rs
@@ -165,7 +165,7 @@ impl JsxOpeningElement {
     pub fn has_accessible_child(&self) -> bool {
         self.parent::<JsxElement>().is_some_and(|parent| {
             parent
-                .children()
+                .elements()
                 .into_iter()
                 .any(|child| child.is_accessible_node().unwrap_or(true))
         })
@@ -786,7 +786,7 @@ impl AnyJsxChild {
                     || !jsx_element.has_truthy_attribute("aria-hidden")
             }
             Self::JsxFragment(fragment) => fragment
-                .children()
+                .elements()
                 .into_iter()
                 .any(|child| child.is_accessible_node().unwrap_or(true)),
             _ => true,

--- a/crates/biome_plugin_loader/src/analyzer_js_plugin.rs
+++ b/crates/biome_plugin_loader/src/analyzer_js_plugin.rs
@@ -289,11 +289,11 @@ mod tests {
                         Object.getPrototypeOf(root),
                         "items",
                     );
-                    const hasChildNodes = "childNodes" in root;
+                    const hasUnknownField = "unknownField" in root;
                     registerDiagnostic(
                         root,
                         "information",
-                        `${root.kind}|${typeof descriptor.get}|${Object.prototype.hasOwnProperty.call(root, "items")}|${hasChildNodes}`,
+                        `${root.kind}|${typeof descriptor.get}|${Object.prototype.hasOwnProperty.call(root, "items")}|${hasUnknownField}`,
                     );
                 },
             });"#,
@@ -317,6 +317,542 @@ mod tests {
             // aren't exposed
             "JS_MODULE|function|false|false"
         );
+    }
+
+    #[test]
+    fn traverses_parents_and_ancestors_of_queried_descendants() {
+        let plugin = load_test_plugin_from_source(
+            "/plugin.js",
+            r#"import { ast, defineRule, registerDiagnostic } from "@biomejs/plugin-api";
+            export const ancestry = defineRule({
+                query: ast("JS_EXPRESSION_STATEMENT", "JS_NUMBER_LITERAL_EXPRESSION", "JS_YIELD_ARGUMENT"),
+                run(node) {
+                    const ancestors = node.ancestors();
+                    if (!Array.isArray(ancestors)) throw new Error("Expected an array");
+                    const kinds = ancestors.map(ancestor => ancestor.kind).join(",");
+                    let parent = node.parent;
+                    for (const ancestor of ancestors) {
+                        if (parent?.kind !== ancestor.kind || parent.text !== ancestor.text) {
+                            throw new Error("Parent chain differs from ancestors");
+                        }
+                        parent = parent.parent;
+                    }
+                    if (parent !== undefined) throw new Error("Parent chain must end at the root");
+                    const fresh = node.ancestors();
+                    if (fresh === ancestors) throw new Error("Expected a fresh array");
+                    ancestors.length = 0;
+                    if (fresh.map(ancestor => ancestor.kind).join(",") !== kinds ||
+                        node.ancestors().map(ancestor => ancestor.kind).join(",") !== kinds) {
+                        throw new Error("Mutating an array changed the ancestry");
+                    }
+                    registerDiagnostic(node, "information", kinds);
+                },
+            });"#,
+            None,
+        );
+
+        for (content, kind, malformed, expected) in [
+            (
+                "{ call(); }",
+                JsSyntaxKind::JS_EXPRESSION_STATEMENT,
+                false,
+                "JS_STATEMENT_LIST,JS_BLOCK_STATEMENT,JS_MODULE_ITEM_LIST,JS_MODULE",
+            ),
+            (
+                "call(1, 2);",
+                JsSyntaxKind::JS_NUMBER_LITERAL_EXPRESSION,
+                false,
+                "JS_CALL_ARGUMENT_LIST,JS_CALL_ARGUMENTS,JS_CALL_EXPRESSION,JS_EXPRESSION_STATEMENT,JS_MODULE_ITEM_LIST,JS_MODULE",
+            ),
+            (
+                "call((1));",
+                JsSyntaxKind::JS_NUMBER_LITERAL_EXPRESSION,
+                false,
+                "JS_PARENTHESIZED_EXPRESSION,JS_CALL_ARGUMENT_LIST,JS_CALL_ARGUMENTS,JS_CALL_EXPRESSION,JS_EXPRESSION_STATEMENT,JS_MODULE_ITEM_LIST,JS_MODULE",
+            ),
+            (
+                "yield 10;",
+                JsSyntaxKind::JS_YIELD_ARGUMENT,
+                true,
+                "JS_BOGUS_EXPRESSION,JS_EXPRESSION_STATEMENT,JS_MODULE_ITEM_LIST,JS_MODULE",
+            ),
+        ] {
+            let parse = biome_js_parser::parse(
+                content,
+                JsFileSource::js_module(),
+                JsParserOptions::default(),
+            );
+            assert_eq!(parse.has_errors(), malformed, "{content}");
+            let node = parse
+                .syntax()
+                .descendants()
+                .find(|node| node.kind() == kind)
+                .unwrap();
+            let result = plugin.evaluate(node.into(), "/file.js".into());
+            let [entry] = result.entries.as_slice() else {
+                panic!("expected a single diagnostic for {content}, got {result:?}");
+            };
+            assert_eq!(
+                PrintDescription(&entry.diagnostic).to_string(),
+                expected,
+                "{content}"
+            );
+        }
+    }
+
+    #[test]
+    fn reports_ancestor_ranges_from_child_access() {
+        let plugin = load_test_plugin_from_source(
+            "/plugin.js",
+            r#"import { ast, defineRule, registerDiagnostic } from "@biomejs/plugin-api";
+            export const ancestry = defineRule({
+                query: ast("JS_MODULE"),
+                run(root) {
+                    const node = root.items[0].expression.arguments.args[1].expression;
+                    registerDiagnostic(node.parent, "information", node.parent.kind);
+                    for (const ancestor of node.ancestors()) {
+                        registerDiagnostic(ancestor, "information", ancestor.kind);
+                    }
+                },
+            });"#,
+            None,
+        );
+        let parse = biome_js_parser::parse(
+            "  call(1, (2));  ",
+            JsFileSource::js_module(),
+            JsParserOptions::default(),
+        );
+        assert!(!parse.has_errors());
+        let result = plugin.evaluate(parse.syntax().into(), "/file.js".into());
+        let expected = [
+            ("JS_PARENTHESIZED_EXPRESSION", 10, 13),
+            ("JS_PARENTHESIZED_EXPRESSION", 10, 13),
+            ("JS_CALL_ARGUMENT_LIST", 7, 13),
+            ("JS_CALL_ARGUMENTS", 6, 14),
+            ("JS_CALL_EXPRESSION", 2, 14),
+            ("JS_EXPRESSION_STATEMENT", 2, 15),
+            ("JS_MODULE_ITEM_LIST", 2, 15),
+            ("JS_MODULE", 2, 15),
+        ];
+        assert_eq!(result.entries.len(), expected.len(), "{result:?}");
+        for (entry, (kind, start, end)) in result.entries.iter().zip(expected) {
+            assert_eq!(PrintDescription(&entry.diagnostic).to_string(), kind);
+            assert_eq!(
+                entry.diagnostic.span(),
+                Some(TextRange::new(start.into(), end.into())),
+                "{kind}"
+            );
+        }
+    }
+
+    #[test]
+    fn roots_have_no_parent_or_ancestors() {
+        let plugin = load_test_plugin_from_source(
+            "/plugin.js",
+            r#"import { ast, defineRule, registerDiagnostic } from "@biomejs/plugin-api";
+            export const ancestry = defineRule({
+                query: ast("JS_MODULE", "JS_SCRIPT", "TS_DECLARATION_MODULE"),
+                run(root) {
+                    const ancestors = root.ancestors();
+                    if (root.parent !== undefined || !Array.isArray(ancestors) || ancestors.length !== 0) {
+                        throw new Error("Expected a root without a parent or ancestors");
+                    }
+                    const fresh = root.ancestors();
+                    if (fresh === ancestors) throw new Error("Expected a fresh root array");
+                    ancestors.push(root);
+                    if (fresh.length !== 0 || root.ancestors().length !== 0) {
+                        throw new Error("Mutating an array changed the root ancestry");
+                    }
+                    const [directives, list] = root.children();
+                    const listKind = root.kind === "JS_SCRIPT" ? "JS_STATEMENT_LIST" : "JS_MODULE_ITEM_LIST";
+                    if (root.children().length !== 2 || directives.kind !== "JS_DIRECTIVE_LIST" ||
+                        directives.children().length !== 0 || list.kind !== listKind) {
+                        throw new Error("Expected root list nodes, including empty directives");
+                    }
+                    for (const child of [directives, list]) {
+                        if (Array.isArray(child) || child.parent.kind !== root.kind ||
+                            child.ancestors().map(ancestor => ancestor.kind).join(",") !== root.kind) {
+                            throw new Error("Expected the root as the list's only ancestor");
+                        }
+                    }
+                    const items = root.items ?? root.statements;
+                    const child = items[0];
+                    if (!Array.isArray(items) || child.text !== list.children()[0].text ||
+                        child.parent.kind !== listKind ||
+                        child.ancestors().map(ancestor => ancestor.kind).join(",") !== `${listKind},${root.kind}`) {
+                        throw new Error("Expected the list between the child and root");
+                    }
+                    registerDiagnostic(root, "information", root.kind);
+                },
+            });"#,
+            None,
+        );
+        for (content, source, expected) in [
+            ("let value;", JsFileSource::js_module(), "JS_MODULE"),
+            ("let value;", JsFileSource::js_script(), "JS_SCRIPT"),
+            (
+                "declare const value: number;",
+                JsFileSource::d_ts(),
+                "TS_DECLARATION_MODULE",
+            ),
+        ] {
+            let parse = biome_js_parser::parse(content, source, JsParserOptions::default());
+            assert!(!parse.has_errors(), "{content}");
+            let result = plugin.evaluate(parse.syntax().into(), "/file.js".into());
+            let [entry] = result.entries.as_slice() else {
+                panic!("expected a single diagnostic for {expected}, got {result:?}");
+            };
+            assert_eq!(PrintDescription(&entry.diagnostic).to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn traversal_members_are_shared_non_enumerable_and_validate_receivers() {
+        let plugin = load_test_plugin_from_source(
+            "/plugin.js",
+            r#"import { ast, defineRule, registerDiagnostic } from "@biomejs/plugin-api";
+            export const ancestry = defineRule({
+                query: ast("JS_MODULE"),
+                run(root) {
+                    const child = root.items[0];
+                    const list = child.parent;
+                    for (const name of ["parent", "ancestors", "children"]) {
+                        let owner = Object.getPrototypeOf(root);
+                        while (owner && !Object.prototype.hasOwnProperty.call(owner, name)) {
+                            owner = Object.getPrototypeOf(owner);
+                        }
+                        if (!owner || !owner.isPrototypeOf(child) || !owner.isPrototypeOf(list)) {
+                            throw new Error(`${name} must belong to a shared prototype`);
+                        }
+                        const descriptor = Object.getOwnPropertyDescriptor(owner, name);
+                        const member = name === "parent" ? descriptor.get : descriptor.value;
+                        if (descriptor.enumerable || typeof member !== "function") {
+                            throw new Error(`${name} has the wrong descriptor`);
+                        }
+                        for (const node of [root, child, list]) {
+                            if (Object.prototype.hasOwnProperty.call(node, name)) {
+                                throw new Error(`${name} must not be an own property`);
+                            }
+                            for (const key in node) {
+                                if (key === name) throw new Error(`${name} must not be enumerable`);
+                            }
+                        }
+                        for (const receiver of [undefined, null, 1, "node", {}, [], Object.create(child)]) {
+                            let threw = false;
+                            try {
+                                member.call(receiver);
+                            } catch (error) {
+                                if (!(error instanceof TypeError)) throw error;
+                                threw = true;
+                            }
+                            if (!threw) throw new Error(`${name} accepted an invalid receiver`);
+                        }
+                    }
+                    registerDiagnostic(root, "information", "Traversal prototype contract holds");
+                },
+            });"#,
+            None,
+        );
+        let parse = biome_js_parser::parse(
+            "let value;",
+            JsFileSource::js_module(),
+            JsParserOptions::default(),
+        );
+        let result = plugin.evaluate(parse.syntax().into(), "/file.js".into());
+        let [entry] = result.entries.as_slice() else {
+            panic!("expected a single diagnostic, got {result:?}");
+        };
+        assert_eq!(
+            PrintDescription(&entry.diagnostic).to_string(),
+            "Traversal prototype contract holds"
+        );
+    }
+
+    #[test]
+    fn children_return_fresh_raw_nodes_in_source_order() {
+        let plugin = load_test_plugin_from_source(
+            "/plugin.js",
+            r#"import { ast, defineRule, registerDiagnostic } from "@biomejs/plugin-api";
+            export const children = defineRule({
+                query: ast("JS_MODULE", "JS_BLOCK_STATEMENT", "JS_CALL_EXPRESSION", "JS_CALL_ARGUMENTS",
+                    "JS_PARENTHESIZED_EXPRESSION", "JS_NUMBER_LITERAL_EXPRESSION", "JS_EXPRESSION_STATEMENT",
+                    "JS_BOGUS_EXPRESSION", "JSX_ELEMENT", "JSX_EXPRESSION_CHILD",
+                    "JS_DIRECTIVE_LIST", "JS_MODULE_ITEM_LIST", "JS_STATEMENT_LIST", "JS_CALL_ARGUMENT_LIST", "JSX_CHILD_LIST"),
+                run(node) {
+                    const children = node.children();
+                    if (!Array.isArray(children)) throw new Error("Expected an array");
+                    const describe = nodes => nodes.map(child => `${child.kind}:${child.text}`).join("|");
+                    const description = describe(children);
+                    for (const child of children) {
+                        if (Array.isArray(child)) throw new Error("Expected a syntax node, not an array");
+                        if (child.parent?.kind !== node.kind || child.parent.text !== node.text) {
+                            throw new Error("Expected the immediate syntax parent");
+                        }
+                        if (describe(child.ancestors()) !== describe([node, ...node.ancestors()])) {
+                            throw new Error("Expected the raw ancestor chain");
+                        }
+                        if (!Array.isArray(child.children())) throw new Error("Child cannot traverse children");
+                    }
+                    if (node.kind === "JSX_ELEMENT") {
+                        if (!Array.isArray(node.elements) || children[1].kind !== "JSX_CHILD_LIST" ||
+                            describe(node.elements) !== describe(children[1].children()) ||
+                            describe([node.openingElement, children[1], node.closingElement]) !== description) {
+                            throw new Error("JSX fields must remain separate from generic children");
+                        }
+                    }
+                    const fresh = node.children();
+                    if (fresh === children) throw new Error("Expected a fresh array");
+                    children.length = 0;
+                    children.push(node);
+                    if (describe(fresh) !== description || describe(node.children()) !== description) {
+                        throw new Error("Mutating an array changed the children");
+                    }
+                    registerDiagnostic(node, "information", description);
+                },
+            });"#,
+            None,
+        );
+        for (content, kind, malformed, expected) in [
+            (
+                "\"use strict\"; \"custom\"; let a; call();",
+                JsSyntaxKind::JS_MODULE,
+                false,
+                "JS_DIRECTIVE_LIST:\"use strict\"; \"custom\";|JS_MODULE_ITEM_LIST:let a; call();",
+            ),
+            (
+                "\"use strict\"; \"custom\"; let a; call();",
+                JsSyntaxKind::JS_DIRECTIVE_LIST,
+                false,
+                "JS_DIRECTIVE:\"use strict\";|JS_DIRECTIVE:\"custom\";",
+            ),
+            (
+                "let a; call();",
+                JsSyntaxKind::JS_MODULE_ITEM_LIST,
+                false,
+                "JS_VARIABLE_STATEMENT:let a;|JS_EXPRESSION_STATEMENT:call();",
+            ),
+            (
+                "{ first(); { second(); } }",
+                JsSyntaxKind::JS_BLOCK_STATEMENT,
+                false,
+                "JS_STATEMENT_LIST:first(); { second(); }",
+            ),
+            (
+                "{ first(); { second(); } }",
+                JsSyntaxKind::JS_STATEMENT_LIST,
+                false,
+                "JS_EXPRESSION_STATEMENT:first();|JS_BLOCK_STATEMENT:{ second(); }",
+            ),
+            (
+                "call(1, (2), 3);",
+                JsSyntaxKind::JS_CALL_EXPRESSION,
+                false,
+                "JS_IDENTIFIER_EXPRESSION:call|JS_CALL_ARGUMENTS:(1, (2), 3)",
+            ),
+            (
+                "call(1, (2), 3);",
+                JsSyntaxKind::JS_CALL_ARGUMENTS,
+                false,
+                "JS_CALL_ARGUMENT_LIST:1, (2), 3",
+            ),
+            (
+                "call(1, (2), 3);",
+                JsSyntaxKind::JS_CALL_ARGUMENT_LIST,
+                false,
+                "JS_NUMBER_LITERAL_EXPRESSION:1|JS_PARENTHESIZED_EXPRESSION:(2)|JS_NUMBER_LITERAL_EXPRESSION:3",
+            ),
+            (
+                "call((2));",
+                JsSyntaxKind::JS_PARENTHESIZED_EXPRESSION,
+                false,
+                "JS_NUMBER_LITERAL_EXPRESSION:2",
+            ),
+            (
+                "<a>hello{value}<b /></a>;",
+                JsSyntaxKind::JSX_ELEMENT,
+                false,
+                "JSX_OPENING_ELEMENT:<a>|JSX_CHILD_LIST:hello{value}<b />|JSX_CLOSING_ELEMENT:</a>",
+            ),
+            (
+                "<a>hello{value}<b /></a>;",
+                JsSyntaxKind::JSX_CHILD_LIST,
+                false,
+                "JSX_TEXT:hello|JSX_EXPRESSION_CHILD:{value}|JSX_SELF_CLOSING_ELEMENT:<b />",
+            ),
+            ("1;", JsSyntaxKind::JS_NUMBER_LITERAL_EXPRESSION, false, ""),
+            (
+                "",
+                JsSyntaxKind::JS_MODULE,
+                false,
+                "JS_DIRECTIVE_LIST:|JS_MODULE_ITEM_LIST:",
+            ),
+            ("", JsSyntaxKind::JS_DIRECTIVE_LIST, false, ""),
+            ("", JsSyntaxKind::JS_MODULE_ITEM_LIST, false, ""),
+            (
+                "{}",
+                JsSyntaxKind::JS_BLOCK_STATEMENT,
+                false,
+                "JS_STATEMENT_LIST:",
+            ),
+            ("{}", JsSyntaxKind::JS_STATEMENT_LIST, false, ""),
+            (
+                "call();",
+                JsSyntaxKind::JS_CALL_ARGUMENTS,
+                false,
+                "JS_CALL_ARGUMENT_LIST:",
+            ),
+            ("call();", JsSyntaxKind::JS_CALL_ARGUMENT_LIST, false, ""),
+            (
+                "<a></a>;",
+                JsSyntaxKind::JSX_ELEMENT,
+                false,
+                "JSX_OPENING_ELEMENT:<a>|JSX_CHILD_LIST:|JSX_CLOSING_ELEMENT:</a>",
+            ),
+            ("<a></a>;", JsSyntaxKind::JSX_CHILD_LIST, false, ""),
+            ("<a>{}</a>;", JsSyntaxKind::JSX_EXPRESSION_CHILD, false, ""),
+            (
+                "yield 10;",
+                JsSyntaxKind::JS_EXPRESSION_STATEMENT,
+                true,
+                "JS_BOGUS_EXPRESSION:yield 10",
+            ),
+            (
+                "yield 10;",
+                JsSyntaxKind::JS_BOGUS_EXPRESSION,
+                true,
+                "JS_YIELD_ARGUMENT:10",
+            ),
+        ] {
+            let parse =
+                biome_js_parser::parse(content, JsFileSource::jsx(), JsParserOptions::default());
+            assert_eq!(parse.has_errors(), malformed, "{content}");
+            let node = parse
+                .syntax()
+                .descendants()
+                .find(|node| node.kind() == kind)
+                .unwrap();
+            let result = plugin.evaluate(node.into(), "/file.jsx".into());
+            let [entry] = result.entries.as_slice() else {
+                panic!("expected a single diagnostic for {content}, got {result:?}");
+            };
+            assert_eq!(
+                PrintDescription(&entry.diagnostic).to_string(),
+                expected,
+                "{content}: {kind:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn queries_lists_and_reports_diagnostics_on_lists_and_their_children() {
+        let plugin = load_test_plugin_from_source(
+            "/plugin.js",
+            r#"import { ast, defineRule, registerDiagnostic } from "@biomejs/plugin-api";
+            export const children = defineRule({
+                query: ast("JS_CALL_ARGUMENT_LIST"),
+                run(list) {
+                    if (Array.isArray(list) || list.kind !== "JS_CALL_ARGUMENT_LIST" || list.text !== "1, 2" ||
+                        list.parent.kind !== "JS_CALL_ARGUMENTS" ||
+                        list.ancestors().map(node => node.kind).join(",") !==
+                            "JS_CALL_ARGUMENTS,JS_CALL_EXPRESSION,JS_EXPRESSION_STATEMENT,JS_MODULE_ITEM_LIST,JS_MODULE") {
+                        throw new Error("Expected a queryable list wrapper with ancestry");
+                    }
+                    registerDiagnostic(list, "information", list.kind);
+                    for (const child of list.children()) {
+                        if (child.parent.kind !== list.kind || child.parent.text !== list.text) {
+                            throw new Error("Expected the list as the argument's parent");
+                        }
+                        registerDiagnostic(child, "information", child.valueToken);
+                    }
+                },
+            });"#,
+            None,
+        );
+        assert_eq!(
+            plugin.query(),
+            [JsSyntaxKind::JS_CALL_ARGUMENT_LIST.to_raw()]
+        );
+        let parse = biome_js_parser::parse(
+            "call(1, 2);",
+            JsFileSource::js_module(),
+            JsParserOptions::default(),
+        );
+        assert!(!parse.has_errors());
+        let list = parse
+            .syntax()
+            .descendants()
+            .find(|node| plugin.query().contains(&node.kind().to_raw()))
+            .unwrap();
+        let result = plugin.evaluate(list.into(), "/file.js".into());
+        let expected = [("JS_CALL_ARGUMENT_LIST", 5, 9), ("1", 5, 6), ("2", 8, 9)];
+        assert_eq!(result.entries.len(), expected.len(), "{result:?}");
+        for (entry, (message, start, end)) in result.entries.iter().zip(expected) {
+            assert_eq!(PrintDescription(&entry.diagnostic).to_string(), message);
+            assert_eq!(
+                entry.diagnostic.span(),
+                Some(TextRange::new(start.into(), end.into())),
+                "{message}"
+            );
+        }
+    }
+
+    #[test]
+    fn reports_children_ranges_and_exposes_normal_fields() {
+        let plugin = load_test_plugin_from_source(
+            "/plugin.js",
+            r#"import { ast, defineRule, registerDiagnostic } from "@biomejs/plugin-api";
+            export const children = defineRule({
+                query: ast("JS_MODULE"),
+                run(root) {
+                    const items = root.children()[1];
+                    const statement = items.children()[0];
+                    const call = statement.children()[0];
+                    const args = call.children()[1];
+                    if (statement.expression.text !== call.text || call.arguments.text !== args.text) {
+                        throw new Error("Child fields differ from generic traversal");
+                    }
+                    const list = args.children()[0];
+                    const [first, wrapped] = list.children();
+                    const second = wrapped.children()[0];
+                    if (first.valueToken !== "1" || wrapped.expression.valueToken !== "2" ||
+                        second.valueToken !== "2" || !Array.isArray(args.args) || args.args.length !== 2 ||
+                        !Array.isArray(root.items) || root.items[0].text !== statement.text ||
+                        args.args[0].text !== first.text || args.args[1].text !== wrapped.text) {
+                        throw new Error("Expected normal fields on children");
+                    }
+                    for (const node of [items, statement, call, args, list, first, wrapped, second]) {
+                        registerDiagnostic(node, "information", node.kind);
+                    }
+                },
+            });"#,
+            None,
+        );
+        let parse = biome_js_parser::parse(
+            "  call(1, (2));  ",
+            JsFileSource::js_module(),
+            JsParserOptions::default(),
+        );
+        assert!(!parse.has_errors());
+        let result = plugin.evaluate(parse.syntax().into(), "/file.js".into());
+        let expected = [
+            ("JS_MODULE_ITEM_LIST", 2, 15),
+            ("JS_EXPRESSION_STATEMENT", 2, 15),
+            ("JS_CALL_EXPRESSION", 2, 14),
+            ("JS_CALL_ARGUMENTS", 6, 14),
+            ("JS_CALL_ARGUMENT_LIST", 7, 13),
+            ("JS_NUMBER_LITERAL_EXPRESSION", 7, 8),
+            ("JS_PARENTHESIZED_EXPRESSION", 10, 13),
+            ("JS_NUMBER_LITERAL_EXPRESSION", 11, 12),
+        ];
+        assert_eq!(result.entries.len(), expected.len(), "{result:?}");
+        for (entry, (kind, start, end)) in result.entries.iter().zip(expected) {
+            assert_eq!(PrintDescription(&entry.diagnostic).to_string(), kind);
+            assert_eq!(
+                entry.diagnostic.span(),
+                Some(TextRange::new(start.into(), end.into())),
+                "{kind}"
+            );
+        }
     }
 
     #[test]

--- a/crates/biome_react_compiler/src/convert_ast/jsx.rs
+++ b/crates/biome_react_compiler/src/convert_ast/jsx.rs
@@ -53,7 +53,7 @@ pub(super) fn convert_jsx_element(
             )?,
         }),
         children: element
-            .children()
+            .elements()
             .into_iter()
             .map(|child| convert_jsx_child(ctx, child))
             .collect::<Result<Vec<_>>>()?,
@@ -132,7 +132,7 @@ pub(super) fn convert_jsx_fragment(
             base: ctx.base(closing.syntax().text_trimmed_range()),
         },
         children: fragment
-            .children()
+            .elements()
             .into_iter()
             .map(|child| convert_jsx_child(ctx, child))
             .collect::<Result<Vec<_>>>()?,

--- a/crates/biome_service/src/workspace/server.tests.rs
+++ b/crates/biome_service/src/workspace/server.tests.rs
@@ -4555,27 +4555,36 @@ fn typescript_plugin_reports_diagnostics_through_the_workspace() {
 
     const PLUGIN_PATH: &str = "/project/plugin.ts";
     const PLUGIN_SOURCE: &str = r#"import { ast, defineRule, registerDiagnostic } from "@biomejs/plugin-api";
-import type { AnyJsRoot, Severity } from "@biomejs/plugin-api";
+import type { Severity } from "@biomejs/plugin-api";
 
 export const noTopLevelVar = defineRule({
-    query: ast("JS_MODULE"),
-    run(root: AnyJsRoot): void {
-        for (const item of root.items) {
-            if (
-                item.kind === "JS_VARIABLE_STATEMENT" &&
-                item.declaration?.kindToken === "var"
-            ) {
-                registerDiagnostic(
-                    item,
-                    "warning" satisfies Severity,
-                    "Use let or const instead of a top-level var declaration.",
-                );
-            }
+    query: ast("JS_VARIABLE_STATEMENT"),
+    run(node): void {
+        if (
+            node.parent?.kind === "JS_MODULE_ITEM_LIST" &&
+            node.parent.parent?.kind === "JS_MODULE" &&
+            node.declaration?.kindToken === "var"
+        ) {
+            registerDiagnostic(
+                node,
+                "warning" satisfies Severity,
+                "Use let or const instead of a top-level var declaration.",
+            );
+        }
+    },
+});
+
+export const reportArguments = defineRule({
+    query: ast("JS_CALL_ARGUMENT_LIST"),
+    run(list): void {
+        registerDiagnostic(list, "warning", "Argument list.");
+        for (const arg of list.children()) {
+            registerDiagnostic(arg, "warning", `Argument: ${arg.text}`);
         }
     },
 });"#;
     const FILE_PATH: &str = "/project/file.ts";
-    const FILE_CONTENT: &str = "var foo: number = 1;\nexport const bar: string = `${foo}`;\n";
+    const FILE_CONTENT: &str = "var foo: number = 1;\nexport const bar: string = `${foo}`;\nexport function nested() {\n    var local: number = 2;\n    return local;\n}\nnested(3, 4);\n";
 
     let fs = MemoryFileSystem::default();
     fs.insert(Utf8PathBuf::from(PLUGIN_PATH), PLUGIN_SOURCE);
@@ -4628,9 +4637,37 @@ export const noTopLevelVar = defineRule({
 
     assert_eq!(result.parse_errors, 0);
 
-    let diagnostics = format!("{:?}", result.diagnostics);
-    assert!(
-        diagnostics.contains("top-level var declaration"),
-        "Expected a diagnostic from the TypeScript plugin, got: {diagnostics}"
+    let diagnostics: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.category() == Some(biome_diagnostics::category!("plugin")))
+        .collect();
+    assert_eq!(diagnostics.len(), 4, "{:#?}", result.diagnostics);
+    let diagnostic = diagnostics[0];
+    assert_eq!(diagnostic.severity(), Severity::Warning);
+    assert_eq!(
+        serde_json::to_value(diagnostic).unwrap()["description"],
+        "Use let or const instead of a top-level var declaration."
     );
+    assert_eq!(
+        diagnostic.location().span,
+        Some(TextRange::new(TextSize::from(0), TextSize::from(20)))
+    );
+    for (text, message) in [
+        ("3, 4", "Argument list."),
+        ("3", "Argument: 3"),
+        ("4", "Argument: 4"),
+    ] {
+        let start = FILE_CONTENT.find(text).unwrap() as u32;
+        let range = TextRange::new(
+            TextSize::from(start),
+            TextSize::from(start + text.len() as u32),
+        );
+        let diagnostic = diagnostics
+            .iter()
+            .find(|diagnostic| serde_json::to_value(diagnostic).unwrap()["description"] == message)
+            .unwrap();
+        assert_eq!(diagnostic.severity(), Severity::Warning);
+        assert_eq!(diagnostic.location().span, Some(range));
+    }
 }

--- a/packages/@biomejs/plugin-api/js_ast.d.ts
+++ b/packages/@biomejs/plugin-api/js_ast.d.ts
@@ -3,10 +3,23 @@
 export interface JsAstNode {
 	readonly kind: string;
 	readonly text: string;
+	/** The immediate parent node, including list containers. Undefined at the root.
+	 * Repeated access does not guarantee the same JavaScript object identity. */
+	readonly parent: AnyJsAstNode | undefined;
+	/** Returns a fresh array of enclosing nodes, nearest first, excluding this node
+	 * and including list containers and the root. Roots return an empty array.
+	 * Returned nodes do not have stable JavaScript object identity. */
+	ancestors(): readonly AnyJsAstNode[];
+	/** Returns a fresh array of immediate child nodes in source order, including list
+	 * containers and omitting tokens. Call children() on a list node to iterate its elements.
+	 * Nodes without child nodes return an empty array. Named list fields remain arrays.
+	 * Returned nodes do not have stable JavaScript object identity. */
+	children(): readonly AnyJsAstNode[];
 }
+export type AnyJsAstNode = JsNodeByKind[keyof JsNodeByKind];
 export interface AstroImplicitFragment extends JsAstNode {
 	readonly kind: "ASTRO_IMPLICIT_FRAGMENT";
-	readonly children: JsxChildList;
+	readonly elements: JsxChildList;
 }
 export interface JsAccessorModifier extends JsAstNode {
 	readonly kind: "JS_ACCESSOR_MODIFIER";
@@ -1031,7 +1044,7 @@ export interface JsxClosingFragment extends JsAstNode {
 export interface JsxElement extends JsAstNode {
 	readonly kind: "JSX_ELEMENT";
 	readonly openingElement: JsxOpeningElement | undefined;
-	readonly children: JsxChildList;
+	readonly elements: JsxChildList;
 	readonly closingElement: JsxClosingElement | undefined;
 }
 export interface JsxExpressionAttributeValue extends JsAstNode {
@@ -1049,7 +1062,7 @@ export interface JsxExpressionChild extends JsAstNode {
 export interface JsxFragment extends JsAstNode {
 	readonly kind: "JSX_FRAGMENT";
 	readonly openingFragment: JsxOpeningFragment | undefined;
-	readonly children: JsxChildList;
+	readonly elements: JsxChildList;
 	readonly closingFragment: JsxClosingFragment | undefined;
 }
 export interface JsxMemberName extends JsAstNode {
@@ -2598,53 +2611,213 @@ export interface JsNodeByKind {
 	readonly JS_BOGUS_STATEMENT: JsBogusStatement;
 	readonly JS_BOGUS_VARIABLE_DECLARATION: JsBogusVariableDeclaration;
 	readonly TS_BOGUS_TYPE: TsBogusType;
+	readonly JS_ARRAY_ASSIGNMENT_PATTERN_ELEMENT_LIST: JsArrayAssignmentPatternElementListNode;
+	readonly JS_ARRAY_BINDING_PATTERN_ELEMENT_LIST: JsArrayBindingPatternElementListNode;
+	readonly JS_ARRAY_ELEMENT_LIST: JsArrayElementListNode;
+	readonly JS_CALL_ARGUMENT_LIST: JsCallArgumentListNode;
+	readonly JS_CLASS_MEMBER_LIST: JsClassMemberListNode;
+	readonly JS_CONSTRUCTOR_MODIFIER_LIST: JsConstructorModifierListNode;
+	readonly JS_CONSTRUCTOR_PARAMETER_LIST: JsConstructorParameterListNode;
+	readonly JS_DECORATOR_LIST: JsDecoratorListNode;
+	readonly JS_DIRECTIVE_LIST: JsDirectiveListNode;
+	readonly JS_EXPORT_NAMED_FROM_SPECIFIER_LIST: JsExportNamedFromSpecifierListNode;
+	readonly JS_EXPORT_NAMED_SPECIFIER_LIST: JsExportNamedSpecifierListNode;
+	readonly JS_IMPORT_ASSERTION_ENTRY_LIST: JsImportAssertionEntryListNode;
+	readonly JS_METHOD_MODIFIER_LIST: JsMethodModifierListNode;
+	readonly JS_MODULE_ITEM_LIST: JsModuleItemListNode;
+	readonly JS_NAMED_IMPORT_SPECIFIER_LIST: JsNamedImportSpecifierListNode;
+	readonly JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY_LIST: JsObjectAssignmentPatternPropertyListNode;
+	readonly JS_OBJECT_BINDING_PATTERN_PROPERTY_LIST: JsObjectBindingPatternPropertyListNode;
+	readonly JS_OBJECT_MEMBER_LIST: JsObjectMemberListNode;
+	readonly JS_PARAMETER_LIST: JsParameterListNode;
+	readonly JS_PROPERTY_MODIFIER_LIST: JsPropertyModifierListNode;
+	readonly JS_STATEMENT_LIST: JsStatementListNode;
+	readonly JS_SWITCH_CASE_LIST: JsSwitchCaseListNode;
+	readonly JS_TEMPLATE_ELEMENT_LIST: JsTemplateElementListNode;
+	readonly JS_VARIABLE_DECLARATOR_LIST: JsVariableDeclaratorListNode;
+	readonly JSX_ATTRIBUTE_LIST: JsxAttributeListNode;
+	readonly JSX_CHILD_LIST: JsxChildListNode;
+	readonly TS_ENUM_MEMBER_LIST: TsEnumMemberListNode;
+	readonly TS_INDEX_SIGNATURE_MODIFIER_LIST: TsIndexSignatureModifierListNode;
+	readonly TS_INTERSECTION_TYPE_ELEMENT_LIST: TsIntersectionTypeElementListNode;
+	readonly TS_METHOD_SIGNATURE_MODIFIER_LIST: TsMethodSignatureModifierListNode;
+	readonly TS_PROPERTY_PARAMETER_MODIFIER_LIST: TsPropertyParameterModifierListNode;
+	readonly TS_PROPERTY_SIGNATURE_MODIFIER_LIST: TsPropertySignatureModifierListNode;
+	readonly TS_TEMPLATE_ELEMENT_LIST: TsTemplateElementListNode;
+	readonly TS_TUPLE_TYPE_ELEMENT_LIST: TsTupleTypeElementListNode;
+	readonly TS_TYPE_ARGUMENT_LIST: TsTypeArgumentListNode;
+	readonly TS_TYPE_LIST: TsTypeListNode;
+	readonly TS_TYPE_MEMBER_LIST: TsTypeMemberListNode;
+	readonly TS_TYPE_PARAMETER_LIST: TsTypeParameterListNode;
+	readonly TS_TYPE_PARAMETER_MODIFIER_LIST: TsTypeParameterModifierListNode;
+	readonly TS_UNION_TYPE_VARIANT_LIST: TsUnionTypeVariantListNode;
+}
+export interface JsArrayAssignmentPatternElementListNode extends JsAstNode {
+	readonly kind: "JS_ARRAY_ASSIGNMENT_PATTERN_ELEMENT_LIST";
 }
 export type JsArrayAssignmentPatternElementList =
 	readonly AnyJsArrayAssignmentPatternElement[];
+export interface JsArrayBindingPatternElementListNode extends JsAstNode {
+	readonly kind: "JS_ARRAY_BINDING_PATTERN_ELEMENT_LIST";
+}
 export type JsArrayBindingPatternElementList =
 	readonly AnyJsArrayBindingPatternElement[];
+export interface JsArrayElementListNode extends JsAstNode {
+	readonly kind: "JS_ARRAY_ELEMENT_LIST";
+}
 export type JsArrayElementList = readonly AnyJsArrayElement[];
+export interface JsCallArgumentListNode extends JsAstNode {
+	readonly kind: "JS_CALL_ARGUMENT_LIST";
+}
 export type JsCallArgumentList = readonly AnyJsCallArgument[];
+export interface JsClassMemberListNode extends JsAstNode {
+	readonly kind: "JS_CLASS_MEMBER_LIST";
+}
 export type JsClassMemberList = readonly AnyJsClassMember[];
+export interface JsConstructorModifierListNode extends JsAstNode {
+	readonly kind: "JS_CONSTRUCTOR_MODIFIER_LIST";
+}
 export type JsConstructorModifierList = readonly TsAccessibilityModifier[];
+export interface JsConstructorParameterListNode extends JsAstNode {
+	readonly kind: "JS_CONSTRUCTOR_PARAMETER_LIST";
+}
 export type JsConstructorParameterList = readonly AnyJsConstructorParameter[];
+export interface JsDecoratorListNode extends JsAstNode {
+	readonly kind: "JS_DECORATOR_LIST";
+}
 export type JsDecoratorList = readonly JsDecorator[];
+export interface JsDirectiveListNode extends JsAstNode {
+	readonly kind: "JS_DIRECTIVE_LIST";
+}
 export type JsDirectiveList = readonly JsDirective[];
+export interface JsExportNamedFromSpecifierListNode extends JsAstNode {
+	readonly kind: "JS_EXPORT_NAMED_FROM_SPECIFIER_LIST";
+}
 export type JsExportNamedFromSpecifierList =
 	readonly JsExportNamedFromSpecifier[];
+export interface JsExportNamedSpecifierListNode extends JsAstNode {
+	readonly kind: "JS_EXPORT_NAMED_SPECIFIER_LIST";
+}
 export type JsExportNamedSpecifierList = readonly AnyJsExportNamedSpecifier[];
+export interface JsImportAssertionEntryListNode extends JsAstNode {
+	readonly kind: "JS_IMPORT_ASSERTION_ENTRY_LIST";
+}
 export type JsImportAssertionEntryList = readonly AnyJsImportAssertionEntry[];
+export interface JsMethodModifierListNode extends JsAstNode {
+	readonly kind: "JS_METHOD_MODIFIER_LIST";
+}
 export type JsMethodModifierList = readonly AnyJsMethodModifier[];
+export interface JsModuleItemListNode extends JsAstNode {
+	readonly kind: "JS_MODULE_ITEM_LIST";
+}
 export type JsModuleItemList = readonly AnyJsModuleItem[];
+export interface JsNamedImportSpecifierListNode extends JsAstNode {
+	readonly kind: "JS_NAMED_IMPORT_SPECIFIER_LIST";
+}
 export type JsNamedImportSpecifierList = readonly AnyJsNamedImportSpecifier[];
+export interface JsObjectAssignmentPatternPropertyListNode extends JsAstNode {
+	readonly kind: "JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY_LIST";
+}
 export type JsObjectAssignmentPatternPropertyList =
 	readonly AnyJsObjectAssignmentPatternMember[];
+export interface JsObjectBindingPatternPropertyListNode extends JsAstNode {
+	readonly kind: "JS_OBJECT_BINDING_PATTERN_PROPERTY_LIST";
+}
 export type JsObjectBindingPatternPropertyList =
 	readonly AnyJsObjectBindingPatternMember[];
+export interface JsObjectMemberListNode extends JsAstNode {
+	readonly kind: "JS_OBJECT_MEMBER_LIST";
+}
 export type JsObjectMemberList = readonly AnyJsObjectMember[];
+export interface JsParameterListNode extends JsAstNode {
+	readonly kind: "JS_PARAMETER_LIST";
+}
 export type JsParameterList = readonly AnyJsParameter[];
+export interface JsPropertyModifierListNode extends JsAstNode {
+	readonly kind: "JS_PROPERTY_MODIFIER_LIST";
+}
 export type JsPropertyModifierList = readonly AnyJsPropertyModifier[];
+export interface JsStatementListNode extends JsAstNode {
+	readonly kind: "JS_STATEMENT_LIST";
+}
 export type JsStatementList = readonly AnyJsStatement[];
+export interface JsSwitchCaseListNode extends JsAstNode {
+	readonly kind: "JS_SWITCH_CASE_LIST";
+}
 export type JsSwitchCaseList = readonly AnyJsSwitchClause[];
+export interface JsTemplateElementListNode extends JsAstNode {
+	readonly kind: "JS_TEMPLATE_ELEMENT_LIST";
+}
 export type JsTemplateElementList = readonly AnyJsTemplateElement[];
+export interface JsVariableDeclaratorListNode extends JsAstNode {
+	readonly kind: "JS_VARIABLE_DECLARATOR_LIST";
+}
 export type JsVariableDeclaratorList = readonly JsVariableDeclarator[];
+export interface JsxAttributeListNode extends JsAstNode {
+	readonly kind: "JSX_ATTRIBUTE_LIST";
+}
 export type JsxAttributeList = readonly AnyJsxAttribute[];
+export interface JsxChildListNode extends JsAstNode {
+	readonly kind: "JSX_CHILD_LIST";
+}
 export type JsxChildList = readonly AnyJsxChild[];
+export interface TsEnumMemberListNode extends JsAstNode {
+	readonly kind: "TS_ENUM_MEMBER_LIST";
+}
 export type TsEnumMemberList = readonly TsEnumMember[];
+export interface TsIndexSignatureModifierListNode extends JsAstNode {
+	readonly kind: "TS_INDEX_SIGNATURE_MODIFIER_LIST";
+}
 export type TsIndexSignatureModifierList =
 	readonly AnyTsIndexSignatureModifier[];
+export interface TsIntersectionTypeElementListNode extends JsAstNode {
+	readonly kind: "TS_INTERSECTION_TYPE_ELEMENT_LIST";
+}
 export type TsIntersectionTypeElementList = readonly AnyTsType[];
+export interface TsMethodSignatureModifierListNode extends JsAstNode {
+	readonly kind: "TS_METHOD_SIGNATURE_MODIFIER_LIST";
+}
 export type TsMethodSignatureModifierList =
 	readonly AnyTsMethodSignatureModifier[];
+export interface TsPropertyParameterModifierListNode extends JsAstNode {
+	readonly kind: "TS_PROPERTY_PARAMETER_MODIFIER_LIST";
+}
 export type TsPropertyParameterModifierList =
 	readonly AnyTsPropertyParameterModifier[];
+export interface TsPropertySignatureModifierListNode extends JsAstNode {
+	readonly kind: "TS_PROPERTY_SIGNATURE_MODIFIER_LIST";
+}
 export type TsPropertySignatureModifierList =
 	readonly AnyTsPropertySignatureModifier[];
+export interface TsTemplateElementListNode extends JsAstNode {
+	readonly kind: "TS_TEMPLATE_ELEMENT_LIST";
+}
 export type TsTemplateElementList = readonly AnyTsTemplateElement[];
+export interface TsTupleTypeElementListNode extends JsAstNode {
+	readonly kind: "TS_TUPLE_TYPE_ELEMENT_LIST";
+}
 export type TsTupleTypeElementList = readonly AnyTsTupleTypeElement[];
+export interface TsTypeArgumentListNode extends JsAstNode {
+	readonly kind: "TS_TYPE_ARGUMENT_LIST";
+}
 export type TsTypeArgumentList = readonly AnyTsType[];
+export interface TsTypeListNode extends JsAstNode {
+	readonly kind: "TS_TYPE_LIST";
+}
 export type TsTypeList = readonly TsReferenceType[];
+export interface TsTypeMemberListNode extends JsAstNode {
+	readonly kind: "TS_TYPE_MEMBER_LIST";
+}
 export type TsTypeMemberList = readonly AnyTsTypeMember[];
+export interface TsTypeParameterListNode extends JsAstNode {
+	readonly kind: "TS_TYPE_PARAMETER_LIST";
+}
 export type TsTypeParameterList = readonly TsTypeParameter[];
+export interface TsTypeParameterModifierListNode extends JsAstNode {
+	readonly kind: "TS_TYPE_PARAMETER_MODIFIER_LIST";
+}
 export type TsTypeParameterModifierList = readonly AnyTsTypeParameterModifier[];
+export interface TsUnionTypeVariantListNode extends JsAstNode {
+	readonly kind: "TS_UNION_TYPE_VARIANT_LIST";
+}
 export type TsUnionTypeVariantList = readonly AnyTsType[];

--- a/packages/@biomejs/plugin-api/package.json
+++ b/packages/@biomejs/plugin-api/package.json
@@ -3,6 +3,9 @@
   "name": "@biomejs/plugin-api",
   "version": "0.0.0",
   "description": "JavaScript APIs for Biome JS plugins",
+  "scripts": {
+    "test:types": "tsc --project tsconfig.json"
+  },
   "files": [
     "README.md",
     "LICENSE-APACHE",
@@ -28,7 +31,9 @@
   },
   "author": "Biome Developers and Contributors",
   "bugs": "https://github.com/biomejs/biome/issues",
-  "devDependencies": {},
+  "devDependencies": {
+    "typescript": "7.0.2"
+  },
   "peerDependencies": {
     "@biomejs/biome": "*"
   },

--- a/packages/@biomejs/plugin-api/tsconfig.json
+++ b/packages/@biomejs/plugin-api/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "types": []
+  },
+  "include": [
+    "type-tests/**/*.ts"
+  ]
+}

--- a/packages/@biomejs/plugin-api/type-tests/rules.test.ts
+++ b/packages/@biomejs/plugin-api/type-tests/rules.test.ts
@@ -1,0 +1,81 @@
+import {
+	type AnyJsAstNode,
+	ast,
+	defineRule,
+	type JsCallArgumentList,
+	type JsCallArgumentListNode,
+	type JsFunctionDeclaration,
+	type JsModule,
+	type JsVariableStatement,
+	registerDiagnostic,
+} from "@biomejs/plugin-api";
+
+defineRule({
+	query: ast("JS_VARIABLE_STATEMENT"),
+	run(node) {
+		node satisfies JsVariableStatement;
+		node.kind satisfies "JS_VARIABLE_STATEMENT";
+		// @ts-expect-error A single-kind query must not infer an unrelated node or any.
+		node satisfies JsModule;
+		registerDiagnostic(node, "warning", "Variable statement.") satisfies void;
+	},
+});
+
+defineRule({
+	query: ast("JS_VARIABLE_STATEMENT", "JS_FUNCTION_DECLARATION"),
+	run(node) {
+		node satisfies JsVariableStatement | JsFunctionDeclaration;
+		if (node.kind === "JS_VARIABLE_STATEMENT") {
+			node satisfies JsVariableStatement;
+		} else {
+			node satisfies JsFunctionDeclaration;
+		}
+		// @ts-expect-error A multi-kind query must preserve its union.
+		node satisfies JsVariableStatement;
+		registerDiagnostic(node, "information", "Matched node.");
+	},
+});
+
+defineRule({
+	query: ast("JS_CALL_ARGUMENT_LIST"),
+	run(list) {
+		list satisfies JsCallArgumentListNode;
+		list.kind satisfies "JS_CALL_ARGUMENT_LIST";
+		list.children() satisfies readonly AnyJsAstNode[];
+		// @ts-expect-error A list query infers a wrapper, not a named-field array.
+		list satisfies JsCallArgumentList;
+		// @ts-expect-error A list query must not infer an unrelated node or any.
+		list satisfies JsModule;
+		registerDiagnostic(list, "warning", "Argument list.") satisfies void;
+	},
+});
+
+defineRule({
+	query: ast("JS_CALL_ARGUMENT_LIST", "JS_VARIABLE_STATEMENT"),
+	run(node) {
+		node satisfies JsCallArgumentListNode | JsVariableStatement;
+		if (node.kind === "JS_CALL_ARGUMENT_LIST") {
+			node satisfies JsCallArgumentListNode;
+		} else {
+			node satisfies JsVariableStatement;
+		}
+		// @ts-expect-error A mixed node/list query must preserve its union.
+		node satisfies JsCallArgumentListNode;
+		registerDiagnostic(node, "information", "Matched node or list.");
+	},
+});
+
+declare const node: AnyJsAstNode;
+declare const args: JsCallArgumentList;
+
+registerDiagnostic(node, "warning", "Any AST node.") satisfies void;
+// @ts-expect-error Named-field arrays are not eligible diagnostic targets.
+registerDiagnostic(args, "warning", "Invalid argument array.");
+// @ts-expect-error Diagnostics require an AST node, not its text.
+registerDiagnostic(node.text, "warning", "Invalid node.");
+// @ts-expect-error A possibly absent node must be checked before reporting.
+registerDiagnostic(node.parent, "warning", "Unchecked parent.");
+// @ts-expect-error Severity must belong to the supported severity union.
+registerDiagnostic(node, "invalid", "Invalid severity.");
+// @ts-expect-error Diagnostic messages must be strings.
+registerDiagnostic(node, "warning", 123);

--- a/packages/@biomejs/plugin-api/type-tests/traversal.test.ts
+++ b/packages/@biomejs/plugin-api/type-tests/traversal.test.ts
@@ -1,0 +1,131 @@
+import type {
+	AnyJsAstNode,
+	AnyJsCallArgument,
+	AstroImplicitFragment,
+	JsAstNode,
+	JsCallArgumentList,
+	JsCallArgumentListNode,
+	JsCallArguments,
+	JsFunctionDeclaration,
+	JsModule,
+	JsModuleItemListNode,
+	JsNodeByKind,
+	JsVariableStatement,
+	JsxChildList,
+	JsxChildListNode,
+	JsxElement,
+	JsxFragment,
+} from "@biomejs/plugin-api";
+
+declare const base: JsAstNode;
+declare const anyNode: AnyJsAstNode;
+declare const mappedNode: JsNodeByKind[keyof JsNodeByKind];
+declare const node: JsVariableStatement;
+
+anyNode satisfies JsNodeByKind[keyof JsNodeByKind];
+mappedNode satisfies AnyJsAstNode;
+base.parent satisfies AnyJsAstNode | undefined;
+base.ancestors() satisfies readonly AnyJsAstNode[];
+base.children() satisfies readonly AnyJsAstNode[];
+undefined satisfies typeof base.parent;
+
+// @ts-expect-error Parent absence is represented by undefined, not null.
+null satisfies typeof base.parent;
+// @ts-expect-error The root has no parent, so a parent must be checked first.
+base.parent satisfies AnyJsAstNode;
+// @ts-expect-error Parent links cannot be reassigned.
+base.parent = anyNode;
+// @ts-expect-error Ancestors are not a mutable array.
+base.ancestors() satisfies AnyJsAstNode[];
+// @ts-expect-error Ancestors cannot be appended.
+base.ancestors().push(anyNode);
+// @ts-expect-error Ancestor entries cannot be replaced.
+base.ancestors()[0] = anyNode;
+
+// @ts-expect-error Child nodes are not a mutable array.
+base.children() satisfies AnyJsAstNode[];
+// @ts-expect-error Child nodes cannot be appended.
+base.children().push(anyNode);
+// @ts-expect-error Child entries cannot be replaced.
+base.children()[0] = anyNode;
+
+const parent = node.parent;
+if (parent?.kind === "JS_MODULE_ITEM_LIST") {
+	parent satisfies JsModuleItemListNode;
+	parent.children() satisfies readonly AnyJsAstNode[];
+	// @ts-expect-error A list wrapper is not the module containing it.
+	parent.items;
+	if (parent.parent?.kind === "JS_MODULE") {
+		parent.parent satisfies JsModule;
+		parent.parent.items;
+	}
+}
+
+for (const ancestor of node.ancestors()) {
+	ancestor satisfies AnyJsAstNode;
+	if (ancestor.kind === "JS_FUNCTION_DECLARATION") {
+		ancestor satisfies JsFunctionDeclaration;
+		ancestor.body;
+		// @ts-expect-error Kind narrowing excludes module roots.
+		ancestor.items;
+	} else if (ancestor.kind === "JS_MODULE_ITEM_LIST") {
+		ancestor satisfies JsModuleItemListNode;
+	} else if (ancestor.kind === "JS_MODULE") {
+		ancestor satisfies JsModule;
+	}
+}
+
+for (const child of base.children()) {
+	child satisfies AnyJsAstNode;
+	if (child.kind === "JS_VARIABLE_STATEMENT") {
+		child satisfies JsVariableStatement;
+		child.declaration;
+		// @ts-expect-error Kind narrowing excludes module roots.
+		child.items;
+	} else if (child.kind === "JS_CALL_ARGUMENT_LIST") {
+		child satisfies JsCallArgumentListNode;
+		child.children() satisfies readonly AnyJsAstNode[];
+		// @ts-expect-error A list wrapper is not a named-field array.
+		child satisfies JsCallArgumentList;
+	} else if (child.kind === "JSX_CHILD_LIST") {
+		child satisfies JsxChildListNode;
+	}
+}
+
+declare const args: JsCallArguments;
+declare const list: JsCallArgumentListNode;
+declare const mappedList: JsNodeByKind["JS_CALL_ARGUMENT_LIST"];
+
+list satisfies JsAstNode;
+list satisfies AnyJsAstNode;
+list satisfies JsNodeByKind["JS_CALL_ARGUMENT_LIST"];
+mappedList satisfies JsCallArgumentListNode;
+list.kind satisfies "JS_CALL_ARGUMENT_LIST";
+list.children() satisfies readonly AnyJsAstNode[];
+args.args satisfies JsCallArgumentList;
+args.args satisfies readonly AnyJsCallArgument[];
+// @ts-expect-error Named-field arrays are not AST nodes.
+args.args satisfies JsAstNode;
+// @ts-expect-error Named-field arrays are not list wrappers.
+args.args satisfies JsCallArgumentListNode;
+// @ts-expect-error List wrappers are not arrays.
+list satisfies JsCallArgumentList;
+// @ts-expect-error Named-field arrays are readonly.
+args.args.push(args.args[0]);
+
+declare const jsx: JsxElement;
+declare const fragment: JsxFragment;
+declare const astro: AstroImplicitFragment;
+
+jsx.elements satisfies JsxChildList;
+fragment.elements satisfies JsxChildList;
+astro.elements satisfies JsxChildList;
+jsx.children() satisfies readonly AnyJsAstNode[];
+fragment.children() satisfies readonly AnyJsAstNode[];
+astro.children() satisfies readonly AnyJsAstNode[];
+// @ts-expect-error JSX children is a traversal method, not a named-field array.
+jsx.children satisfies JsxChildList;
+// @ts-expect-error JSX named-field arrays are not list wrappers.
+jsx.elements satisfies JsxChildListNode;
+// @ts-expect-error JSX named-field arrays are readonly.
+jsx.elements.push(jsx.elements[0]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,10 @@ importers:
       '@biomejs/biome':
         specifier: '*'
         version: link:../biome
+    devDependencies:
+      typescript:
+        specifier: 7.0.2
+        version: 7.0.2
 
   packages/@biomejs/wasm-bundler: {}
 
@@ -857,6 +861,126 @@ packages:
     resolution: {integrity: sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
   '@vitest/expect@4.1.5':
     resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
 
@@ -1400,6 +1524,11 @@ packages:
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   undici-types@6.21.0:
@@ -2195,6 +2324,66 @@ snapshots:
 
   '@typescript-eslint/types@8.57.2': {}
 
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
   '@vitest/expect@4.1.5':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -2771,6 +2960,29 @@ snapshots:
       tagged-tag: 1.0.0
 
   typescript@5.9.3: {}
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   undici-types@6.21.0: {}
 

--- a/xtask/codegen/js.ungram
+++ b/xtask/codegen/js.ungram
@@ -2333,7 +2333,7 @@ AnyJsxTag =
 // {cond && <a /> <b />}
 //           ^^^^^^^^^^
 AstroImplicitFragment =
-	children: JsxChildList
+	elements: JsxChildList
 
 // <a />, or <br> in Astro
 // ^^^^^      ^^^^
@@ -2347,7 +2347,7 @@ JsxSelfClosingElement =
 
 JsxElement =
 	opening_element: JsxOpeningElement
-	children: JsxChildList
+	elements: JsxChildList
 	closing_element: JsxClosingElement
 
 JsxOpeningElement =
@@ -2366,7 +2366,7 @@ JsxClosingElement =
 // <>content</>
 JsxFragment =
 	opening_fragment: JsxOpeningFragment
-	children: JsxChildList
+	elements: JsxChildList
 	closing_fragment: JsxClosingFragment
 
 JsxOpeningFragment =

--- a/xtask/codegen/src/generate_js_plugin_ast.rs
+++ b/xtask/codegen/src/generate_js_plugin_ast.rs
@@ -4,7 +4,8 @@ use biome_js_factory::make;
 use biome_js_formatter::{context::JsFormatOptions, format_node};
 use biome_js_syntax::{
     AnyJsDeclarationClause, AnyJsExportClause, AnyJsModuleItem, AnyJsObjectMemberName, AnyTsName,
-    AnyTsType, AnyTsTypeMember, JsSyntaxToken, T, TriviaPieceKind, TsReferenceType,
+    AnyTsReturnType, AnyTsType, AnyTsTypeMember, JsSyntaxToken, T, TriviaPieceKind,
+    TsReferenceType,
 };
 use biome_languages::JsFileSource;
 use biome_rowan::AstNode;
@@ -37,7 +38,13 @@ fn generate_rust(ast: &AstSrc) -> Result<String> {
     let mut prototype_arms = Vec::new();
     let mut kind_name_arms = Vec::new();
 
-    for name in ast.nodes.iter().map(|node| &node.name).chain(&ast.bogus) {
+    for name in ast
+        .nodes
+        .iter()
+        .map(|node| &node.name)
+        .chain(&ast.bogus)
+        .chain(ast.lists.keys())
+    {
         let kind_name = Case::Constant.convert(name);
         let node_kind = format_ident!("{kind_name}");
         kind_name_arms.push(quote! { #kind_name => JsSyntaxKind::#node_kind });
@@ -139,6 +146,63 @@ fn generate_rust(ast: &AstSrc) -> Result<String> {
 }
 
 fn generate_typescript(ast: &AstSrc) -> String {
+    let parent = make::ts_property_signature_type_member(
+        make::js_literal_member_name(make::ident("parent")).into(),
+    )
+    .with_readonly_token(make::token(T![readonly]).with_leading_trivia([
+        (TriviaPieceKind::Newline, "\n"),
+        (
+            TriviaPieceKind::MultiLineComment,
+            "/** The immediate parent node, including list containers. Undefined at the root.\n * Repeated access does not guarantee the same JavaScript object identity. */",
+        ),
+        (TriviaPieceKind::Newline, "\n"),
+    ]))
+    .with_type_annotation(make::ts_type_annotation(
+        make::token(T![:]),
+        union_type([reference_type("AnyJsAstNode").into(), undefined_type()]),
+    ))
+    .with_separator_token_token(make::token(T![;]))
+    .build();
+    let [ancestors, children] = [
+        (
+            "ancestors",
+            "/** Returns a fresh array of enclosing nodes, nearest first, excluding this node\n * and including list containers and the root. Roots return an empty array.\n * Returned nodes do not have stable JavaScript object identity. */",
+        ),
+        (
+            "children",
+            "/** Returns a fresh array of immediate child nodes in source order, including list\n * containers and omitting tokens. Call children() on a list node to iterate its elements.\n * Nodes without child nodes return an empty array. Named list fields remain arrays.\n * Returned nodes do not have stable JavaScript object identity. */",
+        ),
+    ].map(|(name, documentation)| make::ts_method_signature_type_member(
+        make::js_literal_member_name(make::ident(name).with_leading_trivia([
+            (TriviaPieceKind::Newline, "\n"),
+            (
+                TriviaPieceKind::MultiLineComment,
+                documentation,
+            ),
+            (TriviaPieceKind::Newline, "\n"),
+        ]))
+        .into(),
+        make::js_parameters(
+            make::token(T!['(']),
+            make::js_parameter_list([], []),
+            make::token(T![')']),
+        ),
+    )
+    .with_return_type_annotation(make::ts_return_type_annotation(
+        make::token(T![:]),
+        AnyTsReturnType::AnyTsType(make::ts_type_operator_type(
+            make::token(T![readonly]),
+            make::ts_array_type(
+                reference_type("AnyJsAstNode").into(),
+                make::token(T!['[']),
+                make::token(T![']']),
+            )
+            .into(),
+        ).into()),
+    ))
+    .with_separator_token_token(make::token(T![;]))
+    .build());
+
     let mut items = vec![export_interface(
         generated_export_token(),
         "JsAstNode",
@@ -146,8 +210,27 @@ fn generate_typescript(ast: &AstSrc) -> String {
         [
             property("kind", string_type()),
             property("text", string_type()),
+            parent.into(),
+            ancestors.into(),
+            children.into(),
         ],
     )];
+
+    items.push(export_type_alias(
+        make::token(T![export]),
+        "AnyJsAstNode",
+        make::ts_indexed_access_type(
+            reference_type("JsNodeByKind").into(),
+            make::token(T!['[']),
+            make::ts_type_operator_type(
+                make::token(T![keyof]),
+                reference_type("JsNodeByKind").into(),
+            )
+            .into(),
+            make::token(T![']']),
+        )
+        .into(),
+    ));
 
     for node in &ast.nodes {
         let node_kind = Case::Constant.convert(&node.name);
@@ -202,10 +285,25 @@ fn generate_typescript(ast: &AstSrc) -> String {
             .iter()
             .map(|node| &node.name)
             .chain(&ast.bogus)
-            .map(|name| property(&Case::Constant.convert(name), reference_type(name).into())),
+            .map(|name| property(&Case::Constant.convert(name), reference_type(name).into()))
+            .chain(ast.lists.keys().map(|name| {
+                property(
+                    &Case::Constant.convert(name),
+                    reference_type(&format!("{name}Node")).into(),
+                )
+            })),
     ));
 
     for (name, list) in ast.lists() {
+        items.push(export_interface(
+            make::token(T![export]),
+            &format!("{name}Node"),
+            Some("JsAstNode"),
+            [property(
+                "kind",
+                string_literal_type(&Case::Constant.convert(name)),
+            )],
+        ));
         let array_type = make::ts_array_type(
             reference_type(&list.element_name).into(),
             make::token(T!['[']),
@@ -387,8 +485,12 @@ fn property_name(field: &Field) -> String {
     let name = Case::Camel.convert(&method_name.to_string());
 
     match (name.as_str(), field) {
-        ("kind" | "text", Field::Token { .. }) => format!("{name}Token"),
-        ("kind" | "text", Field::Node { .. }) => format!("{name}Node"),
+        ("kind" | "text" | "parent" | "ancestors" | "children", Field::Token { .. }) => {
+            format!("{name}Token")
+        }
+        ("kind" | "text" | "parent" | "ancestors" | "children", Field::Node { .. }) => {
+            format!("{name}Node")
+        }
         _ => name,
     }
 }


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

> Used a coding agent to plan and implement the feature

Part of https://github.com/biomejs/biome/issues/11420

This PR adds traversal methods to navigate the CST:
- `ancestors()`
- `parent`
- `children()`

The current JS grammar had some `children` lists, which could have caused conflicts with the `children()` runtime method. I preferred changing the nodes because `children` is a popular API name for navigation. 

This PR also adds the node list to the navigation. Lists are interned nodes for us; however, I believe we need to expose explicit types to our users; otherwise, there's no clear way to know when one is inside, e.g., an argument call list or a parameter list.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added tests to verify the types and the runtime behaviour. 

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
