### PR TITLE
feat(plugins): add semantic model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,15 +70,27 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "ascii_table"
 version = "4.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4ef8ee0b4eedc5a877a8a768fecfabbe4c8b9791e17763225139a858dabd8e7"
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -1159,6 +1171,7 @@ dependencies = [
  "biome_analyze",
  "biome_diagnostics",
  "biome_js_parser",
+ "biome_js_semantic",
  "biome_js_syntax",
  "biome_js_transform",
  "biome_languages",
@@ -1168,7 +1181,6 @@ dependencies = [
  "boa_engine",
  "camino",
  "rustc-hash 2.1.3",
- "web-time",
 ]
 
 [[package]]
@@ -1720,6 +1732,7 @@ dependencies = [
  "biome_js_formatter",
  "biome_js_parser",
  "biome_js_runtime",
+ "biome_js_semantic",
  "biome_js_syntax",
  "biome_json_parser",
  "biome_json_syntax",
@@ -1740,7 +1753,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "windows 0.62.2",
+ "windows",
 ]
 
 [[package]]
@@ -2219,9 +2232,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.3"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitvec"
@@ -2237,28 +2250,30 @@ dependencies = [
 
 [[package]]
 name = "boa_ast"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6339a700715bda376f5ea65c76e8fe8fc880930d8b0638cea68e7f3da6538e0a"
+checksum = "9221b0a090572b4a118b46c5874c0781fe4bc9546b85f0a615b8bfb609ca4ed7"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.13.1",
  "boa_interner",
  "boa_macros",
  "boa_string",
  "indexmap",
  "num-bigint",
  "rustc-hash 2.1.3",
+ "strum",
 ]
 
 [[package]]
 name = "boa_engine"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1521be326f8a5c8887e95d4ce7f002917a002a23f7b93b9a6a2bf50ed4157824"
+checksum = "5d6aaf7fdc4299df68adb67e1a5440a51d34630a1f5271b9698fd74bc97b60d9"
 dependencies = [
  "aligned-vec",
  "arrayvec",
- "bitflags 2.9.3",
+ "async-channel",
+ "bitflags 2.13.1",
  "boa_ast",
  "boa_gc",
  "boa_interner",
@@ -2268,26 +2283,27 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "cow-utils",
- "dashmap 6.1.0",
+ "dashmap 6.2.1",
  "dynify",
  "fast-float2",
  "float16",
- "futures-channel",
  "futures-concurrency",
  "futures-lite",
- "getrandom 0.3.4",
- "hashbrown 0.16.1",
- "icu_normalizer 2.0.0",
+ "getrandom 0.4.3",
+ "hashbrown 0.17.1",
+ "icu_calendar",
+ "icu_normalizer 2.3.0",
  "indexmap",
- "intrusive-collections 0.9.7",
- "itertools 0.14.0",
+ "intrusive-collections",
+ "itertools 0.15.0",
  "num-bigint",
  "num-integer",
  "num-traits",
  "num_enum",
- "paste",
+ "oneshot",
+ "pastey 0.2.3",
  "portable-atomic",
- "rand 0.9.3",
+ "rand 0.10.2",
  "regress",
  "rustc-hash 2.1.3",
  "ryu-js",
@@ -2297,67 +2313,70 @@ dependencies = [
  "static_assertions",
  "tag_ptr",
  "tap",
+ "temporal_rs",
  "thin-vec",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "time",
+ "timezone_provider",
  "web-time",
  "xsum",
 ]
 
 [[package]]
 name = "boa_gc"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1179f690cbfcbe5364cceee5f1cb577265bb6f07b0be6f210aabe270adcf9da"
+checksum = "af82119558ab1002d1978c8459b53a3ebb506177d29a3aca37c07c1777b1d966"
 dependencies = [
+ "arrayvec",
  "boa_macros",
  "boa_string",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "thin-vec",
 ]
 
 [[package]]
 name = "boa_interner"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20510b8b02bcde9b0a01cf34c0c308c56156503d1d91cdab4c8cfbd292b747ea"
+checksum = "317c631e791f5cb7d0017e43c0a758b0eaffd40c34c4c360e2a6be7752b78cd1"
 dependencies = [
  "boa_gc",
  "boa_macros",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap",
  "once_cell",
- "phf 0.13.1",
+ "phf 0.14.0",
  "rustc-hash 2.1.3",
  "static_assertions",
 ]
 
 [[package]]
 name = "boa_macros"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5822cb4f146d243060e588bc5a5f2e709683fdad3d7111f42c48e6b5c921d23d"
+checksum = "b882fd440dc0f4b7441367cf89567bb077920356750c9a76a16c002d8ec2fa5c"
 dependencies = [
  "cfg-if",
  "cow-utils",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
- "synstructure",
+ "syn 3.0.5",
+ "synstructure 0.14.0",
 ]
 
 [[package]]
 name = "boa_parser"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd957fa9fa93e3a001a8aba5a5cd40c2bbfde486378be4c4b472fd304aaddb"
+checksum = "641e81b3c8cbb7a2140547fb3ea534e9edf210b4e8c920b5fa864a919e11fbcf"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.13.1",
  "boa_ast",
  "boa_interner",
  "boa_macros",
  "fast-float2",
- "icu_properties 2.0.1",
+ "icu_properties 2.3.0",
  "num-bigint",
  "num-traits",
  "regress",
@@ -2366,13 +2385,13 @@ dependencies = [
 
 [[package]]
 name = "boa_string"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2da1d7f4a76fd9040788a122f0d807910800a7b86f5952e9244848c36511de"
+checksum = "30bf86c2bcff5bf2547acbfc516c5d3108ca527cb131511d749bf6fbef762c0e"
 dependencies = [
  "fast-float2",
  "itoa",
- "paste",
+ "pastey 0.2.3",
  "rustc-hash 2.1.3",
  "ryu-js",
  "static_assertions",
@@ -2431,9 +2450,9 @@ checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "bytemuck"
-version = "1.24.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -2460,6 +2479,16 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "calendrical_calculations"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5abbd6eeda6885048d357edc66748eea6e0268e3dd11f326fff5bd248d779c26"
+dependencies = [
+ "core_maths",
+ "displaydoc",
+]
 
 [[package]]
 name = "camino"
@@ -2514,6 +2543,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.0",
+]
 
 [[package]]
 name = "chrono"
@@ -2586,7 +2626,7 @@ dependencies = [
  "anyhow",
  "cc",
  "colored",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "glob",
  "libc",
  "nix",
@@ -2687,6 +2727,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "condtype"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2758,13 +2807,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "cordyceps"
-version = "0.3.4"
+name = "core_maths"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688d7fbb8092b8de775ef2536f36c8c31f2bc4006ece2e8d8ad2d17d00ce0a2a"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
 dependencies = [
- "loom",
- "tracing",
+ "libm",
 ]
 
 [[package]]
@@ -2783,6 +2831,15 @@ name = "cow-utils"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -2909,9 +2966,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -2949,17 +3006,14 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
-dependencies = [
- "powerfmt",
-]
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "derive_builder"
@@ -2991,12 +3045,6 @@ dependencies = [
  "derive_builder_core",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "diatomic-waker"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab03c107fafeb3ee9f5925686dbb7a73bc76e3932abb0d2b365cb64b169cf04c"
 
 [[package]]
 name = "directories"
@@ -3187,10 +3235,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "fast-float2"
-version = "0.2.3"
+name = "event-listener"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fast-float2"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6e8948ce679d00a02a94739ea185595dca7118ed04feb991127e443bd3d761f"
 
 [[package]]
 name = "fastrand"
@@ -3256,7 +3324,7 @@ version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
 dependencies = [
- "spin 0.9.9",
+ "spin",
 ]
 
 [[package]]
@@ -3264,12 +3332,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -3317,19 +3379,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-buffered"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e0e1f38ec07ba4abbde21eed377082f17ccb988be9d988a5adbf4bafc118fd"
-dependencies = [
- "cordyceps",
- "diatomic-waker",
- "futures-core",
- "pin-project-lite",
- "spin 0.10.1",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3341,16 +3390,14 @@ dependencies = [
 
 [[package]]
 name = "futures-concurrency"
-version = "7.6.3"
+version = "7.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eb68017df91f2e477ed4bea586c59eaecaa47ed885a770d0444e21e62572cd2"
+checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
 dependencies = [
  "fixedbitset",
- "futures-buffered",
  "futures-core",
  "futures-lite",
  "pin-project",
- "slab",
  "smallvec",
 ]
 
@@ -3431,19 +3478,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generator"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6bd114ceda131d3b1d665eba35788690ad37f5916457286b32ab6fd3c438dd"
-dependencies = [
- "cfg-if",
- "libc",
- "log",
- "rustversion",
- "windows 0.58.0",
-]
-
-[[package]]
 name = "getopts"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3481,16 +3515,16 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.0",
- "wasip2",
- "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3505,7 +3539,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.13.1",
  "libc",
  "libgit2-sys",
  "log",
@@ -3539,7 +3573,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.13.1",
  "ignore",
  "walkdir",
 ]
@@ -3606,32 +3640,16 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.1.5",
-]
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -3640,7 +3658,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5081f264ed7adee96ea4b4778b6bb9da0a7228b084587aa3bd3ff05da7c5a3b"
 dependencies = [
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -3668,7 +3686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d347c0de239be20ba0982e4822de3124404281e119ae3e11f5d7425a414e1935"
 dependencies = [
  "memchr",
- "pastey",
+ "pastey 0.1.1",
  "phf 0.11.3",
  "phf_codegen",
  "serde_json",
@@ -3781,6 +3799,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71a816c97c42258aa5834d07590b718b4c9a598944cd39a52dc25b351185d678"
 
 [[package]]
+name = "icu_calendar"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58655df2f728e46e4eee80bddebefacf52ec3e77cdb925014b47c5a5905eb55c"
+dependencies = [
+ "calendrical_calculations",
+ "displaydoc",
+ "icu_calendar_data",
+ "icu_locale_core",
+ "icu_locale_fallback",
+ "icu_provider 2.3.1",
+ "tinystr 0.8.4",
+ "zerovec 0.11.8",
+]
+
+[[package]]
+name = "icu_calendar_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc00caaa3fb3201ff7a18aa458e8c3ab042b9da154cfdf948bdde3936c31c36e"
+
+[[package]]
 name = "icu_collections"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3794,29 +3834,51 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
- "yoke 0.8.0",
+ "utf8_iter",
+ "yoke 0.8.3",
  "zerofrom",
- "zerovec 0.11.4",
+ "zerovec 0.11.8",
 ]
 
 [[package]]
 name = "icu_locale_core"
-version = "2.0.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap 0.8.0",
- "tinystr 0.8.1",
- "writeable 0.6.1",
- "zerovec 0.11.4",
+ "serde",
+ "tinystr 0.8.4",
+ "writeable 0.6.4",
+ "zerovec 0.11.8",
 ]
+
+[[package]]
+name = "icu_locale_fallback"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "251af8e57c9400e3eb58242fe5b8b1152b2a64fdf4cf632f923c38ccee6f2fa9"
+dependencies = [
+ "icu_locale_core",
+ "icu_locale_fallback_data",
+ "icu_provider 2.3.1",
+ "potential_utf",
+ "tinystr 0.8.4",
+ "zerovec 0.11.8",
+]
+
+[[package]]
+name = "icu_locale_fallback_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "decf2a22ec8fa68f1a0c1129a3f8583f8f8bc24e8b9ccbe98ead99f62a4dc3a8"
 
 [[package]]
 name = "icu_locid"
@@ -3871,19 +3933,18 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
- "displaydoc",
- "icu_collections 2.0.0",
- "icu_normalizer_data 2.0.0",
- "icu_properties 2.0.1",
- "icu_provider 2.0.0",
+ "icu_collections 2.3.0",
+ "icu_normalizer_data 2.3.0",
+ "icu_properties 2.3.0",
+ "icu_provider 2.3.1",
  "smallvec",
  "utf16_iter",
  "write16",
- "zerovec 0.11.4",
+ "zerovec 0.11.8",
 ]
 
 [[package]]
@@ -3894,9 +3955,9 @@ checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
@@ -3915,18 +3976,17 @@ dependencies = [
 
 [[package]]
 name = "icu_properties"
-version = "2.0.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
  "displaydoc",
- "icu_collections 2.0.0",
+ "icu_collections 2.3.0",
  "icu_locale_core",
- "icu_properties_data 2.0.1",
- "icu_provider 2.0.0",
- "potential_utf",
+ "icu_properties_data 2.3.0",
+ "icu_provider 2.3.1",
  "zerotrie",
- "zerovec 0.11.4",
+ "zerovec 0.11.8",
 ]
 
 [[package]]
@@ -3937,9 +3997,9 @@ checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
@@ -3960,19 +4020,19 @@ dependencies = [
 
 [[package]]
 name = "icu_provider"
-version = "2.0.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
+ "serde",
  "stable_deref_trait",
- "tinystr 0.8.1",
- "writeable 0.6.1",
- "yoke 0.8.0",
+ "writeable 0.6.4",
+ "yoke 0.8.3",
  "zerofrom",
  "zerotrie",
- "zerovec 0.11.4",
+ "zerovec 0.11.8",
 ]
 
 [[package]]
@@ -3985,12 +4045,6 @@ dependencies = [
  "quote",
  "syn 2.0.106",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -4042,7 +4096,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -4080,7 +4134,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.13.1",
  "inotify-sys",
  "libc",
 ]
@@ -4110,21 +4164,9 @@ dependencies = [
 
 [[package]]
 name = "intrusive-collections"
-version = "0.9.7"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
-dependencies = [
- "memoffset",
-]
-
-[[package]]
-name = "intrusive-collections"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b719c59241cfaac1042a6d26787e28ed7ee4a4e21a5a907786f54222d1b0062"
-dependencies = [
- "memoffset",
-]
+checksum = "4275b20e6057cd7733fd8df8a5a31701e4fe44497dad0f3fa0e1c4fb971506be"
 
 [[package]]
 name = "inventory"
@@ -4187,10 +4229,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.15"
+name = "itertools"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "ixdtf"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3667095d64c3ecffc96463a21157b04bf3e252f6e8d5750b20c02e33c194e3"
 
 [[package]]
 name = "jiff"
@@ -4299,12 +4356,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4324,6 +4375,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libmimalloc-sys"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4339,7 +4396,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.13.1",
  "libc",
 ]
 
@@ -4395,19 +4452,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
-name = "loom"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
-dependencies = [
- "cfg-if",
- "generator",
- "scoped-tls",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4419,7 +4463,7 @@ version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a7deb98ef9daaa7500324351a5bab7c80c644cfb86b4be0c4433b582af93510"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.13.1",
  "fluent-uri",
  "percent-encoding",
  "serde",
@@ -4440,15 +4484,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "mimalloc"
@@ -4495,7 +4530,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -4507,7 +4542,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.13.1",
  "crossbeam-channel",
  "fsevent-sys",
  "inotify",
@@ -4537,9 +4572,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -4548,15 +4583,15 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -4572,9 +4607,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -4582,9 +4617,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4621,6 +4656,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oneshot"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe21416a02c693fb9f980befcb230ecc70b0b3d1cc4abf88b9675c4c1457f0c"
 
 [[package]]
 name = "oorandom"
@@ -4698,16 +4739,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "path-absolutize"
@@ -4748,9 +4789,19 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros",
+ "phf_macros 0.13.1",
  "phf_shared 0.13.1",
  "serde",
+]
+
+[[package]]
+name = "phf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
+dependencies = [
+ "phf_macros 0.14.0",
+ "phf_shared 0.14.0",
 ]
 
 [[package]]
@@ -4784,6 +4835,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.14.0",
+]
+
+[[package]]
 name = "phf_macros"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4791,6 +4852,19 @@ checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
  "phf_generator 0.13.1",
  "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa8d0ca26d424d27630da600c6624696e7dec8bf7b3b492b383c5dc49e5e085"
+dependencies = [
+ "phf_generator 0.14.0",
+ "phf_shared 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -4810,6 +4884,15 @@ name = "phf_shared"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
 dependencies = [
  "siphasher",
 ]
@@ -4882,9 +4965,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
@@ -4901,7 +4984,8 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
 dependencies = [
- "zerovec 0.11.4",
+ "serde",
+ "zerovec 0.11.8",
 ]
 
 [[package]]
@@ -4971,7 +5055,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.13.1",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -4995,7 +5079,7 @@ dependencies = [
  "newtype-uuid",
  "quick-xml 0.38.4",
  "strip-ansi-escapes",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "uuid",
 ]
 
@@ -5025,7 +5109,7 @@ checksum = "95c589f335db0f6aaa168a7cd27b1fc6920f5e1470c804f814d9cd6e62a0f70b"
 dependencies = [
  "env_logger",
  "log",
- "rand 0.10.1",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -5053,7 +5137,7 @@ dependencies = [
  "rustc-hash 2.1.3",
  "rustls",
  "socket2",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -5074,7 +5158,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -5144,11 +5228,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "getrandom 0.4.2",
+ "chacha20",
+ "getrandom 0.4.3",
  "rand_core 0.10.0",
 ]
 
@@ -5374,7 +5459,7 @@ version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -5385,7 +5470,7 @@ checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5445,11 +5530,10 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "regress"
-version = "0.10.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145bb27393fe455dd64d6cbc8d059adfa392590a45eadf079c01b11857e7b010"
+checksum = "32eef8b209c3c1c15dbad02c1f30f9539f00dc7253e0cbcdaae442a50a09d7c1"
 dependencies = [
- "hashbrown 0.15.5",
  "memchr",
 ]
 
@@ -5584,7 +5668,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dade4812df5c384711475be5fcd8c162555352945401aed22a35bffeab61f657"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -5641,9 +5725,9 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "ryu-js"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
+checksum = "04d056b875a9d2e6cb9a61d127afee9ac5999b9f87bcb32079d1318e505be714"
 
 [[package]]
 name = "salsa"
@@ -5654,10 +5738,10 @@ dependencies = [
  "boxcar",
  "crossbeam-queue",
  "crossbeam-utils",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "hashlink",
  "indexmap",
- "intrusive-collections 0.10.2",
+ "intrusive-collections",
  "inventory",
  "parking_lot",
  "portable-atomic",
@@ -5686,7 +5770,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
- "synstructure",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -5731,14 +5815,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -5860,7 +5938,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -5871,7 +5949,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -6050,12 +6128,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6091,6 +6163,27 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "subtle"
@@ -6132,9 +6225,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6159,6 +6252,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "901704edd0dfe137f1987838ee4f259e4e063c31371bdb423f7ae38ec6f77f02"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -6190,6 +6294,23 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "temporal_rs"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a978fef907a27736827d336c0bfaab14fb8a7509dd6dc2b43c44e51d59aca5b"
+dependencies = [
+ "calendrical_calculations",
+ "core_maths",
+ "icu_calendar",
+ "icu_locale_core",
+ "ixdtf",
+ "num-traits",
+ "timezone_provider",
+ "tinystr 0.8.4",
+ "writeable 0.6.4",
 ]
 
 [[package]]
@@ -6226,9 +6347,9 @@ dependencies = [
 
 [[package]]
 name = "thin-vec"
-version = "0.2.16"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "259cdf8ed4e4aca6f1e9d011e10bd53f524a2d0637d7b28450f6c64ac298c4c6"
+checksum = "79def32ffcd477db1ff26f76dab9e3a91f0bd42a85ca96577089b24623056f9d"
 
 [[package]]
 name = "thiserror"
@@ -6241,11 +6362,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -6261,13 +6382,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -6301,12 +6422,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "itoa",
  "js-sys",
  "libc",
  "num-conv",
@@ -6319,18 +6439,30 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "timezone_provider"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ec4f4eebb4817fde02a411aedc7ac5f66c89c68c49e5d4b17a8139f077af52"
+dependencies = [
+ "tinystr 0.8.4",
+ "zerofrom",
+ "zerotrie",
+ "zerovec 0.11.8",
 ]
 
 [[package]]
@@ -6345,12 +6477,13 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.1"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
- "zerovec 0.11.4",
+ "serde_core",
+ "zerovec 0.11.8",
 ]
 
 [[package]]
@@ -6501,7 +6634,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
@@ -6526,7 +6659,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f0e711655c89181a6bc6a2cc348131fcd9680085f5b06b6af13427a393a6e72"
 dependencies = [
  "bytes",
- "dashmap 6.1.0",
+ "dashmap 6.2.1",
  "futures",
  "httparse",
  "ls-types",
@@ -6564,7 +6697,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
 dependencies = [
  "crossbeam-channel",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "time",
  "tracing-subscriber",
 ]
@@ -6720,12 +6853,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "unit-prefix"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6817,7 +6944,7 @@ version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -6884,15 +7011,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6947,40 +7065,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.9.3",
- "hashbrown 0.15.5",
- "indexmap",
- "semver 1.0.27",
 ]
 
 [[package]]
@@ -7045,22 +7129,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.62.2",
+ "windows-core",
  "windows-future",
  "windows-numerics",
 ]
@@ -7071,20 +7145,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
-dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
+ "windows-core",
 ]
 
 [[package]]
@@ -7093,11 +7154,11 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -7106,20 +7167,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
  "windows-threading",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
 ]
 
 [[package]]
@@ -7127,17 +7177,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7167,17 +7206,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7187,16 +7217,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7509,88 +7529,6 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.106",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.9.3",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver 1.0.27",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "write16"
@@ -7606,9 +7544,9 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "writeable"
-version = "0.6.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "wyz"
@@ -7737,13 +7675,12 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
- "serde",
  "stable_deref_trait",
- "yoke-derive 0.8.0",
+ "yoke-derive 0.8.2",
  "zerofrom",
 ]
 
@@ -7756,40 +7693,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
- "synstructure",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
- "synstructure",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.4"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.4"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
- "synstructure",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -7800,13 +7737,14 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
- "yoke 0.8.0",
+ "yoke 0.8.3",
  "zerofrom",
+ "zerovec 0.11.8",
 ]
 
 [[package]]
