### PR TITLE
feat(plugins): add rule context

### DIFF
--- a/.biome.json
+++ b/.biome.json
@@ -36,7 +36,8 @@
       "!**/benches",
       "!!**/e2e-tests",
       "!!**/target",
-      "!!.cargo"
+      "!!.cargo",
+      "!!packages/@biomejs/plugin-api/type-tests"
     ]
   },
   "formatter": {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1716,6 +1716,7 @@ dependencies = [
  "biome_fs",
  "biome_glob",
  "biome_grit_patterns",
+ "biome_js_analyze",
  "biome_js_formatter",
  "biome_js_parser",
  "biome_js_runtime",

--- a/crates/biome_analyze/src/analyzer_plugin.rs
+++ b/crates/biome_analyze/src/analyzer_plugin.rs
@@ -8,7 +8,8 @@ use std::{fmt::Debug, sync::Arc};
 
 use crate::matcher::SignalRuleKey;
 use crate::{
-    PluginSignal, RuleCategory, RuleDiagnostic, SignalEntry, Visitor, VisitorContext, profiling,
+    PluginSignal, RuleCategory, RuleDiagnostic, ServiceBag, SignalEntry, Visitor, VisitorContext,
+    profiling,
 };
 
 /// Slice of analyzer plugins that can be cheaply cloned.
@@ -52,7 +53,12 @@ pub trait AnalyzerPlugin: Debug + Send + Sync {
 
     fn query(&self) -> Vec<RawSyntaxKind>;
 
-    fn evaluate(&self, node: AnySyntaxNode, path: Utf8PathBuf) -> PluginEvalResult;
+    fn evaluate(
+        &self,
+        node: AnySyntaxNode,
+        path: Utf8PathBuf,
+        services: &ServiceBag,
+    ) -> PluginEvalResult;
 
     /// Returns true if this plugin should run on the given file path.
     fn applies_to_file(&self, _path: &Utf8Path) -> bool {
@@ -179,9 +185,11 @@ where
         }
 
         let rule_timer = profiling::start_plugin_rule(self.plugin.name());
-        let eval_result = self
-            .plugin
-            .evaluate(node.clone().into(), ctx.options.file_path.clone());
+        let eval_result = self.plugin.evaluate(
+            node.clone().into(),
+            ctx.options.file_path.clone(),
+            ctx.services,
+        );
         rule_timer.stop();
 
         let signals = eval_result.entries.into_iter().map(|entry| {
@@ -316,7 +324,11 @@ where
             }
 
             let rule_timer = profiling::start_plugin_rule(plugin.name());
-            let eval_result = plugin.evaluate(node.clone().into(), ctx.options.file_path.clone());
+            let eval_result = plugin.evaluate(
+                node.clone().into(),
+                ctx.options.file_path.clone(),
+                ctx.services,
+            );
             rule_timer.stop();
 
             let signals = eval_result.entries.into_iter().map(|entry| {

--- a/crates/biome_js_runtime/src/context.rs
+++ b/crates/biome_js_runtime/src/context.rs
@@ -2,10 +2,12 @@ use crate::JsModuleLoader;
 use crate::ast::JsAstNode;
 use crate::mutation::JsMutation;
 use crate::plugin_api::JsPluginApi;
+use crate::rule_context::create_rule_context;
 use crate::source::read_module_source;
 use crate::token::JsAstToken;
 use biome_analyze::PluginDiagnosticEntry;
 use biome_js_syntax::{JsSyntaxKind, JsSyntaxNode};
+use biome_languages::JsFileSource;
 use biome_resolver::FsWithResolverProxy;
 use boa_engine::builtins::promise::PromiseState;
 use boa_engine::object::builtins::{JsArray, JsFunction};
@@ -220,5 +222,10 @@ impl JsExecContext {
         let result = function.call(this, args, &mut self.ctx);
         self.api.set_source(None);
         result
+    }
+
+    /// Creates file metadata whose values remain associated with this invocation's source.
+    pub fn create_rule_context(&mut self, path: &Utf8Path, source_type: JsFileSource) -> JsValue {
+        create_rule_context(path, source_type, &mut self.ctx)
     }
 }

--- a/crates/biome_js_runtime/src/lib.rs
+++ b/crates/biome_js_runtime/src/lib.rs
@@ -4,6 +4,7 @@ mod generated;
 mod module_loader;
 mod mutation;
 mod plugin_api;
+mod rule_context;
 mod source;
 mod token;
 

--- a/crates/biome_js_runtime/src/rule_context.rs
+++ b/crates/biome_js_runtime/src/rule_context.rs
@@ -1,0 +1,150 @@
+use biome_languages::JsFileSource;
+use biome_languages::javascript::{
+    JsEmbeddingKind, Language, LanguageVariant, LanguageVersion, ModuleKind, SvelteEmbeddingKind,
+    SvelteFileKind,
+};
+use boa_engine::object::ObjectInitializer;
+use boa_engine::property::Attribute;
+use boa_engine::{Context, JsString, JsValue, js_string};
+use camino::Utf8Path;
+
+pub(crate) fn create_rule_context(
+    path: &Utf8Path,
+    source_type: JsFileSource,
+    context: &mut Context,
+) -> JsValue {
+    let language = match source_type.language() {
+        Language::JavaScript => ObjectInitializer::new(context)
+            .property(
+                js_string!("kind"),
+                js_string!("javascript"),
+                Attribute::ENUMERABLE,
+            )
+            .build(),
+        Language::TypeScript { definition_file } => ObjectInitializer::new(context)
+            .property(
+                js_string!("kind"),
+                js_string!("typescript"),
+                Attribute::ENUMERABLE,
+            )
+            .property(
+                js_string!("definitionFile"),
+                definition_file,
+                Attribute::ENUMERABLE,
+            )
+            .build(),
+    };
+    let variant = match source_type.variant() {
+        LanguageVariant::Standard => js_string!("standard"),
+        LanguageVariant::StandardRestricted => js_string!("standardRestricted"),
+        LanguageVariant::Jsx => js_string!("jsx"),
+    };
+    let module_kind = match source_type.module_kind() {
+        ModuleKind::Module => js_string!("module"),
+        ModuleKind::Script => js_string!("script"),
+    };
+    let version = match source_type.version() {
+        LanguageVersion::ES2022 => js_string!("es2022"),
+        LanguageVersion::ESNext => js_string!("esNext"),
+    };
+    let embedding_kind = embedding_kind(source_type.as_embedding_kind(), context);
+    let source_type = ObjectInitializer::new(context)
+        .property(js_string!("language"), language, Attribute::ENUMERABLE)
+        .property(js_string!("variant"), variant, Attribute::ENUMERABLE)
+        .property(js_string!("moduleKind"), module_kind, Attribute::ENUMERABLE)
+        .property(js_string!("version"), version, Attribute::ENUMERABLE)
+        .property(
+            js_string!("embeddingKind"),
+            embedding_kind,
+            Attribute::ENUMERABLE,
+        )
+        .build();
+    ObjectInitializer::new(context)
+        .property(
+            js_string!("filePath"),
+            JsString::from(path.as_str()),
+            Attribute::ENUMERABLE,
+        )
+        .property(js_string!("sourceType"), source_type, Attribute::ENUMERABLE)
+        .build()
+        .into()
+}
+
+fn embedding_kind(kind: &JsEmbeddingKind, context: &mut Context) -> JsValue {
+    let mut object = ObjectInitializer::new(context);
+    match kind {
+        JsEmbeddingKind::None => {
+            object.property(
+                js_string!("kind"),
+                js_string!("none"),
+                Attribute::ENUMERABLE,
+            );
+        }
+        JsEmbeddingKind::Astro {
+            frontmatter,
+            is_class_attribute,
+        } => {
+            object
+                .property(
+                    js_string!("kind"),
+                    js_string!("astro"),
+                    Attribute::ENUMERABLE,
+                )
+                .property(
+                    js_string!("frontmatter"),
+                    *frontmatter,
+                    Attribute::ENUMERABLE,
+                )
+                .property(
+                    js_string!("isClassAttribute"),
+                    *is_class_attribute,
+                    Attribute::ENUMERABLE,
+                );
+        }
+        JsEmbeddingKind::Vue {
+            setup,
+            is_source,
+            event_handler,
+            ..
+        } => {
+            object
+                .property(js_string!("kind"), js_string!("vue"), Attribute::ENUMERABLE)
+                .property(js_string!("setup"), *setup, Attribute::ENUMERABLE)
+                .property(js_string!("isSource"), *is_source, Attribute::ENUMERABLE)
+                .property(
+                    js_string!("eventHandler"),
+                    *event_handler,
+                    Attribute::ENUMERABLE,
+                );
+        }
+        JsEmbeddingKind::Svelte {
+            file_kind,
+            embedding_kind,
+        } => {
+            let file_kind = match file_kind {
+                SvelteFileKind::Component => js_string!("component"),
+                SvelteFileKind::SourceModule => js_string!("sourceModule"),
+            };
+            let embedding_kind = match embedding_kind {
+                SvelteEmbeddingKind::Source => js_string!("source"),
+                SvelteEmbeddingKind::Expression => js_string!("expression"),
+                SvelteEmbeddingKind::SnippetSignature => js_string!("snippetSignature"),
+                SvelteEmbeddingKind::LegacyConst => js_string!("legacyConst"),
+                SvelteEmbeddingKind::Declaration => js_string!("declaration"),
+            };
+            object
+                .property(
+                    js_string!("kind"),
+                    js_string!("svelte"),
+                    Attribute::ENUMERABLE,
+                )
+                .property(js_string!("fileKind"), file_kind, Attribute::ENUMERABLE)
+                .property(
+                    js_string!("embeddingKind"),
+                    embedding_kind,
+                    Attribute::ENUMERABLE,
+                );
+        }
+    }
+    object.build().into()
+}

--- a/crates/biome_plugin_loader/Cargo.toml
+++ b/crates/biome_plugin_loader/Cargo.toml
@@ -41,6 +41,7 @@ schemars                 = { workspace = true, optional = true }
 serde                    = { workspace = true }
 
 [dev-dependencies]
+biome_js_analyze   = { path = "../biome_js_analyze" }
 biome_js_formatter = { path = "../biome_js_formatter" }
 biome_js_parser    = { path = "../biome_js_parser" }
 biome_languages    = { path = "../biome_languages", features = ["lang_js"] }

--- a/crates/biome_plugin_loader/src/analyzer_grit_plugin.rs
+++ b/crates/biome_plugin_loader/src/analyzer_grit_plugin.rs
@@ -1,6 +1,7 @@
 use crate::{AnalyzerPlugin, PluginDiagnostic, file_matches_includes};
 use biome_analyze::{
-    PluginActionData, PluginDiagnosticEntry, PluginEvalResult, PluginTargetLanguage, RuleDiagnostic,
+    PluginActionData, PluginDiagnosticEntry, PluginEvalResult, PluginTargetLanguage,
+    RuleDiagnostic, ServiceBag,
 };
 use biome_console::markup;
 use biome_css_syntax::{CssRoot, CssSyntaxNode};
@@ -92,7 +93,12 @@ impl AnalyzerPlugin for AnalyzerGritPlugin {
         file_matches_includes(self.includes.as_deref(), path)
     }
 
-    fn evaluate(&self, node: AnySyntaxNode, path: Utf8PathBuf) -> PluginEvalResult {
+    fn evaluate(
+        &self,
+        node: AnySyntaxNode,
+        path: Utf8PathBuf,
+        _services: &ServiceBag,
+    ) -> PluginEvalResult {
         let name = self.name();
 
         let (root, source_range, original_text) = match self.language() {

--- a/crates/biome_plugin_loader/src/analyzer_js_plugin.rs
+++ b/crates/biome_plugin_loader/src/analyzer_js_plugin.rs
@@ -7,12 +7,14 @@ use camino::{Utf8Path, Utf8PathBuf};
 
 use biome_analyze::{
     AnalyzerPlugin, PluginDiagnosticEntry, PluginEvalResult, PluginTargetLanguage, RuleDiagnostic,
+    ServiceBag,
 };
 use biome_console::markup;
 use biome_diagnostics::category;
 use biome_glob::NormalizedGlob;
 use biome_js_runtime::{JsExecContext, JsPluginRule};
 use biome_js_syntax::JsSyntaxNode;
+use biome_languages::JsFileSource;
 use biome_resolver::FsWithResolverProxy;
 use biome_rowan::{AnySyntaxNode, RawSyntaxKind, SyntaxKind};
 use biome_text_size::TextRange;
@@ -116,7 +118,26 @@ impl AnalyzerPlugin for AnalyzerJsPlugin {
         self.kinds.clone()
     }
 
-    fn evaluate(&self, node: AnySyntaxNode, _path: Utf8PathBuf) -> PluginEvalResult {
+    fn evaluate(
+        &self,
+        node: AnySyntaxNode,
+        path: Utf8PathBuf,
+        services: &ServiceBag,
+    ) -> PluginEvalResult {
+        let Some(source_type) = services.get_service::<JsFileSource>() else {
+            return PluginEvalResult {
+                entries: vec![PluginDiagnosticEntry {
+                    diagnostic: RuleDiagnostic::new(
+                        category!("plugin"),
+                        None::<TextRange>,
+                        markup!(
+                            "Could not run the plugin because the analyzed file's source type is unavailable."
+                        ),
+                    ),
+                    action: None,
+                }],
+            };
+        };
         let mut plugin = match self
             .loaded
             .get_mut_or_try_init(|| load_plugin(self.fs.clone(), &self.path))
@@ -156,8 +177,8 @@ impl AnalyzerPlugin for AnalyzerJsPlugin {
 
         for rule in rules.iter().filter(|rule| rule.kinds.contains(&kind)) {
             let ast = ctx.create_js_ast(node.clone());
-            let result =
-                ctx.call_function(&rule.run, &JsValue::undefined(), std::slice::from_ref(&ast));
+            let context = ctx.create_rule_context(&path, *source_type);
+            let result = ctx.call_function(&rule.run, &JsValue::undefined(), &[ast, context]);
 
             // Drain the diagnostics even on errors, so a failed rule can't leak
             // its diagnostics into the next one.
@@ -193,7 +214,249 @@ mod tests {
     use biome_fs::MemoryFileSystem;
     use biome_js_parser::JsParserOptions;
     use biome_js_syntax::JsSyntaxKind;
-    use biome_languages::JsFileSource;
+
+    fn services(source_type: JsFileSource) -> ServiceBag {
+        let mut services = ServiceBag::default();
+        services.insert_service(source_type);
+        services
+    }
+
+    #[test]
+    fn rule_context_represents_source_type() {
+        use biome_languages::javascript::{
+            JsEmbeddingKind, LanguageVersion, SvelteEmbeddingKind, SvelteFileKind,
+        };
+
+        let plugin = load_test_plugin_from_source(
+            "/plugin.js",
+            r#"import { ast, defineRule, registerDiagnostic } from "@biomejs/plugin-api";
+            export const sourceMode = defineRule({
+                query: ast("JS_MODULE", "JS_SCRIPT", "TS_DECLARATION_MODULE"),
+                run(root, context) {
+                    const source = context.sourceType;
+                    registerDiagnostic(root, "information", JSON.stringify([
+                        source.language, source.variant, source.moduleKind,
+                        source.version, source.embeddingKind,
+                    ]));
+                },
+            });"#,
+            None,
+        );
+        for (source, expected) in [
+            (
+                JsFileSource::js_module(),
+                r#"[{"kind":"javascript"},"standard","module","es2022",{"kind":"none"}]"#,
+            ),
+            (
+                JsFileSource::js_script(),
+                r#"[{"kind":"javascript"},"standard","script","es2022",{"kind":"none"}]"#,
+            ),
+            (
+                JsFileSource::jsx(),
+                r#"[{"kind":"javascript"},"jsx","module","es2022",{"kind":"none"}]"#,
+            ),
+            (
+                JsFileSource::ts(),
+                r#"[{"kind":"typescript","definitionFile":false},"standard","module","es2022",{"kind":"none"}]"#,
+            ),
+            (
+                JsFileSource::ts_restricted(),
+                r#"[{"kind":"typescript","definitionFile":false},"standardRestricted","module","es2022",{"kind":"none"}]"#,
+            ),
+            (
+                JsFileSource::tsx(),
+                r#"[{"kind":"typescript","definitionFile":false},"jsx","module","es2022",{"kind":"none"}]"#,
+            ),
+            (
+                JsFileSource::d_ts(),
+                r#"[{"kind":"typescript","definitionFile":true},"standard","module","es2022",{"kind":"none"}]"#,
+            ),
+            (
+                JsFileSource::js_module().with_version(LanguageVersion::ESNext),
+                r#"[{"kind":"javascript"},"standard","module","esNext",{"kind":"none"}]"#,
+            ),
+            (
+                JsFileSource::js_module().with_embedding_kind(JsEmbeddingKind::Astro {
+                    frontmatter: true,
+                    is_class_attribute: false,
+                }),
+                r#"[{"kind":"javascript"},"standard","module","es2022",{"kind":"astro","frontmatter":true,"isClassAttribute":false}]"#,
+            ),
+            (
+                JsFileSource::js_module().with_embedding_kind(JsEmbeddingKind::Astro {
+                    frontmatter: false,
+                    is_class_attribute: true,
+                }),
+                r#"[{"kind":"javascript"},"standard","module","es2022",{"kind":"astro","frontmatter":false,"isClassAttribute":true}]"#,
+            ),
+            (
+                JsFileSource::js_module().with_embedding_kind(JsEmbeddingKind::Vue {
+                    setup: true,
+                    is_source: true,
+                    event_handler: false,
+                    allow_statements: true,
+                }),
+                r#"[{"kind":"javascript"},"standard","module","es2022",{"kind":"vue","setup":true,"isSource":true,"eventHandler":false}]"#,
+            ),
+            (
+                JsFileSource::js_module().with_embedding_kind(JsEmbeddingKind::Vue {
+                    setup: false,
+                    is_source: false,
+                    event_handler: true,
+                    allow_statements: false,
+                }),
+                r#"[{"kind":"javascript"},"standard","module","es2022",{"kind":"vue","setup":false,"isSource":false,"eventHandler":true}]"#,
+            ),
+            (
+                JsFileSource::js_module().with_embedding_kind(JsEmbeddingKind::Svelte {
+                    file_kind: SvelteFileKind::SourceModule,
+                    embedding_kind: SvelteEmbeddingKind::Source,
+                }),
+                r#"[{"kind":"javascript"},"standard","module","es2022",{"kind":"svelte","fileKind":"sourceModule","embeddingKind":"source"}]"#,
+            ),
+            (
+                JsFileSource::js_module().with_embedding_kind(JsEmbeddingKind::Svelte {
+                    file_kind: SvelteFileKind::Component,
+                    embedding_kind: SvelteEmbeddingKind::Expression,
+                }),
+                r#"[{"kind":"javascript"},"standard","module","es2022",{"kind":"svelte","fileKind":"component","embeddingKind":"expression"}]"#,
+            ),
+            (
+                JsFileSource::js_module().with_embedding_kind(JsEmbeddingKind::Svelte {
+                    file_kind: SvelteFileKind::Component,
+                    embedding_kind: SvelteEmbeddingKind::SnippetSignature,
+                }),
+                r#"[{"kind":"javascript"},"standard","module","es2022",{"kind":"svelte","fileKind":"component","embeddingKind":"snippetSignature"}]"#,
+            ),
+            (
+                JsFileSource::js_module().with_embedding_kind(JsEmbeddingKind::Svelte {
+                    file_kind: SvelteFileKind::Component,
+                    embedding_kind: SvelteEmbeddingKind::LegacyConst,
+                }),
+                r#"[{"kind":"javascript"},"standard","module","es2022",{"kind":"svelte","fileKind":"component","embeddingKind":"legacyConst"}]"#,
+            ),
+            (
+                JsFileSource::js_module().with_embedding_kind(JsEmbeddingKind::Svelte {
+                    file_kind: SvelteFileKind::Component,
+                    embedding_kind: SvelteEmbeddingKind::Declaration,
+                }),
+                r#"[{"kind":"javascript"},"standard","module","es2022",{"kind":"svelte","fileKind":"component","embeddingKind":"declaration"}]"#,
+            ),
+        ] {
+            let parse = biome_js_parser::parse(
+                "",
+                source.with_embedding_kind(JsEmbeddingKind::None),
+                JsParserOptions::default(),
+            );
+            let result =
+                plugin.evaluate(parse.syntax().into(), "/file.js".into(), &services(source));
+            let [entry] = result.entries.as_slice() else {
+                panic!("expected one diagnostic for {source:?}: {result:?}");
+            };
+            assert_eq!(PrintDescription(&entry.diagnostic).to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn rule_context_is_readonly_and_retains_its_file() {
+        let plugin = load_test_plugin_from_source(
+            "/plugin.js",
+            r#"import { ast, defineRule, registerDiagnostic } from "@biomejs/plugin-api";
+            let saved;
+            export const contextValues = defineRule({
+                query: ast("JS_MODULE"),
+                run(root, context) {
+                    const objects = [context, context.sourceType,
+                        context.sourceType.language, context.sourceType.embeddingKind];
+                    const readonly = objects.every(object => Object.keys(object).every(key =>
+                        !Reflect.set(object, key, null) &&
+                        !Reflect.deleteProperty(object, key) &&
+                        !Reflect.defineProperty(object, key, { value: null })
+                    ));
+                    registerDiagnostic(root, "information", JSON.stringify([
+                        context, saved, readonly,
+                    ]));
+                    saved = context;
+                },
+            });"#,
+            None,
+        );
+        let mut previous = serde_json::Value::Null;
+        for (path, source, language) in [
+            (
+                "/src/café.js",
+                JsFileSource::js_module(),
+                serde_json::json!({"kind": "javascript"}),
+            ),
+            (
+                "relative/文件.ts",
+                JsFileSource::ts(),
+                serde_json::json!({"kind": "typescript", "definitionFile": false}),
+            ),
+        ] {
+            let parse = biome_js_parser::parse("", source, JsParserOptions::default());
+            let result = plugin.evaluate(parse.syntax().into(), path.into(), &services(source));
+            let [entry] = result.entries.as_slice() else {
+                panic!("expected one diagnostic: {result:?}");
+            };
+            let current = serde_json::json!({
+                "filePath": path,
+                "sourceType": {
+                    "language": language, "variant": "standard", "moduleKind": "module",
+                    "version": "es2022", "embeddingKind": { "kind": "none" },
+                },
+            });
+            let actual: serde_json::Value =
+                serde_json::from_str(&PrintDescription(&entry.diagnostic).to_string()).unwrap();
+            assert_eq!(actual, serde_json::json!([current, previous, true]));
+            previous = current;
+        }
+    }
+
+    #[test]
+    fn rule_context_receives_analyzer_services_for_descendants() {
+        use biome_analyze::{AnalysisFilter, AnalyzerOptions, ControlFlow, Never};
+        use biome_js_analyze::JsAnalyzerServices;
+
+        let plugin = load_test_plugin_from_source(
+            "/plugin.js",
+            r#"import { ast, defineRule, registerDiagnostic } from "@biomejs/plugin-api";
+            export const contextValues = defineRule({
+                query: ast("JS_VARIABLE_STATEMENT"),
+                run(node, context) {
+                    registerDiagnostic(node, "information",
+                        `${context.filePath}|${context.sourceType.language.kind}|${context.sourceType.variant}`);
+                },
+            });"#,
+            None,
+        );
+        let source = JsFileSource::tsx();
+        let parse =
+            biome_js_parser::parse("let value: number;", source, JsParserOptions::default());
+        assert!(!parse.has_errors());
+        let mut options = AnalyzerOptions::default();
+        options.file_path = "/component.js".into();
+        let plugins: Vec<Arc<Box<dyn AnalyzerPlugin>>> = vec![Arc::new(Box::new(plugin))];
+        let mut messages = Vec::new();
+        let (_, diagnostics) = biome_js_analyze::analyze(
+            &parse.tree(),
+            AnalysisFilter {
+                enabled_rules: Some(&[]),
+                ..AnalysisFilter::default()
+            },
+            &options,
+            &plugins,
+            JsAnalyzerServices::default().with_source_type(source),
+            |signal| {
+                if let Some(diagnostic) = signal.diagnostic() {
+                    messages.push(PrintDescription(&diagnostic).to_string());
+                }
+                ControlFlow::<Never>::Continue(())
+            },
+        );
+        assert!(diagnostics.is_empty(), "{diagnostics:?}");
+        assert_eq!(messages, ["/component.js|typescript|jsx"]);
+    }
 
     /// Renders the diagnostics of a single evaluation the same way the CLI does, by attaching the
     /// path and the content of the analyzed file so the code frame can be printed.
@@ -322,7 +585,11 @@ mod tests {
             JsParserOptions::default(),
         );
 
-        let result = plugin.evaluate(parse.syntax().into(), "/file.js".into());
+        let result = plugin.evaluate(
+            parse.syntax().into(),
+            "/file.js".into(),
+            &services(JsFileSource::js_module()),
+        );
 
         let [entry] = result.entries.as_slice() else {
             panic!("expected a single diagnostic, got {result:?}");
@@ -405,7 +672,11 @@ mod tests {
                 .descendants()
                 .find(|node| node.kind() == kind)
                 .unwrap();
-            let result = plugin.evaluate(node.into(), "/file.js".into());
+            let result = plugin.evaluate(
+                node.into(),
+                "/file.js".into(),
+                &services(JsFileSource::js_module()),
+            );
             let [entry] = result.entries.as_slice() else {
                 panic!("expected a single diagnostic for {content}, got {result:?}");
             };
@@ -440,7 +711,11 @@ mod tests {
             JsParserOptions::default(),
         );
         assert!(!parse.has_errors());
-        let result = plugin.evaluate(parse.syntax().into(), "/file.js".into());
+        let result = plugin.evaluate(
+            parse.syntax().into(),
+            "/file.js".into(),
+            &services(JsFileSource::js_module()),
+        );
         let expected = [
             ("JS_PARENTHESIZED_EXPRESSION", 10, 13),
             ("JS_PARENTHESIZED_EXPRESSION", 10, 13),
@@ -515,7 +790,8 @@ mod tests {
         ] {
             let parse = biome_js_parser::parse(content, source, JsParserOptions::default());
             assert!(!parse.has_errors(), "{content}");
-            let result = plugin.evaluate(parse.syntax().into(), "/file.js".into());
+            let result =
+                plugin.evaluate(parse.syntax().into(), "/file.js".into(), &services(source));
             let [entry] = result.entries.as_slice() else {
                 panic!("expected a single diagnostic for {expected}, got {result:?}");
             };
@@ -575,7 +851,11 @@ mod tests {
             JsFileSource::js_module(),
             JsParserOptions::default(),
         );
-        let result = plugin.evaluate(parse.syntax().into(), "/file.js".into());
+        let result = plugin.evaluate(
+            parse.syntax().into(),
+            "/file.js".into(),
+            &services(JsFileSource::js_module()),
+        );
         let [entry] = result.entries.as_slice() else {
             panic!("expected a single diagnostic, got {result:?}");
         };
@@ -748,7 +1028,11 @@ mod tests {
                 .descendants()
                 .find(|node| node.kind() == kind)
                 .unwrap();
-            let result = plugin.evaluate(node.into(), "/file.jsx".into());
+            let result = plugin.evaluate(
+                node.into(),
+                "/file.jsx".into(),
+                &services(JsFileSource::jsx()),
+            );
             let [entry] = result.entries.as_slice() else {
                 panic!("expected a single diagnostic for {content}, got {result:?}");
             };
@@ -800,7 +1084,11 @@ mod tests {
             .descendants()
             .find(|node| plugin.query().contains(&node.kind().to_raw()))
             .unwrap();
-        let result = plugin.evaluate(list.into(), "/file.js".into());
+        let result = plugin.evaluate(
+            list.into(),
+            "/file.js".into(),
+            &services(JsFileSource::js_module()),
+        );
         let expected = [("JS_CALL_ARGUMENT_LIST", 5, 9), ("1", 5, 6), ("2", 8, 9)];
         assert_eq!(result.entries.len(), expected.len(), "{result:?}");
         for (entry, (message, start, end)) in result.entries.iter().zip(expected) {
@@ -850,7 +1138,11 @@ mod tests {
             JsParserOptions::default(),
         );
         assert!(!parse.has_errors());
-        let result = plugin.evaluate(parse.syntax().into(), "/file.js".into());
+        let result = plugin.evaluate(
+            parse.syntax().into(),
+            "/file.js".into(),
+            &services(JsFileSource::js_module()),
+        );
         let expected = [
             ("JS_MODULE_ITEM_LIST", 2, 15),
             ("JS_EXPRESSION_STATEMENT", 2, 15),
@@ -965,7 +1257,11 @@ mod tests {
         );
 
         let plugin = load_test_plugin_from_source("/plugin.js", source, None);
-        let result = plugin.evaluate(parse.syntax().into(), "/file.js".into());
+        let result = plugin.evaluate(
+            parse.syntax().into(),
+            "/file.js".into(),
+            &services(JsFileSource::js_module()),
+        );
 
         snap_diagnostics(
             "reports_top_level_var_declarations_using_ast_fields",
@@ -1011,7 +1307,11 @@ mod tests {
                 render_diagnostics(
                     "/file.js",
                     content,
-                    plugin.evaluate(node.into(), "/file.js".into()),
+                    plugin.evaluate(
+                        node.into(),
+                        "/file.js".into(),
+                        &services(JsFileSource::js_module()),
+                    ),
                 )
             })
             .collect();
@@ -1047,7 +1347,11 @@ mod tests {
             JsParserOptions::default(),
         );
 
-        let result = plugin.evaluate(parse.syntax().into(), "/file.js".into());
+        let result = plugin.evaluate(
+            parse.syntax().into(),
+            "/file.js".into(),
+            &services(JsFileSource::js_module()),
+        );
 
         let [entry] = result.entries.as_slice() else {
             panic!("expected a single diagnostic, got {result:?}");
@@ -1108,7 +1412,11 @@ mod tests {
                     JsParserOptions::default(),
                 );
 
-                plugin.evaluate(parse.syntax().into(), "/foo.js".into())
+                plugin.evaluate(
+                    parse.syntax().into(),
+                    "/foo.js".into(),
+                    &services(JsFileSource::js_module()),
+                )
             })
         };
 
@@ -1122,7 +1430,11 @@ mod tests {
                     JsParserOptions::default(),
                 );
 
-                plugin.evaluate(parse.syntax().into(), "/bar.js".into())
+                plugin.evaluate(
+                    parse.syntax().into(),
+                    "/bar.js".into(),
+                    &services(JsFileSource::js_module()),
+                )
             })
         };
 
@@ -1176,7 +1488,11 @@ mod tests {
                 JsParserOptions::default(),
             );
             assert!(!parse.has_errors(), "{source}");
-            let result = plugin.evaluate(parse.syntax().into(), "/file.js".into());
+            let result = plugin.evaluate(
+                parse.syntax().into(),
+                "/file.js".into(),
+                &services(JsFileSource::js_module()),
+            );
             assert_eq!(parse.syntax().text_with_trivia(), source);
             (plugin_source, result)
         }
@@ -1452,7 +1768,11 @@ mod tests {
                 );
                 let mut diagnostics = String::new();
                 for _ in 0..2 {
-                    let result = plugin.evaluate(parse.syntax().into(), "/file.js".into());
+                    let result = plugin.evaluate(
+                        parse.syntax().into(),
+                        "/file.js".into(),
+                        &services(JsFileSource::js_module()),
+                    );
                     let [before, failure, healthy] = result.entries.as_slice() else {
                         panic!("{descriptor}: {result:?}");
                     };
@@ -1607,7 +1927,11 @@ mod tests {
                     }});"#
                 );
                 let plugin = load_test_plugin_from_source("/plugin.js", &plugin_source, None);
-                let result = plugin.evaluate(call.clone().into(), "/file.js".into());
+                let result = plugin.evaluate(
+                    call.clone().into(),
+                    "/file.js".into(),
+                    &services(JsFileSource::js_module()),
+                );
                 let mut native = BatchMutation::new(root.clone());
                 if case == "repeated_node_removal" {
                     native.remove_element(first.clone().into());
@@ -1678,7 +2002,11 @@ mod tests {
             );
             let mut diagnostics = String::new();
             for invocation in 0..3 {
-                let result = plugin.evaluate(parse.syntax().into(), "/file.js".into());
+                let result = plugin.evaluate(
+                    parse.syntax().into(),
+                    "/file.js".into(),
+                    &services(JsFileSource::js_module()),
+                );
                 assert_eq!(result.entries.len(), if invocation == 0 { 0 } else { 2 });
                 if invocation > 0 {
                     for (entry, message, expected) in [
@@ -1763,7 +2091,11 @@ mod tests {
             );
             assert!(
                 plugin
-                    .evaluate(foreign.syntax().into(), "/other.js".into())
+                    .evaluate(
+                        foreign.syntax().into(),
+                        "/other.js".into(),
+                        &services(JsFileSource::js_module())
+                    )
                     .entries
                     .is_empty()
             );
@@ -1773,7 +2105,11 @@ mod tests {
                 JsFileSource::js_module(),
                 JsParserOptions::default(),
             );
-            let result = plugin.evaluate(parse.syntax().into(), "/file.js".into());
+            let result = plugin.evaluate(
+                parse.syntax().into(),
+                "/file.js".into(),
+                &services(JsFileSource::js_module()),
+            );
             let [entry] = result.entries.as_slice() else {
                 panic!("expected one diagnostic: {result:?}");
             };
@@ -1828,7 +2164,11 @@ mod tests {
                 );
                 assert!(
                     plugin
-                        .evaluate(original.syntax().into(), "/file.js".into())
+                        .evaluate(
+                            original.syntax().into(),
+                            "/file.js".into(),
+                            &services(JsFileSource::js_module())
+                        )
                         .entries
                         .is_empty()
                 );
@@ -1837,7 +2177,11 @@ mod tests {
                     JsFileSource::js_module(),
                     JsParserOptions::default(),
                 );
-                let result = plugin.evaluate(foreign.syntax().into(), "/file.js".into());
+                let result = plugin.evaluate(
+                    foreign.syntax().into(),
+                    "/file.js".into(),
+                    &services(JsFileSource::js_module()),
+                );
                 let [entry] = result.entries.as_slice() else {
                     panic!("{case}: {result:?}");
                 };

--- a/packages/@biomejs/plugin-api/index.d.ts
+++ b/packages/@biomejs/plugin-api/index.d.ts
@@ -26,6 +26,51 @@ export interface AstQuery<N extends JsAstNode> {
 	readonly [queriedNode]?: N;
 }
 
+/** File information supplied to each invocation of a rule. */
+export interface RuleContext {
+	/** The analyzed file's path, as supplied by Biome. */
+	readonly filePath: string;
+	/** The parsing mode of the analyzed source, including embedded snippets. */
+	readonly sourceType: JsFileSource;
+}
+
+/** JavaScript or TypeScript parsing settings for the analyzed source. */
+export interface JsFileSource {
+	readonly language:
+		| { readonly kind: "javascript" }
+		| { readonly kind: "typescript"; readonly definitionFile: boolean };
+	/** Syntax extensions permitted in this source. */
+	readonly variant: "standard" | "standardRestricted" | "jsx";
+	readonly moduleKind: "module" | "script";
+	readonly version: "es2022" | "esNext";
+	readonly embeddingKind: JsEmbeddingKind;
+}
+
+/** The host framework and parsing mode of embedded JavaScript or TypeScript. */
+export type JsEmbeddingKind =
+	| { readonly kind: "none" }
+	| {
+			readonly kind: "astro";
+			readonly frontmatter: boolean;
+			readonly isClassAttribute: boolean;
+	  }
+	| {
+			readonly kind: "vue";
+			readonly setup: boolean;
+			readonly isSource: boolean;
+			readonly eventHandler: boolean;
+	  }
+	| {
+			readonly kind: "svelte";
+			readonly fileKind: "component" | "sourceModule";
+			readonly embeddingKind:
+				| "source"
+				| "expression"
+				| "snippetSignature"
+				| "legacyConst"
+				| "declaration";
+	  };
+
 /**
  * A lint rule, created with {@link defineRule} and exported from the plugin
  * with `export const`. The name of the export is used as the rule name.
@@ -38,8 +83,20 @@ export interface Rule<N extends JsAstNode> {
 
 	/**
 	 * Called with every node matching the query.
+	 * `context` information is read-only
+	 *
+	 * For example, inspect declarations only in TypeScript sources:
+	 * ```ts
+	 * export const myRule = defineRule({
+	 *   query: ast("JS_VARIABLE_STATEMENT"),
+	 *   run(node, context) {
+	 *     if (context.sourceType.language.kind !== "typescript") return;
+	 *     registerDiagnostic(node, "information", `Declaration in ${context.filePath}.`);
+	 *   },
+	 * });
+	 * ```
 	 */
-	run(node: N): void;
+	run(node: N, context: RuleContext): void;
 }
 
 /**

--- a/packages/@biomejs/plugin-api/type-tests/rule-context.test.ts
+++ b/packages/@biomejs/plugin-api/type-tests/rule-context.test.ts
@@ -1,0 +1,58 @@
+import {
+	ast,
+	defineRule,
+	type JsFileSource,
+	type JsVariableStatement,
+	type RuleContext,
+} from "@biomejs/plugin-api";
+
+defineRule({
+	query: ast("JS_VARIABLE_STATEMENT"),
+	run(node, context) {
+		node satisfies JsVariableStatement;
+		context satisfies RuleContext;
+		context.filePath satisfies string;
+		context.sourceType satisfies JsFileSource;
+		if (context.sourceType.language.kind === "typescript") {
+			context.sourceType.language.definitionFile satisfies boolean;
+			// @ts-expect-error Source metadata is read-only.
+			context.sourceType.language.definitionFile = true;
+		} else {
+			// @ts-expect-error JavaScript sources have no definition-file flag.
+			context.sourceType.language.definitionFile;
+		}
+		const embedding = context.sourceType.embeddingKind;
+		switch (embedding.kind) {
+			case "astro":
+				embedding.frontmatter satisfies boolean;
+				embedding.isClassAttribute satisfies boolean;
+				break;
+			case "vue":
+				embedding.setup satisfies boolean;
+				embedding.isSource satisfies boolean;
+				embedding.eventHandler satisfies boolean;
+				break;
+			case "svelte":
+				embedding.fileKind satisfies "component" | "sourceModule";
+				embedding.embeddingKind satisfies
+					| "source"
+					| "expression"
+					| "snippetSignature"
+					| "legacyConst"
+					| "declaration";
+				break;
+			case "none":
+				break;
+			default:
+				embedding satisfies never;
+		}
+		// @ts-expect-error File paths are read-only.
+		context.filePath = "another.ts";
+		// @ts-expect-error Source types are read-only.
+		context.sourceType = context.sourceType;
+		// @ts-expect-error Nested source metadata is read-only.
+		context.sourceType.variant = "jsx";
+		// @ts-expect-error Embedding tags are read-only.
+		embedding.kind = "none";
+	},
+});


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

> Used a coding agent for design and implementation

Part of #11420 

This PR adds a `context` argument to the `run` function. In this PR, the context provide:
- `filePath`: the current file
- `sourceType`: a JS representation of `JsFileSource`. I retained most all the information. What's been removed is `allow_statements` from the vue embedding

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added new unit tests

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
