### PR TITLE
perf(css_formatter): skip verbatim bookkeeping in release builds

### DIFF
--- a/.changeset/fuzzy-pots-show.md
+++ b/.changeset/fuzzy-pots-show.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Improved formatting performance for SCSS string and URL interpolation.

--- a/.changeset/fuzzy-pots-show.md
+++ b/.changeset/fuzzy-pots-show.md
@@ -1,5 +1,0 @@
----
-"@biomejs/biome": patch
----
-
-Improved formatting performance for SCSS string and URL interpolation.

--- a/crates/biome_css_formatter/src/verbatim.rs
+++ b/crates/biome_css_formatter/src/verbatim.rs
@@ -10,7 +10,9 @@ use biome_formatter::{
     Buffer, CstFormatContext, Format, FormatContext, FormatElement, FormatError, FormatResult,
     FormatWithRule, LINE_TERMINATORS, normalize_newlines,
 };
-use biome_rowan::{AstNode, Direction, SyntaxElement, TextRange, TextSize};
+#[cfg(debug_assertions)]
+use biome_rowan::SyntaxElement;
+use biome_rowan::{AstNode, Direction, TextRange, TextSize};
 
 /// "Formats" a node according to its original formatting in the source text. Being able to format
 /// a node "as is" is useful if a node contains syntax errors. Formatting a node with syntax errors
@@ -82,6 +84,7 @@ where
 {
     fn fmt(&self, f: &mut Formatter<CssFormatContext>) -> FormatResult<()> {
         debug_assert!(self.node.text_trimmed_range().contains_range(self.range));
+        #[cfg(debug_assertions)]
         mark_css_verbatim_subtree(self.node, f);
 
         let mut last_end = self.range.start();
@@ -137,6 +140,7 @@ impl Format<CssFormatContext> for FormatCssVerbatimNode<'_> {
 
         let preserve_outer_trivia = self.node.parent().is_none();
 
+        #[cfg(debug_assertions)]
         for element in self.node.descendants_with_tokens(Direction::Next) {
             match element {
                 SyntaxElement::Token(token) => f.state_mut().track_token(&token),
@@ -256,6 +260,7 @@ impl Format<CssFormatContext> for FormatCssVerbatimNode<'_> {
 ///
 /// Use this when a formatter writes verbatim source for a node and its child
 /// formatters do not run, such as string interpolation `#{ get($map) }`.
+#[cfg(debug_assertions)]
 fn mark_css_verbatim_subtree(node: &CssSyntaxNode, f: &Formatter<CssFormatContext>) {
     mark_css_verbatim_node(node, f);
 
@@ -268,6 +273,7 @@ fn mark_css_verbatim_subtree(node: &CssSyntaxNode, f: &Formatter<CssFormatContex
     }
 }
 
+#[cfg(debug_assertions)]
 fn mark_css_verbatim_node(node: &CssSyntaxNode, f: &Formatter<CssFormatContext>) {
     let comments = f.context().comments();
     comments.mark_suppression_checked(node);

--- a/crates/biome_css_formatter/tests/specs/css/suppression_trailing_comments.css
+++ b/crates/biome_css_formatter/tests/specs/css/suppression_trailing_comments.css
@@ -3,3 +3,8 @@
 	background: linear-gradient( 90deg, red,   blue ); /* keep this trailing comment after the suppressed declaration */
 	color: red;
 }
+
+/* before rule */
+/* biome-ignore format: preserve the entire rule */
+.suppressed { /* first */ color:   red; /* between */ margin:1px  2px; /* last */ } /* after rule */
+.formatted{color:blue;}

--- a/crates/biome_css_formatter/tests/specs/css/suppression_trailing_comments.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/suppression_trailing_comments.css.snap
@@ -12,6 +12,11 @@ info: css/suppression_trailing_comments.css
 	color: red;
 }
 
+/* before rule */
+/* biome-ignore format: preserve the entire rule */
+.suppressed { /* first */ color:   red; /* between */ margin:1px  2px; /* last */ } /* after rule */
+.formatted{color:blue;}
+
 ```
 
 
@@ -24,9 +29,17 @@ info: css/suppression_trailing_comments.css
 	color: red;
 }
 
+/* before rule */
+/* biome-ignore format: preserve the entire rule */
+.suppressed { /* first */ color:   red; /* between */ margin:1px  2px; /* last */ } /* after rule */
+.formatted {
+	color: blue;
+}
+
 ```
 
 # Lines exceeding max width of 80 characters
 ```
     3: 	background: linear-gradient( 90deg, red,   blue ); /* keep this trailing comment after the suppressed declaration */
+    9: .suppressed { /* first */ color:   red; /* between */ margin:1px  2px; /* last */ } /* after rule */
 ```

--- a/crates/biome_css_formatter/tests/specs/css/verbatim-recovery.css
+++ b/crates/biome_css_formatter/tests/specs/css/verbatim-recovery.css
@@ -1,0 +1,5 @@
+@font-face{
+/* before */9font-family:  /* inside */broken;/* after */
+font-family:Valid;
+}
+.following{color:red;}

--- a/crates/biome_css_formatter/tests/specs/css/verbatim-recovery.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/verbatim-recovery.css.snap
@@ -1,0 +1,30 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/verbatim-recovery.css
+---
+
+# Input
+
+```css
+@font-face{
+/* before */9font-family:  /* inside */broken;/* after */
+font-family:Valid;
+}
+.following{color:red;}
+
+```
+
+
+# Formatted
+
+```css
+@font-face {
+	/* before */ 9font-family:  /* inside */broken
+	/* after */
+	font-family: Valid;
+}
+.following {
+	color: red;
+}
+
+```

--- a/crates/biome_css_formatter/tests/specs/scss/declaration/verbatim-ranges.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/declaration/verbatim-ranges.scss
@@ -1,0 +1,4 @@
+.ranges{
+background:/* before url */url( images/#{ /* first */ $name   /* last */ }.png )/* after url */;
+content:/* before string */"#{ /* first */ mix(  ".5" , $amount ) /* last */ }"/* after string */;
+}

--- a/crates/biome_css_formatter/tests/specs/scss/declaration/verbatim-ranges.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/declaration/verbatim-ranges.scss.snap
@@ -1,0 +1,31 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: scss/declaration/verbatim-ranges.scss
+---
+
+# Input
+
+```scss
+.ranges{
+background:/* before url */url( images/#{ /* first */ $name   /* last */ }.png )/* after url */;
+content:/* before string */"#{ /* first */ mix(  ".5" , $amount ) /* last */ }"/* after string */;
+}
+
+```
+
+
+# Formatted
+
+```scss
+.ranges {
+	background:/* before url */ url(images/#{ /* first */ $name   /* last */ }.png) /* after url */;
+	content:/* before string */ "#{ /* first */ mix(  "0.5" , $amount ) /* last */ }" /* after string */;
+}
+
+```
+
+# Lines exceeding max width of 80 characters
+```
+    2: 	background:/* before url */ url(images/#{ /* first */ $name   /* last */ }.png) /* after url */;
+    3: 	content:/* before string */ "#{ /* first */ mix(  "0.5" , $amount ) /* last */ }" /* after string */;
+```


### PR DESCRIPTION
## Summary

Disabled `mark_css_verbatim_subtree` in prod code for scss

## Test Plan

- Green CI