@@ -7822,13 +7760,14 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.4"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
- "yoke 0.8.0",
+ "serde",
+ "yoke 0.8.3",
  "zerofrom",
- "zerovec-derive 0.11.1",
+ "zerovec-derive 0.11.6",
 ]
 
 [[package]]
@@ -7844,13 +7783,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.1"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 3.0.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ biome_yaml_formatter         = { path = "./crates/biome_yaml_formatter", version
 biome_yaml_parser            = { path = "./crates/biome_yaml_parser", version = "0.0.1" }
 biome_yaml_syntax            = { path = "./crates/biome_yaml_syntax", version = "0.0.1" }
 biome_languages              = { path = "./crates/biome_languages", version = "0.1.0" }
-boa_engine                   = "0.21.1"
+boa_engine                   = "0.22.0"
 boxcar                       = "0.2.14"
 bpaf                         = { version = "0.9.27", features = ["derive"] }
 camino                       = "1.2.5"

--- a/crates/biome_js_runtime/Cargo.toml
+++ b/crates/biome_js_runtime/Cargo.toml
@@ -15,6 +15,7 @@ publish              = true
 biome_analyze      = { workspace = true }
 biome_diagnostics  = { workspace = true }
 biome_js_parser    = { workspace = true }
+biome_js_semantic  = { workspace = true }
 biome_js_syntax    = { workspace = true }
 biome_js_transform = { workspace = true }
 biome_languages    = { workspace = true, features = ["lang_js"] }
@@ -27,7 +28,6 @@ rustc-hash         = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 boa_engine = { workspace = true, features = ["js"] }
-web-time   = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/biome_js_runtime/src/context.rs
+++ b/crates/biome_js_runtime/src/context.rs
@@ -3,9 +3,11 @@ use crate::ast::JsAstNode;
 use crate::mutation::JsMutation;
 use crate::plugin_api::JsPluginApi;
 use crate::rule_context::create_rule_context;
+use crate::semantic::register_semantic;
 use crate::source::read_module_source;
 use crate::token::JsAstToken;
-use biome_analyze::PluginDiagnosticEntry;
+use biome_analyze::{PluginDiagnosticEntry, ServiceBag};
+use biome_js_semantic::SemanticModel;
 use biome_js_syntax::{JsSyntaxKind, JsSyntaxNode};
 use biome_languages::JsFileSource;
 use biome_resolver::FsWithResolverProxy;
@@ -19,22 +21,6 @@ use camino::Utf8Path;
 use std::rc::Rc;
 use std::sync::Arc;
 
