### PR TITLE
fix(react-compiler): bump vendored React Compiler crates to fix non-ASCII panic

### DIFF
--- a/.changeset/react-compiler-non-ascii-panic.md
+++ b/.changeset/react-compiler-non-ascii-panic.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11678](https://github.com/biomejs/biome/issues/11678): [`useReactCompiler`](https://biomejs.dev/linter/rules/use-react-compiler/) no longer panics on files that contain non-ASCII characters. The panic dropped the whole file from the run, so every diagnostic in it was silently lost. This bumps the vendored React Compiler crates to pick up the upstream fix from [react/react#37539](https://github.com/react/react/pull/37539).

--- a/.changeset/react-compiler-non-ascii-panic.md
+++ b/.changeset/react-compiler-non-ascii-panic.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#11678](https://github.com/biomejs/biome/issues/11678): [`useReactCompiler`](https://biomejs.dev/linter/rules/use-react-compiler/) no longer panics on files that contain non-ASCII characters. The panic dropped the whole file from the run, so every diagnostic in it was silently lost. This bumps the vendored React Compiler crates to pick up the upstream fix from [react/react#37539](https://github.com/react/react/pull/37539).
+Fixed [#11678](https://github.com/biomejs/biome/issues/11678): [`useReactCompiler`](https://biomejs.dev/linter/rules/use-react-compiler/) no longer panics on files that contain non-ASCII characters. This bumps the React Compiler version.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5216,7 +5216,7 @@ dependencies = [
 [[package]]
 name = "react_compiler"
 version = "0.0.1-oidc.0"
-source = "git+https://github.com/react/react?rev=6c0e1047e392da04bccb36e84c04e1d1412901d6#6c0e1047e392da04bccb36e84c04e1d1412901d6"
+source = "git+https://github.com/react/react?rev=78c2d377d79a7284339fc24b560dd503daf314cc#78c2d377d79a7284339fc24b560dd503daf314cc"
 dependencies = [
  "indexmap",
  "react_compiler_ast",
@@ -5237,7 +5237,7 @@ dependencies = [
 [[package]]
 name = "react_compiler_ast"
 version = "0.0.1-oidc.0"
-source = "git+https://github.com/react/react?rev=6c0e1047e392da04bccb36e84c04e1d1412901d6#6c0e1047e392da04bccb36e84c04e1d1412901d6"
+source = "git+https://github.com/react/react?rev=78c2d377d79a7284339fc24b560dd503daf314cc#78c2d377d79a7284339fc24b560dd503daf314cc"
 dependencies = [
  "indexmap",
  "react_compiler_diagnostics",
@@ -5250,7 +5250,7 @@ dependencies = [
 [[package]]
 name = "react_compiler_diagnostics"
 version = "0.0.1-oidc.0"
-source = "git+https://github.com/react/react?rev=6c0e1047e392da04bccb36e84c04e1d1412901d6#6c0e1047e392da04bccb36e84c04e1d1412901d6"
+source = "git+https://github.com/react/react?rev=78c2d377d79a7284339fc24b560dd503daf314cc#78c2d377d79a7284339fc24b560dd503daf314cc"
 dependencies = [
  "rustc-hash 2.1.3",
  "serde",
@@ -5259,7 +5259,7 @@ dependencies = [
 [[package]]
 name = "react_compiler_hir"
 version = "0.0.1-oidc.0"
-source = "git+https://github.com/react/react?rev=6c0e1047e392da04bccb36e84c04e1d1412901d6#6c0e1047e392da04bccb36e84c04e1d1412901d6"
+source = "git+https://github.com/react/react?rev=78c2d377d79a7284339fc24b560dd503daf314cc#78c2d377d79a7284339fc24b560dd503daf314cc"
 dependencies = [
  "indexmap",
  "react_compiler_diagnostics",
@@ -5271,7 +5271,7 @@ dependencies = [
 [[package]]
 name = "react_compiler_inference"
 version = "0.0.1-oidc.0"
-source = "git+https://github.com/react/react?rev=6c0e1047e392da04bccb36e84c04e1d1412901d6#6c0e1047e392da04bccb36e84c04e1d1412901d6"
+source = "git+https://github.com/react/react?rev=78c2d377d79a7284339fc24b560dd503daf314cc#78c2d377d79a7284339fc24b560dd503daf314cc"
 dependencies = [
  "indexmap",
  "react_compiler_diagnostics",
@@ -5286,7 +5286,7 @@ dependencies = [
 [[package]]
 name = "react_compiler_lowering"
 version = "0.0.1-oidc.0"
-source = "git+https://github.com/react/react?rev=6c0e1047e392da04bccb36e84c04e1d1412901d6#6c0e1047e392da04bccb36e84c04e1d1412901d6"
+source = "git+https://github.com/react/react?rev=78c2d377d79a7284339fc24b560dd503daf314cc#78c2d377d79a7284339fc24b560dd503daf314cc"
 dependencies = [
  "indexmap",
  "react_compiler_ast",
@@ -5299,7 +5299,7 @@ dependencies = [
 [[package]]
 name = "react_compiler_optimization"
 version = "0.0.1-oidc.0"
-source = "git+https://github.com/react/react?rev=6c0e1047e392da04bccb36e84c04e1d1412901d6#6c0e1047e392da04bccb36e84c04e1d1412901d6"
+source = "git+https://github.com/react/react?rev=78c2d377d79a7284339fc24b560dd503daf314cc#78c2d377d79a7284339fc24b560dd503daf314cc"
 dependencies = [
  "indexmap",
  "react_compiler_diagnostics",
@@ -5312,7 +5312,7 @@ dependencies = [
 [[package]]
 name = "react_compiler_reactive_scopes"
 version = "0.0.1-oidc.0"
-source = "git+https://github.com/react/react?rev=6c0e1047e392da04bccb36e84c04e1d1412901d6#6c0e1047e392da04bccb36e84c04e1d1412901d6"
+source = "git+https://github.com/react/react?rev=78c2d377d79a7284339fc24b560dd503daf314cc#78c2d377d79a7284339fc24b560dd503daf314cc"
 dependencies = [
  "hmac-sha256",
  "indexmap",
@@ -5326,7 +5326,7 @@ dependencies = [
 [[package]]
 name = "react_compiler_ssa"
 version = "0.0.1-oidc.0"
-source = "git+https://github.com/react/react?rev=6c0e1047e392da04bccb36e84c04e1d1412901d6#6c0e1047e392da04bccb36e84c04e1d1412901d6"
+source = "git+https://github.com/react/react?rev=78c2d377d79a7284339fc24b560dd503daf314cc#78c2d377d79a7284339fc24b560dd503daf314cc"
 dependencies = [
  "indexmap",
  "react_compiler_diagnostics",
@@ -5337,7 +5337,7 @@ dependencies = [
 [[package]]
 name = "react_compiler_typeinference"
 version = "0.0.1-oidc.0"
-source = "git+https://github.com/react/react?rev=6c0e1047e392da04bccb36e84c04e1d1412901d6#6c0e1047e392da04bccb36e84c04e1d1412901d6"
+source = "git+https://github.com/react/react?rev=78c2d377d79a7284339fc24b560dd503daf314cc#78c2d377d79a7284339fc24b560dd503daf314cc"
 dependencies = [
  "react_compiler_diagnostics",
  "react_compiler_hir",
@@ -5348,7 +5348,7 @@ dependencies = [
 [[package]]
 name = "react_compiler_utils"
 version = "0.0.1-oidc.0"
-source = "git+https://github.com/react/react?rev=6c0e1047e392da04bccb36e84c04e1d1412901d6#6c0e1047e392da04bccb36e84c04e1d1412901d6"
+source = "git+https://github.com/react/react?rev=78c2d377d79a7284339fc24b560dd503daf314cc#78c2d377d79a7284339fc24b560dd503daf314cc"
 dependencies = [
  "indexmap",
  "rustc-hash 2.1.3",
@@ -5357,7 +5357,7 @@ dependencies = [
 [[package]]
 name = "react_compiler_validation"
 version = "0.0.1-oidc.0"
-source = "git+https://github.com/react/react?rev=6c0e1047e392da04bccb36e84c04e1d1412901d6#6c0e1047e392da04bccb36e84c04e1d1412901d6"
+source = "git+https://github.com/react/react?rev=78c2d377d79a7284339fc24b560dd503daf314cc#78c2d377d79a7284339fc24b560dd503daf314cc"
 dependencies = [
  "indexmap",
  "react_compiler_diagnostics",

--- a/crates/biome_js_analyze/tests/specs/nursery/useReactCompiler/effectSetStateNonAscii.package.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/useReactCompiler/effectSetStateNonAscii.package.json
@@ -1,0 +1,5 @@
+{
+    "dependencies": {
+        "react": "^19.0.0"
+    }
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useReactCompiler/effectSetStateNonAscii.tsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/useReactCompiler/effectSetStateNonAscii.tsx
@@ -1,0 +1,14 @@
+// should generate diagnostics
+
+import { useEffect, useState } from "react";
+
+export function useOnlineStatus({ paused }: { paused: boolean }) {
+    const [isOnline, setIsOnline] = useState(true);
+
+    // 非ASCII文字を含むコメントなので、これ以降はUTF-16のオフセットとUTF-8のバイト位置がずれる。
+    useEffect(() => {
+        setIsOnline(true);
+    }, [paused]);
+
+    return isOnline;
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useReactCompiler/effectSetStateNonAscii.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useReactCompiler/effectSetStateNonAscii.tsx.snap
@@ -1,0 +1,46 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: effectSetStateNonAscii.tsx
+---
+# Input
+```tsx
+// should generate diagnostics
+
+import { useEffect, useState } from "react";
+
+export function useOnlineStatus({ paused }: { paused: boolean }) {
+    const [isOnline, setIsOnline] = useState(true);
+
+    // 非ASCII文字を含むコメントなので、これ以降はUTF-16のオフセットとUTF-8のバイト位置がずれる。
+    useEffect(() => {
+        setIsOnline(true);
+    }, [paused]);
+
+    return isOnline;
+}
+
+```
+
+# Diagnostics
+```
+effectSetStateNonAscii.tsx:10:9 lint/nursery/useReactCompiler ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This effect synchronously updates state.
+  
+     8 │     // 非ASCII文字を含むコメントなので、これ以降はUTF-16のオフセットとUTF-8のバイト位置がずれる。
+     9 │     useEffect(() => {
+  > 10 │         setIsOnline(true);
+       │         ^^^^^^^^^^^
+    11 │     }, [paused]);
+    12 │ 
+  
+  i Updating state directly inside an effect can trigger cascading renders and hurt performance. Effects should synchronize with external systems instead.
+  
+  i Derive the value during render, initialize state lazily, or update state from an external subscription callback instead.
+  
+  i This rule is still being actively worked on, so it may be missing features or have rough edges. Visit https://github.com/biomejs/biome/issues/10974 for more information or to report possible bugs.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```

--- a/crates/biome_react_compiler/Cargo.toml
+++ b/crates/biome_react_compiler/Cargo.toml
@@ -20,9 +20,9 @@ biome_languages    = { workspace = true, features = ["lang_js"] }
 biome_line_index   = { workspace = true }
 biome_rowan        = { workspace = true }
 indexmap           = { workspace = true }
-react_compiler     = { git = "https://github.com/react/react", rev = "6c0e1047e392da04bccb36e84c04e1d1412901d6" }
-react_compiler_ast = { git = "https://github.com/react/react", rev = "6c0e1047e392da04bccb36e84c04e1d1412901d6" }
-react_compiler_hir = { git = "https://github.com/react/react", rev = "6c0e1047e392da04bccb36e84c04e1d1412901d6" }
+react_compiler     = { git = "https://github.com/react/react", rev = "78c2d377d79a7284339fc24b560dd503daf314cc" }
+react_compiler_ast = { git = "https://github.com/react/react", rev = "78c2d377d79a7284339fc24b560dd503daf314cc" }
+react_compiler_hir = { git = "https://github.com/react/react", rev = "78c2d377d79a7284339fc24b560dd503daf314cc" }
 rustc-hash         = { workspace = true }
 serde_json         = { workspace = true }
 


### PR DESCRIPTION
## Summary

Fixes #11678

`useReactCompiler` crashed on files containing multibyte characters (such as Japanese), which dropped those files from the lint run entirely.

The root cause has been fixed upstream in React Compiler. The crates are currently pinned to `6c0e1047`, which is 7 commits before that fix, so this bumps them to `78c2d377`.

Upstream fix https://github.com/react/react/pull/37539

Investigated and patched with Claude Code.

## Test Plan

Added `effectSetStateNonAscii.tsx`. Before the bump it panics and the file is dropped from the run:
```
× processing panicked: start byte index 289 is not a char boundary; it is inside 'ト'
Checked 0 files in 26ms.
```

After, it reports the diagnostic and names the identifier correctly:
```
effectSetStateNonAscii.tsx:10:9 lint/nursery/useReactCompiler
  > 10 │         setIsOnline(true);
       │         ^^^^^^^^^^^
Checked 1 file. Found 1 error.
```

`cargo test -p biome_js_analyze` passes (2947 tests), including the 57 `useReactCompiler` specs.

## Docs