-#[cfg(target_arch = "wasm32")]
-struct Clock;
-
-#[cfg(target_arch = "wasm32")]
-impl boa_engine::context::Clock for Clock {
-    fn now(&self) -> boa_engine::context::time::JsInstant {
-        let now = web_time::SystemTime::now();
-        let duration = now
-            .duration_since(web_time::UNIX_EPOCH)
-            .expect("System clock is before Unix epoch");
-
-        boa_engine::context::time::JsInstant::new(duration.as_secs(), duration.subsec_nanos())
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
 use boa_engine::context::time::StdClock as Clock;
 
 pub struct JsExecContext {
@@ -54,6 +40,8 @@ pub struct JsPluginRule {
     /// The syntax kinds the rule queries.
     pub kinds: Vec<JsSyntaxKind>,
 
+    pub requires_semantic: bool,
+
     /// The `run()` function of the rule, called with every node matching the query.
     pub run: JsFunction,
 }
@@ -63,13 +51,14 @@ impl JsExecContext {
         let module_loader = Rc::new(JsModuleLoader::new(fs.clone()));
         let api = JsPluginApi::new();
         let mut ctx = Context::builder()
-            .clock(Rc::new(Clock))
+            .clock(Rc::new(Clock::default()))
             .module_loader(Rc::clone(&module_loader))
             .build()?;
 
         JsAstNode::register(&mut ctx)?;
         JsAstToken::register(&mut ctx)?;
         JsMutation::register(&mut ctx)?;
+        register_semantic(&mut ctx)?;
 
         module_loader.register_module(
             js_string!("@biomejs/plugin-api"),
@@ -106,18 +95,18 @@ impl JsExecContext {
                 ),
                 None,
                 ctx,
-            )
+            )?
             .then(
                 Some(
                     NativeFunction::from_copy_closure_with_captures(
-                        |_, _, module, context| Ok(module.evaluate(context).into()),
+                        |_, _, module, context| Ok(module.evaluate(context)?.into()),
                         module.clone(),
                     )
                     .to_js_function(ctx.realm()),
                 ),
                 None,
                 ctx,
-            );
+            )?;
 
         loop {
             match promise_result.state() {
@@ -160,11 +149,15 @@ impl JsExecContext {
             };
 
             let query_type = query.get(js_string!("type"), ctx)?;
-            if query_type.as_string().is_none_or(|ty| ty != "ast") {
-                return Err(JsNativeError::typ()
-                    .with_message(format!("Rule {name} has an unsupported query type"))
-                    .into());
-            }
+            let requires_semantic = match query_type.as_string() {
+                Some(ty) if ty == "ast" => false,
+                Some(ty) if ty == "semantic" => true,
+                _ => return Err(JsNativeError::typ()
+                    .with_message(format!(
+                        "Rule {name} has an unsupported query type. Use ast(...) or semantic(...)."
+                    ))
+                    .into()),
+            };
 
             let kinds = JsArray::from_object(
                 query
@@ -195,6 +188,7 @@ impl JsExecContext {
             rules.push(JsPluginRule {
                 name,
                 kinds: rule_kinds,
+                requires_semantic,
                 run,
             });
         }
@@ -226,6 +220,26 @@ impl JsExecContext {
 
     /// Creates file metadata whose values remain associated with this invocation's source.
     pub fn create_rule_context(&mut self, path: &Utf8Path, source_type: JsFileSource) -> JsValue {
-        create_rule_context(path, source_type, &mut self.ctx)
+        create_rule_context(path, source_type, None, &mut self.ctx)
+    }
+
+    pub fn call_rule(
+        &mut self,
+        rule: &JsPluginRule,
+        node: JsSyntaxNode,
+        path: &Utf8Path,
+        source_type: JsFileSource,
+        services: &ServiceBag,
+    ) -> JsResult<JsValue> {
+        let model = if rule.requires_semantic {
+            Some(services.get_service::<SemanticModel>().ok_or_else(|| {
+                JsNativeError::typ().with_message("The semantic model is unavailable. Supply a SemanticModel service when analyzing semantic plugin rules.")
+            })?)
+        } else {
+            None
+        };
+        let ast = self.create_js_ast(node);
+        let context = create_rule_context(path, source_type, model, &mut self.ctx);
+        self.call_function(&rule.run, &JsValue::undefined(), &[ast, context])
     }
 }

--- a/crates/biome_js_runtime/src/lib.rs
+++ b/crates/biome_js_runtime/src/lib.rs
@@ -5,6 +5,7 @@ mod module_loader;
 mod mutation;
 mod plugin_api;
 mod rule_context;
+mod semantic;
 mod source;
 mod token;
 

--- a/crates/biome_js_runtime/src/module_loader.rs
+++ b/crates/biome_js_runtime/src/module_loader.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use boa_engine::module::{ModuleLoader, Referrer};
+use boa_engine::module::{ModuleLoader, ModuleRequest, Referrer};
 use boa_engine::{JsNativeError, JsResult, JsString, Module, Source};
 use camino::{Utf8Path, Utf8PathBuf};
 use rustc_hash::FxHashMap;
@@ -35,10 +35,11 @@ impl ModuleLoader for JsModuleLoader {
     async fn load_imported_module(
         self: Rc<JsModuleLoader>,
         referrer: Referrer,
-        specifier: JsString,
+        request: ModuleRequest,
         context: &RefCell<&mut boa_engine::Context>,
     ) -> JsResult<Module> {
-        if let Some(module) = self.builtins.borrow().get(&specifier) {
+        let specifier = request.specifier();
+        if let Some(module) = self.builtins.borrow().get(specifier) {
             return Ok(module.clone());
         }
 

--- a/crates/biome_js_runtime/src/plugin_api.rs
+++ b/crates/biome_js_runtime/src/plugin_api.rs
@@ -8,7 +8,9 @@ use boa_engine::module::SyntheticModuleInitializer;
 use boa_engine::object::builtins::JsArray;
 use boa_engine::object::{FunctionObjectBuilder, ObjectInitializer};
 use boa_engine::property::Attribute;
-use boa_engine::{Context, JsNativeError, JsResult, JsValue, Module, NativeFunction, js_string};
+use boa_engine::{
+    Context, JsNativeError, JsResult, JsString, JsValue, Module, NativeFunction, js_string,
+};
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -96,6 +98,14 @@ impl JsPluginApi {
         .name("ast")
         .build();
 
+        let semantic = FunctionObjectBuilder::new(
+            context.realm(),
+            NativeFunction::from_fn_ptr(Self::semantic_query),
+        )
+        .length(1)
+        .name("semantic")
+        .build();
+
         let define_rule = FunctionObjectBuilder::new(
             context.realm(),
             NativeFunction::from_fn_ptr(Self::define_rule),
@@ -123,17 +133,21 @@ impl JsPluginApi {
             &[
                 js_string!("registerDiagnostic"),
                 js_string!("ast"),
+                js_string!("semantic"),
                 js_string!("defineRule"),
                 js_string!("createMutation"),
                 js_string!("factory"),
             ],
             SyntheticModuleInitializer::from_copy_closure_with_captures(
-                |module, (register_diagnostic, ast, define_rule, create_mutation, factory), _| {
+                |module,
+                 (register_diagnostic, ast, semantic, define_rule, create_mutation, factory),
+                 _| {
                     module.set_export(
                         &js_string!("registerDiagnostic"),
                         register_diagnostic.clone().into(),
                     )?;
                     module.set_export(&js_string!("ast"), ast.clone().into())?;
+                    module.set_export(&js_string!("semantic"), semantic.clone().into())?;
                     module.set_export(&js_string!("defineRule"), define_rule.clone().into())?;
                     module.set_export(
                         &js_string!("createMutation"),
@@ -144,6 +158,7 @@ impl JsPluginApi {
                 (
                     register_diagnostic,
                     ast,
+                    semantic,
                     define_rule,
                     create_mutation,
                     factory,
@@ -157,9 +172,21 @@ impl JsPluginApi {
 
     /// Implements `ast(...kinds)`: builds an AST query object from syntax kind names.
     fn ast_query(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        Self::node_query("ast", args, context)
+    }
+
+    fn semantic_query(
+        _this: &JsValue,
+        args: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        Self::node_query("semantic", args, context)
+    }
+
+    fn node_query(query_type: &str, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         if args.is_empty() {
             return Err(JsNativeError::typ()
-                .with_message("ast() requires at least one node kind. Pass a kind from JsNodeByKind, such as ast(\"JS_CALL_EXPRESSION\").")
+                .with_message(format!("{query_type}() requires at least one node kind. Pass a kind from JsNodeByKind, such as {query_type}(\"JS_CALL_EXPRESSION\")."))
                 .into());
         }
 
@@ -167,7 +194,7 @@ impl JsPluginApi {
         for arg in args {
             let Some(kind) = arg.as_string() else {
                 return Err(JsNativeError::typ()
-                    .with_message("ast() requires node kind names as strings. Pass names such as \"JS_CALL_EXPRESSION\", not node objects.")
+                    .with_message(format!("{query_type}() requires node kind names as strings. Pass names such as \"JS_CALL_EXPRESSION\", not node objects."))
                     .into());
             };
             if JsAstNode::syntax_kind_from_ast_name(&kind.to_std_string_lossy()).is_none() {
@@ -183,7 +210,11 @@ impl JsPluginApi {
 
         let kinds = JsArray::from_iter(kinds, context);
         let query = ObjectInitializer::new(context)
-            .property(js_string!("type"), js_string!("ast"), Attribute::ENUMERABLE)
+            .property(
+                js_string!("type"),
+                JsString::from(query_type),
+                Attribute::ENUMERABLE,
+            )
             .property(js_string!("kinds"), kinds, Attribute::ENUMERABLE)
             .build();
 
@@ -212,7 +243,7 @@ impl JsPluginApi {
         {
             return Err(JsNativeError::typ()
                 .with_message(
-                    "The rule's query property must be a query object. Set it to ast(...) with the node kinds the rule should inspect.",
+                    "The rule's query property must be a query object. Set it to ast(...) or semantic(...) with the node kinds the rule should inspect.",
                 )
                 .into());
         }

--- a/crates/biome_js_runtime/src/rule_context.rs
+++ b/crates/biome_js_runtime/src/rule_context.rs
@@ -11,6 +11,7 @@ use camino::Utf8Path;
 pub(crate) fn create_rule_context(
     path: &Utf8Path,
     source_type: JsFileSource,
+    model: Option<&SemanticModel>,
     context: &mut Context,
 ) -> JsValue {
     let language = match source_type.language() {
@@ -59,15 +60,19 @@ pub(crate) fn create_rule_context(
             Attribute::ENUMERABLE,
         )
         .build();
-    ObjectInitializer::new(context)
+    let model = model.map(|model| JsSemanticModel::wrap(model.clone(), context));
+    let mut object = ObjectInitializer::new(context);
+    object
         .property(
             js_string!("filePath"),
             JsString::from(path.as_str()),
             Attribute::ENUMERABLE,
         )
-        .property(js_string!("sourceType"), source_type, Attribute::ENUMERABLE)
-        .build()
-        .into()
+        .property(js_string!("sourceType"), source_type, Attribute::ENUMERABLE);
+    if let Some(model) = model {
+        object.property(js_string!("model"), model, Attribute::ENUMERABLE);
+    }
+    object.build().into()
 }
 
 fn embedding_kind(kind: &JsEmbeddingKind, context: &mut Context) -> JsValue {
@@ -148,3 +153,5 @@ fn embedding_kind(kind: &JsEmbeddingKind, context: &mut Context) -> JsValue {
     }
     object.build().into()
 }
+use crate::semantic::JsSemanticModel;
+use biome_js_semantic::SemanticModel;

--- a/crates/biome_js_runtime/src/semantic.rs
+++ b/crates/biome_js_runtime/src/semantic.rs
@@ -1,0 +1,379 @@
+use crate::ast::JsAstNode;
+use biome_js_semantic::{
+    Binding, GlobalReference, JsDeclarationKind, Reference, Scope, SemanticModel,
+    UnresolvedReference,
+};
+use biome_js_syntax::binding_ext::AnyJsIdentifierBinding;
+use biome_js_syntax::{AnyJsIdentifierReference, JsSyntaxNode};
+use biome_rowan::AstNode;
+use boa_engine::class::{Class, ClassBuilder};
+use boa_engine::object::builtins::JsArray;
+use boa_engine::object::{JsObject, ObjectInitializer};
+use boa_engine::property::Attribute;
+use boa_engine::{
+    Context, Finalize, JsData, JsNativeError, JsResult, JsValue, NativeFunction, Trace, js_string,
+};
+use std::rc::Rc;
+
+/// Declares a Boa class wrapping an owned semantic handle and its JavaScript methods.
+///
+/// Each method entry is `(name, argument_count, |handle, args, context| { ... })`.
+/// The count excludes `this`: it sets the function's `length` and the exact number
+/// of arguments accepted. The receiver and argument count are checked before the
+/// body runs. `handle` is an `Rc` to the native value; the body returns `JsResult<JsValue>`.
+macro_rules! semantic_object {
+    ($wrapper:ident, $native:ty, $name:literal, $(($method:literal, $arity:literal, |$value:ident, $args:ident, $context:ident| $body:block)),+ $(,)?) => {
+        #[derive(Clone, JsData)]
+        pub(crate) struct $wrapper(Rc<$native>);
+
+        impl Finalize for $wrapper {}
+
+        // SAFETY: Semantic handles own Rust model data, which contains no Boa-managed values.
+        unsafe impl Trace for $wrapper {
+            boa_engine::gc::empty_trace!();
+        }
+
+        impl $wrapper {
+            pub(crate) fn wrap(value: $native, context: &mut Context) -> JsValue {
+                let prototype = context.get_global_class::<Self>().map(|class| class.prototype());
+                JsObject::from_proto_and_data(prototype, Self(Rc::new(value))).into()
+            }
+
+            fn from_value(value: &JsValue) -> JsResult<Rc<$native>> {
+                let object = value.as_object().ok_or_else(|| JsNativeError::typ()
+                    .with_message(concat!("Call this method on a ", $name, " returned by Biome.")))?;
+                let native = object.downcast_ref::<Self>().ok_or_else(|| JsNativeError::typ()
+                    .with_message(concat!("Call this method on a ", $name, " returned by Biome.")))?;
+                Ok(Rc::clone(&native.0))
+            }
+        }
+
+        impl Class for $wrapper {
+            const NAME: &'static str = $name;
+
+            fn init(class: &mut ClassBuilder<'_>) -> JsResult<()> {
+                $(class.method(
+                    js_string!($method), $arity,
+                    NativeFunction::from_fn_ptr(|this, $args, $context| {
+                        let $value = Self::from_value(this)?;
+                        let _ = &$context;
+                        if $args.len() != $arity {
+                            return Err(JsNativeError::typ().with_message(format!(
+                                "{}.{}() requires {} argument(s).", $name, $method, $arity,
+                            )).into());
+                        }
+                        $body
+                    }),
+                );)+
+                Ok(())
+            }
+
+            fn data_constructor(_new_target: &JsValue, _args: &[JsValue], _context: &mut Context) -> JsResult<Self> {
+                Err(JsNativeError::typ().with_message(concat!(
+                    $name, " has no public constructor. Obtain semantic information through context.model in a semantic rule.",
+                )).into())
+            }
+        }
+    };
+}
+
+semantic_object!(
+    JsSemanticModel,
+    SemanticModel,
+    "SemanticModel",
+    ("binding", 1, |model, args, context| {
+        let node = model_node(&model, &args[0])?;
+        let reference = reference_node(node)?;
+        Ok(optional_binding(model.binding(&reference), context))
+    }),
+    ("asBinding", 1, |model, args, context| {
+        let node = model_node(&model, &args[0])?;
+        let binding = binding_node(node)?;
+        Ok(optional_binding(
+            model.as_binding_by_range(binding.syntax().text_trimmed_range()),
+            context,
+        ))
+    }),
+    ("allBindings", 0, |model, args, context| {
+        Ok(array(model.all_bindings(), JsBinding::wrap, context))
+    }),
+    ("allExportedBindings", 0, |model, args, context| {
+        Ok(array(
+            model.all_exported_bindings(),
+            JsBinding::wrap,
+            context,
+        ))
+    }),
+    ("hasExports", 0, |model, args, context| {
+        Ok(model.has_exports().into())
+    }),
+    ("scopes", 0, |model, args, context| {
+        Ok(array(model.scopes(), JsScope::wrap, context))
+    }),
+    ("globalScope", 0, |model, args, context| {
+        Ok(JsScope::wrap(model.global_scope(), context))
+    }),
+    ("scope", 1, |model, args, context| {
+        let node = model_node(&model, &args[0])?;
+        if node.text_trimmed_range().is_empty() {
+            return Ok(JsValue::undefined());
+        }
+        Ok(JsScope::wrap(model.scope(&node), context))
+    }),
+    ("scopeHoistedTo", 1, |model, args, context| {
+        let node = model_node(&model, &args[0])?;
+        Ok(optional_scope(model.scope_hoisted_to(&node), context))
+    }),
+    ("allGlobalReferences", 0, |model, args, context| {
+        Ok(array(
+            model.all_global_references(),
+            JsGlobalReference::wrap,
+            context,
+        ))
+    }),
+    ("allUnresolvedReferences", 0, |model, args, context| {
+        Ok(array(
+            model.all_unresolved_references(),
+            JsUnresolvedReference::wrap,
+            context,
+        ))
+    }),
+    ("isGlobalReference", 1, |model, args, context| {
+        let node = reference_node(model_node(&model, &args[0])?)?;
+        Ok(model.is_global_reference(&node).into())
+    }),
+    ("isUnresolvedReference", 1, |model, args, context| {
+        let node = reference_node(model_node(&model, &args[0])?)?;
+        Ok(model.is_unresolved_reference(&node).into())
+    }),
+    ("isImported", 1, |model, args, context| {
+        let node = model_node(&model, &args[0])?;
+        let binding = if let Some(reference) = AnyJsIdentifierReference::cast_ref(&node) {
+            model.binding(&reference)
+        } else {
+            let binding = binding_node(node)?;
+            model.as_binding_by_range(binding.syntax().text_trimmed_range())
+        };
+        Ok(binding.is_some_and(|binding| binding.is_imported()).into())
+    }),
+    ("isExported", 1, |model, args, context| {
+        let node = model_node(&model, &args[0])?;
+        let exported = if let Some(reference) = AnyJsIdentifierReference::cast_ref(&node) {
+            model.is_exported(&reference).unwrap_or(false)
+        } else {
+            model.is_exported(&binding_node(node)?)
+        };
+        Ok(exported.into())
+    }),
+);
+
+semantic_object!(
+    JsBinding,
+    Binding,
+    "Binding",
+    ("syntax", 0, |binding, args, context| {
+        Ok(JsAstNode::from_node(binding.syntax(), context))
+    }),
+    ("declarationKind", 0, |binding, args, context| {
+        let kind = match binding.declaration_kind() {
+            JsDeclarationKind::Class => js_string!("class"),
+            JsDeclarationKind::Enum => js_string!("enum"),
+            JsDeclarationKind::Function => js_string!("function"),
+            JsDeclarationKind::Generic => js_string!("generic"),
+            JsDeclarationKind::HoistedValue => js_string!("hoistedValue"),
+            JsDeclarationKind::Import => js_string!("import"),
+            JsDeclarationKind::ImportType => js_string!("importType"),
+            JsDeclarationKind::Interface => js_string!("interface"),
+            JsDeclarationKind::Module => js_string!("module"),
+            JsDeclarationKind::Namespace => js_string!("namespace"),
+            JsDeclarationKind::Type => js_string!("type"),
+            JsDeclarationKind::Unknown => js_string!("unknown"),
+            JsDeclarationKind::Using => js_string!("using"),
+            JsDeclarationKind::Value => js_string!("value"),
+        };
+        Ok(kind.into())
+    }),
+    ("exports", 0, |binding, args, context| {
+        Ok(array(binding.exports(), JsAstNode::from_node, context))
+    }),
+    ("exportRanges", 0, |binding, args, context| {
+        Ok(array(
+            binding.export_ranges().iter().copied(),
+            |range, context| {
+                ObjectInitializer::new(context)
+                    .property(
+                        js_string!("start"),
+                        u32::from(range.start()),
+                        Attribute::ENUMERABLE,
+                    )
+                    .property(
+                        js_string!("end"),
+                        u32::from(range.end()),
+                        Attribute::ENUMERABLE,
+                    )
+                    .build()
+                    .into()
+            },
+            context,
+        ))
+    }),
+    ("scope", 0, |binding, args, context| {
+        Ok(JsScope::wrap(binding.scope(), context))
+    }),
+    ("allReferences", 0, |binding, args, context| {
+        Ok(array(binding.all_references(), JsReference::wrap, context))
+    }),
+    ("allReads", 0, |binding, args, context| {
+        Ok(array(binding.all_reads(), JsReference::wrap, context))
+    }),
+    ("allWrites", 0, |binding, args, context| {
+        Ok(array(binding.all_writes(), JsReference::wrap, context))
+    }),
+    ("isImported", 0, |binding, args, context| {
+        Ok(binding.is_imported().into())
+    }),
+    ("isExported", 0, |binding, args, context| {
+        Ok(binding.is_exported().into())
+    }),
+);
+
+semantic_object!(
+    JsReference,
+    Reference,
+    "Reference",
+    ("syntax", 0, |reference, args, context| {
+        Ok(JsAstNode::from_node(reference.syntax(), context))
+    }),
+    ("binding", 0, |reference, args, context| {
+        Ok(optional_binding(reference.binding(), context))
+    }),
+    ("scope", 0, |reference, args, context| {
+        Ok(JsScope::wrap(reference.scope(), context))
+    }),
+    ("isRead", 0, |reference, args, context| {
+        Ok(reference.is_read().into())
+    }),
+    ("isWrite", 0, |reference, args, context| {
+        Ok(reference.is_write().into())
+    }),
+);
+
+semantic_object!(
+    JsScope,
+    Scope,
+    "Scope",
+    ("syntax", 0, |scope, args, context| {
+        Ok(JsAstNode::from_node(scope.syntax(), context))
+    }),
+    ("isGlobalScope", 0, |scope, args, context| {
+        Ok(scope.is_global_scope().into())
+    }),
+    ("parent", 0, |scope, args, context| {
+        Ok(optional_scope(scope.parent(), context))
+    }),
+    ("children", 0, |scope, args, context| {
+        Ok(array(scope.children(), JsScope::wrap, context))
+    }),
+    ("ancestors", 0, |scope, args, context| {
+        Ok(array(scope.ancestors(), JsScope::wrap, context))
+    }),
+    ("bindings", 0, |scope, args, context| {
+        Ok(array(scope.bindings(), JsBinding::wrap, context))
+    }),
+    ("getBinding", 1, |scope, args, context| {
+        let name = args[0].as_string().ok_or_else(|| {
+            JsNativeError::typ()
+                .with_message("Scope.getBinding() requires an identifier name as a string.")
+        })?;
+        let name = name.to_std_string().map_err(|_| JsNativeError::typ()
+            .with_message("The binding name contains an incomplete Unicode character. Supply a complete identifier name."))?;
+        Ok(optional_binding(scope.get_binding(&name), context))
+    }),
+);
+
+semantic_object!(
+    JsGlobalReference,
+    GlobalReference,
+    "GlobalReference",
+    ("syntax", 0, |reference, args, context| {
+        Ok(JsAstNode::from_node(reference.syntax(), context))
+    }),
+    ("isRead", 0, |reference, args, context| {
+        Ok(reference.is_read().into())
+    }),
+    ("isWrite", 0, |reference, args, context| {
+        Ok(reference.is_write().into())
+    }),
+);
+
+semantic_object!(
+    JsUnresolvedReference,
+    UnresolvedReference,
+    "UnresolvedReference",
+    ("syntax", 0, |reference, args, context| {
+        Ok(JsAstNode::from_node(reference.syntax(), context))
+    }),
+);
+
+fn model_node(model: &SemanticModel, value: &JsValue) -> JsResult<JsSyntaxNode> {
+    let node = JsAstNode::from_value(value)
+        .ok_or_else(|| {
+            JsNativeError::typ()
+                .with_message("Pass a node from the source associated with this semantic model.")
+        })?
+        .node;
+    if node.ancestors().last().as_ref() != Some(model.root().syntax()) {
+        return Err(JsNativeError::typ().with_message(
+            "The node belongs to a different source than this semantic model. Use a node from the model's original source.",
+        ).into());
+    }
+    Ok(node)
+}
+
+fn reference_node(node: JsSyntaxNode) -> JsResult<AnyJsIdentifierReference> {
+    AnyJsIdentifierReference::cast(node).ok_or_else(|| JsNativeError::typ()
+        .with_message("Pass a JsReferenceIdentifier, JsIdentifierAssignment, or JsxReferenceIdentifier node.").into())
+}
+
+fn binding_node(node: JsSyntaxNode) -> JsResult<AnyJsIdentifierBinding> {
+    AnyJsIdentifierBinding::cast(node).ok_or_else(|| JsNativeError::typ()
+        .with_message("Pass an identifier binding, type parameter name, or literal enum member name node.").into())
+}
+
+fn optional_binding(binding: Option<Binding>, context: &mut Context) -> JsValue {
+    binding.map_or_else(JsValue::undefined, |binding| {
+        JsBinding::wrap(binding, context)
+    })
+}
+
+fn optional_scope(scope: Option<Scope>, context: &mut Context) -> JsValue {
+    scope.map_or_else(JsValue::undefined, |scope| JsScope::wrap(scope, context))
+}
+
+fn array<T>(
+    items: impl IntoIterator<Item = T>,
+    wrap: fn(T, &mut Context) -> JsValue,
+    context: &mut Context,
+) -> JsValue {
+    let values = items
+        .into_iter()
+        .map(|item| wrap(item, context))
+        .collect::<Vec<_>>();
+    JsArray::from_iter(values, context).into()
+}
+
+pub(crate) fn register_semantic(context: &mut Context) -> JsResult<()> {
+    fn register<C: Class>(context: &mut Context) -> JsResult<()> {
+        context.register_global_class::<C>()?;
+        context
+            .global_object()
+            .delete_property_or_throw(js_string!(C::NAME), context)?;
+        Ok(())
+    }
+    register::<JsSemanticModel>(context)?;
+    register::<JsBinding>(context)?;
+    register::<JsReference>(context)?;
+    register::<JsScope>(context)?;
+    register::<JsGlobalReference>(context)?;
+    register::<JsUnresolvedReference>(context)
+}

--- a/crates/biome_plugin_loader/Cargo.toml
+++ b/crates/biome_plugin_loader/Cargo.toml
@@ -44,6 +44,7 @@ serde                    = { workspace = true }
 biome_js_analyze   = { path = "../biome_js_analyze" }
 biome_js_formatter = { path = "../biome_js_formatter" }
 biome_js_parser    = { path = "../biome_js_parser" }
+biome_js_semantic  = { path = "../biome_js_semantic" }
 biome_languages    = { path = "../biome_languages", features = ["lang_js"] }
 insta              = { workspace = true }
 serde_json         = { workspace = true }

--- a/crates/biome_plugin_loader/src/analyzer_js_plugin.rs
+++ b/crates/biome_plugin_loader/src/analyzer_js_plugin.rs
@@ -2,7 +2,7 @@ use std::fmt::{Debug, Formatter};
 use std::ops::DerefMut;
 use std::sync::Arc;
 
-use boa_engine::{JsNativeError, JsResult, JsValue};
+use boa_engine::{JsNativeError, JsResult};
 use camino::{Utf8Path, Utf8PathBuf};
 
 use biome_analyze::{
@@ -176,9 +176,7 @@ impl AnalyzerPlugin for AnalyzerJsPlugin {
         let mut entries = Vec::new();
 
         for rule in rules.iter().filter(|rule| rule.kinds.contains(&kind)) {
-            let ast = ctx.create_js_ast(node.clone());
-            let context = ctx.create_rule_context(&path, *source_type);
-            let result = ctx.call_function(&rule.run, &JsValue::undefined(), &[ast, context]);
+            let result = ctx.call_rule(rule, node.clone(), &path, *source_type, services);
 
             // Drain the diagnostics even on errors, so a failed rule can't leak
             // its diagnostics into the next one.
@@ -214,8 +212,9 @@ mod tests {
     use biome_fs::MemoryFileSystem;
     use biome_js_parser::JsParserOptions;
     use biome_js_syntax::JsSyntaxKind;
+    use boa_engine::JsValue;
 
-    fn services(source_type: JsFileSource) -> ServiceBag {
+    pub(super) fn services(source_type: JsFileSource) -> ServiceBag {
         let mut services = ServiceBag::default();
         services.insert_service(source_type);
         services
@@ -460,7 +459,7 @@ mod tests {
 
     /// Renders the diagnostics of a single evaluation the same way the CLI does, by attaching the
     /// path and the content of the analyzed file so the code frame can be printed.
-    fn render_diagnostics(path: &str, source: &str, result: PluginEvalResult) -> String {
+    pub(super) fn render_diagnostics(path: &str, source: &str, result: PluginEvalResult) -> String {
         result
             .entries
             .into_iter()
@@ -482,7 +481,7 @@ mod tests {
             .collect()
     }
 
-    fn snap_diagnostics(
+    pub(super) fn snap_diagnostics(
         test_name: &str,
         plugin_path: &str,
         plugin_source: &str,
@@ -501,7 +500,7 @@ mod tests {
         });
     }
 
-    fn load_test_plugin_from_source(
+    pub(super) fn load_test_plugin_from_source(
         path: &str,
         source: &str,
         includes: Option<&[NormalizedGlob]>,
@@ -1872,6 +1871,7 @@ mod tests {
                     message
                         .lines()
                         .next()
+                        .map(|line| line.rsplit_once(" (").map_or(line, |(message, _)| message))
                         .is_some_and(|line| line.ends_with('.')),
                     "{case}: {message}"
                 );
@@ -2221,3 +2221,7 @@ mod tests {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "semantic.tests.rs"]
+mod semantic_tests;

--- a/crates/biome_plugin_loader/src/semantic.tests.rs
+++ b/crates/biome_plugin_loader/src/semantic.tests.rs
@@ -1,0 +1,481 @@
+use super::tests::{load_test_plugin_from_source, render_diagnostics, services, snap_diagnostics};
+use super::*;
+use biome_analyze::{AnalysisFilter, AnalyzerOptions, ControlFlow, Never};
+use biome_diagnostics::PrintDescription;
+use biome_js_analyze::JsAnalyzerServices;
+use biome_js_parser::{JsParserOptions, parse};
+use biome_js_semantic::{SemanticModel, SemanticModelOptions, semantic_model};
+use biome_js_syntax::JsSyntaxKind;
+use biome_rowan::AstNode;
+use serde_json::{Value, json};
+
+fn native_summary(model: &SemanticModel) -> Value {
+    let mut exported = model
+        .all_exported_bindings()
+        .map(|binding| binding.syntax().text_trimmed().to_string())
+        .collect::<Vec<_>>();
+    exported.sort();
+    let reference = |reference: biome_js_semantic::Reference| {
+        json!([
+            format!("{:?}", reference.syntax().kind()),
+            reference.syntax().text_trimmed().to_string(),
+            reference.is_read(),
+            reference.is_write(),
+            reference
+                .binding()
+                .map(|binding| binding.syntax().text_trimmed().to_string()),
+        ])
+    };
+    json!({
+        "bindings": model.all_bindings().map(|binding| json!([
+            format!("{:?}", binding.syntax().kind()), binding.syntax().text_trimmed().to_string(),
+            binding.all_references().map(reference).collect::<Vec<_>>(),
+            binding.all_reads().map(reference).collect::<Vec<_>>(),
+            binding.all_writes().map(reference).collect::<Vec<_>>(),
+            binding.is_imported(), binding.is_exported(),
+            binding.is_imported(), model.is_exported(&binding.tree()),
+            format!("{:?}", binding.declaration_kind()).char_indices()
+                .map(|(index, ch)| if index == 0 { ch.to_ascii_lowercase() } else { ch }).collect::<String>(),
+            binding.exports().map(|node| json!([
+                format!("{:?}", node.kind()), node.text_trimmed().to_string(),
+            ])).collect::<Vec<_>>(),
+            binding.export_ranges().iter().map(|range| json!({
+                "start": u32::from(range.start()), "end": u32::from(range.end()),
+            })).collect::<Vec<_>>(),
+        ])).collect::<Vec<_>>(),
+        "exported": exported,
+        "hasExports": model.has_exports(),
+        "globals": model.all_global_references().map(|reference| json!([
+            format!("{:?}", reference.syntax().kind()), reference.syntax().text_trimmed().to_string(),
+            reference.is_read(), reference.is_write(),
+        ])).collect::<Vec<_>>(),
+        "unresolved": model.all_unresolved_references().map(|reference| json!([
+            format!("{:?}", reference.syntax().kind()), reference.syntax().text_trimmed().to_string(),
+            model.is_unresolved_reference(&reference.tree()),
+        ])).collect::<Vec<_>>(),
+    })
+}
+
+#[test]
+fn semantic_results_match_the_native_model() {
+    let plugin_source = r#"import { defineRule, semantic, registerDiagnostic } from "@biomejs/plugin-api";
+        export const inspect = defineRule({
+            query: semantic("JS_MODULE", "TS_DECLARATION_MODULE"),
+            run(root, { model }) {
+                const reference = ref => [ref.syntax().kind, ref.syntax().text,
+                    ref.isRead(), ref.isWrite(), ref.binding()?.syntax().text];
+                registerDiagnostic(root, "information", JSON.stringify({
+                    bindings: model.allBindings().map(binding => {
+                        const node = binding.syntax();
+                        const found = model.asBinding(node);
+                        return [found.syntax().kind, found.syntax().text,
+                            binding.allReferences().map(reference),
+                            binding.allReads().map(reference), binding.allWrites().map(reference),
+                            binding.isImported(), binding.isExported(),
+                            model.isImported(node), model.isExported(node),
+                            binding.declarationKind(),
+                            binding.exports().map(site => [site.kind, site.text]),
+                            binding.exportRanges()];
+                    }),
+                    exported: model.allExportedBindings().map(binding => binding.syntax().text).sort(),
+                    hasExports: model.hasExports(),
+                    globals: model.allGlobalReferences().map(ref => [ref.syntax().kind,
+                        ref.syntax().text, ref.isRead(), ref.isWrite()]),
+                    unresolved: model.allUnresolvedReferences().map(ref => [ref.syntax().kind,
+                        ref.syntax().text, model.isUnresolvedReference(ref.syntax())]),
+                }, 0, 2));
+                const nodes = root.children().flatMap(function visit(node) {
+                    return [node, ...node.children().flatMap(visit)];
+                });
+                for (const node of nodes) {
+                    if (!["JS_REFERENCE_IDENTIFIER", "JS_IDENTIFIER_ASSIGNMENT", "JSX_REFERENCE_IDENTIFIER"].includes(node.kind)) continue;
+                    registerDiagnostic(node, "information", JSON.stringify([
+                        model.binding(node)?.syntax().text ?? null,
+                        model.isImported(node), model.isExported(node),
+                        model.isGlobalReference(node), model.isUnresolvedReference(node),
+                    ], 0, 2));
+                }
+            },
+        });"#;
+    let plugin = load_test_plugin_from_source("/plugin.js", plugin_source, None);
+    let mut inputs = Vec::new();
+    let mut rendered = String::new();
+    for (path, source, source_type) in [
+        (
+            "/file.js",
+            "import { external as imported } from 'pkg'; export let outer = 1; function f(outer) { outer = 2; return outer; } outer++; imported; configured; configured = 1; missing;",
+            JsFileSource::js_module(),
+        ),
+        (
+            "/file.ts",
+            "import dependency = require('pkg'); import type TypeDependency = require('types'); interface T {} type U<T> = T; let value: T; value; dependency; type D = TypeDependency;",
+            JsFileSource::ts(),
+        ),
+        (
+            "/file.jsx",
+            "const Café = () => null; let café = 1; café; <Café />; <Missing />;",
+            JsFileSource::jsx(),
+        ),
+        (
+            "/file.d.ts",
+            "declare const value: number;",
+            JsFileSource::d_ts(),
+        ),
+        (
+            "/malformed.js",
+            "let broken = ; broken;",
+            JsFileSource::js_module(),
+        ),
+        (
+            "/exports.js",
+            "export const café = 1; const local = 2; export { local as renamed, café as renamedCafé, local as again }; export default local; export * from 'pkg'; export { remote } from 'other';",
+            JsFileSource::js_module(),
+        ),
+        (
+            "/reexports.js",
+            "export * from 'pkg'; export { remote as alias } from 'other'; export default 42; export {};",
+            JsFileSource::js_module(),
+        ),
+        (
+            "/kinds.ts",
+            "var hoisted; using resource = acquire(); export class C {} export enum E { Member } namespace N { export const x = 1; } module M {} export type Alias<T> = T; declare module 'pkg' { export const external: number; }",
+            JsFileSource::ts(),
+        ),
+    ] {
+        let parsed = parse(source, source_type, JsParserOptions::default());
+        let model = semantic_model(
+            &parsed.tree(),
+            SemanticModelOptions {
+                globals: ["configured".to_string()].into_iter().collect(),
+                ..SemanticModelOptions::from(&source_type)
+            },
+        );
+        let mut bag = services(source_type);
+        bag.insert_service(model.clone());
+        let result = plugin.evaluate(parsed.syntax().into(), path.into(), &bag);
+        let (summary, references) = result
+            .entries
+            .split_first()
+            .expect("expected semantic output");
+        let actual = PrintDescription(&summary.diagnostic).to_string();
+        assert_eq!(
+            serde_json::from_str::<Value>(&actual).expect(&actual),
+            native_summary(&model),
+            "{source}"
+        );
+        let expected: Vec<_> = parsed
+            .syntax()
+            .descendants()
+            .filter_map(biome_js_syntax::AnyJsIdentifierReference::cast)
+            .map(|node| {
+                json!([
+                    model
+                        .binding(&node)
+                        .map(|binding| binding.syntax().text_trimmed().to_string()),
+                    model
+                        .binding(&node)
+                        .is_some_and(|binding| binding.is_imported()),
+                    model.is_exported(&node).unwrap_or(false),
+                    model.is_global_reference(&node),
+                    model.is_unresolved_reference(&node),
+                ])
+            })
+            .collect();
+        let actual: Vec<Value> = references
+            .iter()
+            .map(|entry| {
+                let message = PrintDescription(&entry.diagnostic).to_string();
+                serde_json::from_str(&message).expect(&message)
+            })
+            .collect();
+        assert_eq!(actual, expected, "{source}");
+        inputs.push((path, source));
+        rendered.push_str(&render_diagnostics(path, source, result));
+    }
+    snap_diagnostics(
+        "semantic_model",
+        "/plugin.js",
+        plugin_source,
+        &inputs,
+        rendered,
+    );
+}
+
+#[test]
+fn semantic_rules_use_the_supplied_model_and_syntax_rules_keep_their_context() {
+    let plugin_source = r#"import { ast, createMutation, defineRule, factory, semantic, registerDiagnostic } from "@biomejs/plugin-api";
+        export const aSyntax = defineRule({
+            query: ast("JS_REFERENCE_IDENTIFIER"),
+            run(node, context) {
+                registerDiagnostic(node, "information", `syntax:${"model" in context}`);
+            },
+        });
+        export const bSemantic = defineRule({
+            query: semantic("JS_REFERENCE_IDENTIFIER"),
+            run(node, context) {
+                const binding = context.model.binding(node);
+                const reference = binding.allReads()[0].syntax();
+                const mutation = createMutation(binding.syntax());
+                mutation.replaceToken(reference.token("valueToken"), factory.token("IDENT", "renamed"));
+                registerDiagnostic(reference, "information",
+                    `semantic:${binding.syntax().text}:${binding.allReads().length}:${Reflect.set(context, "model", null)}`,
+                    { mutation, message: "Rename the reference.", kind: "unsafe" });
+            },
+        });"#;
+    let plugin = load_test_plugin_from_source("/plugin.js", plugin_source, None);
+    let source_type = JsFileSource::js_module();
+    let parsed = parse(
+        "let value = 1; value;",
+        source_type,
+        JsParserOptions::default(),
+    );
+    let model = semantic_model(&parsed.tree(), SemanticModelOptions::from(&source_type));
+    let options = AnalyzerOptions::default();
+    let plugins: Vec<Arc<Box<dyn AnalyzerPlugin>>> = vec![Arc::new(Box::new(plugin))];
+    let mut messages = Vec::new();
+    let (_, diagnostics) = biome_js_analyze::analyze(
+        &parsed.tree(),
+        AnalysisFilter {
+            enabled_rules: Some(&[]),
+            ..AnalysisFilter::default()
+        },
+        &options,
+        &plugins,
+        JsAnalyzerServices::default()
+            .with_source_type(source_type)
+            .with_semantic_model(&model),
+        |signal| {
+            if let Some(diagnostic) = signal.diagnostic() {
+                messages.push(PrintDescription(&diagnostic).to_string());
+            }
+            ControlFlow::<Never>::Continue(())
+        },
+    );
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+    messages.sort();
+    assert_eq!(messages, ["semantic:value:1:false", "syntax:false"]);
+
+    let node = parsed
+        .syntax()
+        .descendants()
+        .find(|node| node.kind() == JsSyntaxKind::JS_REFERENCE_IDENTIFIER)
+        .unwrap();
+    let mut bag = services(source_type);
+    bag.insert_service(model);
+    let result = plugins[0].evaluate(node.clone().into(), "/file.js".into(), &bag);
+    let actions: Vec<_> = result
+        .entries
+        .iter()
+        .filter_map(|entry| entry.action.as_ref())
+        .collect();
+    let [action] = actions.as_slice() else {
+        panic!("expected one fix: {result:?}")
+    };
+    assert_eq!(
+        action.text_edit.new_string("let value = 1; value;"),
+        "let value = 1; renamed;"
+    );
+    let mut rendered = render_diagnostics("/file.js", "let value = 1; value;", result);
+    let result = plugins[0].evaluate(node.into(), "/file.js".into(), &services(source_type));
+    let messages: Vec<_> = result
+        .entries
+        .iter()
+        .map(|entry| PrintDescription(&entry.diagnostic).to_string())
+        .collect();
+    assert_eq!(messages.len(), 2);
+    assert_eq!(messages[0], "syntax:false");
+    assert!(
+        messages[1].contains("The semantic model is unavailable."),
+        "{messages:?}"
+    );
+    rendered.push_str(&render_diagnostics(
+        "/file.js",
+        "let value = 1; value;",
+        result,
+    ));
+    snap_diagnostics(
+        "semantic_model_context_and_fixes",
+        "/plugin.js",
+        plugin_source,
+        &[("/file.js", "let value = 1; value;")],
+        rendered,
+    );
+}
+
+#[test]
+fn semantic_handles_retain_their_source() {
+    let plugin_source = r#"import { defineRule, semantic, registerDiagnostic } from "@biomejs/plugin-api";
+        let saved;
+        export const retained = defineRule({
+            query: semantic("JS_MODULE"),
+            run(root, { model }) {
+                const bindings = model.allBindings();
+                const binding = bindings[0];
+                bindings.length = 0;
+                if (saved) {
+                    const node = saved.reference.syntax();
+                    registerDiagnostic(root, "information", JSON.stringify([
+                        binding.syntax().text, saved.model.binding(node).syntax().text,
+                        saved.binding.allReads().length, model.allBindings().length,
+                        saved.scope.bindings().map(binding => binding.syntax().text),
+                    ], 0, 2));
+                    model.binding(node);
+                } else {
+                    saved = { model, binding, reference: binding.allReads()[0], scope: model.globalScope() };
+                }
+            },
+        });"#;
+    let plugin = load_test_plugin_from_source("/plugin.js", plugin_source, None);
+    let source_type = JsFileSource::js_module();
+    let inputs = [
+        ("/file.js", "let first = 1; first;"),
+        ("/file.js", "let second = 2; second;"),
+    ];
+    let mut rendered = String::new();
+    for (index, (path, source)) in inputs.into_iter().enumerate() {
+        let parsed = parse(source, source_type, JsParserOptions::default());
+        let mut bag = services(source_type);
+        bag.insert_service(semantic_model(
+            &parsed.tree(),
+            SemanticModelOptions::default(),
+        ));
+        let result = plugin.evaluate(parsed.syntax().into(), "/file.js".into(), &bag);
+        if index == 0 {
+            assert!(result.entries.is_empty());
+        } else {
+            let [retained, error] = result.entries.as_slice() else {
+                panic!("{result:?}")
+            };
+            assert_eq!(
+                serde_json::from_str::<Value>(&PrintDescription(&retained.diagnostic).to_string())
+                    .unwrap(),
+                json!(["second", "first", 1, 1, ["first"]])
+            );
+            assert!(
+                PrintDescription(&error.diagnostic)
+                    .to_string()
+                    .contains("The node belongs to a different source")
+            );
+        }
+        rendered.push_str(&render_diagnostics(path, source, result));
+    }
+    snap_diagnostics(
+        "semantic_model_retained_handles",
+        "/plugin.js",
+        plugin_source,
+        &inputs,
+        rendered,
+    );
+}
+
+#[test]
+fn semantic_scopes_preserve_nesting_bindings_and_hoisting() {
+    // Boa parses this fixture on the test thread's stack; avoid deeply nested expressions.
+    let plugin_source = r#"import { defineRule, semantic, registerDiagnostic } from "@biomejs/plugin-api";
+        function describe(scope) {
+            if (!scope) return null;
+            const names = [];
+            for (const binding of scope.bindings()) {
+                names.push(binding.syntax().text);
+            }
+            return [scope.syntax().kind, names];
+        }
+        export const scopes = defineRule({
+            query: semantic("JS_MODULE"),
+            run(root, { model }) {
+                const scopes = model.scopes();
+                const global = model.globalScope();
+                const children = global.children();
+                children.length = 0;
+                const scopeDetails = [];
+                for (const scope of scopes) {
+                    const lookup = [];
+                    for (const name of ["outer", "value", "hoisted", "café", "caf\\u00e9", "Value", "missing"]) {
+                        const binding = scope.getBinding(name);
+                        const node = binding?.syntax();
+                        lookup.push([name, node ? [node.kind, node.text] : null]);
+                    }
+                    const detail = {
+                        scope: describe(scope),
+                        global: scope.isGlobalScope(),
+                        parent: describe(scope.parent()),
+                        ancestors: scope.ancestors().map(describe),
+                        lookup,
+                    };
+                    scopeDetails.push(detail);
+                }
+                const bindingDetails = [];
+                for (const binding of model.allBindings()) {
+                    const references = [];
+                    for (const reference of binding.allReferences()) {
+                        const detail = {
+                            scope: describe(reference.scope()),
+                            lookup: describe(model.scope(reference.syntax())),
+                        };
+                        references.push(detail);
+                    }
+                    const detail = {
+                        name: binding.syntax().text,
+                        scope: describe(binding.scope()),
+                        hoisted: describe(model.scopeHoistedTo(binding.syntax())),
+                        references,
+                    };
+                    bindingDetails.push(detail);
+                }
+                const result = {
+                    global: describe(global),
+                    rootScope: describe(model.scope(root)),
+                    children: global.children().map(describe),
+                    scopes: scopeDetails,
+                    bindings: bindingDetails,
+                };
+                registerDiagnostic(root, "information", JSON.stringify(result, 0, 2));
+            },
+        });"#;
+    let plugin = load_test_plugin_from_source("/plugin.js", plugin_source, None);
+    let mut inputs = Vec::new();
+    let mut rendered = String::new();
+    for (path, source, source_type) in [
+        (
+            "/scopes.js",
+            "const outer = 0; { let value = 1; function inner(param) { { var hoisted = param; let café = hoisted; café; outer; } } }",
+            JsFileSource::js_module(),
+        ),
+        (
+            "/scopes.ts",
+            "interface Value {} const Value = 0; { type Local = Value; const café = 1; café; }",
+            JsFileSource::ts(),
+        ),
+        ("/empty.js", "", JsFileSource::js_module()),
+        ("/comments.js", "/* scope */", JsFileSource::js_module()),
+        (
+            "/malformed.js",
+            "function broken( {",
+            JsFileSource::js_module(),
+        ),
+    ] {
+        let parsed = parse(source, source_type, JsParserOptions::default());
+        let model = semantic_model(&parsed.tree(), SemanticModelOptions::from(&source_type));
+        let mut bag = services(source_type);
+        bag.insert_service(model);
+        let result = plugin.evaluate(parsed.syntax().into(), path.into(), &bag);
+        let [entry] = result.entries.as_slice() else {
+            panic!("{path}: {result:?}")
+        };
+        let message = PrintDescription(&entry.diagnostic).to_string();
+        let value: Value = serde_json::from_str(&message).expect(&message);
+        if parsed.syntax().text_trimmed_range().is_empty() {
+            assert_eq!(value["rootScope"], Value::Null);
+            assert_eq!(value["global"], json!(["JS_MODULE", []]));
+        }
+        inputs.push((path, source));
+        rendered.push_str(&render_diagnostics(path, source, result));
+    }
+    snap_diagnostics(
+        "semantic_model_scopes",
+        "/plugin.js",
+        plugin_source,
+        &inputs,
+        rendered,
+    );
+}

--- a/crates/biome_plugin_loader/src/snapshots/mutations_invalid_fix_descriptors_boxed_kind.snap
+++ b/crates/biome_plugin_loader/src/snapshots/mutations_invalid_fix_descriptors_boxed_kind.snap
@@ -81,7 +81,7 @@ call(1,2);
 
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule aFailed errored: TypeError: The fix.kind property must be a string. Set it to "safe" or "unsafe".
+  i Rule aFailed errored: TypeError: The fix.kind property must be a string. Set it to "safe" or "unsafe". (/plugin.js:14:51)
         at run (/plugin.js:14:51)
   
 
@@ -113,7 +113,7 @@ call(1,2);
 
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule aFailed errored: TypeError: The fix.kind property must be a string. Set it to "safe" or "unsafe".
+  i Rule aFailed errored: TypeError: The fix.kind property must be a string. Set it to "safe" or "unsafe". (/plugin.js:14:51)
         at run (/plugin.js:14:51)
   
 

--- a/crates/biome_plugin_loader/src/snapshots/mutations_invalid_fix_descriptors_empty.snap
+++ b/crates/biome_plugin_loader/src/snapshots/mutations_invalid_fix_descriptors_empty.snap
@@ -77,7 +77,7 @@ call(1,2);
 
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule aFailed errored: TypeError: The fix.message property must be a string. Set it to a description of the change, such as "Replace var with let.".
+  i Rule aFailed errored: TypeError: The fix.message property must be a string. Set it to a description of the change, such as "Replace var with let.". (/plugin.js:14:51)
         at run (/plugin.js:14:51)
   
 
@@ -109,7 +109,7 @@ call(1,2);
 
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule aFailed errored: TypeError: The fix.message property must be a string. Set it to a description of the change, such as "Replace var with let.".
+  i Rule aFailed errored: TypeError: The fix.message property must be a string. Set it to a description of the change, such as "Replace var with let.". (/plugin.js:14:51)
         at run (/plugin.js:14:51)
   
 

--- a/crates/biome_plugin_loader/src/snapshots/mutations_invalid_fix_descriptors_invalid_kind.snap
+++ b/crates/biome_plugin_loader/src/snapshots/mutations_invalid_fix_descriptors_invalid_kind.snap
@@ -81,7 +81,7 @@ call(1,2);
 
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule aFailed errored: TypeError: Unknown fix kind "invalid". Set fix.kind to "safe" or "unsafe".
+  i Rule aFailed errored: TypeError: Unknown fix kind "invalid". Set fix.kind to "safe" or "unsafe". (/plugin.js:14:51)
         at run (/plugin.js:14:51)
   
 
@@ -113,7 +113,7 @@ call(1,2);
 
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule aFailed errored: TypeError: Unknown fix kind "invalid". Set fix.kind to "safe" or "unsafe".
+  i Rule aFailed errored: TypeError: Unknown fix kind "invalid". Set fix.kind to "safe" or "unsafe". (/plugin.js:14:51)
         at run (/plugin.js:14:51)
   
 

--- a/crates/biome_plugin_loader/src/snapshots/mutations_invalid_fix_descriptors_invalid_message.snap
+++ b/crates/biome_plugin_loader/src/snapshots/mutations_invalid_fix_descriptors_invalid_message.snap
@@ -81,7 +81,7 @@ call(1,2);
 
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule aFailed errored: TypeError: The fix.message property must be a string. Set it to a description of the change, such as "Replace var with let.".
+  i Rule aFailed errored: TypeError: The fix.message property must be a string. Set it to a description of the change, such as "Replace var with let.". (/plugin.js:14:51)
         at run (/plugin.js:14:51)
   
 
@@ -113,7 +113,7 @@ call(1,2);
 
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule aFailed errored: TypeError: The fix.message property must be a string. Set it to a description of the change, such as "Replace var with let.".
+  i Rule aFailed errored: TypeError: The fix.message property must be a string. Set it to a description of the change, such as "Replace var with let.". (/plugin.js:14:51)
         at run (/plugin.js:14:51)
   
 

--- a/crates/biome_plugin_loader/src/snapshots/mutations_invalid_fix_descriptors_invalid_mutation.snap
+++ b/crates/biome_plugin_loader/src/snapshots/mutations_invalid_fix_descriptors_invalid_mutation.snap
@@ -81,7 +81,7 @@ call(1,2);
 
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule aFailed errored: TypeError: The fix's mutation property is not a mutation object. Set it to the value returned by createMutation(node).
+  i Rule aFailed errored: TypeError: The fix's mutation property is not a mutation object. Set it to the value returned by createMutation(node). (/plugin.js:14:51)
         at run (/plugin.js:14:51)
   
 
@@ -113,7 +113,7 @@ call(1,2);
 
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule aFailed errored: TypeError: The fix's mutation property is not a mutation object. Set it to the value returned by createMutation(node).
+  i Rule aFailed errored: TypeError: The fix's mutation property is not a mutation object. Set it to the value returned by createMutation(node). (/plugin.js:14:51)
         at run (/plugin.js:14:51)
   
 

--- a/crates/biome_plugin_loader/src/snapshots/mutations_invalid_fix_descriptors_missing_kind.snap
+++ b/crates/biome_plugin_loader/src/snapshots/mutations_invalid_fix_descriptors_missing_kind.snap
@@ -80,7 +80,7 @@ call(1,2);
 
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule aFailed errored: TypeError: The fix.kind property must be a string. Set it to "safe" or "unsafe".
+  i Rule aFailed errored: TypeError: The fix.kind property must be a string. Set it to "safe" or "unsafe". (/plugin.js:14:51)
         at run (/plugin.js:14:51)
   
 
@@ -112,7 +112,7 @@ call(1,2);
 
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule aFailed errored: TypeError: The fix.kind property must be a string. Set it to "safe" or "unsafe".
+  i Rule aFailed errored: TypeError: The fix.kind property must be a string. Set it to "safe" or "unsafe". (/plugin.js:14:51)
         at run (/plugin.js:14:51)
   
 

--- a/crates/biome_plugin_loader/src/snapshots/mutations_invalid_fix_descriptors_null.snap
+++ b/crates/biome_plugin_loader/src/snapshots/mutations_invalid_fix_descriptors_null.snap
@@ -77,7 +77,7 @@ call(1,2);
 
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule aFailed errored: TypeError: The fix argument to registerDiagnostic() is not an object. Pass an object with mutation, message, and kind properties, or omit the fix argument.
+  i Rule aFailed errored: TypeError: The fix argument to registerDiagnostic() is not an object. Pass an object with mutation, message, and kind properties, or omit the fix argument. (/plugin.js:14:51)
         at run (/plugin.js:14:51)
   
 
@@ -109,7 +109,7 @@ call(1,2);
 
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule aFailed errored: TypeError: The fix argument to registerDiagnostic() is not an object. Pass an object with mutation, message, and kind properties, or omit the fix argument.
+  i Rule aFailed errored: TypeError: The fix argument to registerDiagnostic() is not an object. Pass an object with mutation, message, and kind properties, or omit the fix argument. (/plugin.js:14:51)
         at run (/plugin.js:14:51)
   
 

--- a/crates/biome_plugin_loader/src/snapshots/mutations_invalid_fix_descriptors_throwing_message_getter.snap
+++ b/crates/biome_plugin_loader/src/snapshots/mutations_invalid_fix_descriptors_throwing_message_getter.snap
@@ -83,7 +83,7 @@ call(1,2);
 
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule aFailed errored: TypeError: factory.token() does not support the kind "UNKNOWN". Use a name from the JsTokenKind definition, such as "IDENT" or "LET_KW".
+  i Rule aFailed errored: TypeError: factory.token() does not support the kind "UNKNOWN". Use a name from the JsTokenKind definition, such as "IDENT" or "LET_KW". (/plugin.js:14:51)
         at get message (/plugin.js:14:139)
         at registerDiagnostic (native)
         at run (/plugin.js:14:51)
@@ -117,7 +117,7 @@ call(1,2);
 
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule aFailed errored: TypeError: factory.token() does not support the kind "UNKNOWN". Use a name from the JsTokenKind definition, such as "IDENT" or "LET_KW".
+  i Rule aFailed errored: TypeError: factory.token() does not support the kind "UNKNOWN". Use a name from the JsTokenKind definition, such as "IDENT" or "LET_KW". (/plugin.js:14:51)
         at get message (/plugin.js:14:139)
         at registerDiagnostic (native)
         at run (/plugin.js:14:51)

--- a/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_consumed_target.snap
+++ b/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_consumed_target.snap
@@ -63,6 +63,6 @@ call(1,2);
 
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule fixer errored: TypeError: This mutation has already been passed to registerDiagnostic(). Create a new mutation for each diagnostic, and finish adding edits before registering it.
+  i Rule fixer errored: TypeError: This mutation has already been passed to registerDiagnostic(). Create a new mutation for each diagnostic, and finish adding edits before registering it. (/plugin.js:19:40)
         at run (/plugin.js:19:40)
 ```

--- a/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_create_mutation_arity.snap
+++ b/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_create_mutation_arity.snap
@@ -43,6 +43,6 @@ call(1,2);
 ```block
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule fixer errored: TypeError: createMutation() requires exactly one node. Pass the node supplied to run() or a node reached through its fields or traversal methods.
+  i Rule fixer errored: TypeError: createMutation() requires exactly one node. Pass the node supplied to run() or a node reached through its fields or traversal methods. (/plugin.js:14:15)
         at run (/plugin.js:14:15)
 ```

--- a/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_factory_arity.snap
+++ b/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_factory_arity.snap
@@ -43,6 +43,6 @@ call(1,2);
 ```block
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule fixer errored: TypeError: factory.token() received the wrong number of arguments. Pass a kind string as the first argument and, when needed, a text string as the second argument, with no additional arguments.
+  i Rule fixer errored: TypeError: factory.token() received the wrong number of arguments. Pass a kind string as the first argument and, when needed, a text string as the second argument, with no additional arguments. (/plugin.js:14:14)
         at run (/plugin.js:14:14)
 ```

--- a/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_factory_fixed_spelling.snap
+++ b/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_factory_fixed_spelling.snap
@@ -43,6 +43,6 @@ call(1,2);
 ```block
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule fixer errored: TypeError: factory.token() requires the spelling "," for kind COMMA, but the text argument is ";". Omit the text argument or change it to ",".
+  i Rule fixer errored: TypeError: factory.token() requires the spelling "," for kind COMMA, but the text argument is ";". Omit the text argument or change it to ",". (/plugin.js:14:14)
         at run (/plugin.js:14:14)
 ```

--- a/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_factory_text_type.snap
+++ b/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_factory_text_type.snap
@@ -43,6 +43,6 @@ call(1,2);
 ```block
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule fixer errored: TypeError: The text argument to factory.token() is not a string. Pass a string value, not a String object.
+  i Rule fixer errored: TypeError: The text argument to factory.token() is not a string. Pass a string value, not a String object. (/plugin.js:14:14)
         at run (/plugin.js:14:14)
 ```

--- a/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_forged_anchor.snap
+++ b/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_forged_anchor.snap
@@ -43,6 +43,6 @@ call(1,2);
 ```block
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule fixer errored: TypeError: createMutation() received a value that is not a Biome node. Pass the node supplied to run() or one of its child nodes, not a token, string, or plain object.
+  i Rule fixer errored: TypeError: createMutation() received a value that is not a Biome node. Pass the node supplied to run() or one of its child nodes, not a token, string, or plain object. (/plugin.js:14:15)
         at run (/plugin.js:14:15)
 ```

--- a/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_list_field_array.snap
+++ b/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_list_field_array.snap
@@ -43,6 +43,6 @@ call(1,2);
 ```block
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule fixer errored: TypeError: JsCallArguments.withArgs() for field args requires a JsCallArgumentListNode, but the argument is not a Biome node. Pass a matching node from a node field or node.children(), not a plain object or array.
+  i Rule fixer errored: TypeError: JsCallArguments.withArgs() for field args requires a JsCallArgumentListNode, but the argument is not a Biome node. Pass a matching node from a node field or node.children(), not a plain object or array. (/plugin.js:14:14)
         at run (/plugin.js:14:14)
 ```

--- a/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_optional_field_null.snap
+++ b/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_optional_field_null.snap
@@ -43,6 +43,6 @@ call(1,2);
 ```block
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule fixer errored: TypeError: JsExpressionStatement.withSemicolonToken() for field semicolonToken requires a JsAstToken, but the argument is not a Biome token. Pass a token returned by node.token("semicolonToken") or factory.token(), not a string or plain object.
+  i Rule fixer errored: TypeError: JsExpressionStatement.withSemicolonToken() for field semicolonToken requires a JsAstToken, but the argument is not a Biome token. Pass a token returned by node.token("semicolonToken") or factory.token(), not a string or plain object. (/plugin.js:14:29)
         at run (/plugin.js:14:29)
 ```

--- a/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_remove_element_receiver.snap
+++ b/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_remove_element_receiver.snap
@@ -43,6 +43,6 @@ call(1,2);
 ```block
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule fixer errored: TypeError: removeElement() was called without a mutation object. Call it on the object returned by createMutation(node).
+  i Rule fixer errored: TypeError: removeElement() was called without a mutation object. Call it on the object returned by createMutation(node). (/plugin.js:14:28)
         at run (/plugin.js:14:28)
 ```

--- a/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_remove_node_type.snap
+++ b/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_remove_node_type.snap
@@ -43,6 +43,6 @@ call(1,2);
 ```block
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule fixer errored: TypeError: The first argument to removeNode() must be a Biome node from the source passed to createMutation(). Read the node through its fields or traversal methods; do not pass a token, string, or plain object.
+  i Rule fixer errored: TypeError: The first argument to removeNode() must be a Biome node from the source passed to createMutation(). Read the node through its fields or traversal methods; do not pass a token, string, or plain object. (/plugin.js:14:20)
         at run (/plugin.js:14:20)
 ```

--- a/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_remove_token_arity.snap
+++ b/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_remove_token_arity.snap
@@ -43,6 +43,6 @@ call(1,2);
 ```block
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule fixer errored: TypeError: removeToken() requires exactly one argument. Pass the token to remove.
+  i Rule fixer errored: TypeError: removeToken() requires exactly one argument. Pass the token to remove. (/plugin.js:14:21)
         at run (/plugin.js:14:21)
 ```

--- a/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_replace_element_receiver.snap
+++ b/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_replace_element_receiver.snap
@@ -43,6 +43,6 @@ call(1,2);
 ```block
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule fixer errored: TypeError: replaceElement() was called without a mutation object. Call it on the object returned by createMutation(node).
+  i Rule fixer errored: TypeError: replaceElement() was called without a mutation object. Call it on the object returned by createMutation(node). (/plugin.js:14:29)
         at run (/plugin.js:14:29)
 ```

--- a/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_replace_node_type.snap
+++ b/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_replace_node_type.snap
@@ -43,6 +43,6 @@ call(1,2);
 ```block
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule fixer errored: TypeError: The second argument to replaceNode() must be a Biome node. Use a node from run(), its fields, or a node field-update method; do not pass a token, string, or plain object.
+  i Rule fixer errored: TypeError: The second argument to replaceNode() must be a Biome node. Use a node from run(), its fields, or a node field-update method; do not pass a token, string, or plain object. (/plugin.js:14:21)
         at run (/plugin.js:14:21)
 ```

--- a/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_replace_token_arity.snap
+++ b/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_replace_token_arity.snap
@@ -43,6 +43,6 @@ call(1,2);
 ```block
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule fixer errored: TypeError: replaceToken() requires exactly two arguments. Pass the token to replace first, then its replacement.
+  i Rule fixer errored: TypeError: replaceToken() requires exactly two arguments. Pass the token to replace first, then its replacement. (/plugin.js:14:22)
         at run (/plugin.js:14:22)
 ```

--- a/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_unknown_token_field.snap
+++ b/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_unknown_token_field.snap
@@ -43,6 +43,6 @@ call(1,2);
 ```block
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule fixer errored: TypeError: node.token("unknown") cannot find a token field named "unknown" on a node of kind JS_NUMBER_LITERAL_EXPRESSION. Check this node's plugin API type definition and pass a token field name declared for that type.
+  i Rule fixer errored: TypeError: node.token("unknown") cannot find a token field named "unknown" on a node of kind JS_NUMBER_LITERAL_EXPRESSION. Check this node's plugin API type definition and pass a token field name declared for that type. (/plugin.js:14:12)
         at run (/plugin.js:14:12)
 ```

--- a/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_wrong_token_field_kind.snap
+++ b/crates/biome_plugin_loader/src/snapshots/mutations_invalid_operations_wrong_token_field_kind.snap
@@ -43,6 +43,6 @@ call(1,2);
 ```block
 /file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Rule fixer errored: TypeError: JsNumberLiteralExpression.withValueToken() for field valueToken received a token that does not match the allowed token choices: "js_number_literal". Pass a matching JsAstToken from node.token("valueToken") or factory.token().
+  i Rule fixer errored: TypeError: JsNumberLiteralExpression.withValueToken() for field valueToken received a token that does not match the allowed token choices: "js_number_literal". Pass a matching JsAstToken from node.token("valueToken") or factory.token(). (/plugin.js:14:21)
         at run (/plugin.js:14:21)
 ```

--- a/crates/biome_plugin_loader/src/snapshots/reject_typescript_plugin_with_unerasable_syntax.snap
+++ b/crates/biome_plugin_loader/src/snapshots/reject_typescript_plugin_with_unerasable_syntax.snap
@@ -22,5 +22,5 @@ No input was analyzed.
 ```block
 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Failed to compile the JS plugin: SyntaxError: /plugin.ts: enum declarations cannot be stripped because they generate runtime code.
+  × Failed to compile the JS plugin: SyntaxError: /plugin.ts: enum declarations cannot be stripped because they generate runtime code. (native)
 ```

--- a/crates/biome_plugin_loader/src/snapshots/semantic_model.snap
+++ b/crates/biome_plugin_loader/src/snapshots/semantic_model.snap
@@ -1,0 +1,1384 @@
+---
+source: crates/biome_plugin_loader/src/analyzer_js_plugin.rs
+expression: content
+---
+# Plugin
+
+## `/plugin.js`
+
+```js
+import { defineRule, semantic, registerDiagnostic } from "@biomejs/plugin-api";
+export const inspect = defineRule({
+	query: semantic("JS_MODULE", "TS_DECLARATION_MODULE"),
+	run(root, { model }) {
+		const reference = (ref) => [
+			ref.syntax().kind,
+			ref.syntax().text,
+			ref.isRead(),
+			ref.isWrite(),
+			ref.binding()?.syntax().text,
+		];
+		registerDiagnostic(
+			root,
+			"information",
+			JSON.stringify(
+				{
+					bindings: model.allBindings().map((binding) => {
+						const node = binding.syntax();
+						const found = model.asBinding(node);
+						return [
+							found.syntax().kind,
+							found.syntax().text,
+							binding.allReferences().map(reference),
+							binding.allReads().map(reference),
+							binding.allWrites().map(reference),
+							binding.isImported(),
+							binding.isExported(),
+							model.isImported(node),
+							model.isExported(node),
+							binding.declarationKind(),
+							binding.exports().map((site) => [site.kind, site.text]),
+							binding.exportRanges(),
+						];
+					}),
+					exported: model
+						.allExportedBindings()
+						.map((binding) => binding.syntax().text)
+						.sort(),
+					hasExports: model.hasExports(),
+					globals: model
+						.allGlobalReferences()
+						.map((ref) => [
+							ref.syntax().kind,
+							ref.syntax().text,
+							ref.isRead(),
+							ref.isWrite(),
+						]),
+					unresolved: model
+						.allUnresolvedReferences()
+						.map((ref) => [
+							ref.syntax().kind,
+							ref.syntax().text,
+							model.isUnresolvedReference(ref.syntax()),
+						]),
+				},
+				0,
+				2,
+			),
+		);
+		const nodes = root.children().flatMap(function visit(node) {
+			return [node, ...node.children().flatMap(visit)];
+		});
+		for (const node of nodes) {
+			if (
+				![
+					"JS_REFERENCE_IDENTIFIER",
+					"JS_IDENTIFIER_ASSIGNMENT",
+					"JSX_REFERENCE_IDENTIFIER",
+				].includes(node.kind)
+			)
+				continue;
+			registerDiagnostic(
+				node,
+				"information",
+				JSON.stringify(
+					[
+						model.binding(node)?.syntax().text ?? null,
+						model.isImported(node),
+						model.isExported(node),
+						model.isGlobalReference(node),
+						model.isUnresolvedReference(node),
+					],
+					0,
+					2,
+				),
+			);
+		}
+	},
+});
+```
+
+# Input
+
+## `/file.js`
+
+```js
+import { external as imported } from 'pkg'; export let outer = 1; function f(outer) { outer = 2; return outer; } outer++; imported; configured; configured = 1; missing;
+```
+
+## `/file.ts`
+
+```ts
+import dependency = require('pkg'); import type TypeDependency = require('types'); interface T {} type U<T> = T; let value: T; value; dependency; type D = TypeDependency;
+```
+
+## `/file.jsx`
+
+```jsx
+const Café = () => null; let café = 1; café; <Café />; <Missing />;
+```
+
+## `/file.d.ts`
+
+```ts
+declare const value: number;
+```
+
+## `/malformed.js`
+
+```js
+let broken = ; broken;
+```
+
+## `/exports.js`
+
+```js
+export const café = 1; const local = 2; export { local as renamed, café as renamedCafé, local as again }; export default local; export * from 'pkg'; export { remote } from 'other';
+```
+
+## `/reexports.js`
+
+```js
+export * from 'pkg'; export { remote as alias } from 'other'; export default 42; export {};
+```
+
+## `/kinds.ts`
+
+```ts
+var hoisted; using resource = acquire(); export class C {} export enum E { Member } namespace N { export const x = 1; } module M {} export type Alias<T> = T; declare module 'pkg' { export const external: number; }
+```
+
+# Diagnostics
+
+```block
+/file.js:1:1 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i {
+      "bindings": [
+        [
+          "JS_IDENTIFIER_BINDING",
+          "imported",
+          [
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "imported",
+              true,
+              false,
+              "imported"
+            ]
+          ],
+          [
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "imported",
+              true,
+              false,
+              "imported"
+            ]
+          ],
+          [],
+          true,
+          false,
+          true,
+          false,
+          "import",
+          [],
+          []
+        ],
+        [
+          "JS_IDENTIFIER_BINDING",
+          "outer",
+          [
+            [
+              "JS_IDENTIFIER_ASSIGNMENT",
+              "outer",
+              false,
+              true,
+              "outer"
+            ]
+          ],
+          [],
+          [
+            [
+              "JS_IDENTIFIER_ASSIGNMENT",
+              "outer",
+              false,
+              true,
+              "outer"
+            ]
+          ],
+          false,
+          true,
+          false,
+          true,
+          "value",
+          [
+            [
+              "JS_IDENTIFIER_BINDING",
+              "outer"
+            ]
+          ],
+          [
+            {
+              "start": 55,
+              "end": 60
+            }
+          ]
+        ],
+        [
+          "JS_IDENTIFIER_BINDING",
+          "f",
+          [],
+          [],
+          [],
+          false,
+          false,
+          false,
+          false,
+          "function",
+          [],
+          []
+        ],
+        [
+          "JS_IDENTIFIER_BINDING",
+          "outer",
+          [
+            [
+              "JS_IDENTIFIER_ASSIGNMENT",
+              "outer",
+              false,
+              true,
+              "outer"
+            ],
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "outer",
+              true,
+              false,
+              "outer"
+            ]
+          ],
+          [
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "outer",
+              true,
+              false,
+              "outer"
+            ]
+          ],
+          [
+            [
+              "JS_IDENTIFIER_ASSIGNMENT",
+              "outer",
+              false,
+              true,
+              "outer"
+            ]
+          ],
+          false,
+          false,
+          false,
+          false,
+          "value",
+          [],
+          []
+        ]
+      ],
+      "exported": [
+        "outer"
+      ],
+      "hasExports": true,
+      "globals": [
+        [
+          "JS_REFERENCE_IDENTIFIER",
+          "configured",
+          true,
+          false
+        ],
+        [
+          "JS_IDENTIFIER_ASSIGNMENT",
+          "configured",
+          false,
+          true
+        ]
+      ],
+      "unresolved": [
+        [
+          "JS_REFERENCE_IDENTIFIER",
+          "missing",
+          true
+        ]
+      ]
+    }
+  
+  > 1 │ import { external as imported } from 'pkg'; export let outer = 1; function f(outer) { outer = 2; return outer; } outer++; imported; configured; configured = 1; missing;
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  
+
+/file.js:1:87 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i [
+      "outer",
+      false,
+      false,
+      false,
+      false
+    ]
+  
+  > 1 │ import { external as imported } from 'pkg'; export let outer = 1; function f(outer) { outer = 2; return outer; } outer++; imported; configured; configured = 1; missing;
+      │                                                                                       ^^^^^
+  
+
+/file.js:1:105 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i [
+      "outer",
+      false,
+      false,
+      false,
+      false
+    ]
+  
+  > 1 │ import { external as imported } from 'pkg'; export let outer = 1; function f(outer) { outer = 2; return outer; } outer++; imported; configured; configured = 1; missing;
+      │                                                                                                         ^^^^^
+  
+
+/file.js:1:114 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i [
+      "outer",
+      false,
+      true,
+      false,
+      false
+    ]
+  
+  > 1 │ import { external as imported } from 'pkg'; export let outer = 1; function f(outer) { outer = 2; return outer; } outer++; imported; configured; configured = 1; missing;
+      │                                                                                                                  ^^^^^
+  
+
+/file.js:1:123 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i [
+      "imported",
+      true,
+      false,
+      false,
+      false
+    ]
+  
+  > 1 │ import { external as imported } from 'pkg'; export let outer = 1; function f(outer) { outer = 2; return outer; } outer++; imported; configured; configured = 1; missing;
+      │                                                                                                                           ^^^^^^^^
+  
+
+/file.js:1:133 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i [
+      null,
+      false,
+      false,
+      true,
+      false
+    ]
+  
+  > 1 │ import { external as imported } from 'pkg'; export let outer = 1; function f(outer) { outer = 2; return outer; } outer++; imported; configured; configured = 1; missing;
+      │                                                                                                                                     ^^^^^^^^^^
+  
+
+/file.js:1:145 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i [
+      null,
+      false,
+      false,
+      true,
+      false
+    ]
+  
+  > 1 │ import { external as imported } from 'pkg'; export let outer = 1; function f(outer) { outer = 2; return outer; } outer++; imported; configured; configured = 1; missing;
+      │                                                                                                                                                 ^^^^^^^^^^
+  
+
+/file.js:1:161 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i [
+      null,
+      false,
+      false,
+      false,
+      true
+    ]
+  
+  > 1 │ import { external as imported } from 'pkg'; export let outer = 1; function f(outer) { outer = 2; return outer; } outer++; imported; configured; configured = 1; missing;
+      │                                                                                                                                                                 ^^^^^^^
+  
+
+/file.ts:1:1 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i {
+      "bindings": [
+        [
+          "JS_IDENTIFIER_BINDING",
+          "dependency",
+          [
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "dependency",
+              true,
+              false,
+              "dependency"
+            ]
+          ],
+          [
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "dependency",
+              true,
+              false,
+              "dependency"
+            ]
+          ],
+          [],
+          true,
+          false,
+          true,
+          false,
+          "import",
+          [],
+          []
+        ],
+        [
+          "JS_IDENTIFIER_BINDING",
+          "TypeDependency",
+          [
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "TypeDependency",
+              true,
+              false,
+              "TypeDependency"
+            ]
+          ],
+          [
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "TypeDependency",
+              true,
+              false,
+              "TypeDependency"
+            ]
+          ],
+          [],
+          true,
+          false,
+          true,
+          false,
+          "importType",
+          [],
+          []
+        ],
+        [
+          "TS_IDENTIFIER_BINDING",
+          "T",
+          [
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "T",
+              true,
+              false,
+              "T"
+            ]
+          ],
+          [
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "T",
+              true,
+              false,
+              "T"
+            ]
+          ],
+          [],
+          false,
+          false,
+          false,
+          false,
+          "interface",
+          [],
+          []
+        ],
+        [
+          "TS_IDENTIFIER_BINDING",
+          "U",
+          [],
+          [],
+          [],
+          false,
+          false,
+          false,
+          false,
+          "type",
+          [],
+          []
+        ],
+        [
+          "TS_TYPE_PARAMETER_NAME",
+          "T",
+          [
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "T",
+              true,
+              false,
+              "T"
+            ]
+          ],
+          [
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "T",
+              true,
+              false,
+              "T"
+            ]
+          ],
+          [],
+          false,
+          false,
+          false,
+          false,
+          "generic",
+          [],
+          []
+        ],
+        [
+          "JS_IDENTIFIER_BINDING",
+          "value",
+          [
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "value",
+              true,
+              false,
+              "value"
+            ]
+          ],
+          [
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "value",
+              true,
+              false,
+              "value"
+            ]
+          ],
+          [],
+          false,
+          false,
+          false,
+          false,
+          "value",
+          [],
+          []
+        ],
+        [
+          "TS_IDENTIFIER_BINDING",
+          "D",
+          [],
+          [],
+          [],
+          false,
+          false,
+          false,
+          false,
+          "type",
+          [],
+          []
+        ]
+      ],
+      "exported": [],
+      "hasExports": false,
+      "globals": [],
+      "unresolved": []
+    }
+  
+  > 1 │ import dependency = require('pkg'); import type TypeDependency = require('types'); interface T {} type U<T> = T; let value: T; value; dependency; type D = TypeDependency;
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  
+
+/file.ts:1:111 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i [
+      "T",
+      false,
+      false,
+      false,
+      false
+    ]
+  
+  > 1 │ import dependency = require('pkg'); import type TypeDependency = require('types'); interface T {} type U<T> = T; let value: T; value; dependency; type D = TypeDependency;
+      │                                                                                                               ^
+  
+
+/file.ts:1:125 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i [
+      "T",
+      false,
+      false,
+      false,
+      false
+    ]
+  
+  > 1 │ import dependency = require('pkg'); import type TypeDependency = require('types'); interface T {} type U<T> = T; let value: T; value; dependency; type D = TypeDependency;
+      │                                                                                                                             ^
+  
+
+/file.ts:1:128 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i [
+      "value",
+      false,
+      false,
+      false,
+      false
+    ]
+  
+  > 1 │ import dependency = require('pkg'); import type TypeDependency = require('types'); interface T {} type U<T> = T; let value: T; value; dependency; type D = TypeDependency;
+      │                                                                                                                                ^^^^^
+  
+
+/file.ts:1:135 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i [
+      "dependency",
+      true,
+      false,
+      false,
+      false
+    ]
+  
+  > 1 │ import dependency = require('pkg'); import type TypeDependency = require('types'); interface T {} type U<T> = T; let value: T; value; dependency; type D = TypeDependency;
+      │                                                                                                                                       ^^^^^^^^^^
+  
+
+/file.ts:1:156 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i [
+      "TypeDependency",
+      true,
+      false,
+      false,
+      false
+    ]
+  
+  > 1 │ import dependency = require('pkg'); import type TypeDependency = require('types'); interface T {} type U<T> = T; let value: T; value; dependency; type D = TypeDependency;
+      │                                                                                                                                                            ^^^^^^^^^^^^^^
+  
+
+/file.jsx:1:1 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i {
+      "bindings": [
+        [
+          "JS_IDENTIFIER_BINDING",
+          "Café",
+          [
+            [
+              "JSX_REFERENCE_IDENTIFIER",
+              "Café",
+              true,
+              false,
+              "Café"
+            ]
+          ],
+          [
+            [
+              "JSX_REFERENCE_IDENTIFIER",
+              "Café",
+              true,
+              false,
+              "Café"
+            ]
+          ],
+          [],
+          false,
+          false,
+          false,
+          false,
+          "value",
+          [],
+          []
+        ],
+        [
+          "JS_IDENTIFIER_BINDING",
+          "café",
+          [
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "café",
+              true,
+              false,
+              "café"
+            ]
+          ],
+          [
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "café",
+              true,
+              false,
+              "café"
+            ]
+          ],
+          [],
+          false,
+          false,
+          false,
+          false,
+          "value",
+          [],
+          []
+        ]
+      ],
+      "exported": [],
+      "hasExports": false,
+      "globals": [],
+      "unresolved": [
+        [
+          "JSX_REFERENCE_IDENTIFIER",
+          "Missing",
+          true
+        ]
+      ]
+    }
+  
+  > 1 │ const Café = () => null; let café = 1; café; <Café />; <Missing />;
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  
+
+/file.jsx:1:40 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i [
+      "café",
+      false,
+      false,
+      false,
+      false
+    ]
+  
+  > 1 │ const Café = () => null; let café = 1; café; <Café />; <Missing />;
+      │                                        ^^^^
+  
+
+/file.jsx:1:47 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i [
+      "Café",
+      false,
+      false,
+      false,
+      false
+    ]
+  
+  > 1 │ const Café = () => null; let café = 1; café; <Café />; <Missing />;
+      │                                               ^^^^
+  
+
+/file.jsx:1:57 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i [
+      null,
+      false,
+      false,
+      false,
+      true
+    ]
+  
+  > 1 │ const Café = () => null; let café = 1; café; <Café />; <Missing />;
+      │                                                         ^^^^^^^
+  
+
+/file.d.ts:1:1 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i {
+      "bindings": [
+        [
+          "JS_IDENTIFIER_BINDING",
+          "value",
+          [],
+          [],
+          [],
+          false,
+          false,
+          false,
+          false,
+          "value",
+          [],
+          []
+        ]
+      ],
+      "exported": [],
+      "hasExports": false,
+      "globals": [],
+      "unresolved": []
+    }
+  
+  > 1 │ declare const value: number;
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  
+
+/malformed.js:1:1 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i {
+      "bindings": [
+        [
+          "JS_IDENTIFIER_BINDING",
+          "broken",
+          [
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "broken",
+              true,
+              false,
+              "broken"
+            ]
+          ],
+          [
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "broken",
+              true,
+              false,
+              "broken"
+            ]
+          ],
+          [],
+          false,
+          false,
+          false,
+          false,
+          "value",
+          [],
+          []
+        ]
+      ],
+      "exported": [],
+      "hasExports": false,
+      "globals": [],
+      "unresolved": []
+    }
+  
+  > 1 │ let broken = ; broken;
+      │ ^^^^^^^^^^^^^^^^^^^^^^
+  
+
+/malformed.js:1:16 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i [
+      "broken",
+      false,
+      false,
+      false,
+      false
+    ]
+  
+  > 1 │ let broken = ; broken;
+      │                ^^^^^^
+  
+
+/exports.js:1:1 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i {
+      "bindings": [
+        [
+          "JS_IDENTIFIER_BINDING",
+          "café",
+          [
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "café",
+              true,
+              false,
+              "café"
+            ]
+          ],
+          [
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "café",
+              true,
+              false,
+              "café"
+            ]
+          ],
+          [],
+          false,
+          true,
+          false,
+          true,
+          "value",
+          [
+            [
+              "JS_IDENTIFIER_BINDING",
+              "café"
+            ],
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "café"
+            ]
+          ],
+          [
+            {
+              "start": 13,
+              "end": 18
+            },
+            {
+              "start": 68,
+              "end": 73
+            }
+          ]
+        ],
+        [
+          "JS_IDENTIFIER_BINDING",
+          "local",
+          [
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "local",
+              true,
+              false,
+              "local"
+            ],
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "local",
+              true,
+              false,
+              "local"
+            ],
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "local",
+              true,
+              false,
+              "local"
+            ]
+          ],
+          [
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "local",
+              true,
+              false,
+              "local"
+            ],
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "local",
+              true,
+              false,
+              "local"
+            ],
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "local",
+              true,
+              false,
+              "local"
+            ]
+          ],
+          [],
+          false,
+          true,
+          false,
+          true,
+          "value",
+          [
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "local"
+            ],
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "local"
+            ],
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "local"
+            ]
+          ],
+          [
+            {
+              "start": 50,
+              "end": 55
+            },
+            {
+              "start": 91,
+              "end": 96
+            },
+            {
+              "start": 124,
+              "end": 129
+            }
+          ]
+        ]
+      ],
+      "exported": [
+        "café",
+        "local"
+      ],
+      "hasExports": true,
+      "globals": [],
+      "unresolved": []
+    }
+  
+  > 1 │ export const café = 1; const local = 2; export { local as renamed, café as renamedCafé, local as again }; export default local; export * from 'pkg'; export { remote } from 'other';
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  
+
+/exports.js:1:50 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i [
+      "local",
+      false,
+      true,
+      false,
+      false
+    ]
+  
+  > 1 │ export const café = 1; const local = 2; export { local as renamed, café as renamedCafé, local as again }; export default local; export * from 'pkg'; export { remote } from 'other';
+      │                                                  ^^^^^
+  
+
+/exports.js:1:68 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i [
+      "café",
+      false,
+      true,
+      false,
+      false
+    ]
+  
+  > 1 │ export const café = 1; const local = 2; export { local as renamed, café as renamedCafé, local as again }; export default local; export * from 'pkg'; export { remote } from 'other';
+      │                                                                    ^^^^
+  
+
+/exports.js:1:89 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i [
+      "local",
+      false,
+      true,
+      false,
+      false
+    ]
+  
+  > 1 │ export const café = 1; const local = 2; export { local as renamed, café as renamedCafé, local as again }; export default local; export * from 'pkg'; export { remote } from 'other';
+      │                                                                                         ^^^^^
+  
+
+/exports.js:1:122 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i [
+      "local",
+      false,
+      true,
+      false,
+      false
+    ]
+  
+  > 1 │ export const café = 1; const local = 2; export { local as renamed, café as renamedCafé, local as again }; export default local; export * from 'pkg'; export { remote } from 'other';
+      │                                                                                                                          ^^^^^
+  
+
+/reexports.js:1:1 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i {
+      "bindings": [],
+      "exported": [],
+      "hasExports": false,
+      "globals": [],
+      "unresolved": []
+    }
+  
+  > 1 │ export * from 'pkg'; export { remote as alias } from 'other'; export default 42; export {};
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  
+
+/kinds.ts:1:1 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i {
+      "bindings": [
+        [
+          "JS_IDENTIFIER_BINDING",
+          "hoisted",
+          [],
+          [],
+          [],
+          false,
+          false,
+          false,
+          false,
+          "hoistedValue",
+          [],
+          []
+        ],
+        [
+          "JS_IDENTIFIER_BINDING",
+          "resource",
+          [],
+          [],
+          [],
+          false,
+          false,
+          false,
+          false,
+          "using",
+          [],
+          []
+        ],
+        [
+          "JS_IDENTIFIER_BINDING",
+          "C",
+          [],
+          [],
+          [],
+          false,
+          true,
+          false,
+          true,
+          "class",
+          [
+            [
+              "JS_IDENTIFIER_BINDING",
+              "C"
+            ]
+          ],
+          [
+            {
+              "start": 54,
+              "end": 55
+            }
+          ]
+        ],
+        [
+          "JS_IDENTIFIER_BINDING",
+          "E",
+          [],
+          [],
+          [],
+          false,
+          true,
+          false,
+          true,
+          "enum",
+          [
+            [
+              "JS_IDENTIFIER_BINDING",
+              "E"
+            ]
+          ],
+          [
+            {
+              "start": 71,
+              "end": 72
+            }
+          ]
+        ],
+        [
+          "TS_LITERAL_ENUM_MEMBER_NAME",
+          "Member",
+          [],
+          [],
+          [],
+          false,
+          false,
+          false,
+          false,
+          "enum",
+          [],
+          []
+        ],
+        [
+          "TS_IDENTIFIER_BINDING",
+          "N",
+          [],
+          [],
+          [],
+          false,
+          false,
+          false,
+          false,
+          "namespace",
+          [],
+          []
+        ],
+        [
+          "JS_IDENTIFIER_BINDING",
+          "x",
+          [],
+          [],
+          [],
+          false,
+          true,
+          false,
+          true,
+          "value",
+          [
+            [
+              "JS_IDENTIFIER_BINDING",
+              "x"
+            ]
+          ],
+          [
+            {
+              "start": 111,
+              "end": 112
+            }
+          ]
+        ],
+        [
+          "TS_IDENTIFIER_BINDING",
+          "M",
+          [],
+          [],
+          [],
+          false,
+          false,
+          false,
+          false,
+          "module",
+          [],
+          []
+        ],
+        [
+          "TS_IDENTIFIER_BINDING",
+          "Alias",
+          [],
+          [],
+          [],
+          false,
+          true,
+          false,
+          true,
+          "type",
+          [
+            [
+              "TS_IDENTIFIER_BINDING",
+              "Alias"
+            ]
+          ],
+          [
+            {
+              "start": 144,
+              "end": 149
+            }
+          ]
+        ],
+        [
+          "TS_TYPE_PARAMETER_NAME",
+          "T",
+          [
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "T",
+              true,
+              false,
+              "T"
+            ]
+          ],
+          [
+            [
+              "JS_REFERENCE_IDENTIFIER",
+              "T",
+              true,
+              false,
+              "T"
+            ]
+          ],
+          [],
+          false,
+          false,
+          false,
+          false,
+          "generic",
+          [],
+          []
+        ],
+        [
+          "JS_IDENTIFIER_BINDING",
+          "external",
+          [],
+          [],
+          [],
+          false,
+          true,
+          false,
+          true,
+          "value",
+          [
+            [
+              "JS_IDENTIFIER_BINDING",
+              "external"
+            ]
+          ],
+          [
+            {
+              "start": 194,
+              "end": 202
+            }
+          ]
+        ]
+      ],
+      "exported": [
+        "Alias",
+        "C",
+        "E",
+        "external",
+        "x"
+      ],
+      "hasExports": true,
+      "globals": [],
+      "unresolved": [
+        [
+          "JS_REFERENCE_IDENTIFIER",
+          "acquire",
+          true
+        ]
+      ]
+    }
+  
+  > 1 │ var hoisted; using resource = acquire(); export class C {} export enum E { Member } namespace N { export const x = 1; } module M {} export type Alias<T> = T; declare module 'pkg' { export const external: number; }
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  
+
+/kinds.ts:1:31 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i [
+      null,
+      false,
+      false,
+      false,
+      true
+    ]
+  
+  > 1 │ var hoisted; using resource = acquire(); export class C {} export enum E { Member } namespace N { export const x = 1; } module M {} export type Alias<T> = T; declare module 'pkg' { export const external: number; }
+      │                               ^^^^^^^
+  
+
+/kinds.ts:1:156 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i [
+      "T",
+      false,
+      false,
+      false,
+      false
+    ]
+  
+  > 1 │ var hoisted; using resource = acquire(); export class C {} export enum E { Member } namespace N { export const x = 1; } module M {} export type Alias<T> = T; declare module 'pkg' { export const external: number; }
+      │                                                                                                                                                            ^
+```

--- a/crates/biome_plugin_loader/src/snapshots/semantic_model_context_and_fixes.snap
+++ b/crates/biome_plugin_loader/src/snapshots/semantic_model_context_and_fixes.snap
@@ -1,0 +1,87 @@
+---
+source: crates/biome_plugin_loader/src/analyzer_js_plugin.rs
+expression: content
+---
+# Plugin
+
+## `/plugin.js`
+
+```js
+import {
+	ast,
+	createMutation,
+	defineRule,
+	factory,
+	semantic,
+	registerDiagnostic,
+} from "@biomejs/plugin-api";
+export const aSyntax = defineRule({
+	query: ast("JS_REFERENCE_IDENTIFIER"),
+	run(node, context) {
+		registerDiagnostic(node, "information", `syntax:${"model" in context}`);
+	},
+});
+export const bSemantic = defineRule({
+	query: semantic("JS_REFERENCE_IDENTIFIER"),
+	run(node, context) {
+		const binding = context.model.binding(node);
+		const reference = binding.allReads()[0].syntax();
+		const mutation = createMutation(binding.syntax());
+		mutation.replaceToken(
+			reference.token("valueToken"),
+			factory.token("IDENT", "renamed"),
+		);
+		registerDiagnostic(
+			reference,
+			"information",
+			`semantic:${binding.syntax().text}:${binding.allReads().length}:${Reflect.set(context, "model", null)}`,
+			{ mutation, message: "Rename the reference.", kind: "unsafe" },
+		);
+	},
+});
+```
+
+# Input
+
+## `/file.js`
+
+```js
+let value = 1; value;
+```
+
+# Diagnostics
+
+```block
+/file.js:1:16 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i syntax:false
+  
+  > 1 │ let value = 1; value;
+      │                ^^^^^
+  
+
+/file.js:1:16 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i semantic:value:1:false
+  
+  > 1 │ let value = 1; value;
+      │                ^^^^^
+  
+  i Unsafe fix: Rename the reference.
+  
+  - let·value·=·1;·value;
+  + let·value·=·1;·renamed;
+  
+
+/file.js:1:16 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i syntax:false
+  
+  > 1 │ let value = 1; value;
+      │                ^^^^^
+  
+
+/file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Rule bSemantic errored: TypeError: The semantic model is unavailable. Supply a SemanticModel service when analyzing semantic plugin rules. (native)
+```

--- a/crates/biome_plugin_loader/src/snapshots/semantic_model_retained_handles.snap
+++ b/crates/biome_plugin_loader/src/snapshots/semantic_model_retained_handles.snap
@@ -1,0 +1,85 @@
+---
+source: crates/biome_plugin_loader/src/analyzer_js_plugin.rs
+expression: content
+---
+# Plugin
+
+## `/plugin.js`
+
+```js
+import { defineRule, semantic, registerDiagnostic } from "@biomejs/plugin-api";
+let saved;
+export const retained = defineRule({
+	query: semantic("JS_MODULE"),
+	run(root, { model }) {
+		const bindings = model.allBindings();
+		const binding = bindings[0];
+		bindings.length = 0;
+		if (saved) {
+			const node = saved.reference.syntax();
+			registerDiagnostic(
+				root,
+				"information",
+				JSON.stringify(
+					[
+						binding.syntax().text,
+						saved.model.binding(node).syntax().text,
+						saved.binding.allReads().length,
+						model.allBindings().length,
+						saved.scope.bindings().map((binding) => binding.syntax().text),
+					],
+					0,
+					2,
+				),
+			);
+			model.binding(node);
+		} else {
+			saved = {
+				model,
+				binding,
+				reference: binding.allReads()[0],
+				scope: model.globalScope(),
+			};
+		}
+	},
+});
+```
+
+# Input
+
+## `/file.js`
+
+```js
+let first = 1; first;
+```
+
+## `/file.js`
+
+```js
+let second = 2; second;
+```
+
+# Diagnostics
+
+```block
+/file.js:1:1 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i [
+      "second",
+      "first",
+      1,
+      1,
+      [
+        "first"
+      ]
+    ]
+  
+  > 1 │ let second = 2; second;
+      │ ^^^^^^^^^^^^^^^^^^^^^^^
+  
+
+/file.js plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Rule retained errored: TypeError: The node belongs to a different source than this semantic model. Use a node from the model's original source. (/plugin.js:16:34)
+        at run (/plugin.js:16:34)
+```

--- a/crates/biome_plugin_loader/src/snapshots/semantic_model_scopes.snap
+++ b/crates/biome_plugin_loader/src/snapshots/semantic_model_scopes.snap
@@ -1,0 +1,1266 @@
+---
+source: crates/biome_plugin_loader/src/analyzer_js_plugin.rs
+expression: content
+---
+# Plugin
+
+## `/plugin.js`
+
+```js
+import { defineRule, semantic, registerDiagnostic } from "@biomejs/plugin-api";
+function describe(scope) {
+	if (!scope) return null;
+	const names = [];
+	for (const binding of scope.bindings()) {
+		names.push(binding.syntax().text);
+	}
+	return [scope.syntax().kind, names];
+}
+export const scopes = defineRule({
+	query: semantic("JS_MODULE"),
+	run(root, { model }) {
+		const scopes = model.scopes();
+		const global = model.globalScope();
+		const children = global.children();
+		children.length = 0;
+		const scopeDetails = [];
+		for (const scope of scopes) {
+			const lookup = [];
+			for (const name of [
+				"outer",
+				"value",
+				"hoisted",
+				"café",
+				"caf\\u00e9",
+				"Value",
+				"missing",
+			]) {
+				const binding = scope.getBinding(name);
+				const node = binding?.syntax();
+				lookup.push([name, node ? [node.kind, node.text] : null]);
+			}
+			const detail = {
+				scope: describe(scope),
+				global: scope.isGlobalScope(),
+				parent: describe(scope.parent()),
+				ancestors: scope.ancestors().map(describe),
+				lookup,
+			};
+			scopeDetails.push(detail);
+		}
+		const bindingDetails = [];
+		for (const binding of model.allBindings()) {
+			const references = [];
+			for (const reference of binding.allReferences()) {
+				const detail = {
+					scope: describe(reference.scope()),
+					lookup: describe(model.scope(reference.syntax())),
+				};
+				references.push(detail);
+			}
+			const detail = {
+				name: binding.syntax().text,
+				scope: describe(binding.scope()),
+				hoisted: describe(model.scopeHoistedTo(binding.syntax())),
+				references,
+			};
+			bindingDetails.push(detail);
+		}
+		const result = {
+			global: describe(global),
+			rootScope: describe(model.scope(root)),
+			children: global.children().map(describe),
+			scopes: scopeDetails,
+			bindings: bindingDetails,
+		};
+		registerDiagnostic(root, "information", JSON.stringify(result, 0, 2));
+	},
+});
+```
+
+# Input
+
+## `/scopes.js`
+
+```js
+const outer = 0; { let value = 1; function inner(param) { { var hoisted = param; let café = hoisted; café; outer; } } }
+```
+
+## `/scopes.ts`
+
+```ts
+interface Value {} const Value = 0; { type Local = Value; const café = 1; café; }
+```
+
+## `/empty.js`
+
+```js
+
+```
+
+## `/comments.js`
+
+```js
+/* scope */
+```
+
+## `/malformed.js`
+
+```js
+function broken( {
+```
+
+# Diagnostics
+
+```block
+/scopes.js:1:1 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i {
+      "global": [
+        "JS_MODULE",
+        [
+          "outer"
+        ]
+      ],
+      "rootScope": [
+        "JS_MODULE",
+        [
+          "outer"
+        ]
+      ],
+      "children": [
+        [
+          "JS_BLOCK_STATEMENT",
+          [
+            "value",
+            "inner"
+          ]
+        ]
+      ],
+      "scopes": [
+        {
+          "scope": [
+            "JS_MODULE",
+            [
+              "outer"
+            ]
+          ],
+          "global": true,
+          "parent": null,
+          "ancestors": [
+            [
+              "JS_MODULE",
+              [
+                "outer"
+              ]
+            ]
+          ],
+          "lookup": [
+            [
+              "outer",
+              [
+                "JS_IDENTIFIER_BINDING",
+                "outer"
+              ]
+            ],
+            [
+              "value",
+              null
+            ],
+            [
+              "hoisted",
+              null
+            ],
+            [
+              "café",
+              null
+            ],
+            [
+              "caf\\u00e9",
+              null
+            ],
+            [
+              "Value",
+              null
+            ],
+            [
+              "missing",
+              null
+            ]
+          ]
+        },
+        {
+          "scope": [
+            "JS_BLOCK_STATEMENT",
+            [
+              "value",
+              "inner"
+            ]
+          ],
+          "global": false,
+          "parent": [
+            "JS_MODULE",
+            [
+              "outer"
+            ]
+          ],
+          "ancestors": [
+            [
+              "JS_BLOCK_STATEMENT",
+              [
+                "value",
+                "inner"
+              ]
+            ],
+            [
+              "JS_MODULE",
+              [
+                "outer"
+              ]
+            ]
+          ],
+          "lookup": [
+            [
+              "outer",
+              null
+            ],
+            [
+              "value",
+              [
+                "JS_IDENTIFIER_BINDING",
+                "value"
+              ]
+            ],
+            [
+              "hoisted",
+              null
+            ],
+            [
+              "café",
+              null
+            ],
+            [
+              "caf\\u00e9",
+              null
+            ],
+            [
+              "Value",
+              null
+            ],
+            [
+              "missing",
+              null
+            ]
+          ]
+        },
+        {
+          "scope": [
+            "JS_FUNCTION_DECLARATION",
+            [
+              "param"
+            ]
+          ],
+          "global": false,
+          "parent": [
+            "JS_BLOCK_STATEMENT",
+            [
+              "value",
+              "inner"
+            ]
+          ],
+          "ancestors": [
+            [
+              "JS_FUNCTION_DECLARATION",
+              [
+                "param"
+              ]
+            ],
+            [
+              "JS_BLOCK_STATEMENT",
+              [
+                "value",
+                "inner"
+              ]
+            ],
+            [
+              "JS_MODULE",
+              [
+                "outer"
+              ]
+            ]
+          ],
+          "lookup": [
+            [
+              "outer",
+              null
+            ],
+            [
+              "value",
+              null
+            ],
+            [
+              "hoisted",
+              null
+            ],
+            [
+              "café",
+              null
+            ],
+            [
+              "caf\\u00e9",
+              null
+            ],
+            [
+              "Value",
+              null
+            ],
+            [
+              "missing",
+              null
+            ]
+          ]
+        },
+        {
+          "scope": [
+            "JS_FUNCTION_BODY",
+            [
+              "hoisted"
+            ]
+          ],
+          "global": false,
+          "parent": [
+            "JS_FUNCTION_DECLARATION",
+            [
+              "param"
+            ]
+          ],
+          "ancestors": [
+            [
+              "JS_FUNCTION_BODY",
+              [
+                "hoisted"
+              ]
+            ],
+            [
+              "JS_FUNCTION_DECLARATION",
+              [
+                "param"
+              ]
+            ],
+            [
+              "JS_BLOCK_STATEMENT",
+              [
+                "value",
+                "inner"
+              ]
+            ],
+            [
+              "JS_MODULE",
+              [
+                "outer"
+              ]
+            ]
+          ],
+          "lookup": [
+            [
+              "outer",
+              null
+            ],
+            [
+              "value",
+              null
+            ],
+            [
+              "hoisted",
+              [
+                "JS_IDENTIFIER_BINDING",
+                "hoisted"
+              ]
+            ],
+            [
+              "café",
+              null
+            ],
+            [
+              "caf\\u00e9",
+              null
+            ],
+            [
+              "Value",
+              null
+            ],
+            [
+              "missing",
+              null
+            ]
+          ]
+        },
+        {
+          "scope": [
+            "JS_BLOCK_STATEMENT",
+            [
+              "café"
+            ]
+          ],
+          "global": false,
+          "parent": [
+            "JS_FUNCTION_BODY",
+            [
+              "hoisted"
+            ]
+          ],
+          "ancestors": [
+            [
+              "JS_BLOCK_STATEMENT",
+              [
+                "café"
+              ]
+            ],
+            [
+              "JS_FUNCTION_BODY",
+              [
+                "hoisted"
+              ]
+            ],
+            [
+              "JS_FUNCTION_DECLARATION",
+              [
+                "param"
+              ]
+            ],
+            [
+              "JS_BLOCK_STATEMENT",
+              [
+                "value",
+                "inner"
+              ]
+            ],
+            [
+              "JS_MODULE",
+              [
+                "outer"
+              ]
+            ]
+          ],
+          "lookup": [
+            [
+              "outer",
+              null
+            ],
+            [
+              "value",
+              null
+            ],
+            [
+              "hoisted",
+              null
+            ],
+            [
+              "café",
+              [
+                "JS_IDENTIFIER_BINDING",
+                "café"
+              ]
+            ],
+            [
+              "caf\\u00e9",
+              [
+                "JS_IDENTIFIER_BINDING",
+                "café"
+              ]
+            ],
+            [
+              "Value",
+              null
+            ],
+            [
+              "missing",
+              null
+            ]
+          ]
+        }
+      ],
+      "bindings": [
+        {
+          "name": "outer",
+          "scope": [
+            "JS_MODULE",
+            [
+              "outer"
+            ]
+          ],
+          "hoisted": null,
+          "references": [
+            {
+              "scope": [
+                "JS_BLOCK_STATEMENT",
+                [
+                  "café"
+                ]
+              ],
+              "lookup": [
+                "JS_BLOCK_STATEMENT",
+                [
+                  "café"
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "name": "value",
+          "scope": [
+            "JS_BLOCK_STATEMENT",
+            [
+              "value",
+              "inner"
+            ]
+          ],
+          "hoisted": null,
+          "references": []
+        },
+        {
+          "name": "inner",
+          "scope": [
+            "JS_FUNCTION_DECLARATION",
+            [
+              "param"
+            ]
+          ],
+          "hoisted": [
+            "JS_BLOCK_STATEMENT",
+            [
+              "value",
+              "inner"
+            ]
+          ],
+          "references": []
+        },
+        {
+          "name": "param",
+          "scope": [
+            "JS_FUNCTION_DECLARATION",
+            [
+              "param"
+            ]
+          ],
+          "hoisted": null,
+          "references": [
+            {
+              "scope": [
+                "JS_BLOCK_STATEMENT",
+                [
+                  "café"
+                ]
+              ],
+              "lookup": [
+                "JS_BLOCK_STATEMENT",
+                [
+                  "café"
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "name": "hoisted",
+          "scope": [
+            "JS_BLOCK_STATEMENT",
+            [
+              "café"
+            ]
+          ],
+          "hoisted": [
+            "JS_FUNCTION_BODY",
+            [
+              "hoisted"
+            ]
+          ],
+          "references": [
+            {
+              "scope": [
+                "JS_BLOCK_STATEMENT",
+                [
+                  "café"
+                ]
+              ],
+              "lookup": [
+                "JS_BLOCK_STATEMENT",
+                [
+                  "café"
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "name": "café",
+          "scope": [
+            "JS_BLOCK_STATEMENT",
+            [
+              "café"
+            ]
+          ],
+          "hoisted": null,
+          "references": [
+            {
+              "scope": [
+                "JS_BLOCK_STATEMENT",
+                [
+                  "café"
+                ]
+              ],
+              "lookup": [
+                "JS_BLOCK_STATEMENT",
+                [
+                  "café"
+                ]
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  
+  > 1 │ const outer = 0; { let value = 1; function inner(param) { { var hoisted = param; let café = hoisted; café; outer; } } }
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  
+
+/scopes.ts:1:1 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i {
+      "global": [
+        "JS_MODULE",
+        [
+          "Value",
+          "Value"
+        ]
+      ],
+      "rootScope": [
+        "JS_MODULE",
+        [
+          "Value",
+          "Value"
+        ]
+      ],
+      "children": [
+        [
+          "TS_INTERFACE_DECLARATION",
+          []
+        ],
+        [
+          "JS_BLOCK_STATEMENT",
+          [
+            "Local",
+            "café"
+          ]
+        ]
+      ],
+      "scopes": [
+        {
+          "scope": [
+            "JS_MODULE",
+            [
+              "Value",
+              "Value"
+            ]
+          ],
+          "global": true,
+          "parent": null,
+          "ancestors": [
+            [
+              "JS_MODULE",
+              [
+                "Value",
+                "Value"
+              ]
+            ]
+          ],
+          "lookup": [
+            [
+              "outer",
+              null
+            ],
+            [
+              "value",
+              null
+            ],
+            [
+              "hoisted",
+              null
+            ],
+            [
+              "café",
+              null
+            ],
+            [
+              "caf\\u00e9",
+              null
+            ],
+            [
+              "Value",
+              [
+                "JS_IDENTIFIER_BINDING",
+                "Value"
+              ]
+            ],
+            [
+              "missing",
+              null
+            ]
+          ]
+        },
+        {
+          "scope": [
+            "TS_INTERFACE_DECLARATION",
+            []
+          ],
+          "global": false,
+          "parent": [
+            "JS_MODULE",
+            [
+              "Value",
+              "Value"
+            ]
+          ],
+          "ancestors": [
+            [
+              "TS_INTERFACE_DECLARATION",
+              []
+            ],
+            [
+              "JS_MODULE",
+              [
+                "Value",
+                "Value"
+              ]
+            ]
+          ],
+          "lookup": [
+            [
+              "outer",
+              null
+            ],
+            [
+              "value",
+              null
+            ],
+            [
+              "hoisted",
+              null
+            ],
+            [
+              "café",
+              null
+            ],
+            [
+              "caf\\u00e9",
+              null
+            ],
+            [
+              "Value",
+              null
+            ],
+            [
+              "missing",
+              null
+            ]
+          ]
+        },
+        {
+          "scope": [
+            "JS_BLOCK_STATEMENT",
+            [
+              "Local",
+              "café"
+            ]
+          ],
+          "global": false,
+          "parent": [
+            "JS_MODULE",
+            [
+              "Value",
+              "Value"
+            ]
+          ],
+          "ancestors": [
+            [
+              "JS_BLOCK_STATEMENT",
+              [
+                "Local",
+                "café"
+              ]
+            ],
+            [
+              "JS_MODULE",
+              [
+                "Value",
+                "Value"
+              ]
+            ]
+          ],
+          "lookup": [
+            [
+              "outer",
+              null
+            ],
+            [
+              "value",
+              null
+            ],
+            [
+              "hoisted",
+              null
+            ],
+            [
+              "café",
+              [
+                "JS_IDENTIFIER_BINDING",
+                "café"
+              ]
+            ],
+            [
+              "caf\\u00e9",
+              [
+                "JS_IDENTIFIER_BINDING",
+                "café"
+              ]
+            ],
+            [
+              "Value",
+              null
+            ],
+            [
+              "missing",
+              null
+            ]
+          ]
+        },
+        {
+          "scope": [
+            "TS_TYPE_ALIAS_DECLARATION",
+            []
+          ],
+          "global": false,
+          "parent": [
+            "JS_BLOCK_STATEMENT",
+            [
+              "Local",
+              "café"
+            ]
+          ],
+          "ancestors": [
+            [
+              "TS_TYPE_ALIAS_DECLARATION",
+              []
+            ],
+            [
+              "JS_BLOCK_STATEMENT",
+              [
+                "Local",
+                "café"
+              ]
+            ],
+            [
+              "JS_MODULE",
+              [
+                "Value",
+                "Value"
+              ]
+            ]
+          ],
+          "lookup": [
+            [
+              "outer",
+              null
+            ],
+            [
+              "value",
+              null
+            ],
+            [
+              "hoisted",
+              null
+            ],
+            [
+              "café",
+              null
+            ],
+            [
+              "caf\\u00e9",
+              null
+            ],
+            [
+              "Value",
+              null
+            ],
+            [
+              "missing",
+              null
+            ]
+          ]
+        }
+      ],
+      "bindings": [
+        {
+          "name": "Value",
+          "scope": [
+            "TS_INTERFACE_DECLARATION",
+            []
+          ],
+          "hoisted": [
+            "JS_MODULE",
+            [
+              "Value",
+              "Value"
+            ]
+          ],
+          "references": [
+            {
+              "scope": [
+                "TS_TYPE_ALIAS_DECLARATION",
+                []
+              ],
+              "lookup": [
+                "TS_TYPE_ALIAS_DECLARATION",
+                []
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Value",
+          "scope": [
+            "JS_MODULE",
+            [
+              "Value",
+              "Value"
+            ]
+          ],
+          "hoisted": null,
+          "references": []
+        },
+        {
+          "name": "Local",
+          "scope": [
+            "TS_TYPE_ALIAS_DECLARATION",
+            []
+          ],
+          "hoisted": [
+            "JS_BLOCK_STATEMENT",
+            [
+              "Local",
+              "café"
+            ]
+          ],
+          "references": []
+        },
+        {
+          "name": "café",
+          "scope": [
+            "JS_BLOCK_STATEMENT",
+            [
+              "Local",
+              "café"
+            ]
+          ],
+          "hoisted": null,
+          "references": [
+            {
+              "scope": [
+                "JS_BLOCK_STATEMENT",
+                [
+                  "Local",
+                  "café"
+                ]
+              ],
+              "lookup": [
+                "JS_BLOCK_STATEMENT",
+                [
+                  "Local",
+                  "café"
+                ]
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  
+  > 1 │ interface Value {} const Value = 0; { type Local = Value; const café = 1; café; }
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  
+
+/empty.js:1:1 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i {
+      "global": [
+        "JS_MODULE",
+        []
+      ],
+      "rootScope": null,
+      "children": [],
+      "scopes": [
+        {
+          "scope": [
+            "JS_MODULE",
+            []
+          ],
+          "global": true,
+          "parent": null,
+          "ancestors": [
+            [
+              "JS_MODULE",
+              []
+            ]
+          ],
+          "lookup": [
+            [
+              "outer",
+              null
+            ],
+            [
+              "value",
+              null
+            ],
+            [
+              "hoisted",
+              null
+            ],
+            [
+              "café",
+              null
+            ],
+            [
+              "caf\\u00e9",
+              null
+            ],
+            [
+              "Value",
+              null
+            ],
+            [
+              "missing",
+              null
+            ]
+          ]
+        }
+      ],
+      "bindings": []
+    }
+  
+  > 1 │ 
+      │ 
+  
+
+/comments.js:1:12 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i {
+      "global": [
+        "JS_MODULE",
+        []
+      ],
+      "rootScope": null,
+      "children": [],
+      "scopes": [
+        {
+          "scope": [
+            "JS_MODULE",
+            []
+          ],
+          "global": true,
+          "parent": null,
+          "ancestors": [
+            [
+              "JS_MODULE",
+              []
+            ]
+          ],
+          "lookup": [
+            [
+              "outer",
+              null
+            ],
+            [
+              "value",
+              null
+            ],
+            [
+              "hoisted",
+              null
+            ],
+            [
+              "café",
+              null
+            ],
+            [
+              "caf\\u00e9",
+              null
+            ],
+            [
+              "Value",
+              null
+            ],
+            [
+              "missing",
+              null
+            ]
+          ]
+        }
+      ],
+      "bindings": []
+    }
+  
+  > 1 │ /* scope */
+      │            
+  
+
+/malformed.js:1:1 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i {
+      "global": [
+        "JS_FUNCTION_DECLARATION",
+        [
+          "broken"
+        ]
+      ],
+      "rootScope": [
+        "JS_FUNCTION_DECLARATION",
+        [
+          "broken"
+        ]
+      ],
+      "children": [
+        [
+          "JS_FUNCTION_DECLARATION",
+          []
+        ]
+      ],
+      "scopes": [
+        {
+          "scope": [
+            "JS_FUNCTION_DECLARATION",
+            [
+              "broken"
+            ]
+          ],
+          "global": true,
+          "parent": null,
+          "ancestors": [
+            [
+              "JS_FUNCTION_DECLARATION",
+              [
+                "broken"
+              ]
+            ]
+          ],
+          "lookup": [
+            [
+              "outer",
+              null
+            ],
+            [
+              "value",
+              null
+            ],
+            [
+              "hoisted",
+              null
+            ],
+            [
+              "café",
+              null
+            ],
+            [
+              "caf\\u00e9",
+              null
+            ],
+            [
+              "Value",
+              null
+            ],
+            [
+              "missing",
+              null
+            ]
+          ]
+        },
+        {
+          "scope": [
+            "JS_FUNCTION_DECLARATION",
+            []
+          ],
+          "global": false,
+          "parent": [
+            "JS_FUNCTION_DECLARATION",
+            [
+              "broken"
+            ]
+          ],
+          "ancestors": [
+            [
+              "JS_FUNCTION_DECLARATION",
+              []
+            ],
+            [
+              "JS_FUNCTION_DECLARATION",
+              [
+                "broken"
+              ]
+            ]
+          ],
+          "lookup": [
+            [
+              "outer",
+              null
+            ],
+            [
+              "value",
+              null
+            ],
+            [
+              "hoisted",
+              null
+            ],
+            [
+              "café",
+              null
+            ],
+            [
+              "caf\\u00e9",
+              null
+            ],
+            [
+              "Value",
+              null
+            ],
+            [
+              "missing",
+              null
+            ]
+          ]
+        }
+      ],
+      "bindings": [
+        {
+          "name": "broken",
+          "scope": [
+            "JS_FUNCTION_DECLARATION",
+            [
+              "broken"
+            ]
+          ],
+          "hoisted": [
+            "JS_FUNCTION_DECLARATION",
+            [
+              "broken"
+            ]
+          ],
+          "references": []
+        }
+      ]
+    }
+  
+  > 1 │ function broken( {
+      │ ^^^^^^^^^^^^^^^^^^
+```

--- a/packages/@biomejs/plugin-api/index.d.ts
+++ b/packages/@biomejs/plugin-api/index.d.ts
@@ -7,9 +7,11 @@ import type {
 	JsNodeByKind,
 	JsTokenKind,
 } from "./js_ast";
+import type { SemanticModel } from "./semantic";
 
 export * from "./diagnostics";
 export * from "./js_ast";
+export * from "./semantic";
 
 declare const queriedNode: unique symbol;
 declare const nativeMutation: unique symbol;
@@ -20,11 +22,14 @@ declare const nativeMutation: unique symbol;
  * `N` is the union of the node types matched by the query; it only exists at
  * the type level, to infer the argument type of {@link Rule#run}.
  */
-export interface AstQuery<N extends JsAstNode> {
-	readonly type: "ast";
+interface Query<N extends JsAstNode, K extends keyof ContextByQuery> {
+	readonly type: K;
 	readonly kinds: readonly (keyof JsNodeByKind)[];
 	readonly [queriedNode]?: N;
 }
+
+export type AstQuery<N extends JsAstNode> = Query<N, "ast">;
+export type SemanticQuery<N extends JsAstNode> = Query<N, "semantic">;
 
 /** File information supplied to each invocation of a rule. */
 export interface RuleContext {
@@ -33,6 +38,17 @@ export interface RuleContext {
 	/** The parsing mode of the analyzed source, including embedded snippets. */
 	readonly sourceType: JsFileSource;
 }
+
+/** File information and semantic analysis supplied to a semantic rule. */
+export interface SemanticRuleContext extends RuleContext {
+	/** Bindings and references in the original analyzed source. */
+	readonly model: SemanticModel;
+}
+
+type ContextByQuery = {
+	ast: RuleContext;
+	semantic: SemanticRuleContext;
+};
 
 /** JavaScript or TypeScript parsing settings for the analyzed source. */
 export interface JsFileSource {
@@ -75,11 +91,14 @@ export type JsEmbeddingKind =
  * A lint rule, created with {@link defineRule} and exported from the plugin
  * with `export const`. The name of the export is used as the rule name.
  */
-export interface Rule<N extends JsAstNode> {
+export interface Rule<
+	N extends JsAstNode,
+	K extends keyof ContextByQuery = "ast",
+> {
 	/**
 	 * The query selecting the nodes the rule runs on.
 	 */
-	readonly query: AstQuery<N>;
+	readonly query: Query<N, K>;
 
 	/**
 	 * Called with every node matching the query.
@@ -96,7 +115,7 @@ export interface Rule<N extends JsAstNode> {
 	 * });
 	 * ```
 	 */
-	run(node: N, context: RuleContext): void;
+	readonly run: (node: NoInfer<N>, context: NoInfer<ContextByQuery[K]>) => void;
 }
 
 /**
@@ -107,10 +126,33 @@ export function ast<K extends readonly (keyof JsNodeByKind)[]>(
 ): AstQuery<JsNodeByKind[K[number]]>;
 
 /**
+ * Matches nodes by their syntax kinds and provides a semantic model in `context`.
+ *
+ * For example, inspect every read of a declared binding:
+ * ```ts
+ * export const inspectReads = defineRule({
+ *   query: semantic("JS_IDENTIFIER_BINDING"),
+ *   run(node, context) {
+ *     const binding = context.model.asBinding(node);
+ *     for (const reference of binding?.allReads() ?? []) {
+ *       registerDiagnostic(reference.syntax(), "information", "Binding read here.");
+ *     }
+ *   },
+ * });
+ * ```
+ */
+export function semantic<K extends readonly (keyof JsNodeByKind)[]>(
+	...kinds: K
+): SemanticQuery<JsNodeByKind[K[number]]>;
+
+/**
  * Defines a lint rule. Export the returned rule with `export const` to
  * register it to the analyzer.
  */
-export function defineRule<N extends JsAstNode>(rule: Rule<N>): Rule<N>;
+export function defineRule<
+	N extends JsAstNode,
+	K extends keyof ContextByQuery = "ast",
+>(rule: Rule<N, K>): Rule<N, K>;
 
 /**
  * Collects replacements and removals for one code fix without changing the

--- a/packages/@biomejs/plugin-api/package.json
+++ b/packages/@biomejs/plugin-api/package.json
@@ -12,7 +12,8 @@
     "LICENSE-MIT",
     "diagnostics.d.ts",
     "index.d.ts",
-    "js_ast.d.ts"
+    "js_ast.d.ts",
+    "semantic.d.ts"
   ],
   "exports": {
     ".": {

--- a/packages/@biomejs/plugin-api/semantic.d.ts
+++ b/packages/@biomejs/plugin-api/semantic.d.ts
@@ -1,0 +1,611 @@
+import type {
+	AnyJsAstNode,
+	JsIdentifierAssignment,
+	JsIdentifierBinding,
+	JsReferenceIdentifier,
+	JsxReferenceIdentifier,
+	TsIdentifierBinding,
+	TsLiteralEnumMemberName,
+	TsTypeParameterName,
+} from "./js_ast";
+
+/** Identifier nodes that refer to a binding or an external name. */
+export type AnyJsIdentifierReference =
+	| JsReferenceIdentifier
+	| JsIdentifierAssignment
+	| JsxReferenceIdentifier;
+
+/** Identifier nodes that introduce bindings. */
+export type AnyJsIdentifierBinding =
+	| JsIdentifierBinding
+	| TsIdentifierBinding
+	| TsTypeParameterName
+	| TsLiteralEnumMemberName;
+
+/** The semantic classification of a binding's declaration. */
+export type JsDeclarationKind =
+	/** Class binding, including named class expressions. */
+	| "class"
+	/** TypeScript enum declaration or member. */
+	| "enum"
+	/** Function declaration or overload signature. */
+	| "function"
+	/** Generic type parameter. */
+	| "generic"
+	/** Hoisted value, such as `var` or a named function expression. */
+	| "hoistedValue"
+	/** Import binding, including TypeScript `import =`. */
+	| "import"
+	/** Type-only import binding. */
+	| "importType"
+	/** TypeScript interface declaration. */
+	| "interface"
+	/** TypeScript module declaration. */
+	| "module"
+	/** TypeScript namespace declaration. */
+	| "namespace"
+	/** Type alias declaration. */
+	| "type"
+	/** Declaration not classified by the model. */
+	| "unknown"
+	/** Explicit resource-management binding. */
+	| "using"
+	/** Value binding, such as `let`, `const`, or a parameter. */
+	| "value";
+
+/**
+ * A range in the analyzed source, measured in UTF-8 bytes.
+ * The range starts at `start` and stops before `end`.
+ * For example, `{ start: 2, end: 5 }` covers bytes 2, 3, and 4; byte 5 is not included.
+ */
+export interface TextRange {
+	/** Starting byte offset, included in the range. */
+	readonly start: number;
+	/** Byte offset immediately after the range. */
+	readonly end: number;
+}
+
+/**
+ * Bindings and references in one analyzed source snapshot.
+ * Access it through `context.model` in a rule using `semantic(...)`.
+ *
+ * Node arguments must belong to this model's source. Saved models and handles
+ * retain their original source; prepared code fixes do not update the model.
+ * Collection methods return fresh arrays whose contents can be inspected with
+ * normal JavaScript iteration and array methods.
+ */
+export interface SemanticModel {
+	/**
+	 * Resolves an identifier use to the binding it refers to, respecting shadowing.
+	 * Returns `undefined` for configured globals and unresolved references.
+	 *
+	 * In a rule querying `semantic("JS_REFERENCE_IDENTIFIER")`, highlight the
+	 * declaration of the referenced name:
+	 * ```ts
+	 * const binding = context.model.binding(node);
+	 * if (binding) {
+	 *   registerDiagnostic(binding.syntax(), "information", "Declared here.");
+	 * }
+	 * ```
+	 */
+	binding(reference: AnyJsIdentifierReference): Binding | undefined;
+	/**
+	 * Looks up the binding introduced by a declaration's identifier node.
+	 * Returns `undefined` when the model does not track that declaration.
+	 *
+	 * In a rule querying `semantic("JS_IDENTIFIER_BINDING")`, report how many
+	 * references resolve to the declaration:
+	 * ```ts
+	 * const binding = context.model.asBinding(node);
+	 * if (binding) {
+	 *   const count = binding.allReferences().length;
+	 *   registerDiagnostic(node, "information", `${count} references.`);
+	 * }
+	 * ```
+	 */
+	asBinding(node: AnyJsIdentifierBinding): Binding | undefined;
+	/**
+	 * Returns all tracked bindings in the source, including nested scopes.
+	 * Declarations with the same spelling can introduce separate bindings.
+	 *
+	 * In a semantic rule querying the root, highlight each declaration:
+	 * ```ts
+	 * for (const binding of context.model.allBindings()) {
+	 *   registerDiagnostic(binding.syntax(), "information", "Declaration.");
+	 * }
+	 * ```
+	 */
+	allBindings(): readonly Binding[];
+	/**
+	 * Returns the bindings marked as exported by the model, with each binding
+	 * appearing once even if it has multiple export sites. Order is unspecified.
+	 * Re-exports that introduce no local binding are not included.
+	 *
+	 * In a semantic rule querying the root, highlight exported declarations:
+	 * ```ts
+	 * for (const binding of context.model.allExportedBindings()) {
+	 *   registerDiagnostic(binding.syntax(), "information", "Exported declaration.");
+	 * }
+	 * ```
+	 */
+	allExportedBindings(): readonly Binding[];
+	/**
+	 * Returns whether the model tracks at least one exported binding.
+	 * This is not a check for export syntax: an empty export, a re-export without
+	 * a local binding, or an exported literal can leave this value `false`.
+	 *
+	 * In a semantic rule querying the root, check for exported bindings:
+	 * ```ts
+	 * if (context.model.hasExports()) {
+	 *   registerDiagnostic(node, "information", "This source exports bindings.");
+	 * }
+	 * ```
+	 */
+	hasExports(): boolean;
+	/**
+	 * Returns all scopes in this source, including the global scope and nested scopes.
+	 *
+	 * In a semantic rule querying the root, inspect each scope's declarations:
+	 * ```ts
+	 * for (const scope of context.model.scopes()) {
+	 *   for (const binding of scope.bindings()) {
+	 *     registerDiagnostic(binding.syntax(), "information", "Declared in this scope.");
+	 *   }
+	 * }
+	 * ```
+	 */
+	scopes(): readonly Scope[];
+	/**
+	 * Returns the outermost scope of this source, including for an empty file.
+	 * This scope has no parent. It is distinct from the configured global names
+	 * returned by `allGlobalReferences()`.
+	 *
+	 * In a semantic rule, inspect bindings in the outermost scope:
+	 * ```ts
+	 * const scope = context.model.globalScope();
+	 * const names = scope.bindings().map(binding => binding.syntax().text);
+	 * ```
+	 */
+	globalScope(): Scope;
+	/**
+	 * Returns the most specific scope containing the node's trimmed source range.
+	 * Returns `undefined` for an empty node. Use `globalScope()` to obtain a scope
+	 * for an empty file.
+	 *
+	 * In a semantic rule, inspect the scope surrounding the matched node:
+	 * ```ts
+	 * const scope = context.model.scope(node);
+	 * if (scope) {
+	 *   registerDiagnostic(scope.syntax(), "information", "Containing scope.");
+	 * }
+	 * ```
+	 */
+	scope(node: AnyJsAstNode): Scope | undefined;
+	/**
+	 * Returns the scope a declaration's identifier was hoisted to, if the model
+	 * records one. This can differ from the scope containing its source text.
+	 *
+	 * In a rule querying `semantic("JS_IDENTIFIER_BINDING")`, inspect hoisting:
+	 * ```ts
+	 * const scope = context.model.scopeHoistedTo(node);
+	 * if (scope) {
+	 *   registerDiagnostic(scope.syntax(), "information", "Declaration is hoisted here.");
+	 * }
+	 * ```
+	 */
+	scopeHoistedTo(node: AnyJsAstNode): Scope | undefined;
+	/**
+	 * Returns references resolved to globals configured in the supplied model.
+	 * Locally shadowed names resolve to local bindings instead.
+	 *
+	 * In a semantic rule querying the root, highlight uses of configured globals:
+	 * ```ts
+	 * for (const reference of context.model.allGlobalReferences()) {
+	 *   registerDiagnostic(reference.syntax(), "information", "Uses a global.");
+	 * }
+	 * ```
+	 */
+	allGlobalReferences(): readonly GlobalReference[];
+	/**
+	 * Returns references that resolve to neither a local binding nor a global
+	 * configured in the supplied model.
+	 *
+	 * In a semantic rule querying the root, highlight unresolved names:
+	 * ```ts
+	 * for (const reference of context.model.allUnresolvedReferences()) {
+	 *   registerDiagnostic(reference.syntax(), "warning", "Unresolved name.");
+	 * }
+	 * ```
+	 */
+	allUnresolvedReferences(): readonly UnresolvedReference[];
+	/**
+	 * Returns whether an identifier use resolves to a configured global.
+	 * Returns `false` for local bindings and unresolved references.
+	 *
+	 * In a rule querying `semantic("JS_REFERENCE_IDENTIFIER")`, distinguish
+	 * configured globals from other identifier uses:
+	 * ```ts
+	 * if (context.model.isGlobalReference(node)) {
+	 *   registerDiagnostic(node, "information", "Uses a configured global.");
+	 * }
+	 * ```
+	 */
+	isGlobalReference(reference: AnyJsIdentifierReference): boolean;
+	/**
+	 * Returns whether an identifier use has no local binding or configured global.
+	 * A reference to a declaration later in the source can still resolve.
+	 *
+	 * In a rule querying `semantic("JS_REFERENCE_IDENTIFIER")`, report names the
+	 * model cannot resolve:
+	 * ```ts
+	 * if (context.model.isUnresolvedReference(node)) {
+	 *   registerDiagnostic(node, "warning", "This name could not be resolved.");
+	 * }
+	 * ```
+	 */
+	isUnresolvedReference(reference: AnyJsIdentifierReference): boolean;
+	/**
+	 * Returns whether a declaration is imported, or a reference resolves to an
+	 * imported declaration. Returns `false` when a reference has no local binding.
+	 *
+	 * In a rule querying `semantic("JS_REFERENCE_IDENTIFIER")`, highlight uses
+	 * of imported names:
+	 * ```ts
+	 * if (context.model.isImported(node)) {
+	 *   registerDiagnostic(node, "information", "Uses an imported binding.");
+	 * }
+	 * ```
+	 */
+	isImported(node: AnyJsIdentifierBinding | AnyJsIdentifierReference): boolean;
+	/**
+	 * Returns whether a declaration is exported, or a reference resolves to an
+	 * exported declaration. Returns `false` when a reference has no local binding.
+	 *
+	 * In a rule querying `semantic("JS_IDENTIFIER_BINDING")`, highlight exported
+	 * declarations:
+	 * ```ts
+	 * if (context.model.isExported(node)) {
+	 *   registerDiagnostic(node, "information", "This binding is exported.");
+	 * }
+	 * ```
+	 */
+	isExported(node: AnyJsIdentifierBinding | AnyJsIdentifierReference): boolean;
+}
+
+/**
+ * A declaration and the references that resolve to it.
+ * The examples use a `binding` obtained from `context.model.binding(...)`
+ * or `context.model.asBinding(...)`.
+ */
+export interface Binding {
+	/**
+	 * Returns the model's declaration classification, such as `"function"`,
+	 * `"importType"`, or `"hoistedValue"`. This describes how the binding was
+	 * declared, rather than the syntax kind of its identifier node.
+	 *
+	 * Highlight hoisted value bindings:
+	 * ```ts
+	 * if (binding.declarationKind() === "hoistedValue") {
+	 *   registerDiagnostic(binding.syntax(), "information", "Hoisted value binding.");
+	 * }
+	 * ```
+	 */
+	declarationKind(): JsDeclarationKind;
+	/**
+	 * Returns the identifier nodes at this binding's tracked export sites.
+	 * A directly exported declaration yields its identifier binding; an export
+	 * specifier yields the local identifier reference, not its exported alias.
+	 * Returns an empty array for a binding with no tracked export sites.
+	 *
+	 * Highlight the places that export this binding:
+	 * ```ts
+	 * for (const site of binding.exports()) {
+	 *   registerDiagnostic(site, "information", "Exported here.");
+	 * }
+	 * ```
+	 */
+	exports(): readonly (AnyJsIdentifierBinding | AnyJsIdentifierReference)[];
+	/**
+	 * Returns the model's source ranges for this binding's export sites.
+	 * Offsets count UTF-8 bytes, with an inclusive start and exclusive end;
+	 * they are not JavaScript string indices. Returns an empty array when no
+	 * export sites are tracked.
+	 *
+	 * Report the recorded byte offsets alongside the declaration:
+	 * ```ts
+	 * const locations = binding.exportRanges()
+	 *   .map(range => `${range.start}..${range.end}`)
+	 *   .join(", ");
+	 * registerDiagnostic(binding.syntax(), "information", `Export byte ranges: ${locations}.`);
+	 * ```
+	 */
+	exportRanges(): readonly TextRange[];
+	/**
+	 * Returns the identifier node introducing this binding, rather than the
+	 * enclosing declaration statement. The node can be used in diagnostics and fixes.
+	 *
+	 * Highlight the declaration's name:
+	 * ```ts
+	 * const identifier = binding.syntax();
+	 * registerDiagnostic(identifier, "information", `Declares ${identifier.text}.`);
+	 * ```
+	 */
+	syntax(): AnyJsIdentifierBinding;
+	/**
+	 * Returns the scope containing the declaration's identifier in the source.
+	 * For hoisted declarations, use `context.model.scopeHoistedTo(binding.syntax())`
+	 * to inspect the destination scope instead.
+	 *
+	 * Inspect the declaration's surrounding scope:
+	 * ```ts
+	 * const scope = binding.scope();
+	 * registerDiagnostic(scope.syntax(), "information", "Declaration appears here.");
+	 * ```
+	 */
+	scope(): Scope;
+	/**
+	 * Returns all references that resolve to this binding, including reads and writes.
+	 * References to a different binding with the same spelling are excluded.
+	 *
+	 * Highlight every reference to this declaration:
+	 * ```ts
+	 * for (const reference of binding.allReferences()) {
+	 *   registerDiagnostic(reference.syntax(), "information", "References this binding.");
+	 * }
+	 * ```
+	 */
+	allReferences(): readonly Reference[];
+	/**
+	 * Returns references classified as reads by the semantic model.
+	 *
+	 * Highlight the places that read this binding:
+	 * ```ts
+	 * for (const reference of binding.allReads()) {
+	 *   registerDiagnostic(reference.syntax(), "information", "Reads this binding.");
+	 * }
+	 * ```
+	 */
+	allReads(): readonly Reference[];
+	/**
+	 * Returns references classified as writes by the semantic model.
+	 *
+	 * Highlight the places that write to this binding:
+	 * ```ts
+	 * for (const reference of binding.allWrites()) {
+	 *   registerDiagnostic(reference.syntax(), "information", "Writes to this binding.");
+	 * }
+	 * ```
+	 */
+	allWrites(): readonly Reference[];
+	/**
+	 * Returns whether this binding has an import declaration kind in the model.
+	 *
+	 * Highlight an imported declaration:
+	 * ```ts
+	 * if (binding.isImported()) {
+	 *   registerDiagnostic(binding.syntax(), "information", "Imported binding.");
+	 * }
+	 * ```
+	 */
+	isImported(): boolean;
+	/**
+	 * Returns whether this binding is exported from the source.
+	 *
+	 * Highlight an exported declaration:
+	 * ```ts
+	 * if (binding.isExported()) {
+	 *   registerDiagnostic(binding.syntax(), "information", "Exported binding.");
+	 * }
+	 * ```
+	 */
+	isExported(): boolean;
+}
+
+/**
+ * A reference resolved to a local binding.
+ * The examples use a `reference` obtained from a binding's reference arrays.
+ */
+export interface Reference {
+	/**
+	 * Returns the identifier node at the reference site. The node can be used in
+	 * diagnostics and fixes.
+	 *
+	 * Highlight the identifier use rather than its declaration:
+	 * ```ts
+	 * registerDiagnostic(reference.syntax(), "information", "Referenced here.");
+	 * ```
+	 */
+	syntax(): AnyJsIdentifierReference;
+	/**
+	 * Returns the binding this reference resolves to.
+	 *
+	 * Follow a reference back to its declaration:
+	 * ```ts
+	 * const declaration = reference.binding();
+	 * if (declaration) {
+	 *   registerDiagnostic(declaration.syntax(), "information", "Declared here.");
+	 * }
+	 * ```
+	 */
+	binding(): Binding | undefined;
+	/**
+	 * Returns the scope containing this identifier use, which can differ from the
+	 * scope containing its declaration.
+	 *
+	 * Highlight the scope where the reference occurs:
+	 * ```ts
+	 * registerDiagnostic(reference.scope().syntax(), "information", "Reference scope.");
+	 * ```
+	 */
+	scope(): Scope;
+	/**
+	 * Returns whether the model classifies this reference as a read.
+	 *
+	 * Report only read references while inspecting a binding's references:
+	 * ```ts
+	 * if (reference.isRead()) {
+	 *   registerDiagnostic(reference.syntax(), "information", "Read access.");
+	 * }
+	 * ```
+	 */
+	isRead(): boolean;
+	/**
+	 * Returns whether the model classifies this reference as a write.
+	 *
+	 * Report only write references while inspecting a binding's references:
+	 * ```ts
+	 * if (reference.isWrite()) {
+	 *   registerDiagnostic(reference.syntax(), "information", "Write access.");
+	 * }
+	 * ```
+	 */
+	isWrite(): boolean;
+}
+
+/**
+ * A lexical scope in one source snapshot. Obtain scopes through the semantic
+ * model, a binding, or a resolved reference. The examples use a `scope` returned
+ * by one of those APIs. Collection methods return fresh arrays.
+ */
+export interface Scope {
+	/**
+	 * Returns the syntax node associated with this scope, such as a module,
+	 * function, or block. The node can be used in diagnostics and fixes.
+	 *
+	 * Highlight the code that defines this scope:
+	 * ```ts
+	 * registerDiagnostic(scope.syntax(), "information", "Scope starts here.");
+	 * ```
+	 */
+	syntax(): AnyJsAstNode;
+	/**
+	 * Returns whether this is the source's outermost scope.
+	 *
+	 * Inspect nested scopes only:
+	 * ```ts
+	 * if (!scope.isGlobalScope()) {
+	 *   registerDiagnostic(scope.syntax(), "information", "Nested scope.");
+	 * }
+	 * ```
+	 */
+	isGlobalScope(): boolean;
+	/**
+	 * Returns the immediately enclosing scope, or `undefined` for the global scope.
+	 *
+	 * Highlight the containing scope:
+	 * ```ts
+	 * const parent = scope.parent();
+	 * if (parent) {
+	 *   registerDiagnostic(parent.syntax(), "information", "Parent scope.");
+	 * }
+	 * ```
+	 */
+	parent(): Scope | undefined;
+	/**
+	 * Returns this scope's immediate child scopes, without their descendants.
+	 *
+	 * Inspect each directly nested scope:
+	 * ```ts
+	 * for (const child of scope.children()) {
+	 *   registerDiagnostic(child.syntax(), "information", "Child scope.");
+	 * }
+	 * ```
+	 */
+	children(): readonly Scope[];
+	/**
+	 * Returns this scope followed by its parents, ending with the global scope.
+	 * The first entry is the current scope itself.
+	 *
+	 * Search outward for the nearest binding named `value`:
+	 * ```ts
+	 * for (const ancestor of scope.ancestors()) {
+	 *   const binding = ancestor.getBinding("value");
+	 *   if (binding) {
+	 *     registerDiagnostic(binding.syntax(), "information", "Nearest declaration.");
+	 *     break;
+	 *   }
+	 * }
+	 * ```
+	 */
+	ancestors(): readonly Scope[];
+	/**
+	 * Returns bindings declared in or hoisted to this scope. Bindings belonging
+	 * to parent or child scopes are excluded.
+	 *
+	 * List this scope's binding names:
+	 * ```ts
+	 * const names = scope.bindings().map(binding => binding.syntax().text);
+	 * ```
+	 */
+	bindings(): readonly Binding[];
+	/**
+	 * Looks up a binding in this scope only; parent scopes are not searched.
+	 * Returns `undefined` when the name is absent. Unicode escapes are decoded.
+	 * When a TypeScript name has both type and value bindings, the value binding
+	 * is preferred, falling back to the type binding if no value exists.
+	 *
+	 * Inspect a binding declared in this scope:
+	 * ```ts
+	 * const binding = scope.getBinding("value");
+	 * if (binding) {
+	 *   registerDiagnostic(binding.syntax(), "information", "Local declaration.");
+	 * }
+	 * ```
+	 */
+	getBinding(name: string): Binding | undefined;
+}
+
+/**
+ * A reference resolved to a global configured in the supplied model.
+ * The examples use a `reference` from `context.model.allGlobalReferences()`.
+ */
+export interface GlobalReference {
+	/**
+	 * Returns the identifier node that uses the configured global.
+	 *
+	 * Highlight the global's name at its use site:
+	 * ```ts
+	 * const identifier = reference.syntax();
+	 * registerDiagnostic(identifier, "information", `Uses global ${identifier.text}.`);
+	 * ```
+	 */
+	syntax(): AnyJsIdentifierReference;
+	/**
+	 * Returns whether the model classifies this global reference as a read.
+	 *
+	 * Highlight reads of configured globals:
+	 * ```ts
+	 * if (reference.isRead()) {
+	 *   registerDiagnostic(reference.syntax(), "information", "Reads a global.");
+	 * }
+	 * ```
+	 */
+	isRead(): boolean;
+	/**
+	 * Returns whether the model classifies this global reference as a write.
+	 *
+	 * Report assignments to configured globals:
+	 * ```ts
+	 * if (reference.isWrite()) {
+	 *   registerDiagnostic(reference.syntax(), "warning", "Writes to a global.");
+	 * }
+	 * ```
+	 */
+	isWrite(): boolean;
+}
+
+/** A reference without a local binding or configured global. */
+export interface UnresolvedReference {
+	/**
+	 * Returns the identifier node whose name could not be resolved.
+	 *
+	 * Highlight each unresolved name in a semantic rule:
+	 * ```ts
+	 * for (const reference of context.model.allUnresolvedReferences()) {
+	 *   const identifier = reference.syntax();
+	 *   registerDiagnostic(identifier, "warning", `Cannot resolve ${identifier.text}.`);
+	 * }
+	 * ```
+	 */
+	syntax(): AnyJsIdentifierReference;
+}

--- a/packages/@biomejs/plugin-api/type-tests/semantic.test.ts
+++ b/packages/@biomejs/plugin-api/type-tests/semantic.test.ts
@@ -1,0 +1,122 @@
+import {
+	ast,
+	defineRule,
+	type Binding,
+	type JsIdentifierBinding,
+	type JsDeclarationKind,
+	type JsReferenceIdentifier,
+	type Reference,
+	type RuleContext,
+	type Scope,
+	type SemanticModel,
+	type SemanticRuleContext,
+	type TextRange,
+	semantic,
+} from "@biomejs/plugin-api";
+
+defineRule({
+	query: semantic("JS_REFERENCE_IDENTIFIER"),
+	run(node, context) {
+		node satisfies JsReferenceIdentifier;
+		context satisfies SemanticRuleContext;
+		context.model satisfies SemanticModel;
+		context.model.binding(node) satisfies Binding | undefined;
+		context.model.isImported(node) satisfies boolean;
+		context.model.isExported(node) satisfies boolean;
+		context.model.hasExports() satisfies boolean;
+		context.model.allExportedBindings() satisfies readonly Binding[];
+		context.model.isGlobalReference(node) satisfies boolean;
+		context.model.isUnresolvedReference(node) satisfies boolean;
+		context.model.allGlobalReferences().map(reference => reference.isRead());
+		context.model.allUnresolvedReferences().map(reference => reference.syntax());
+		context.model.scope(node) satisfies Scope | undefined;
+		context.model.scopeHoistedTo(node) satisfies Scope | undefined;
+		context.model.scopes() satisfies readonly Scope[];
+		const scope = context.model.globalScope();
+		scope satisfies Scope;
+		scope.parent() satisfies Scope | undefined;
+		scope.children() satisfies readonly Scope[];
+		scope.ancestors() satisfies readonly Scope[];
+		scope.bindings() satisfies readonly Binding[];
+		scope.getBinding("value") satisfies Binding | undefined;
+		scope.isGlobalScope() satisfies boolean;
+		context.model.scope(scope.syntax());
+		for (const binding of scope.bindings()) {
+			binding.scope() satisfies Scope;
+			binding.declarationKind() satisfies JsDeclarationKind;
+			binding.exports().map(site => context.model.isExported(site));
+			binding.exportRanges() satisfies readonly TextRange[];
+			for (const range of binding.exportRanges()) {
+				range.start satisfies number;
+				range.end satisfies number;
+				// @ts-expect-error Export range endpoints are read-only.
+				range.start = 0;
+			}
+			for (const reference of binding.allReferences()) {
+				reference.scope() satisfies Scope;
+			}
+		}
+		// @ts-expect-error Scope collections are read-only.
+		scope.children().push(scope);
+		// @ts-expect-error Scope lookup requires a source node, not a scope handle.
+		context.model.scope(scope);
+		// @ts-expect-error Reference queries preserve the matched node type.
+		node satisfies JsIdentifierBinding;
+		// @ts-expect-error A reference does not introduce a binding.
+		context.model.asBinding(node);
+		// @ts-expect-error The supplied model is read-only.
+		context.model = context.model;
+	},
+});
+
+defineRule({
+	query: semantic("JS_IDENTIFIER_BINDING", "JS_REFERENCE_IDENTIFIER"),
+	run(node, context) {
+		node satisfies JsIdentifierBinding | JsReferenceIdentifier;
+		if (node.kind === "JS_IDENTIFIER_BINDING") {
+			const binding = context.model.asBinding(node);
+			binding?.allReferences() satisfies readonly Reference[] | undefined;
+			binding?.allReads().map(reference => reference.binding());
+			binding?.allWrites().map(reference => reference.isWrite());
+		} else {
+			context.model.binding(node);
+		}
+	},
+});
+
+defineRule({
+	query: ast("JS_REFERENCE_IDENTIFIER"),
+	run(node, context) {
+		node satisfies JsReferenceIdentifier;
+		context satisfies RuleContext;
+		// @ts-expect-error Syntax queries do not expose the model.
+		context.model;
+	},
+});
+
+defineRule({
+	query: ast("JS_REFERENCE_IDENTIFIER"),
+	// @ts-expect-error A callback cannot request a model through its annotation.
+	run(_node: JsReferenceIdentifier, _context: SemanticRuleContext) {},
+});
+
+defineRule({
+	query: semantic("JS_REFERENCE_IDENTIFIER"),
+	// @ts-expect-error A callback cannot override the queried node type.
+	run(_node: JsIdentifierBinding, _context: SemanticRuleContext) {},
+});
+
+defineRule({
+	query: semantic("JS_IDENTIFIER_BINDING"),
+	run(node) {
+		node satisfies JsIdentifierBinding;
+	},
+});
+
+defineRule<JsReferenceIdentifier>({
+	query: ast("JS_REFERENCE_IDENTIFIER"),
+	run(node, context) {
+		node satisfies JsReferenceIdentifier;
+		context satisfies RuleContext;
+	},
+});


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

> Used a coding agent to design and implement the feature

Part of #11420 

This PR adds support for querying the semantic model via a new `semantic` query, similar to our Rust APIs. A new TypeScript type has been added, so that `context.model` is available only when `semantic` is used.

The JS semantic model **isn't** a 1:1 port. Only the following features have been ported:
- bindings
- references
- scopes
- globals
- exports

Out of scope for now:
- captures
- calls
- jsdoc
- types

Ranges haven't been added because users can call `.syntax()` and retrieve the range from there.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added new tests. Some tests call `JSON.stringify` in the message. This's a trick to snapshot the semantic model data and make sure it's up to date and correct.

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
