### PR TITLE
fix(css_parser): accept unquoted URLs starting with @ or !

### DIFF
--- a/.changeset/old-clocks-bet.md
+++ b/.changeset/old-clocks-bet.md
@@ -1,0 +1,10 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed parsing of unquoted CSS and SCSS URLs beginning with `@` or `!`, such as `url(@/assets/icon.svg)` and `url(!font.woff2)`. Preserved escaped and non-ASCII whitespace in raw URLs during formatting.
+
+```diff
+-background-image: url(image\);
++background-image: url(image\ );
+```

--- a/.changeset/old-clocks-bet.md
+++ b/.changeset/old-clocks-bet.md
@@ -2,7 +2,7 @@
 "@biomejs/biome": patch
 ---
 
-Fixed parsing of unquoted CSS and SCSS URLs beginning with `@` or `!`, such as `url(@/assets/icon.svg)` and `url(!font.woff2)`. Preserved escaped and non-ASCII whitespace in raw URLs during formatting.
+Fixed parsing of unquoted CSS URLs beginning with `@` or `!`, such as `url(@/assets/icon.svg)` and `url(!font.woff2)`. Preserved escaped and non-ASCII whitespace in raw URLs during formatting.
 
 ```diff
 -background-image: url(image\);

--- a/crates/biome_css_formatter/src/css/value/url_value_raw.rs
+++ b/crates/biome_css_formatter/src/css/value/url_value_raw.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use biome_css_syntax::{CssUrlValueRaw, CssUrlValueRawFields};
+use biome_css_syntax::{CssUrlValueRaw, CssUrlValueRawFields, is_css_whitespace_byte};
 use biome_formatter::write;
 
 #[derive(Debug, Clone, Default)]
@@ -8,15 +8,28 @@ impl FormatNodeRule<CssUrlValueRaw> for FormatCssUrlValueRaw {
     fn fmt_fields(&self, node: &CssUrlValueRaw, f: &mut CssFormatter) -> FormatResult<()> {
         let CssUrlValueRawFields { value_token } = node.as_fields();
         let value_token = value_token?;
-        let token_text = value_token.token_text();
+        let token_text = value_token.text_trimmed();
+        let trimmed =
+            token_text.trim_end_matches(|c: char| c.is_ascii() && is_css_whitespace_byte(c as u8));
+        let whitespace = &token_text[trimmed.len()..];
+
+        // Keep escaped whitespace so `url(@a\ )` doesn't become the unclosed `url(@a\)`.
+        let keep_escaped_whitespace = if whitespace.starts_with([' ', '\t']) {
+            let backslashes = trimmed.len() - trimmed.trim_end_matches('\\').len();
+            backslashes % 2 == 1
+        } else {
+            false
+        };
+        let trimmed = if keep_escaped_whitespace {
+            &token_text[..trimmed.len() + 1]
+        } else {
+            trimmed
+        };
         write!(
             f,
             [format_replaced(
                 &value_token,
-                &text(
-                    token_text.trim(),
-                    Some(value_token.text_trimmed_range().start())
-                )
+                &text(trimmed, Some(value_token.text_trimmed_range().start()))
             )]
         )
     }

--- a/crates/biome_css_formatter/tests/specs/css/value/release-url-asset-aliases.css
+++ b/crates/biome_css_formatter/tests/specs/css/value/release-url-asset-aliases.css
@@ -1,0 +1,8 @@
+.check{ background-image :url(  @/assets/svg/for-css/check.svg  );width:1px}
+.footer{background-image:url(@site/static/img/showcase/gh-footer-light.svg);color:red}
+@font-face{font-family:"!PaulMaul";src:url( !PaulMaul.woff2 ) format( "woff2" );font-display:swap}
+.controls{background:url( @/assets/a\)b.svg ) , url(!font\20 name.woff2),url(@/icons/\é.svg);width:1px}
+.modifiers{background:url( "image.png" format( "png" ) );width:1px}
+.escaped-tail { first: url(@a\ ); second: url(!a\ ); even: url(@a\\  ); odd: url(!a\\\  ); hex: url(@a\20  ); width: 1px; }
+.unicode-tail { first: url(@a ); second: url(!a ); width: 1px; }
+.escaped-tab { background: url(@a\	); color: red; }

--- a/crates/biome_css_formatter/tests/specs/css/value/release-url-asset-aliases.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/value/release-url-asset-aliases.css.snap
@@ -1,0 +1,64 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/value/release-url-asset-aliases.css
+---
+
+# Input
+
+```css
+.check{ background-image :url(  @/assets/svg/for-css/check.svg  );width:1px}
+.footer{background-image:url(@site/static/img/showcase/gh-footer-light.svg);color:red}
+@font-face{font-family:"!PaulMaul";src:url( !PaulMaul.woff2 ) format( "woff2" );font-display:swap}
+.controls{background:url( @/assets/a\)b.svg ) , url(!font\20 name.woff2),url(@/icons/\é.svg);width:1px}
+.modifiers{background:url( "image.png" format( "png" ) );width:1px}
+.escaped-tail { first: url(@a\ ); second: url(!a\ ); even: url(@a\\  ); odd: url(!a\\\  ); hex: url(@a\20  ); width: 1px; }
+.unicode-tail { first: url(@a ); second: url(!a ); width: 1px; }
+.escaped-tab { background: url(@a\	); color: red; }
+
+```
+
+
+# Formatted
+
+```css
+.check {
+	background-image: url(@/assets/svg/for-css/check.svg);
+	width: 1px;
+}
+.footer {
+	background-image: url(@site/static/img/showcase/gh-footer-light.svg);
+	color: red;
+}
+@font-face {
+	font-family: "!PaulMaul";
+	src: url(!PaulMaul.woff2) format("woff2");
+	font-display: swap;
+}
+.controls {
+	background:
+		url(@/assets/a\)b.svg), url(!font\20 name.woff2), url(@/icons/\é.svg);
+	width: 1px;
+}
+.modifiers {
+	background: url("image.png" format("png"));
+	width: 1px;
+}
+.escaped-tail {
+	first: url(@a\ );
+	second: url(!a\ );
+	even: url(@a\\);
+	odd: url(!a\\\ );
+	hex: url(@a\20);
+	width: 1px;
+}
+.unicode-tail {
+	first: url(@a );
+	second: url(!a );
+	width: 1px;
+}
+.escaped-tab {
+	background: url(@a\	);
+	color: red;
+}
+
+```

--- a/crates/biome_css_formatter/tests/specs/prettier/css/inline-url/inline_url.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/inline-url/inline_url.css.snap
@@ -132,26 +132,6 @@ info: css/inline-url/inline_url.css
 }
 ```
 
-# Errors
-```
-inline_url.css:29:19 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Unexpected value or character.
-  
-    28 │ .validUnqotedUrlsThatAreParsedByLess {
-  > 29 │   background: url(@foo);
-       │                   ^
-    30 │ }
-    31 │ 
-  
-  i Expected one of:
-  
-  - function
-  - identifier
-  
-
-```
-
 # Lines exceeding max width of 80 characters
 ```
    11:   background-image: url(/images/product/simple_product_manager/breadcrumb/chevron_right.png);

--- a/crates/biome_css_formatter/tests/specs/prettier/scss/inline-url/inline_url.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/scss/inline-url/inline_url.scss.snap
@@ -132,26 +132,6 @@ info: scss/inline-url/inline_url.scss
 }
 ```
 
-# Errors
-```
-inline_url.scss:29:19 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Unexpected value or character.
-  
-    28 │ .validUnqotedUrlsThatAreParsedByLess {
-  > 29 │   background: url(@foo);
-       │                   ^
-    30 │ }
-    31 │ 
-  
-  i Expected one of:
-  
-  - function
-  - identifier
-  
-
-```
-
 # Lines exceeding max width of 80 characters
 ```
    11:   background-image: url(/images/product/simple_product_manager/breadcrumb/chevron_right.png);

--- a/crates/biome_css_formatter/tests/specs/scss/value/release-url-asset-aliases.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/value/release-url-asset-aliases.scss
@@ -1,0 +1,11 @@
+$name:  "check";$path : "icons/check";
+.check{ background-image :url(  @/assets/svg/for-css/check.svg  );width:1px}
+.footer{background-image:url(@site/static/img/showcase/gh-footer-light.svg);color:red}
+@font-face{font-family:"!PaulMaul";src:url( !PaulMaul.woff2 ) format( "woff2" );font-display:swap}
+.controls{background:url( @/assets/a\)b.svg ) , url(!font\20 name.woff2),url(@/icons/\é.svg);width:1px}
+.dynamic{background: url(  @/assets/#{$name}.svg  );mask:url(!#{$name}.woff2);other:url( $path+".svg" );width:1px}
+.modifiers{background:url( "image.png" format( "png" ) );width:1px}
+.functions{a:url(fn( "image.svg" ));b:url(foo#{"-bar"}( "image.svg" ));width:1px}
+.escaped-tail { first: url(@a\ ); second: url(!a\ ); even: url(@a\\  ); odd: url(!a\\\  ); hex: url(@a\20  ); width: 1px; }
+.unicode-tail { first: url(@a ); second: url(!a ); width: 1px; }
+.escaped-tab { background: url(@a\	); color: red; }

--- a/crates/biome_css_formatter/tests/specs/scss/value/release-url-asset-aliases.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/value/release-url-asset-aliases.scss.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: scss/value/release-url-asset-aliases.scss
+---
+
+# Input
+
+```scss
+$name:  "check";$path : "icons/check";
+.check{ background-image :url(  @/assets/svg/for-css/check.svg  );width:1px}
+.footer{background-image:url(@site/static/img/showcase/gh-footer-light.svg);color:red}
+@font-face{font-family:"!PaulMaul";src:url( !PaulMaul.woff2 ) format( "woff2" );font-display:swap}
+.controls{background:url( @/assets/a\)b.svg ) , url(!font\20 name.woff2),url(@/icons/\é.svg);width:1px}
+.dynamic{background: url(  @/assets/#{$name}.svg  );mask:url(!#{$name}.woff2);other:url( $path+".svg" );width:1px}
+.modifiers{background:url( "image.png" format( "png" ) );width:1px}
+.functions{a:url(fn( "image.svg" ));b:url(foo#{"-bar"}( "image.svg" ));width:1px}
+.escaped-tail { first: url(@a\ ); second: url(!a\ ); even: url(@a\\  ); odd: url(!a\\\  ); hex: url(@a\20  ); width: 1px; }
+.unicode-tail { first: url(@a ); second: url(!a ); width: 1px; }
+.escaped-tab { background: url(@a\	); color: red; }
+
+```
+
+
+# Formatted
+
+```scss
+$name: "check";
+$path: "icons/check";
+.check {
+	background-image: url(@/assets/svg/for-css/check.svg);
+	width: 1px;
+}
+.footer {
+	background-image: url(@site/static/img/showcase/gh-footer-light.svg);
+	color: red;
+}
+@font-face {
+	font-family: "!PaulMaul";
+	src: url(!PaulMaul.woff2) format("woff2");
+	font-display: swap;
+}
+.controls {
+	background:
+		url(@/assets/a\)b.svg),
+		url(!font\20 name.woff2),
+		url(@/icons/\é.svg);
+	width: 1px;
+}
+.dynamic {
+	background: url(@/assets/#{$name}.svg);
+	mask: url(!#{$name}.woff2);
+	other: url($path + ".svg");
+	width: 1px;
+}
+.modifiers {
+	background: url("image.png" format("png"));
+	width: 1px;
+}
+.functions {
+	a: url(fn("image.svg"));
+	b: url(foo#{"-bar"}("image.svg"));
+	width: 1px;
+}
+.escaped-tail {
+	first: url(@a\ );
+	second: url(!a\ );
+	even: url(@a\\);
+	odd: url(!a\\\ );
+	hex: url(@a\20);
+	width: 1px;
+}
+.unicode-tail {
+	first: url(@a );
+	second: url(!a );
+	width: 1px;
+}
+.escaped-tab {
+	background: url(@a\	);
+	color: red;
+}
+
+```

--- a/crates/biome_css_parser/src/lexer/scan_cursor/url.rs
+++ b/crates/biome_css_parser/src/lexer/scan_cursor/url.rs
@@ -355,7 +355,7 @@ impl<'src> UrlBodyScanner<'src> {
     fn is_url_raw_value_start(byte: u8) -> bool {
         matches!(
             lookup_byte(byte),
-            IDT | DOL | UNI | PRD | SLH | ZER | DIG | TLD | HAS
+            IDT | DOL | UNI | PRD | SLH | ZER | DIG | TLD | HAS | AT_ | EXL
         )
     }
 

--- a/crates/biome_css_parser/src/lexer/tests.rs
+++ b/crates/biome_css_parser/src/lexer/tests.rs
@@ -194,55 +194,8 @@ fn url_body_classification_emits_raw_url_value() {
 }
 
 #[test]
-fn url_body_classification_preserves_asset_alias_ranges() {
-    for scss in [false, true] {
-        for body in [
-            "@/assets/svg/for-css/check.svg",
-            "@site/static/img/showcase/gh-footer-light.svg",
-            "!PaulMaul.woff2",
-            r"@/assets/a\)b.svg",
-            r"!font\20 name.woff2",
-            r"@/icons/\é.svg",
-            "@/other.svg \t",
-            "!Other.woff2  ",
-            r"@a\ ",
-            r"!a\\\  ",
-            r"@a\\  ",
-            "@a\u{00a0}",
-            "!a\u{2003}",
-        ] {
-            for terminated in [false, true] {
-                let source = format!("url( \t{body}{}", if terminated { ")" } else { "" });
-                let source_type = if scss { CssFileSource::scss() } else { CssFileSource::css() };
-                let mut lexer = CssLexer::from_str(&source).with_source_type(source_type);
-                assert_eq!(lexer.next_token(CssLexContext::Regular), CssSyntaxKind::URL_KW);
-                assert_eq!(lexer.next_token(CssLexContext::Regular), T!['(']);
-                let context = url_body_lex_context(&lexer, scss);
-                let end = 6 + body.len();
-                assert!(matches!(context, CssLexContext::UrlRawValue(scan)
-                    if scan.start == 6 && scan.end == end && scan.terminated == terminated),
-                    "{source_type:?} {source:?}: {context:?}");
-                assert_eq!(lexer.next_token(context), CssSyntaxKind::WHITESPACE);
-                assert_eq!(lexer.next_token(context), CssSyntaxKind::CSS_URL_VALUE_RAW_LITERAL);
-                assert_eq!(lexer.current_range(), TextRange::new(TextSize::from(6), TextSize::from(end as u32)));
-                assert_eq!(&source[lexer.current_range()], body);
-                if terminated {
-                    assert_eq!(lexer.next_token(CssLexContext::Regular), T![')']);
-                    assert_eq!(&source[lexer.current_range()], ")");
-                }
-                assert_eq!(lexer.next_token(CssLexContext::Regular), EOF);
-                assert_eq!(lexer.current_range(), TextRange::empty(TextSize::from(source.len() as u32)));
-                assert_eq!(lexer.finish().len(), usize::from(!terminated));
-            }
-        }
-    }
-}
-
-#[test]
 fn scss_url_value_scanner_classifies_structured_bodies() {
     for source in [
-        "@/assets/#{$name}.svg)",
-        "!#{$name}.woff2)",
         "images/#{$name}.png)",
         "#{$base}/#{$theme}/logo.svg)",
         "fonts/#{$family}.woff2)",

--- a/crates/biome_css_parser/src/lexer/tests.rs
+++ b/crates/biome_css_parser/src/lexer/tests.rs
@@ -194,8 +194,55 @@ fn url_body_classification_emits_raw_url_value() {
 }
 
 #[test]
+fn url_body_classification_preserves_asset_alias_ranges() {
+    for scss in [false, true] {
+        for body in [
+            "@/assets/svg/for-css/check.svg",
+            "@site/static/img/showcase/gh-footer-light.svg",
+            "!PaulMaul.woff2",
+            r"@/assets/a\)b.svg",
+            r"!font\20 name.woff2",
+            r"@/icons/\é.svg",
+            "@/other.svg \t",
+            "!Other.woff2  ",
+            r"@a\ ",
+            r"!a\\\  ",
+            r"@a\\  ",
+            "@a\u{00a0}",
+            "!a\u{2003}",
+        ] {
+            for terminated in [false, true] {
+                let source = format!("url( \t{body}{}", if terminated { ")" } else { "" });
+                let source_type = if scss { CssFileSource::scss() } else { CssFileSource::css() };
+                let mut lexer = CssLexer::from_str(&source).with_source_type(source_type);
+                assert_eq!(lexer.next_token(CssLexContext::Regular), CssSyntaxKind::URL_KW);
+                assert_eq!(lexer.next_token(CssLexContext::Regular), T!['(']);
+                let context = url_body_lex_context(&lexer, scss);
+                let end = 6 + body.len();
+                assert!(matches!(context, CssLexContext::UrlRawValue(scan)
+                    if scan.start == 6 && scan.end == end && scan.terminated == terminated),
+                    "{source_type:?} {source:?}: {context:?}");
+                assert_eq!(lexer.next_token(context), CssSyntaxKind::WHITESPACE);
+                assert_eq!(lexer.next_token(context), CssSyntaxKind::CSS_URL_VALUE_RAW_LITERAL);
+                assert_eq!(lexer.current_range(), TextRange::new(TextSize::from(6), TextSize::from(end as u32)));
+                assert_eq!(&source[lexer.current_range()], body);
+                if terminated {
+                    assert_eq!(lexer.next_token(CssLexContext::Regular), T![')']);
+                    assert_eq!(&source[lexer.current_range()], ")");
+                }
+                assert_eq!(lexer.next_token(CssLexContext::Regular), EOF);
+                assert_eq!(lexer.current_range(), TextRange::empty(TextSize::from(source.len() as u32)));
+                assert_eq!(lexer.finish().len(), usize::from(!terminated));
+            }
+        }
+    }
+}
+
+#[test]
 fn scss_url_value_scanner_classifies_structured_bodies() {
     for source in [
+        "@/assets/#{$name}.svg)",
+        "!#{$name}.woff2)",
         "images/#{$name}.png)",
         "#{$base}/#{$theme}/logo.svg)",
         "fonts/#{$family}.woff2)",

--- a/crates/biome_css_parser/tests/css_test_suite/error/scss/value/release-url-asset-aliases-bang-eof.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/error/scss/value/release-url-asset-aliases-bang-eof.scss
@@ -1,0 +1,1 @@
+a { background: url( 	!font\20 name\)\é.woff2  

--- a/crates/biome_css_parser/tests/css_test_suite/error/scss/value/release-url-asset-aliases-bang-eof.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/scss/value/release-url-asset-aliases-bang-eof.scss.snap
@@ -1,0 +1,131 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+a { background: url( 	!font\20 name\)\é.woff2  
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: CssTypeSelector {
+                        namespace: missing (optional),
+                        ident: CssIdentifier {
+                            value_token: IDENT@0..2 "a" [] [Whitespace(" ")],
+                        },
+                    },
+                    sub_selectors: CssSubSelectorList [],
+                },
+            ],
+            block: CssBogusBlock {
+                items: [
+                    L_CURLY@2..4 "{" [] [Whitespace(" ")],
+                    CssDeclarationOrRuleList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@4..14 "background" [] [],
+                                    },
+                                    colon_token: COLON@14..16 ":" [] [Whitespace(" ")],
+                                    value: ScssExpression {
+                                        items: ScssExpressionItemList [
+                                            CssUrlFunction {
+                                                name: URL_KW@16..19 "url" [] [],
+                                                l_paren_token: L_PAREN@19..22 "(" [] [Whitespace(" \t")],
+                                                value: CssUrlValueRaw {
+                                                    value_token: CSS_URL_VALUE_RAW_LITERAL@22..48 "!font\\20 name\\)\\é.woff2  " [] [],
+                                                },
+                                                modifiers: CssUrlModifierList [],
+                                                r_paren_token: missing (required),
+                                            },
+                                        ],
+                                    },
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: missing (optional),
+                        },
+                    ],
+                ],
+            },
+        },
+    ],
+    eof_token: EOF@48..48 "" [] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..48
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..48
+    0: CSS_QUALIFIED_RULE@0..48
+      0: CSS_SELECTOR_LIST@0..2
+        0: CSS_COMPOUND_SELECTOR@0..2
+          0: CSS_NESTED_SELECTOR_LIST@0..0
+          1: CSS_TYPE_SELECTOR@0..2
+            0: (empty)
+            1: CSS_IDENTIFIER@0..2
+              0: IDENT@0..2 "a" [] [Whitespace(" ")]
+          2: CSS_SUB_SELECTOR_LIST@2..2
+      1: CSS_BOGUS_BLOCK@2..48
+        0: L_CURLY@2..4 "{" [] [Whitespace(" ")]
+        1: CSS_DECLARATION_OR_RULE_LIST@4..48
+          0: CSS_DECLARATION_WITH_SEMICOLON@4..48
+            0: CSS_DECLARATION@4..48
+              0: CSS_GENERIC_PROPERTY@4..48
+                0: CSS_IDENTIFIER@4..14
+                  0: IDENT@4..14 "background" [] []
+                1: COLON@14..16 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@16..48
+                  0: SCSS_EXPRESSION_ITEM_LIST@16..48
+                    0: CSS_URL_FUNCTION@16..48
+                      0: URL_KW@16..19 "url" [] []
+                      1: L_PAREN@19..22 "(" [] [Whitespace(" \t")]
+                      2: CSS_URL_VALUE_RAW@22..48
+                        0: CSS_URL_VALUE_RAW_LITERAL@22..48 "!font\\20 name\\)\\é.woff2  " [] []
+                      3: CSS_URL_MODIFIER_LIST@48..48
+                      4: (empty)
+              1: (empty)
+            1: (empty)
+  2: EOF@48..48 "" [] []
+
+```
+
+## Diagnostics
+
+```
+release-url-asset-aliases-bang-eof.scss:1:23 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Invalid url raw value
+  
+  > 1 │ a { background: url( 	!font\20 name\)\é.woff2··
+      │                      	^^^^^^^^^^^^^^^^^^^^^^^^^
+  
+release-url-asset-aliases-bang-eof.scss:1:48 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `)` but instead the file ends
+  
+  > 1 │ a { background: url( 	!font\20 name\)\é.woff2··
+      │                      	                         
+  
+  i the file ends here
+  
+  > 1 │ a { background: url( 	!font\20 name\)\é.woff2··
+      │                      	                         
+  
+```

--- a/crates/biome_css_parser/tests/css_test_suite/error/scss/value/release-url-asset-aliases.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/error/scss/value/release-url-asset-aliases.scss
@@ -1,0 +1,1 @@
+a {background-image:url(@/assets/svg/for-css/check.svg

--- a/crates/biome_css_parser/tests/css_test_suite/error/scss/value/release-url-asset-aliases.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/scss/value/release-url-asset-aliases.scss.snap
@@ -1,0 +1,131 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+a {background-image:url(@/assets/svg/for-css/check.svg
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: CssTypeSelector {
+                        namespace: missing (optional),
+                        ident: CssIdentifier {
+                            value_token: IDENT@0..2 "a" [] [Whitespace(" ")],
+                        },
+                    },
+                    sub_selectors: CssSubSelectorList [],
+                },
+            ],
+            block: CssBogusBlock {
+                items: [
+                    L_CURLY@2..3 "{" [] [],
+                    CssDeclarationOrRuleList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@3..19 "background-image" [] [],
+                                    },
+                                    colon_token: COLON@19..20 ":" [] [],
+                                    value: ScssExpression {
+                                        items: ScssExpressionItemList [
+                                            CssUrlFunction {
+                                                name: URL_KW@20..23 "url" [] [],
+                                                l_paren_token: L_PAREN@23..24 "(" [] [],
+                                                value: CssUrlValueRaw {
+                                                    value_token: CSS_URL_VALUE_RAW_LITERAL@24..54 "@/assets/svg/for-css/check.svg" [] [],
+                                                },
+                                                modifiers: CssUrlModifierList [],
+                                                r_paren_token: missing (required),
+                                            },
+                                        ],
+                                    },
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: missing (optional),
+                        },
+                    ],
+                ],
+            },
+        },
+    ],
+    eof_token: EOF@54..54 "" [] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..54
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..54
+    0: CSS_QUALIFIED_RULE@0..54
+      0: CSS_SELECTOR_LIST@0..2
+        0: CSS_COMPOUND_SELECTOR@0..2
+          0: CSS_NESTED_SELECTOR_LIST@0..0
+          1: CSS_TYPE_SELECTOR@0..2
+            0: (empty)
+            1: CSS_IDENTIFIER@0..2
+              0: IDENT@0..2 "a" [] [Whitespace(" ")]
+          2: CSS_SUB_SELECTOR_LIST@2..2
+      1: CSS_BOGUS_BLOCK@2..54
+        0: L_CURLY@2..3 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@3..54
+          0: CSS_DECLARATION_WITH_SEMICOLON@3..54
+            0: CSS_DECLARATION@3..54
+              0: CSS_GENERIC_PROPERTY@3..54
+                0: CSS_IDENTIFIER@3..19
+                  0: IDENT@3..19 "background-image" [] []
+                1: COLON@19..20 ":" [] []
+                2: SCSS_EXPRESSION@20..54
+                  0: SCSS_EXPRESSION_ITEM_LIST@20..54
+                    0: CSS_URL_FUNCTION@20..54
+                      0: URL_KW@20..23 "url" [] []
+                      1: L_PAREN@23..24 "(" [] []
+                      2: CSS_URL_VALUE_RAW@24..54
+                        0: CSS_URL_VALUE_RAW_LITERAL@24..54 "@/assets/svg/for-css/check.svg" [] []
+                      3: CSS_URL_MODIFIER_LIST@54..54
+                      4: (empty)
+              1: (empty)
+            1: (empty)
+  2: EOF@54..54 "" [] []
+
+```
+
+## Diagnostics
+
+```
+release-url-asset-aliases.scss:1:25 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Invalid url raw value
+  
+  > 1 │ a {background-image:url(@/assets/svg/for-css/check.svg
+      │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  
+release-url-asset-aliases.scss:1:55 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `)` but instead the file ends
+  
+  > 1 │ a {background-image:url(@/assets/svg/for-css/check.svg
+      │                                                       
+  
+  i the file ends here
+  
+  > 1 │ a {background-image:url(@/assets/svg/for-css/check.svg
+      │                                                       
+  
+```

--- a/crates/biome_css_parser/tests/css_test_suite/error/value/release-url-asset-aliases-bang-eof.css
+++ b/crates/biome_css_parser/tests/css_test_suite/error/value/release-url-asset-aliases-bang-eof.css
@@ -1,0 +1,1 @@
+a { background: url( 	!font\20 name\)\é.woff2  

--- a/crates/biome_css_parser/tests/css_test_suite/error/value/release-url-asset-aliases-bang-eof.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/value/release-url-asset-aliases-bang-eof.css.snap
@@ -1,0 +1,128 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+a { background: url( 	!font\20 name\)\é.woff2  
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: CssTypeSelector {
+                        namespace: missing (optional),
+                        ident: CssIdentifier {
+                            value_token: IDENT@0..2 "a" [] [Whitespace(" ")],
+                        },
+                    },
+                    sub_selectors: CssSubSelectorList [],
+                },
+            ],
+            block: CssBogusBlock {
+                items: [
+                    L_CURLY@2..4 "{" [] [Whitespace(" ")],
+                    CssDeclarationOrRuleList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@4..14 "background" [] [],
+                                    },
+                                    colon_token: COLON@14..16 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssUrlFunction {
+                                            name: URL_KW@16..19 "url" [] [],
+                                            l_paren_token: L_PAREN@19..22 "(" [] [Whitespace(" \t")],
+                                            value: CssUrlValueRaw {
+                                                value_token: CSS_URL_VALUE_RAW_LITERAL@22..48 "!font\\20 name\\)\\é.woff2  " [] [],
+                                            },
+                                            modifiers: CssUrlModifierList [],
+                                            r_paren_token: missing (required),
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: missing (optional),
+                        },
+                    ],
+                ],
+            },
+        },
+    ],
+    eof_token: EOF@48..48 "" [] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..48
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..48
+    0: CSS_QUALIFIED_RULE@0..48
+      0: CSS_SELECTOR_LIST@0..2
+        0: CSS_COMPOUND_SELECTOR@0..2
+          0: CSS_NESTED_SELECTOR_LIST@0..0
+          1: CSS_TYPE_SELECTOR@0..2
+            0: (empty)
+            1: CSS_IDENTIFIER@0..2
+              0: IDENT@0..2 "a" [] [Whitespace(" ")]
+          2: CSS_SUB_SELECTOR_LIST@2..2
+      1: CSS_BOGUS_BLOCK@2..48
+        0: L_CURLY@2..4 "{" [] [Whitespace(" ")]
+        1: CSS_DECLARATION_OR_RULE_LIST@4..48
+          0: CSS_DECLARATION_WITH_SEMICOLON@4..48
+            0: CSS_DECLARATION@4..48
+              0: CSS_GENERIC_PROPERTY@4..48
+                0: CSS_IDENTIFIER@4..14
+                  0: IDENT@4..14 "background" [] []
+                1: COLON@14..16 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@16..48
+                  0: CSS_URL_FUNCTION@16..48
+                    0: URL_KW@16..19 "url" [] []
+                    1: L_PAREN@19..22 "(" [] [Whitespace(" \t")]
+                    2: CSS_URL_VALUE_RAW@22..48
+                      0: CSS_URL_VALUE_RAW_LITERAL@22..48 "!font\\20 name\\)\\é.woff2  " [] []
+                    3: CSS_URL_MODIFIER_LIST@48..48
+                    4: (empty)
+              1: (empty)
+            1: (empty)
+  2: EOF@48..48 "" [] []
+
+```
+
+## Diagnostics
+
+```
+release-url-asset-aliases-bang-eof.css:1:23 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Invalid url raw value
+  
+  > 1 │ a { background: url( 	!font\20 name\)\é.woff2··
+      │                      	^^^^^^^^^^^^^^^^^^^^^^^^^
+  
+release-url-asset-aliases-bang-eof.css:1:48 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `)` but instead the file ends
+  
+  > 1 │ a { background: url( 	!font\20 name\)\é.woff2··
+      │                      	                         
+  
+  i the file ends here
+  
+  > 1 │ a { background: url( 	!font\20 name\)\é.woff2··
+      │                      	                         
+  
+```

--- a/crates/biome_css_parser/tests/css_test_suite/error/value/release-url-asset-aliases.css
+++ b/crates/biome_css_parser/tests/css_test_suite/error/value/release-url-asset-aliases.css
@@ -1,0 +1,1 @@
+a {background-image:url(@/assets/svg/for-css/check.svg

--- a/crates/biome_css_parser/tests/css_test_suite/error/value/release-url-asset-aliases.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/value/release-url-asset-aliases.css.snap
@@ -1,0 +1,128 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+a {background-image:url(@/assets/svg/for-css/check.svg
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: CssTypeSelector {
+                        namespace: missing (optional),
+                        ident: CssIdentifier {
+                            value_token: IDENT@0..2 "a" [] [Whitespace(" ")],
+                        },
+                    },
+                    sub_selectors: CssSubSelectorList [],
+                },
+            ],
+            block: CssBogusBlock {
+                items: [
+                    L_CURLY@2..3 "{" [] [],
+                    CssDeclarationOrRuleList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@3..19 "background-image" [] [],
+                                    },
+                                    colon_token: COLON@19..20 ":" [] [],
+                                    value: CssGenericComponentValueList [
+                                        CssUrlFunction {
+                                            name: URL_KW@20..23 "url" [] [],
+                                            l_paren_token: L_PAREN@23..24 "(" [] [],
+                                            value: CssUrlValueRaw {
+                                                value_token: CSS_URL_VALUE_RAW_LITERAL@24..54 "@/assets/svg/for-css/check.svg" [] [],
+                                            },
+                                            modifiers: CssUrlModifierList [],
+                                            r_paren_token: missing (required),
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: missing (optional),
+                        },
+                    ],
+                ],
+            },
+        },
+    ],
+    eof_token: EOF@54..54 "" [] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..54
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..54
+    0: CSS_QUALIFIED_RULE@0..54
+      0: CSS_SELECTOR_LIST@0..2
+        0: CSS_COMPOUND_SELECTOR@0..2
+          0: CSS_NESTED_SELECTOR_LIST@0..0
+          1: CSS_TYPE_SELECTOR@0..2
+            0: (empty)
+            1: CSS_IDENTIFIER@0..2
+              0: IDENT@0..2 "a" [] [Whitespace(" ")]
+          2: CSS_SUB_SELECTOR_LIST@2..2
+      1: CSS_BOGUS_BLOCK@2..54
+        0: L_CURLY@2..3 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@3..54
+          0: CSS_DECLARATION_WITH_SEMICOLON@3..54
+            0: CSS_DECLARATION@3..54
+              0: CSS_GENERIC_PROPERTY@3..54
+                0: CSS_IDENTIFIER@3..19
+                  0: IDENT@3..19 "background-image" [] []
+                1: COLON@19..20 ":" [] []
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@20..54
+                  0: CSS_URL_FUNCTION@20..54
+                    0: URL_KW@20..23 "url" [] []
+                    1: L_PAREN@23..24 "(" [] []
+                    2: CSS_URL_VALUE_RAW@24..54
+                      0: CSS_URL_VALUE_RAW_LITERAL@24..54 "@/assets/svg/for-css/check.svg" [] []
+                    3: CSS_URL_MODIFIER_LIST@54..54
+                    4: (empty)
+              1: (empty)
+            1: (empty)
+  2: EOF@54..54 "" [] []
+
+```
+
+## Diagnostics
+
+```
+release-url-asset-aliases.css:1:25 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Invalid url raw value
+  
+  > 1 │ a {background-image:url(@/assets/svg/for-css/check.svg
+      │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  
+release-url-asset-aliases.css:1:55 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `)` but instead the file ends
+  
+  > 1 │ a {background-image:url(@/assets/svg/for-css/check.svg
+      │                                                       
+  
+  i the file ends here
+  
+  > 1 │ a {background-image:url(@/assets/svg/for-css/check.svg
+      │                                                       
+  
+```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/value/release-url-asset-aliases.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/value/release-url-asset-aliases.scss
@@ -1,0 +1,25 @@
+$name: "check";
+$path: "icons/check";
+.check { background-image: url(@/assets/svg/for-css/check.svg); width: 1px; }
+.footer { background-image: url(@site/static/img/showcase/gh-footer-light.svg); color: red; }
+@font-face { font-family: "!PaulMaul"; src: url(!PaulMaul.woff2) format("woff2"); font-display: swap; }
+.controls {
+  ordinary: url(image.png);
+  quoted: url("@/assets/svg/for-css/check.svg") url("@site/static/img/showcase/gh-footer-light.svg") url("!PaulMaul.woff2");
+  relative: url(//cdn.example/image.svg);
+  data: url(data:image/svg+xml;base64,AAAA);
+  fragment: url(#icon);
+  escaped: url(@/assets/a\)b.svg) url(!font\20 name.woff2) url(@/icons/\é.svg);
+  other: url(@custom/other.svg) url(!Other.woff2);
+  width: 1px;
+}
+.dynamic {
+  interpolated: url(@/assets/#{$name}.svg) url(!#{$name}.woff2);
+  computed: url($path + ".svg");
+  width: 1px;
+}
+.modifiers { background: url("image.png" format("png")); width: 1px; }
+.functions { plain: url(fn("image.svg")); interpolated: url(foo#{"-bar"}("image.svg")); width: 1px; }
+.escaped-tail { first: url(@a\ ); second: url(!a\ ); even: url(@a\\  ); odd: url(!a\\\  ); hex: url(@a\20  ); width: 1px; }
+.unicode-tail { first: url(@a ); second: url(!a ); width: 1px; }
+.escaped-tab { background: url(@a\	); color: red; }

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/value/release-url-asset-aliases.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/value/release-url-asset-aliases.scss
@@ -23,3 +23,4 @@ $path: "icons/check";
 .escaped-tail { first: url(@a\ ); second: url(!a\ ); even: url(@a\\  ); odd: url(!a\\\  ); hex: url(@a\20  ); width: 1px; }
 .unicode-tail { first: url(@a ); second: url(!a ); width: 1px; }
 .escaped-tab { background: url(@a\	); color: red; }
+.padding { first: url( 	@/other.svg 	); second: url( 	!Other.woff2  ); width: 1px; }

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/value/release-url-asset-aliases.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/value/release-url-asset-aliases.scss.snap
@@ -31,6 +31,7 @@ $path: "icons/check";
 .escaped-tail { first: url(@a\ ); second: url(!a\ ); even: url(@a\\  ); odd: url(!a\\\  ); hex: url(@a\20  ); width: 1px; }
 .unicode-tail { first: url(@a ); second: url(!a ); width: 1px; }
 .escaped-tab { background: url(@a\	); color: red; }
+.padding { first: url( 	@/other.svg 	); second: url( 	!Other.woff2  ); width: 1px; }
 
 ```
 
@@ -1270,17 +1271,109 @@ CssRoot {
                 r_curly_token: R_CURLY@1278..1279 "}" [] [],
             },
         },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@1279..1281 "." [Newline("\n")] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@1281..1289 "padding" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@1289..1291 "{" [] [Whitespace(" ")],
+                items: CssDeclarationOrRuleList [
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@1291..1296 "first" [] [],
+                                },
+                                colon_token: COLON@1296..1298 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssUrlFunction {
+                                            name: URL_KW@1298..1301 "url" [] [],
+                                            l_paren_token: L_PAREN@1301..1304 "(" [] [Whitespace(" \t")],
+                                            value: CssUrlValueRaw {
+                                                value_token: CSS_URL_VALUE_RAW_LITERAL@1304..1317 "@/other.svg \t" [] [],
+                                            },
+                                            modifiers: CssUrlModifierList [],
+                                            r_paren_token: R_PAREN@1317..1318 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@1318..1320 ";" [] [Whitespace(" ")],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@1320..1326 "second" [] [],
+                                },
+                                colon_token: COLON@1326..1328 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssUrlFunction {
+                                            name: URL_KW@1328..1331 "url" [] [],
+                                            l_paren_token: L_PAREN@1331..1334 "(" [] [Whitespace(" \t")],
+                                            value: CssUrlValueRaw {
+                                                value_token: CSS_URL_VALUE_RAW_LITERAL@1334..1348 "!Other.woff2  " [] [],
+                                            },
+                                            modifiers: CssUrlModifierList [],
+                                            r_paren_token: R_PAREN@1348..1349 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@1349..1351 ";" [] [Whitespace(" ")],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@1351..1356 "width" [] [],
+                                },
+                                colon_token: COLON@1356..1358 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssRegularDimension {
+                                            value_token: CSS_NUMBER_LITERAL@1358..1359 "1" [] [],
+                                            unit_token: IDENT@1359..1361 "px" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@1361..1363 ";" [] [Whitespace(" ")],
+                    },
+                ],
+                r_curly_token: R_CURLY@1363..1364 "}" [] [],
+            },
+        },
     ],
-    eof_token: EOF@1279..1280 "" [Newline("\n")] [],
+    eof_token: EOF@1364..1365 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: CSS_ROOT@0..1280
+0: CSS_ROOT@0..1365
   0: (empty)
-  1: CSS_ROOT_ITEM_LIST@0..1279
+  1: CSS_ROOT_ITEM_LIST@0..1364
     0: SCSS_VARIABLE_DECLARATION@0..15
       0: SCSS_VARIABLE@0..5
         0: DOLLAR@0..1 "$" [] []
@@ -2096,6 +2189,67 @@ CssRoot {
               1: (empty)
             1: SEMICOLON@1276..1278 ";" [] [Whitespace(" ")]
         2: R_CURLY@1278..1279 "}" [] []
-  2: EOF@1279..1280 "" [Newline("\n")] []
+    12: CSS_QUALIFIED_RULE@1279..1364
+      0: CSS_SELECTOR_LIST@1279..1289
+        0: CSS_COMPOUND_SELECTOR@1279..1289
+          0: CSS_NESTED_SELECTOR_LIST@1279..1279
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@1279..1289
+            0: CSS_CLASS_SELECTOR@1279..1289
+              0: DOT@1279..1281 "." [Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@1281..1289
+                0: IDENT@1281..1289 "padding" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@1289..1364
+        0: L_CURLY@1289..1291 "{" [] [Whitespace(" ")]
+        1: CSS_DECLARATION_OR_RULE_LIST@1291..1363
+          0: CSS_DECLARATION_WITH_SEMICOLON@1291..1320
+            0: CSS_DECLARATION@1291..1318
+              0: CSS_GENERIC_PROPERTY@1291..1318
+                0: CSS_IDENTIFIER@1291..1296
+                  0: IDENT@1291..1296 "first" [] []
+                1: COLON@1296..1298 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@1298..1318
+                  0: SCSS_EXPRESSION_ITEM_LIST@1298..1318
+                    0: CSS_URL_FUNCTION@1298..1318
+                      0: URL_KW@1298..1301 "url" [] []
+                      1: L_PAREN@1301..1304 "(" [] [Whitespace(" \t")]
+                      2: CSS_URL_VALUE_RAW@1304..1317
+                        0: CSS_URL_VALUE_RAW_LITERAL@1304..1317 "@/other.svg \t" [] []
+                      3: CSS_URL_MODIFIER_LIST@1317..1317
+                      4: R_PAREN@1317..1318 ")" [] []
+              1: (empty)
+            1: SEMICOLON@1318..1320 ";" [] [Whitespace(" ")]
+          1: CSS_DECLARATION_WITH_SEMICOLON@1320..1351
+            0: CSS_DECLARATION@1320..1349
+              0: CSS_GENERIC_PROPERTY@1320..1349
+                0: CSS_IDENTIFIER@1320..1326
+                  0: IDENT@1320..1326 "second" [] []
+                1: COLON@1326..1328 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@1328..1349
+                  0: SCSS_EXPRESSION_ITEM_LIST@1328..1349
+                    0: CSS_URL_FUNCTION@1328..1349
+                      0: URL_KW@1328..1331 "url" [] []
+                      1: L_PAREN@1331..1334 "(" [] [Whitespace(" \t")]
+                      2: CSS_URL_VALUE_RAW@1334..1348
+                        0: CSS_URL_VALUE_RAW_LITERAL@1334..1348 "!Other.woff2  " [] []
+                      3: CSS_URL_MODIFIER_LIST@1348..1348
+                      4: R_PAREN@1348..1349 ")" [] []
+              1: (empty)
+            1: SEMICOLON@1349..1351 ";" [] [Whitespace(" ")]
+          2: CSS_DECLARATION_WITH_SEMICOLON@1351..1363
+            0: CSS_DECLARATION@1351..1361
+              0: CSS_GENERIC_PROPERTY@1351..1361
+                0: CSS_IDENTIFIER@1351..1356
+                  0: IDENT@1351..1356 "width" [] []
+                1: COLON@1356..1358 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@1358..1361
+                  0: SCSS_EXPRESSION_ITEM_LIST@1358..1361
+                    0: CSS_REGULAR_DIMENSION@1358..1361
+                      0: CSS_NUMBER_LITERAL@1358..1359 "1" [] []
+                      1: IDENT@1359..1361 "px" [] []
+              1: (empty)
+            1: SEMICOLON@1361..1363 ";" [] [Whitespace(" ")]
+        2: R_CURLY@1363..1364 "}" [] []
+  2: EOF@1364..1365 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/value/release-url-asset-aliases.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/value/release-url-asset-aliases.scss.snap
@@ -1,0 +1,2101 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+$name: "check";
+$path: "icons/check";
+.check { background-image: url(@/assets/svg/for-css/check.svg); width: 1px; }
+.footer { background-image: url(@site/static/img/showcase/gh-footer-light.svg); color: red; }
+@font-face { font-family: "!PaulMaul"; src: url(!PaulMaul.woff2) format("woff2"); font-display: swap; }
+.controls {
+  ordinary: url(image.png);
+  quoted: url("@/assets/svg/for-css/check.svg") url("@site/static/img/showcase/gh-footer-light.svg") url("!PaulMaul.woff2");
+  relative: url(//cdn.example/image.svg);
+  data: url(data:image/svg+xml;base64,AAAA);
+  fragment: url(#icon);
+  escaped: url(@/assets/a\)b.svg) url(!font\20 name.woff2) url(@/icons/\é.svg);
+  other: url(@custom/other.svg) url(!Other.woff2);
+  width: 1px;
+}
+.dynamic {
+  interpolated: url(@/assets/#{$name}.svg) url(!#{$name}.woff2);
+  computed: url($path + ".svg");
+  width: 1px;
+}
+.modifiers { background: url("image.png" format("png")); width: 1px; }
+.functions { plain: url(fn("image.svg")); interpolated: url(foo#{"-bar"}("image.svg")); width: 1px; }
+.escaped-tail { first: url(@a\ ); second: url(!a\ ); even: url(@a\\  ); odd: url(!a\\\  ); hex: url(@a\20  ); width: 1px; }
+.unicode-tail { first: url(@a ); second: url(!a ); width: 1px; }
+.escaped-tab { background: url(@a\	); color: red; }
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        ScssVariableDeclaration {
+            name: ScssVariable {
+                dollar_token: DOLLAR@0..1 "$" [] [],
+                name: CssIdentifier {
+                    value_token: IDENT@1..5 "name" [] [],
+                },
+            },
+            colon_token: COLON@5..7 ":" [] [Whitespace(" ")],
+            value: ScssExpression {
+                items: ScssExpressionItemList [
+                    CssString {
+                        value_token: CSS_STRING_LITERAL@7..14 "\"check\"" [] [],
+                    },
+                ],
+            },
+            modifiers: ScssVariableModifierList [],
+            semicolon_token: SEMICOLON@14..15 ";" [] [],
+        },
+        ScssVariableDeclaration {
+            name: ScssVariable {
+                dollar_token: DOLLAR@15..17 "$" [Newline("\n")] [],
+                name: CssIdentifier {
+                    value_token: IDENT@17..21 "path" [] [],
+                },
+            },
+            colon_token: COLON@21..23 ":" [] [Whitespace(" ")],
+            value: ScssExpression {
+                items: ScssExpressionItemList [
+                    CssString {
+                        value_token: CSS_STRING_LITERAL@23..36 "\"icons/check\"" [] [],
+                    },
+                ],
+            },
+            modifiers: ScssVariableModifierList [],
+            semicolon_token: SEMICOLON@36..37 ";" [] [],
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@37..39 "." [Newline("\n")] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@39..45 "check" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@45..47 "{" [] [Whitespace(" ")],
+                items: CssDeclarationOrRuleList [
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@47..63 "background-image" [] [],
+                                },
+                                colon_token: COLON@63..65 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssUrlFunction {
+                                            name: URL_KW@65..68 "url" [] [],
+                                            l_paren_token: L_PAREN@68..69 "(" [] [],
+                                            value: CssUrlValueRaw {
+                                                value_token: CSS_URL_VALUE_RAW_LITERAL@69..99 "@/assets/svg/for-css/check.svg" [] [],
+                                            },
+                                            modifiers: CssUrlModifierList [],
+                                            r_paren_token: R_PAREN@99..100 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@100..102 ";" [] [Whitespace(" ")],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@102..107 "width" [] [],
+                                },
+                                colon_token: COLON@107..109 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssRegularDimension {
+                                            value_token: CSS_NUMBER_LITERAL@109..110 "1" [] [],
+                                            unit_token: IDENT@110..112 "px" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@112..114 ";" [] [Whitespace(" ")],
+                    },
+                ],
+                r_curly_token: R_CURLY@114..115 "}" [] [],
+            },
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@115..117 "." [Newline("\n")] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@117..124 "footer" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@124..126 "{" [] [Whitespace(" ")],
+                items: CssDeclarationOrRuleList [
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@126..142 "background-image" [] [],
+                                },
+                                colon_token: COLON@142..144 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssUrlFunction {
+                                            name: URL_KW@144..147 "url" [] [],
+                                            l_paren_token: L_PAREN@147..148 "(" [] [],
+                                            value: CssUrlValueRaw {
+                                                value_token: CSS_URL_VALUE_RAW_LITERAL@148..193 "@site/static/img/showcase/gh-footer-light.svg" [] [],
+                                            },
+                                            modifiers: CssUrlModifierList [],
+                                            r_paren_token: R_PAREN@193..194 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@194..196 ";" [] [Whitespace(" ")],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@196..201 "color" [] [],
+                                },
+                                colon_token: COLON@201..203 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssIdentifier {
+                                            value_token: IDENT@203..206 "red" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@206..208 ";" [] [Whitespace(" ")],
+                    },
+                ],
+                r_curly_token: R_CURLY@208..209 "}" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@209..211 "@" [Newline("\n")] [],
+            rule: CssFontFaceAtRule {
+                declarator: CssFontFaceAtRuleDeclarator {
+                    font_face_token: FONT_FACE_KW@211..221 "font-face" [] [Whitespace(" ")],
+                },
+                block: CssDeclarationBlock {
+                    l_curly_token: L_CURLY@221..223 "{" [] [Whitespace(" ")],
+                    declarations: CssDeclarationList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@223..234 "font-family" [] [],
+                                    },
+                                    colon_token: COLON@234..236 ":" [] [Whitespace(" ")],
+                                    value: ScssExpression {
+                                        items: ScssExpressionItemList [
+                                            CssString {
+                                                value_token: CSS_STRING_LITERAL@236..247 "\"!PaulMaul\"" [] [],
+                                            },
+                                        ],
+                                    },
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@247..249 ";" [] [Whitespace(" ")],
+                        },
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@249..252 "src" [] [],
+                                    },
+                                    colon_token: COLON@252..254 ":" [] [Whitespace(" ")],
+                                    value: ScssExpression {
+                                        items: ScssExpressionItemList [
+                                            CssUrlFunction {
+                                                name: URL_KW@254..257 "url" [] [],
+                                                l_paren_token: L_PAREN@257..258 "(" [] [],
+                                                value: CssUrlValueRaw {
+                                                    value_token: CSS_URL_VALUE_RAW_LITERAL@258..273 "!PaulMaul.woff2" [] [],
+                                                },
+                                                modifiers: CssUrlModifierList [],
+                                                r_paren_token: R_PAREN@273..275 ")" [] [Whitespace(" ")],
+                                            },
+                                            CssFunction {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@275..281 "format" [] [],
+                                                },
+                                                l_paren_token: L_PAREN@281..282 "(" [] [],
+                                                items: CssParameterList [
+                                                    ScssExpression {
+                                                        items: ScssExpressionItemList [
+                                                            CssString {
+                                                                value_token: CSS_STRING_LITERAL@282..289 "\"woff2\"" [] [],
+                                                            },
+                                                        ],
+                                                    },
+                                                ],
+                                                r_paren_token: R_PAREN@289..290 ")" [] [],
+                                            },
+                                        ],
+                                    },
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@290..292 ";" [] [Whitespace(" ")],
+                        },
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@292..304 "font-display" [] [],
+                                    },
+                                    colon_token: COLON@304..306 ":" [] [Whitespace(" ")],
+                                    value: ScssExpression {
+                                        items: ScssExpressionItemList [
+                                            CssIdentifier {
+                                                value_token: IDENT@306..310 "swap" [] [],
+                                            },
+                                        ],
+                                    },
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@310..312 ";" [] [Whitespace(" ")],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@312..313 "}" [] [],
+                },
+            },
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@313..315 "." [Newline("\n")] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@315..324 "controls" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@324..325 "{" [] [],
+                items: CssDeclarationOrRuleList [
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@325..336 "ordinary" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@336..338 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssUrlFunction {
+                                            name: URL_KW@338..341 "url" [] [],
+                                            l_paren_token: L_PAREN@341..342 "(" [] [],
+                                            value: CssUrlValueRaw {
+                                                value_token: CSS_URL_VALUE_RAW_LITERAL@342..351 "image.png" [] [],
+                                            },
+                                            modifiers: CssUrlModifierList [],
+                                            r_paren_token: R_PAREN@351..352 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@352..353 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@353..362 "quoted" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@362..364 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssUrlFunction {
+                                            name: URL_KW@364..367 "url" [] [],
+                                            l_paren_token: L_PAREN@367..368 "(" [] [],
+                                            value: CssString {
+                                                value_token: CSS_STRING_LITERAL@368..400 "\"@/assets/svg/for-css/check.svg\"" [] [],
+                                            },
+                                            modifiers: CssUrlModifierList [],
+                                            r_paren_token: R_PAREN@400..402 ")" [] [Whitespace(" ")],
+                                        },
+                                        CssUrlFunction {
+                                            name: URL_KW@402..405 "url" [] [],
+                                            l_paren_token: L_PAREN@405..406 "(" [] [],
+                                            value: CssString {
+                                                value_token: CSS_STRING_LITERAL@406..453 "\"@site/static/img/showcase/gh-footer-light.svg\"" [] [],
+                                            },
+                                            modifiers: CssUrlModifierList [],
+                                            r_paren_token: R_PAREN@453..455 ")" [] [Whitespace(" ")],
+                                        },
+                                        CssUrlFunction {
+                                            name: URL_KW@455..458 "url" [] [],
+                                            l_paren_token: L_PAREN@458..459 "(" [] [],
+                                            value: CssString {
+                                                value_token: CSS_STRING_LITERAL@459..476 "\"!PaulMaul.woff2\"" [] [],
+                                            },
+                                            modifiers: CssUrlModifierList [],
+                                            r_paren_token: R_PAREN@476..477 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@477..478 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@478..489 "relative" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@489..491 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssUrlFunction {
+                                            name: URL_KW@491..494 "url" [] [],
+                                            l_paren_token: L_PAREN@494..495 "(" [] [],
+                                            value: CssUrlValueRaw {
+                                                value_token: CSS_URL_VALUE_RAW_LITERAL@495..518 "//cdn.example/image.svg" [] [],
+                                            },
+                                            modifiers: CssUrlModifierList [],
+                                            r_paren_token: R_PAREN@518..519 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@519..520 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@520..527 "data" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@527..529 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssUrlFunction {
+                                            name: URL_KW@529..532 "url" [] [],
+                                            l_paren_token: L_PAREN@532..533 "(" [] [],
+                                            value: CssUrlValueRaw {
+                                                value_token: CSS_URL_VALUE_RAW_LITERAL@533..563 "data:image/svg+xml;base64,AAAA" [] [],
+                                            },
+                                            modifiers: CssUrlModifierList [],
+                                            r_paren_token: R_PAREN@563..564 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@564..565 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@565..576 "fragment" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@576..578 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssUrlFunction {
+                                            name: URL_KW@578..581 "url" [] [],
+                                            l_paren_token: L_PAREN@581..582 "(" [] [],
+                                            value: CssUrlValueRaw {
+                                                value_token: CSS_URL_VALUE_RAW_LITERAL@582..587 "#icon" [] [],
+                                            },
+                                            modifiers: CssUrlModifierList [],
+                                            r_paren_token: R_PAREN@587..588 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@588..589 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@589..599 "escaped" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@599..601 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssUrlFunction {
+                                            name: URL_KW@601..604 "url" [] [],
+                                            l_paren_token: L_PAREN@604..605 "(" [] [],
+                                            value: CssUrlValueRaw {
+                                                value_token: CSS_URL_VALUE_RAW_LITERAL@605..622 "@/assets/a\\)b.svg" [] [],
+                                            },
+                                            modifiers: CssUrlModifierList [],
+                                            r_paren_token: R_PAREN@622..624 ")" [] [Whitespace(" ")],
+                                        },
+                                        CssUrlFunction {
+                                            name: URL_KW@624..627 "url" [] [],
+                                            l_paren_token: L_PAREN@627..628 "(" [] [],
+                                            value: CssUrlValueRaw {
+                                                value_token: CSS_URL_VALUE_RAW_LITERAL@628..647 "!font\\20 name.woff2" [] [],
+                                            },
+                                            modifiers: CssUrlModifierList [],
+                                            r_paren_token: R_PAREN@647..649 ")" [] [Whitespace(" ")],
+                                        },
+                                        CssUrlFunction {
+                                            name: URL_KW@649..652 "url" [] [],
+                                            l_paren_token: L_PAREN@652..653 "(" [] [],
+                                            value: CssUrlValueRaw {
+                                                value_token: CSS_URL_VALUE_RAW_LITERAL@653..668 "@/icons/\\é.svg" [] [],
+                                            },
+                                            modifiers: CssUrlModifierList [],
+                                            r_paren_token: R_PAREN@668..669 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@669..670 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@670..678 "other" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@678..680 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssUrlFunction {
+                                            name: URL_KW@680..683 "url" [] [],
+                                            l_paren_token: L_PAREN@683..684 "(" [] [],
+                                            value: CssUrlValueRaw {
+                                                value_token: CSS_URL_VALUE_RAW_LITERAL@684..701 "@custom/other.svg" [] [],
+                                            },
+                                            modifiers: CssUrlModifierList [],
+                                            r_paren_token: R_PAREN@701..703 ")" [] [Whitespace(" ")],
+                                        },
+                                        CssUrlFunction {
+                                            name: URL_KW@703..706 "url" [] [],
+                                            l_paren_token: L_PAREN@706..707 "(" [] [],
+                                            value: CssUrlValueRaw {
+                                                value_token: CSS_URL_VALUE_RAW_LITERAL@707..719 "!Other.woff2" [] [],
+                                            },
+                                            modifiers: CssUrlModifierList [],
+                                            r_paren_token: R_PAREN@719..720 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@720..721 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@721..729 "width" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@729..731 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssRegularDimension {
+                                            value_token: CSS_NUMBER_LITERAL@731..732 "1" [] [],
+                                            unit_token: IDENT@732..734 "px" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@734..735 ";" [] [],
+                    },
+                ],
+                r_curly_token: R_CURLY@735..737 "}" [Newline("\n")] [],
+            },
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@737..739 "." [Newline("\n")] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@739..747 "dynamic" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@747..748 "{" [] [],
+                items: CssDeclarationOrRuleList [
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@748..763 "interpolated" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@763..765 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssUrlFunction {
+                                            name: URL_KW@765..768 "url" [] [],
+                                            l_paren_token: L_PAREN@768..769 "(" [] [],
+                                            value: ScssInterpolatedUrlValue {
+                                                parts: ScssInterpolatedUrlValuePartList [
+                                                    ScssUrlText {
+                                                        value_token: SCSS_URL_CONTENT_LITERAL@769..778 "@/assets/" [] [],
+                                                    },
+                                                    ScssInterpolation {
+                                                        hash_token: HASH@778..779 "#" [] [],
+                                                        l_curly_token: L_CURLY@779..780 "{" [] [],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                ScssVariable {
+                                                                    dollar_token: DOLLAR@780..781 "$" [] [],
+                                                                    name: CssIdentifier {
+                                                                        value_token: IDENT@781..785 "name" [] [],
+                                                                    },
+                                                                },
+                                                            ],
+                                                        },
+                                                        r_curly_token: R_CURLY@785..786 "}" [] [],
+                                                    },
+                                                    ScssUrlText {
+                                                        value_token: SCSS_URL_CONTENT_LITERAL@786..790 ".svg" [] [],
+                                                    },
+                                                ],
+                                            },
+                                            modifiers: CssUrlModifierList [],
+                                            r_paren_token: R_PAREN@790..792 ")" [] [Whitespace(" ")],
+                                        },
+                                        CssUrlFunction {
+                                            name: URL_KW@792..795 "url" [] [],
+                                            l_paren_token: L_PAREN@795..796 "(" [] [],
+                                            value: ScssInterpolatedUrlValue {
+                                                parts: ScssInterpolatedUrlValuePartList [
+                                                    ScssUrlText {
+                                                        value_token: SCSS_URL_CONTENT_LITERAL@796..797 "!" [] [],
+                                                    },
+                                                    ScssInterpolation {
+                                                        hash_token: HASH@797..798 "#" [] [],
+                                                        l_curly_token: L_CURLY@798..799 "{" [] [],
+                                                        value: ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                ScssVariable {
+                                                                    dollar_token: DOLLAR@799..800 "$" [] [],
+                                                                    name: CssIdentifier {
+                                                                        value_token: IDENT@800..804 "name" [] [],
+                                                                    },
+                                                                },
+                                                            ],
+                                                        },
+                                                        r_curly_token: R_CURLY@804..805 "}" [] [],
+                                                    },
+                                                    ScssUrlText {
+                                                        value_token: SCSS_URL_CONTENT_LITERAL@805..811 ".woff2" [] [],
+                                                    },
+                                                ],
+                                            },
+                                            modifiers: CssUrlModifierList [],
+                                            r_paren_token: R_PAREN@811..812 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@812..813 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@813..824 "computed" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@824..826 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssUrlFunction {
+                                            name: URL_KW@826..829 "url" [] [],
+                                            l_paren_token: L_PAREN@829..830 "(" [] [],
+                                            value: ScssExpression {
+                                                items: ScssExpressionItemList [
+                                                    ScssBinaryExpression {
+                                                        left: ScssVariable {
+                                                            dollar_token: DOLLAR@830..831 "$" [] [],
+                                                            name: CssIdentifier {
+                                                                value_token: IDENT@831..836 "path" [] [Whitespace(" ")],
+                                                            },
+                                                        },
+                                                        operator: PLUS@836..838 "+" [] [Whitespace(" ")],
+                                                        right: CssString {
+                                                            value_token: CSS_STRING_LITERAL@838..844 "\".svg\"" [] [],
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                            modifiers: CssUrlModifierList [],
+                                            r_paren_token: R_PAREN@844..845 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@845..846 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@846..854 "width" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@854..856 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssRegularDimension {
+                                            value_token: CSS_NUMBER_LITERAL@856..857 "1" [] [],
+                                            unit_token: IDENT@857..859 "px" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@859..860 ";" [] [],
+                    },
+                ],
+                r_curly_token: R_CURLY@860..862 "}" [Newline("\n")] [],
+            },
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@862..864 "." [Newline("\n")] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@864..874 "modifiers" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@874..876 "{" [] [Whitespace(" ")],
+                items: CssDeclarationOrRuleList [
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@876..886 "background" [] [],
+                                },
+                                colon_token: COLON@886..888 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssUrlFunction {
+                                            name: URL_KW@888..891 "url" [] [],
+                                            l_paren_token: L_PAREN@891..892 "(" [] [],
+                                            value: CssString {
+                                                value_token: CSS_STRING_LITERAL@892..904 "\"image.png\"" [] [Whitespace(" ")],
+                                            },
+                                            modifiers: CssUrlModifierList [
+                                                CssFunction {
+                                                    name: CssIdentifier {
+                                                        value_token: IDENT@904..910 "format" [] [],
+                                                    },
+                                                    l_paren_token: L_PAREN@910..911 "(" [] [],
+                                                    items: CssParameterList [
+                                                        ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                CssString {
+                                                                    value_token: CSS_STRING_LITERAL@911..916 "\"png\"" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                    ],
+                                                    r_paren_token: R_PAREN@916..917 ")" [] [],
+                                                },
+                                            ],
+                                            r_paren_token: R_PAREN@917..918 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@918..920 ";" [] [Whitespace(" ")],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@920..925 "width" [] [],
+                                },
+                                colon_token: COLON@925..927 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssRegularDimension {
+                                            value_token: CSS_NUMBER_LITERAL@927..928 "1" [] [],
+                                            unit_token: IDENT@928..930 "px" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@930..932 ";" [] [Whitespace(" ")],
+                    },
+                ],
+                r_curly_token: R_CURLY@932..933 "}" [] [],
+            },
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@933..935 "." [Newline("\n")] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@935..945 "functions" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@945..947 "{" [] [Whitespace(" ")],
+                items: CssDeclarationOrRuleList [
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@947..952 "plain" [] [],
+                                },
+                                colon_token: COLON@952..954 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssUrlFunction {
+                                            name: URL_KW@954..957 "url" [] [],
+                                            l_paren_token: L_PAREN@957..958 "(" [] [],
+                                            value: missing (optional),
+                                            modifiers: CssUrlModifierList [
+                                                CssFunction {
+                                                    name: CssIdentifier {
+                                                        value_token: IDENT@958..960 "fn" [] [],
+                                                    },
+                                                    l_paren_token: L_PAREN@960..961 "(" [] [],
+                                                    items: CssParameterList [
+                                                        ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                CssString {
+                                                                    value_token: CSS_STRING_LITERAL@961..972 "\"image.svg\"" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                    ],
+                                                    r_paren_token: R_PAREN@972..973 ")" [] [],
+                                                },
+                                            ],
+                                            r_paren_token: R_PAREN@973..974 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@974..976 ";" [] [Whitespace(" ")],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@976..988 "interpolated" [] [],
+                                },
+                                colon_token: COLON@988..990 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssUrlFunction {
+                                            name: URL_KW@990..993 "url" [] [],
+                                            l_paren_token: L_PAREN@993..994 "(" [] [],
+                                            value: missing (optional),
+                                            modifiers: CssUrlModifierList [
+                                                CssFunction {
+                                                    name: ScssInterpolatedIdentifier {
+                                                        items: ScssInterpolatedIdentifierPartList [
+                                                            CssIdentifier {
+                                                                value_token: IDENT@994..997 "foo" [] [],
+                                                            },
+                                                            ScssInterpolation {
+                                                                hash_token: HASH@997..998 "#" [] [],
+                                                                l_curly_token: L_CURLY@998..999 "{" [] [],
+                                                                value: ScssExpression {
+                                                                    items: ScssExpressionItemList [
+                                                                        CssString {
+                                                                            value_token: CSS_STRING_LITERAL@999..1005 "\"-bar\"" [] [],
+                                                                        },
+                                                                    ],
+                                                                },
+                                                                r_curly_token: R_CURLY@1005..1006 "}" [] [],
+                                                            },
+                                                        ],
+                                                    },
+                                                    l_paren_token: L_PAREN@1006..1007 "(" [] [],
+                                                    items: CssParameterList [
+                                                        ScssExpression {
+                                                            items: ScssExpressionItemList [
+                                                                CssString {
+                                                                    value_token: CSS_STRING_LITERAL@1007..1018 "\"image.svg\"" [] [],
+                                                                },
+                                                            ],
+                                                        },
+                                                    ],
+                                                    r_paren_token: R_PAREN@1018..1019 ")" [] [],
+                                                },
+                                            ],
+                                            r_paren_token: R_PAREN@1019..1020 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@1020..1022 ";" [] [Whitespace(" ")],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@1022..1027 "width" [] [],
+                                },
+                                colon_token: COLON@1027..1029 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssRegularDimension {
+                                            value_token: CSS_NUMBER_LITERAL@1029..1030 "1" [] [],
+                                            unit_token: IDENT@1030..1032 "px" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@1032..1034 ";" [] [Whitespace(" ")],
+                    },
+                ],
+                r_curly_token: R_CURLY@1034..1035 "}" [] [],
+            },
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@1035..1037 "." [Newline("\n")] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@1037..1050 "escaped-tail" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@1050..1052 "{" [] [Whitespace(" ")],
+                items: CssDeclarationOrRuleList [
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@1052..1057 "first" [] [],
+                                },
+                                colon_token: COLON@1057..1059 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssUrlFunction {
+                                            name: URL_KW@1059..1062 "url" [] [],
+                                            l_paren_token: L_PAREN@1062..1063 "(" [] [],
+                                            value: CssUrlValueRaw {
+                                                value_token: CSS_URL_VALUE_RAW_LITERAL@1063..1067 "@a\\ " [] [],
+                                            },
+                                            modifiers: CssUrlModifierList [],
+                                            r_paren_token: R_PAREN@1067..1068 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@1068..1070 ";" [] [Whitespace(" ")],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@1070..1076 "second" [] [],
+                                },
+                                colon_token: COLON@1076..1078 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssUrlFunction {
+                                            name: URL_KW@1078..1081 "url" [] [],
+                                            l_paren_token: L_PAREN@1081..1082 "(" [] [],
+                                            value: CssUrlValueRaw {
+                                                value_token: CSS_URL_VALUE_RAW_LITERAL@1082..1086 "!a\\ " [] [],
+                                            },
+                                            modifiers: CssUrlModifierList [],
+                                            r_paren_token: R_PAREN@1086..1087 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@1087..1089 ";" [] [Whitespace(" ")],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@1089..1093 "even" [] [],
+                                },
+                                colon_token: COLON@1093..1095 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssUrlFunction {
+                                            name: URL_KW@1095..1098 "url" [] [],
+                                            l_paren_token: L_PAREN@1098..1099 "(" [] [],
+                                            value: CssUrlValueRaw {
+                                                value_token: CSS_URL_VALUE_RAW_LITERAL@1099..1105 "@a\\\\  " [] [],
+                                            },
+                                            modifiers: CssUrlModifierList [],
+                                            r_paren_token: R_PAREN@1105..1106 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@1106..1108 ";" [] [Whitespace(" ")],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@1108..1111 "odd" [] [],
+                                },
+                                colon_token: COLON@1111..1113 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssUrlFunction {
+                                            name: URL_KW@1113..1116 "url" [] [],
+                                            l_paren_token: L_PAREN@1116..1117 "(" [] [],
+                                            value: CssUrlValueRaw {
+                                                value_token: CSS_URL_VALUE_RAW_LITERAL@1117..1124 "!a\\\\\\  " [] [],
+                                            },
+                                            modifiers: CssUrlModifierList [],
+                                            r_paren_token: R_PAREN@1124..1125 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@1125..1127 ";" [] [Whitespace(" ")],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@1127..1130 "hex" [] [],
+                                },
+                                colon_token: COLON@1130..1132 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssUrlFunction {
+                                            name: URL_KW@1132..1135 "url" [] [],
+                                            l_paren_token: L_PAREN@1135..1136 "(" [] [],
+                                            value: CssUrlValueRaw {
+                                                value_token: CSS_URL_VALUE_RAW_LITERAL@1136..1143 "@a\\20  " [] [],
+                                            },
+                                            modifiers: CssUrlModifierList [],
+                                            r_paren_token: R_PAREN@1143..1144 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@1144..1146 ";" [] [Whitespace(" ")],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@1146..1151 "width" [] [],
+                                },
+                                colon_token: COLON@1151..1153 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssRegularDimension {
+                                            value_token: CSS_NUMBER_LITERAL@1153..1154 "1" [] [],
+                                            unit_token: IDENT@1154..1156 "px" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@1156..1158 ";" [] [Whitespace(" ")],
+                    },
+                ],
+                r_curly_token: R_CURLY@1158..1159 "}" [] [],
+            },
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@1159..1161 "." [Newline("\n")] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@1161..1174 "unicode-tail" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@1174..1176 "{" [] [Whitespace(" ")],
+                items: CssDeclarationOrRuleList [
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@1176..1181 "first" [] [],
+                                },
+                                colon_token: COLON@1181..1183 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssUrlFunction {
+                                            name: URL_KW@1183..1186 "url" [] [],
+                                            l_paren_token: L_PAREN@1186..1187 "(" [] [],
+                                            value: CssUrlValueRaw {
+                                                value_token: CSS_URL_VALUE_RAW_LITERAL@1187..1191 "@a\u{a0}" [] [],
+                                            },
+                                            modifiers: CssUrlModifierList [],
+                                            r_paren_token: R_PAREN@1191..1192 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@1192..1194 ";" [] [Whitespace(" ")],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@1194..1200 "second" [] [],
+                                },
+                                colon_token: COLON@1200..1202 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssUrlFunction {
+                                            name: URL_KW@1202..1205 "url" [] [],
+                                            l_paren_token: L_PAREN@1205..1206 "(" [] [],
+                                            value: CssUrlValueRaw {
+                                                value_token: CSS_URL_VALUE_RAW_LITERAL@1206..1211 "!a\u{2003}" [] [],
+                                            },
+                                            modifiers: CssUrlModifierList [],
+                                            r_paren_token: R_PAREN@1211..1212 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@1212..1214 ";" [] [Whitespace(" ")],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@1214..1219 "width" [] [],
+                                },
+                                colon_token: COLON@1219..1221 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssRegularDimension {
+                                            value_token: CSS_NUMBER_LITERAL@1221..1222 "1" [] [],
+                                            unit_token: IDENT@1222..1224 "px" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@1224..1226 ";" [] [Whitespace(" ")],
+                    },
+                ],
+                r_curly_token: R_CURLY@1226..1227 "}" [] [],
+            },
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@1227..1229 "." [Newline("\n")] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@1229..1241 "escaped-tab" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@1241..1243 "{" [] [Whitespace(" ")],
+                items: CssDeclarationOrRuleList [
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@1243..1253 "background" [] [],
+                                },
+                                colon_token: COLON@1253..1255 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssUrlFunction {
+                                            name: URL_KW@1255..1258 "url" [] [],
+                                            l_paren_token: L_PAREN@1258..1259 "(" [] [],
+                                            value: CssUrlValueRaw {
+                                                value_token: CSS_URL_VALUE_RAW_LITERAL@1259..1263 "@a\\\t" [] [],
+                                            },
+                                            modifiers: CssUrlModifierList [],
+                                            r_paren_token: R_PAREN@1263..1264 ")" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@1264..1266 ";" [] [Whitespace(" ")],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@1266..1271 "color" [] [],
+                                },
+                                colon_token: COLON@1271..1273 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssIdentifier {
+                                            value_token: IDENT@1273..1276 "red" [] [],
+                                        },
+                                    ],
+                                },
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@1276..1278 ";" [] [Whitespace(" ")],
+                    },
+                ],
+                r_curly_token: R_CURLY@1278..1279 "}" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@1279..1280 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..1280
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..1279
+    0: SCSS_VARIABLE_DECLARATION@0..15
+      0: SCSS_VARIABLE@0..5
+        0: DOLLAR@0..1 "$" [] []
+        1: CSS_IDENTIFIER@1..5
+          0: IDENT@1..5 "name" [] []
+      1: COLON@5..7 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@7..14
+        0: SCSS_EXPRESSION_ITEM_LIST@7..14
+          0: CSS_STRING@7..14
+            0: CSS_STRING_LITERAL@7..14 "\"check\"" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@14..14
+      4: SEMICOLON@14..15 ";" [] []
+    1: SCSS_VARIABLE_DECLARATION@15..37
+      0: SCSS_VARIABLE@15..21
+        0: DOLLAR@15..17 "$" [Newline("\n")] []
+        1: CSS_IDENTIFIER@17..21
+          0: IDENT@17..21 "path" [] []
+      1: COLON@21..23 ":" [] [Whitespace(" ")]
+      2: SCSS_EXPRESSION@23..36
+        0: SCSS_EXPRESSION_ITEM_LIST@23..36
+          0: CSS_STRING@23..36
+            0: CSS_STRING_LITERAL@23..36 "\"icons/check\"" [] []
+      3: SCSS_VARIABLE_MODIFIER_LIST@36..36
+      4: SEMICOLON@36..37 ";" [] []
+    2: CSS_QUALIFIED_RULE@37..115
+      0: CSS_SELECTOR_LIST@37..45
+        0: CSS_COMPOUND_SELECTOR@37..45
+          0: CSS_NESTED_SELECTOR_LIST@37..37
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@37..45
+            0: CSS_CLASS_SELECTOR@37..45
+              0: DOT@37..39 "." [Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@39..45
+                0: IDENT@39..45 "check" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@45..115
+        0: L_CURLY@45..47 "{" [] [Whitespace(" ")]
+        1: CSS_DECLARATION_OR_RULE_LIST@47..114
+          0: CSS_DECLARATION_WITH_SEMICOLON@47..102
+            0: CSS_DECLARATION@47..100
+              0: CSS_GENERIC_PROPERTY@47..100
+                0: CSS_IDENTIFIER@47..63
+                  0: IDENT@47..63 "background-image" [] []
+                1: COLON@63..65 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@65..100
+                  0: SCSS_EXPRESSION_ITEM_LIST@65..100
+                    0: CSS_URL_FUNCTION@65..100
+                      0: URL_KW@65..68 "url" [] []
+                      1: L_PAREN@68..69 "(" [] []
+                      2: CSS_URL_VALUE_RAW@69..99
+                        0: CSS_URL_VALUE_RAW_LITERAL@69..99 "@/assets/svg/for-css/check.svg" [] []
+                      3: CSS_URL_MODIFIER_LIST@99..99
+                      4: R_PAREN@99..100 ")" [] []
+              1: (empty)
+            1: SEMICOLON@100..102 ";" [] [Whitespace(" ")]
+          1: CSS_DECLARATION_WITH_SEMICOLON@102..114
+            0: CSS_DECLARATION@102..112
+              0: CSS_GENERIC_PROPERTY@102..112
+                0: CSS_IDENTIFIER@102..107
+                  0: IDENT@102..107 "width" [] []
+                1: COLON@107..109 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@109..112
+                  0: SCSS_EXPRESSION_ITEM_LIST@109..112
+                    0: CSS_REGULAR_DIMENSION@109..112
+                      0: CSS_NUMBER_LITERAL@109..110 "1" [] []
+                      1: IDENT@110..112 "px" [] []
+              1: (empty)
+            1: SEMICOLON@112..114 ";" [] [Whitespace(" ")]
+        2: R_CURLY@114..115 "}" [] []
+    3: CSS_QUALIFIED_RULE@115..209
+      0: CSS_SELECTOR_LIST@115..124
+        0: CSS_COMPOUND_SELECTOR@115..124
+          0: CSS_NESTED_SELECTOR_LIST@115..115
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@115..124
+            0: CSS_CLASS_SELECTOR@115..124
+              0: DOT@115..117 "." [Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@117..124
+                0: IDENT@117..124 "footer" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@124..209
+        0: L_CURLY@124..126 "{" [] [Whitespace(" ")]
+        1: CSS_DECLARATION_OR_RULE_LIST@126..208
+          0: CSS_DECLARATION_WITH_SEMICOLON@126..196
+            0: CSS_DECLARATION@126..194
+              0: CSS_GENERIC_PROPERTY@126..194
+                0: CSS_IDENTIFIER@126..142
+                  0: IDENT@126..142 "background-image" [] []
+                1: COLON@142..144 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@144..194
+                  0: SCSS_EXPRESSION_ITEM_LIST@144..194
+                    0: CSS_URL_FUNCTION@144..194
+                      0: URL_KW@144..147 "url" [] []
+                      1: L_PAREN@147..148 "(" [] []
+                      2: CSS_URL_VALUE_RAW@148..193
+                        0: CSS_URL_VALUE_RAW_LITERAL@148..193 "@site/static/img/showcase/gh-footer-light.svg" [] []
+                      3: CSS_URL_MODIFIER_LIST@193..193
+                      4: R_PAREN@193..194 ")" [] []
+              1: (empty)
+            1: SEMICOLON@194..196 ";" [] [Whitespace(" ")]
+          1: CSS_DECLARATION_WITH_SEMICOLON@196..208
+            0: CSS_DECLARATION@196..206
+              0: CSS_GENERIC_PROPERTY@196..206
+                0: CSS_IDENTIFIER@196..201
+                  0: IDENT@196..201 "color" [] []
+                1: COLON@201..203 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@203..206
+                  0: SCSS_EXPRESSION_ITEM_LIST@203..206
+                    0: CSS_IDENTIFIER@203..206
+                      0: IDENT@203..206 "red" [] []
+              1: (empty)
+            1: SEMICOLON@206..208 ";" [] [Whitespace(" ")]
+        2: R_CURLY@208..209 "}" [] []
+    4: CSS_AT_RULE@209..313
+      0: AT@209..211 "@" [Newline("\n")] []
+      1: CSS_FONT_FACE_AT_RULE@211..313
+        0: CSS_FONT_FACE_AT_RULE_DECLARATOR@211..221
+          0: FONT_FACE_KW@211..221 "font-face" [] [Whitespace(" ")]
+        1: CSS_DECLARATION_BLOCK@221..313
+          0: L_CURLY@221..223 "{" [] [Whitespace(" ")]
+          1: CSS_DECLARATION_LIST@223..312
+            0: CSS_DECLARATION_WITH_SEMICOLON@223..249
+              0: CSS_DECLARATION@223..247
+                0: CSS_GENERIC_PROPERTY@223..247
+                  0: CSS_IDENTIFIER@223..234
+                    0: IDENT@223..234 "font-family" [] []
+                  1: COLON@234..236 ":" [] [Whitespace(" ")]
+                  2: SCSS_EXPRESSION@236..247
+                    0: SCSS_EXPRESSION_ITEM_LIST@236..247
+                      0: CSS_STRING@236..247
+                        0: CSS_STRING_LITERAL@236..247 "\"!PaulMaul\"" [] []
+                1: (empty)
+              1: SEMICOLON@247..249 ";" [] [Whitespace(" ")]
+            1: CSS_DECLARATION_WITH_SEMICOLON@249..292
+              0: CSS_DECLARATION@249..290
+                0: CSS_GENERIC_PROPERTY@249..290
+                  0: CSS_IDENTIFIER@249..252
+                    0: IDENT@249..252 "src" [] []
+                  1: COLON@252..254 ":" [] [Whitespace(" ")]
+                  2: SCSS_EXPRESSION@254..290
+                    0: SCSS_EXPRESSION_ITEM_LIST@254..290
+                      0: CSS_URL_FUNCTION@254..275
+                        0: URL_KW@254..257 "url" [] []
+                        1: L_PAREN@257..258 "(" [] []
+                        2: CSS_URL_VALUE_RAW@258..273
+                          0: CSS_URL_VALUE_RAW_LITERAL@258..273 "!PaulMaul.woff2" [] []
+                        3: CSS_URL_MODIFIER_LIST@273..273
+                        4: R_PAREN@273..275 ")" [] [Whitespace(" ")]
+                      1: CSS_FUNCTION@275..290
+                        0: CSS_IDENTIFIER@275..281
+                          0: IDENT@275..281 "format" [] []
+                        1: L_PAREN@281..282 "(" [] []
+                        2: CSS_PARAMETER_LIST@282..289
+                          0: SCSS_EXPRESSION@282..289
+                            0: SCSS_EXPRESSION_ITEM_LIST@282..289
+                              0: CSS_STRING@282..289
+                                0: CSS_STRING_LITERAL@282..289 "\"woff2\"" [] []
+                        3: R_PAREN@289..290 ")" [] []
+                1: (empty)
+              1: SEMICOLON@290..292 ";" [] [Whitespace(" ")]
+            2: CSS_DECLARATION_WITH_SEMICOLON@292..312
+              0: CSS_DECLARATION@292..310
+                0: CSS_GENERIC_PROPERTY@292..310
+                  0: CSS_IDENTIFIER@292..304
+                    0: IDENT@292..304 "font-display" [] []
+                  1: COLON@304..306 ":" [] [Whitespace(" ")]
+                  2: SCSS_EXPRESSION@306..310
+                    0: SCSS_EXPRESSION_ITEM_LIST@306..310
+                      0: CSS_IDENTIFIER@306..310
+                        0: IDENT@306..310 "swap" [] []
+                1: (empty)
+              1: SEMICOLON@310..312 ";" [] [Whitespace(" ")]
+          2: R_CURLY@312..313 "}" [] []
+    5: CSS_QUALIFIED_RULE@313..737
+      0: CSS_SELECTOR_LIST@313..324
+        0: CSS_COMPOUND_SELECTOR@313..324
+          0: CSS_NESTED_SELECTOR_LIST@313..313
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@313..324
+            0: CSS_CLASS_SELECTOR@313..324
+              0: DOT@313..315 "." [Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@315..324
+                0: IDENT@315..324 "controls" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@324..737
+        0: L_CURLY@324..325 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@325..735
+          0: CSS_DECLARATION_WITH_SEMICOLON@325..353
+            0: CSS_DECLARATION@325..352
+              0: CSS_GENERIC_PROPERTY@325..352
+                0: CSS_IDENTIFIER@325..336
+                  0: IDENT@325..336 "ordinary" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@336..338 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@338..352
+                  0: SCSS_EXPRESSION_ITEM_LIST@338..352
+                    0: CSS_URL_FUNCTION@338..352
+                      0: URL_KW@338..341 "url" [] []
+                      1: L_PAREN@341..342 "(" [] []
+                      2: CSS_URL_VALUE_RAW@342..351
+                        0: CSS_URL_VALUE_RAW_LITERAL@342..351 "image.png" [] []
+                      3: CSS_URL_MODIFIER_LIST@351..351
+                      4: R_PAREN@351..352 ")" [] []
+              1: (empty)
+            1: SEMICOLON@352..353 ";" [] []
+          1: CSS_DECLARATION_WITH_SEMICOLON@353..478
+            0: CSS_DECLARATION@353..477
+              0: CSS_GENERIC_PROPERTY@353..477
+                0: CSS_IDENTIFIER@353..362
+                  0: IDENT@353..362 "quoted" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@362..364 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@364..477
+                  0: SCSS_EXPRESSION_ITEM_LIST@364..477
+                    0: CSS_URL_FUNCTION@364..402
+                      0: URL_KW@364..367 "url" [] []
+                      1: L_PAREN@367..368 "(" [] []
+                      2: CSS_STRING@368..400
+                        0: CSS_STRING_LITERAL@368..400 "\"@/assets/svg/for-css/check.svg\"" [] []
+                      3: CSS_URL_MODIFIER_LIST@400..400
+                      4: R_PAREN@400..402 ")" [] [Whitespace(" ")]
+                    1: CSS_URL_FUNCTION@402..455
+                      0: URL_KW@402..405 "url" [] []
+                      1: L_PAREN@405..406 "(" [] []
+                      2: CSS_STRING@406..453
+                        0: CSS_STRING_LITERAL@406..453 "\"@site/static/img/showcase/gh-footer-light.svg\"" [] []
+                      3: CSS_URL_MODIFIER_LIST@453..453
+                      4: R_PAREN@453..455 ")" [] [Whitespace(" ")]
+                    2: CSS_URL_FUNCTION@455..477
+                      0: URL_KW@455..458 "url" [] []
+                      1: L_PAREN@458..459 "(" [] []
+                      2: CSS_STRING@459..476
+                        0: CSS_STRING_LITERAL@459..476 "\"!PaulMaul.woff2\"" [] []
+                      3: CSS_URL_MODIFIER_LIST@476..476
+                      4: R_PAREN@476..477 ")" [] []
+              1: (empty)
+            1: SEMICOLON@477..478 ";" [] []
+          2: CSS_DECLARATION_WITH_SEMICOLON@478..520
+            0: CSS_DECLARATION@478..519
+              0: CSS_GENERIC_PROPERTY@478..519
+                0: CSS_IDENTIFIER@478..489
+                  0: IDENT@478..489 "relative" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@489..491 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@491..519
+                  0: SCSS_EXPRESSION_ITEM_LIST@491..519
+                    0: CSS_URL_FUNCTION@491..519
+                      0: URL_KW@491..494 "url" [] []
+                      1: L_PAREN@494..495 "(" [] []
+                      2: CSS_URL_VALUE_RAW@495..518
+                        0: CSS_URL_VALUE_RAW_LITERAL@495..518 "//cdn.example/image.svg" [] []
+                      3: CSS_URL_MODIFIER_LIST@518..518
+                      4: R_PAREN@518..519 ")" [] []
+              1: (empty)
+            1: SEMICOLON@519..520 ";" [] []
+          3: CSS_DECLARATION_WITH_SEMICOLON@520..565
+            0: CSS_DECLARATION@520..564
+              0: CSS_GENERIC_PROPERTY@520..564
+                0: CSS_IDENTIFIER@520..527
+                  0: IDENT@520..527 "data" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@527..529 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@529..564
+                  0: SCSS_EXPRESSION_ITEM_LIST@529..564
+                    0: CSS_URL_FUNCTION@529..564
+                      0: URL_KW@529..532 "url" [] []
+                      1: L_PAREN@532..533 "(" [] []
+                      2: CSS_URL_VALUE_RAW@533..563
+                        0: CSS_URL_VALUE_RAW_LITERAL@533..563 "data:image/svg+xml;base64,AAAA" [] []
+                      3: CSS_URL_MODIFIER_LIST@563..563
+                      4: R_PAREN@563..564 ")" [] []
+              1: (empty)
+            1: SEMICOLON@564..565 ";" [] []
+          4: CSS_DECLARATION_WITH_SEMICOLON@565..589
+            0: CSS_DECLARATION@565..588
+              0: CSS_GENERIC_PROPERTY@565..588
+                0: CSS_IDENTIFIER@565..576
+                  0: IDENT@565..576 "fragment" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@576..578 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@578..588
+                  0: SCSS_EXPRESSION_ITEM_LIST@578..588
+                    0: CSS_URL_FUNCTION@578..588
+                      0: URL_KW@578..581 "url" [] []
+                      1: L_PAREN@581..582 "(" [] []
+                      2: CSS_URL_VALUE_RAW@582..587
+                        0: CSS_URL_VALUE_RAW_LITERAL@582..587 "#icon" [] []
+                      3: CSS_URL_MODIFIER_LIST@587..587
+                      4: R_PAREN@587..588 ")" [] []
+              1: (empty)
+            1: SEMICOLON@588..589 ";" [] []
+          5: CSS_DECLARATION_WITH_SEMICOLON@589..670
+            0: CSS_DECLARATION@589..669
+              0: CSS_GENERIC_PROPERTY@589..669
+                0: CSS_IDENTIFIER@589..599
+                  0: IDENT@589..599 "escaped" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@599..601 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@601..669
+                  0: SCSS_EXPRESSION_ITEM_LIST@601..669
+                    0: CSS_URL_FUNCTION@601..624
+                      0: URL_KW@601..604 "url" [] []
+                      1: L_PAREN@604..605 "(" [] []
+                      2: CSS_URL_VALUE_RAW@605..622
+                        0: CSS_URL_VALUE_RAW_LITERAL@605..622 "@/assets/a\\)b.svg" [] []
+                      3: CSS_URL_MODIFIER_LIST@622..622
+                      4: R_PAREN@622..624 ")" [] [Whitespace(" ")]
+                    1: CSS_URL_FUNCTION@624..649
+                      0: URL_KW@624..627 "url" [] []
+                      1: L_PAREN@627..628 "(" [] []
+                      2: CSS_URL_VALUE_RAW@628..647
+                        0: CSS_URL_VALUE_RAW_LITERAL@628..647 "!font\\20 name.woff2" [] []
+                      3: CSS_URL_MODIFIER_LIST@647..647
+                      4: R_PAREN@647..649 ")" [] [Whitespace(" ")]
+                    2: CSS_URL_FUNCTION@649..669
+                      0: URL_KW@649..652 "url" [] []
+                      1: L_PAREN@652..653 "(" [] []
+                      2: CSS_URL_VALUE_RAW@653..668
+                        0: CSS_URL_VALUE_RAW_LITERAL@653..668 "@/icons/\\é.svg" [] []
+                      3: CSS_URL_MODIFIER_LIST@668..668
+                      4: R_PAREN@668..669 ")" [] []
+              1: (empty)
+            1: SEMICOLON@669..670 ";" [] []
+          6: CSS_DECLARATION_WITH_SEMICOLON@670..721
+            0: CSS_DECLARATION@670..720
+              0: CSS_GENERIC_PROPERTY@670..720
+                0: CSS_IDENTIFIER@670..678
+                  0: IDENT@670..678 "other" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@678..680 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@680..720
+                  0: SCSS_EXPRESSION_ITEM_LIST@680..720
+                    0: CSS_URL_FUNCTION@680..703
+                      0: URL_KW@680..683 "url" [] []
+                      1: L_PAREN@683..684 "(" [] []
+                      2: CSS_URL_VALUE_RAW@684..701
+                        0: CSS_URL_VALUE_RAW_LITERAL@684..701 "@custom/other.svg" [] []
+                      3: CSS_URL_MODIFIER_LIST@701..701
+                      4: R_PAREN@701..703 ")" [] [Whitespace(" ")]
+                    1: CSS_URL_FUNCTION@703..720
+                      0: URL_KW@703..706 "url" [] []
+                      1: L_PAREN@706..707 "(" [] []
+                      2: CSS_URL_VALUE_RAW@707..719
+                        0: CSS_URL_VALUE_RAW_LITERAL@707..719 "!Other.woff2" [] []
+                      3: CSS_URL_MODIFIER_LIST@719..719
+                      4: R_PAREN@719..720 ")" [] []
+              1: (empty)
+            1: SEMICOLON@720..721 ";" [] []
+          7: CSS_DECLARATION_WITH_SEMICOLON@721..735
+            0: CSS_DECLARATION@721..734
+              0: CSS_GENERIC_PROPERTY@721..734
+                0: CSS_IDENTIFIER@721..729
+                  0: IDENT@721..729 "width" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@729..731 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@731..734
+                  0: SCSS_EXPRESSION_ITEM_LIST@731..734
+                    0: CSS_REGULAR_DIMENSION@731..734
+                      0: CSS_NUMBER_LITERAL@731..732 "1" [] []
+                      1: IDENT@732..734 "px" [] []
+              1: (empty)
+            1: SEMICOLON@734..735 ";" [] []
+        2: R_CURLY@735..737 "}" [Newline("\n")] []
+    6: CSS_QUALIFIED_RULE@737..862
+      0: CSS_SELECTOR_LIST@737..747
+        0: CSS_COMPOUND_SELECTOR@737..747
+          0: CSS_NESTED_SELECTOR_LIST@737..737
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@737..747
+            0: CSS_CLASS_SELECTOR@737..747
+              0: DOT@737..739 "." [Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@739..747
+                0: IDENT@739..747 "dynamic" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@747..862
+        0: L_CURLY@747..748 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@748..860
+          0: CSS_DECLARATION_WITH_SEMICOLON@748..813
+            0: CSS_DECLARATION@748..812
+              0: CSS_GENERIC_PROPERTY@748..812
+                0: CSS_IDENTIFIER@748..763
+                  0: IDENT@748..763 "interpolated" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@763..765 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@765..812
+                  0: SCSS_EXPRESSION_ITEM_LIST@765..812
+                    0: CSS_URL_FUNCTION@765..792
+                      0: URL_KW@765..768 "url" [] []
+                      1: L_PAREN@768..769 "(" [] []
+                      2: SCSS_INTERPOLATED_URL_VALUE@769..790
+                        0: SCSS_INTERPOLATED_URL_VALUE_PART_LIST@769..790
+                          0: SCSS_URL_TEXT@769..778
+                            0: SCSS_URL_CONTENT_LITERAL@769..778 "@/assets/" [] []
+                          1: SCSS_INTERPOLATION@778..786
+                            0: HASH@778..779 "#" [] []
+                            1: L_CURLY@779..780 "{" [] []
+                            2: SCSS_EXPRESSION@780..785
+                              0: SCSS_EXPRESSION_ITEM_LIST@780..785
+                                0: SCSS_VARIABLE@780..785
+                                  0: DOLLAR@780..781 "$" [] []
+                                  1: CSS_IDENTIFIER@781..785
+                                    0: IDENT@781..785 "name" [] []
+                            3: R_CURLY@785..786 "}" [] []
+                          2: SCSS_URL_TEXT@786..790
+                            0: SCSS_URL_CONTENT_LITERAL@786..790 ".svg" [] []
+                      3: CSS_URL_MODIFIER_LIST@790..790
+                      4: R_PAREN@790..792 ")" [] [Whitespace(" ")]
+                    1: CSS_URL_FUNCTION@792..812
+                      0: URL_KW@792..795 "url" [] []
+                      1: L_PAREN@795..796 "(" [] []
+                      2: SCSS_INTERPOLATED_URL_VALUE@796..811
+                        0: SCSS_INTERPOLATED_URL_VALUE_PART_LIST@796..811
+                          0: SCSS_URL_TEXT@796..797
+                            0: SCSS_URL_CONTENT_LITERAL@796..797 "!" [] []
+                          1: SCSS_INTERPOLATION@797..805
+                            0: HASH@797..798 "#" [] []
+                            1: L_CURLY@798..799 "{" [] []
+                            2: SCSS_EXPRESSION@799..804
+                              0: SCSS_EXPRESSION_ITEM_LIST@799..804
+                                0: SCSS_VARIABLE@799..804
+                                  0: DOLLAR@799..800 "$" [] []
+                                  1: CSS_IDENTIFIER@800..804
+                                    0: IDENT@800..804 "name" [] []
+                            3: R_CURLY@804..805 "}" [] []
+                          2: SCSS_URL_TEXT@805..811
+                            0: SCSS_URL_CONTENT_LITERAL@805..811 ".woff2" [] []
+                      3: CSS_URL_MODIFIER_LIST@811..811
+                      4: R_PAREN@811..812 ")" [] []
+              1: (empty)
+            1: SEMICOLON@812..813 ";" [] []
+          1: CSS_DECLARATION_WITH_SEMICOLON@813..846
+            0: CSS_DECLARATION@813..845
+              0: CSS_GENERIC_PROPERTY@813..845
+                0: CSS_IDENTIFIER@813..824
+                  0: IDENT@813..824 "computed" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@824..826 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@826..845
+                  0: SCSS_EXPRESSION_ITEM_LIST@826..845
+                    0: CSS_URL_FUNCTION@826..845
+                      0: URL_KW@826..829 "url" [] []
+                      1: L_PAREN@829..830 "(" [] []
+                      2: SCSS_EXPRESSION@830..844
+                        0: SCSS_EXPRESSION_ITEM_LIST@830..844
+                          0: SCSS_BINARY_EXPRESSION@830..844
+                            0: SCSS_VARIABLE@830..836
+                              0: DOLLAR@830..831 "$" [] []
+                              1: CSS_IDENTIFIER@831..836
+                                0: IDENT@831..836 "path" [] [Whitespace(" ")]
+                            1: PLUS@836..838 "+" [] [Whitespace(" ")]
+                            2: CSS_STRING@838..844
+                              0: CSS_STRING_LITERAL@838..844 "\".svg\"" [] []
+                      3: CSS_URL_MODIFIER_LIST@844..844
+                      4: R_PAREN@844..845 ")" [] []
+              1: (empty)
+            1: SEMICOLON@845..846 ";" [] []
+          2: CSS_DECLARATION_WITH_SEMICOLON@846..860
+            0: CSS_DECLARATION@846..859
+              0: CSS_GENERIC_PROPERTY@846..859
+                0: CSS_IDENTIFIER@846..854
+                  0: IDENT@846..854 "width" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@854..856 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@856..859
+                  0: SCSS_EXPRESSION_ITEM_LIST@856..859
+                    0: CSS_REGULAR_DIMENSION@856..859
+                      0: CSS_NUMBER_LITERAL@856..857 "1" [] []
+                      1: IDENT@857..859 "px" [] []
+              1: (empty)
+            1: SEMICOLON@859..860 ";" [] []
+        2: R_CURLY@860..862 "}" [Newline("\n")] []
+    7: CSS_QUALIFIED_RULE@862..933
+      0: CSS_SELECTOR_LIST@862..874
+        0: CSS_COMPOUND_SELECTOR@862..874
+          0: CSS_NESTED_SELECTOR_LIST@862..862
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@862..874
+            0: CSS_CLASS_SELECTOR@862..874
+              0: DOT@862..864 "." [Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@864..874
+                0: IDENT@864..874 "modifiers" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@874..933
+        0: L_CURLY@874..876 "{" [] [Whitespace(" ")]
+        1: CSS_DECLARATION_OR_RULE_LIST@876..932
+          0: CSS_DECLARATION_WITH_SEMICOLON@876..920
+            0: CSS_DECLARATION@876..918
+              0: CSS_GENERIC_PROPERTY@876..918
+                0: CSS_IDENTIFIER@876..886
+                  0: IDENT@876..886 "background" [] []
+                1: COLON@886..888 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@888..918
+                  0: SCSS_EXPRESSION_ITEM_LIST@888..918
+                    0: CSS_URL_FUNCTION@888..918
+                      0: URL_KW@888..891 "url" [] []
+                      1: L_PAREN@891..892 "(" [] []
+                      2: CSS_STRING@892..904
+                        0: CSS_STRING_LITERAL@892..904 "\"image.png\"" [] [Whitespace(" ")]
+                      3: CSS_URL_MODIFIER_LIST@904..917
+                        0: CSS_FUNCTION@904..917
+                          0: CSS_IDENTIFIER@904..910
+                            0: IDENT@904..910 "format" [] []
+                          1: L_PAREN@910..911 "(" [] []
+                          2: CSS_PARAMETER_LIST@911..916
+                            0: SCSS_EXPRESSION@911..916
+                              0: SCSS_EXPRESSION_ITEM_LIST@911..916
+                                0: CSS_STRING@911..916
+                                  0: CSS_STRING_LITERAL@911..916 "\"png\"" [] []
+                          3: R_PAREN@916..917 ")" [] []
+                      4: R_PAREN@917..918 ")" [] []
+              1: (empty)
+            1: SEMICOLON@918..920 ";" [] [Whitespace(" ")]
+          1: CSS_DECLARATION_WITH_SEMICOLON@920..932
+            0: CSS_DECLARATION@920..930
+              0: CSS_GENERIC_PROPERTY@920..930
+                0: CSS_IDENTIFIER@920..925
+                  0: IDENT@920..925 "width" [] []
+                1: COLON@925..927 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@927..930
+                  0: SCSS_EXPRESSION_ITEM_LIST@927..930
+                    0: CSS_REGULAR_DIMENSION@927..930
+                      0: CSS_NUMBER_LITERAL@927..928 "1" [] []
+                      1: IDENT@928..930 "px" [] []
+              1: (empty)
+            1: SEMICOLON@930..932 ";" [] [Whitespace(" ")]
+        2: R_CURLY@932..933 "}" [] []
+    8: CSS_QUALIFIED_RULE@933..1035
+      0: CSS_SELECTOR_LIST@933..945
+        0: CSS_COMPOUND_SELECTOR@933..945
+          0: CSS_NESTED_SELECTOR_LIST@933..933
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@933..945
+            0: CSS_CLASS_SELECTOR@933..945
+              0: DOT@933..935 "." [Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@935..945
+                0: IDENT@935..945 "functions" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@945..1035
+        0: L_CURLY@945..947 "{" [] [Whitespace(" ")]
+        1: CSS_DECLARATION_OR_RULE_LIST@947..1034
+          0: CSS_DECLARATION_WITH_SEMICOLON@947..976
+            0: CSS_DECLARATION@947..974
+              0: CSS_GENERIC_PROPERTY@947..974
+                0: CSS_IDENTIFIER@947..952
+                  0: IDENT@947..952 "plain" [] []
+                1: COLON@952..954 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@954..974
+                  0: SCSS_EXPRESSION_ITEM_LIST@954..974
+                    0: CSS_URL_FUNCTION@954..974
+                      0: URL_KW@954..957 "url" [] []
+                      1: L_PAREN@957..958 "(" [] []
+                      2: (empty)
+                      3: CSS_URL_MODIFIER_LIST@958..973
+                        0: CSS_FUNCTION@958..973
+                          0: CSS_IDENTIFIER@958..960
+                            0: IDENT@958..960 "fn" [] []
+                          1: L_PAREN@960..961 "(" [] []
+                          2: CSS_PARAMETER_LIST@961..972
+                            0: SCSS_EXPRESSION@961..972
+                              0: SCSS_EXPRESSION_ITEM_LIST@961..972
+                                0: CSS_STRING@961..972
+                                  0: CSS_STRING_LITERAL@961..972 "\"image.svg\"" [] []
+                          3: R_PAREN@972..973 ")" [] []
+                      4: R_PAREN@973..974 ")" [] []
+              1: (empty)
+            1: SEMICOLON@974..976 ";" [] [Whitespace(" ")]
+          1: CSS_DECLARATION_WITH_SEMICOLON@976..1022
+            0: CSS_DECLARATION@976..1020
+              0: CSS_GENERIC_PROPERTY@976..1020
+                0: CSS_IDENTIFIER@976..988
+                  0: IDENT@976..988 "interpolated" [] []
+                1: COLON@988..990 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@990..1020
+                  0: SCSS_EXPRESSION_ITEM_LIST@990..1020
+                    0: CSS_URL_FUNCTION@990..1020
+                      0: URL_KW@990..993 "url" [] []
+                      1: L_PAREN@993..994 "(" [] []
+                      2: (empty)
+                      3: CSS_URL_MODIFIER_LIST@994..1019
+                        0: CSS_FUNCTION@994..1019
+                          0: SCSS_INTERPOLATED_IDENTIFIER@994..1006
+                            0: SCSS_INTERPOLATED_IDENTIFIER_PART_LIST@994..1006
+                              0: CSS_IDENTIFIER@994..997
+                                0: IDENT@994..997 "foo" [] []
+                              1: SCSS_INTERPOLATION@997..1006
+                                0: HASH@997..998 "#" [] []
+                                1: L_CURLY@998..999 "{" [] []
+                                2: SCSS_EXPRESSION@999..1005
+                                  0: SCSS_EXPRESSION_ITEM_LIST@999..1005
+                                    0: CSS_STRING@999..1005
+                                      0: CSS_STRING_LITERAL@999..1005 "\"-bar\"" [] []
+                                3: R_CURLY@1005..1006 "}" [] []
+                          1: L_PAREN@1006..1007 "(" [] []
+                          2: CSS_PARAMETER_LIST@1007..1018
+                            0: SCSS_EXPRESSION@1007..1018
+                              0: SCSS_EXPRESSION_ITEM_LIST@1007..1018
+                                0: CSS_STRING@1007..1018
+                                  0: CSS_STRING_LITERAL@1007..1018 "\"image.svg\"" [] []
+                          3: R_PAREN@1018..1019 ")" [] []
+                      4: R_PAREN@1019..1020 ")" [] []
+              1: (empty)
+            1: SEMICOLON@1020..1022 ";" [] [Whitespace(" ")]
+          2: CSS_DECLARATION_WITH_SEMICOLON@1022..1034
+            0: CSS_DECLARATION@1022..1032
+              0: CSS_GENERIC_PROPERTY@1022..1032
+                0: CSS_IDENTIFIER@1022..1027
+                  0: IDENT@1022..1027 "width" [] []
+                1: COLON@1027..1029 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@1029..1032
+                  0: SCSS_EXPRESSION_ITEM_LIST@1029..1032
+                    0: CSS_REGULAR_DIMENSION@1029..1032
+                      0: CSS_NUMBER_LITERAL@1029..1030 "1" [] []
+                      1: IDENT@1030..1032 "px" [] []
+              1: (empty)
+            1: SEMICOLON@1032..1034 ";" [] [Whitespace(" ")]
+        2: R_CURLY@1034..1035 "}" [] []
+    9: CSS_QUALIFIED_RULE@1035..1159
+      0: CSS_SELECTOR_LIST@1035..1050
+        0: CSS_COMPOUND_SELECTOR@1035..1050
+          0: CSS_NESTED_SELECTOR_LIST@1035..1035
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@1035..1050
+            0: CSS_CLASS_SELECTOR@1035..1050
+              0: DOT@1035..1037 "." [Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@1037..1050
+                0: IDENT@1037..1050 "escaped-tail" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@1050..1159
+        0: L_CURLY@1050..1052 "{" [] [Whitespace(" ")]
+        1: CSS_DECLARATION_OR_RULE_LIST@1052..1158
+          0: CSS_DECLARATION_WITH_SEMICOLON@1052..1070
+            0: CSS_DECLARATION@1052..1068
+              0: CSS_GENERIC_PROPERTY@1052..1068
+                0: CSS_IDENTIFIER@1052..1057
+                  0: IDENT@1052..1057 "first" [] []
+                1: COLON@1057..1059 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@1059..1068
+                  0: SCSS_EXPRESSION_ITEM_LIST@1059..1068
+                    0: CSS_URL_FUNCTION@1059..1068
+                      0: URL_KW@1059..1062 "url" [] []
+                      1: L_PAREN@1062..1063 "(" [] []
+                      2: CSS_URL_VALUE_RAW@1063..1067
+                        0: CSS_URL_VALUE_RAW_LITERAL@1063..1067 "@a\\ " [] []
+                      3: CSS_URL_MODIFIER_LIST@1067..1067
+                      4: R_PAREN@1067..1068 ")" [] []
+              1: (empty)
+            1: SEMICOLON@1068..1070 ";" [] [Whitespace(" ")]
+          1: CSS_DECLARATION_WITH_SEMICOLON@1070..1089
+            0: CSS_DECLARATION@1070..1087
+              0: CSS_GENERIC_PROPERTY@1070..1087
+                0: CSS_IDENTIFIER@1070..1076
+                  0: IDENT@1070..1076 "second" [] []
+                1: COLON@1076..1078 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@1078..1087
+                  0: SCSS_EXPRESSION_ITEM_LIST@1078..1087
+                    0: CSS_URL_FUNCTION@1078..1087
+                      0: URL_KW@1078..1081 "url" [] []
+                      1: L_PAREN@1081..1082 "(" [] []
+                      2: CSS_URL_VALUE_RAW@1082..1086
+                        0: CSS_URL_VALUE_RAW_LITERAL@1082..1086 "!a\\ " [] []
+                      3: CSS_URL_MODIFIER_LIST@1086..1086
+                      4: R_PAREN@1086..1087 ")" [] []
+              1: (empty)
+            1: SEMICOLON@1087..1089 ";" [] [Whitespace(" ")]
+          2: CSS_DECLARATION_WITH_SEMICOLON@1089..1108
+            0: CSS_DECLARATION@1089..1106
+              0: CSS_GENERIC_PROPERTY@1089..1106
+                0: CSS_IDENTIFIER@1089..1093
+                  0: IDENT@1089..1093 "even" [] []
+                1: COLON@1093..1095 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@1095..1106
+                  0: SCSS_EXPRESSION_ITEM_LIST@1095..1106
+                    0: CSS_URL_FUNCTION@1095..1106
+                      0: URL_KW@1095..1098 "url" [] []
+                      1: L_PAREN@1098..1099 "(" [] []
+                      2: CSS_URL_VALUE_RAW@1099..1105
+                        0: CSS_URL_VALUE_RAW_LITERAL@1099..1105 "@a\\\\  " [] []
+                      3: CSS_URL_MODIFIER_LIST@1105..1105
+                      4: R_PAREN@1105..1106 ")" [] []
+              1: (empty)
+            1: SEMICOLON@1106..1108 ";" [] [Whitespace(" ")]
+          3: CSS_DECLARATION_WITH_SEMICOLON@1108..1127
+            0: CSS_DECLARATION@1108..1125
+              0: CSS_GENERIC_PROPERTY@1108..1125
+                0: CSS_IDENTIFIER@1108..1111
+                  0: IDENT@1108..1111 "odd" [] []
+                1: COLON@1111..1113 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@1113..1125
+                  0: SCSS_EXPRESSION_ITEM_LIST@1113..1125
+                    0: CSS_URL_FUNCTION@1113..1125
+                      0: URL_KW@1113..1116 "url" [] []
+                      1: L_PAREN@1116..1117 "(" [] []
+                      2: CSS_URL_VALUE_RAW@1117..1124
+                        0: CSS_URL_VALUE_RAW_LITERAL@1117..1124 "!a\\\\\\  " [] []
+                      3: CSS_URL_MODIFIER_LIST@1124..1124
+                      4: R_PAREN@1124..1125 ")" [] []
+              1: (empty)
+            1: SEMICOLON@1125..1127 ";" [] [Whitespace(" ")]
+          4: CSS_DECLARATION_WITH_SEMICOLON@1127..1146
+            0: CSS_DECLARATION@1127..1144
+              0: CSS_GENERIC_PROPERTY@1127..1144
+                0: CSS_IDENTIFIER@1127..1130
+                  0: IDENT@1127..1130 "hex" [] []
+                1: COLON@1130..1132 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@1132..1144
+                  0: SCSS_EXPRESSION_ITEM_LIST@1132..1144
+                    0: CSS_URL_FUNCTION@1132..1144
+                      0: URL_KW@1132..1135 "url" [] []
+                      1: L_PAREN@1135..1136 "(" [] []
+                      2: CSS_URL_VALUE_RAW@1136..1143
+                        0: CSS_URL_VALUE_RAW_LITERAL@1136..1143 "@a\\20  " [] []
+                      3: CSS_URL_MODIFIER_LIST@1143..1143
+                      4: R_PAREN@1143..1144 ")" [] []
+              1: (empty)
+            1: SEMICOLON@1144..1146 ";" [] [Whitespace(" ")]
+          5: CSS_DECLARATION_WITH_SEMICOLON@1146..1158
+            0: CSS_DECLARATION@1146..1156
+              0: CSS_GENERIC_PROPERTY@1146..1156
+                0: CSS_IDENTIFIER@1146..1151
+                  0: IDENT@1146..1151 "width" [] []
+                1: COLON@1151..1153 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@1153..1156
+                  0: SCSS_EXPRESSION_ITEM_LIST@1153..1156
+                    0: CSS_REGULAR_DIMENSION@1153..1156
+                      0: CSS_NUMBER_LITERAL@1153..1154 "1" [] []
+                      1: IDENT@1154..1156 "px" [] []
+              1: (empty)
+            1: SEMICOLON@1156..1158 ";" [] [Whitespace(" ")]
+        2: R_CURLY@1158..1159 "}" [] []
+    10: CSS_QUALIFIED_RULE@1159..1227
+      0: CSS_SELECTOR_LIST@1159..1174
+        0: CSS_COMPOUND_SELECTOR@1159..1174
+          0: CSS_NESTED_SELECTOR_LIST@1159..1159
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@1159..1174
+            0: CSS_CLASS_SELECTOR@1159..1174
+              0: DOT@1159..1161 "." [Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@1161..1174
+                0: IDENT@1161..1174 "unicode-tail" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@1174..1227
+        0: L_CURLY@1174..1176 "{" [] [Whitespace(" ")]
+        1: CSS_DECLARATION_OR_RULE_LIST@1176..1226
+          0: CSS_DECLARATION_WITH_SEMICOLON@1176..1194
+            0: CSS_DECLARATION@1176..1192
+              0: CSS_GENERIC_PROPERTY@1176..1192
+                0: CSS_IDENTIFIER@1176..1181
+                  0: IDENT@1176..1181 "first" [] []
+                1: COLON@1181..1183 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@1183..1192
+                  0: SCSS_EXPRESSION_ITEM_LIST@1183..1192
+                    0: CSS_URL_FUNCTION@1183..1192
+                      0: URL_KW@1183..1186 "url" [] []
+                      1: L_PAREN@1186..1187 "(" [] []
+                      2: CSS_URL_VALUE_RAW@1187..1191
+                        0: CSS_URL_VALUE_RAW_LITERAL@1187..1191 "@a\u{a0}" [] []
+                      3: CSS_URL_MODIFIER_LIST@1191..1191
+                      4: R_PAREN@1191..1192 ")" [] []
+              1: (empty)
+            1: SEMICOLON@1192..1194 ";" [] [Whitespace(" ")]
+          1: CSS_DECLARATION_WITH_SEMICOLON@1194..1214
+            0: CSS_DECLARATION@1194..1212
+              0: CSS_GENERIC_PROPERTY@1194..1212
+                0: CSS_IDENTIFIER@1194..1200
+                  0: IDENT@1194..1200 "second" [] []
+                1: COLON@1200..1202 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@1202..1212
+                  0: SCSS_EXPRESSION_ITEM_LIST@1202..1212
+                    0: CSS_URL_FUNCTION@1202..1212
+                      0: URL_KW@1202..1205 "url" [] []
+                      1: L_PAREN@1205..1206 "(" [] []
+                      2: CSS_URL_VALUE_RAW@1206..1211
+                        0: CSS_URL_VALUE_RAW_LITERAL@1206..1211 "!a\u{2003}" [] []
+                      3: CSS_URL_MODIFIER_LIST@1211..1211
+                      4: R_PAREN@1211..1212 ")" [] []
+              1: (empty)
+            1: SEMICOLON@1212..1214 ";" [] [Whitespace(" ")]
+          2: CSS_DECLARATION_WITH_SEMICOLON@1214..1226
+            0: CSS_DECLARATION@1214..1224
+              0: CSS_GENERIC_PROPERTY@1214..1224
+                0: CSS_IDENTIFIER@1214..1219
+                  0: IDENT@1214..1219 "width" [] []
+                1: COLON@1219..1221 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@1221..1224
+                  0: SCSS_EXPRESSION_ITEM_LIST@1221..1224
+                    0: CSS_REGULAR_DIMENSION@1221..1224
+                      0: CSS_NUMBER_LITERAL@1221..1222 "1" [] []
+                      1: IDENT@1222..1224 "px" [] []
+              1: (empty)
+            1: SEMICOLON@1224..1226 ";" [] [Whitespace(" ")]
+        2: R_CURLY@1226..1227 "}" [] []
+    11: CSS_QUALIFIED_RULE@1227..1279
+      0: CSS_SELECTOR_LIST@1227..1241
+        0: CSS_COMPOUND_SELECTOR@1227..1241
+          0: CSS_NESTED_SELECTOR_LIST@1227..1227
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@1227..1241
+            0: CSS_CLASS_SELECTOR@1227..1241
+              0: DOT@1227..1229 "." [Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@1229..1241
+                0: IDENT@1229..1241 "escaped-tab" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@1241..1279
+        0: L_CURLY@1241..1243 "{" [] [Whitespace(" ")]
+        1: CSS_DECLARATION_OR_RULE_LIST@1243..1278
+          0: CSS_DECLARATION_WITH_SEMICOLON@1243..1266
+            0: CSS_DECLARATION@1243..1264
+              0: CSS_GENERIC_PROPERTY@1243..1264
+                0: CSS_IDENTIFIER@1243..1253
+                  0: IDENT@1243..1253 "background" [] []
+                1: COLON@1253..1255 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@1255..1264
+                  0: SCSS_EXPRESSION_ITEM_LIST@1255..1264
+                    0: CSS_URL_FUNCTION@1255..1264
+                      0: URL_KW@1255..1258 "url" [] []
+                      1: L_PAREN@1258..1259 "(" [] []
+                      2: CSS_URL_VALUE_RAW@1259..1263
+                        0: CSS_URL_VALUE_RAW_LITERAL@1259..1263 "@a\\\t" [] []
+                      3: CSS_URL_MODIFIER_LIST@1263..1263
+                      4: R_PAREN@1263..1264 ")" [] []
+              1: (empty)
+            1: SEMICOLON@1264..1266 ";" [] [Whitespace(" ")]
+          1: CSS_DECLARATION_WITH_SEMICOLON@1266..1278
+            0: CSS_DECLARATION@1266..1276
+              0: CSS_GENERIC_PROPERTY@1266..1276
+                0: CSS_IDENTIFIER@1266..1271
+                  0: IDENT@1266..1271 "color" [] []
+                1: COLON@1271..1273 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@1273..1276
+                  0: SCSS_EXPRESSION_ITEM_LIST@1273..1276
+                    0: CSS_IDENTIFIER@1273..1276
+                      0: IDENT@1273..1276 "red" [] []
+              1: (empty)
+            1: SEMICOLON@1276..1278 ";" [] [Whitespace(" ")]
+        2: R_CURLY@1278..1279 "}" [] []
+  2: EOF@1279..1280 "" [Newline("\n")] []
+
+```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/value/release-url-asset-aliases.css
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/value/release-url-asset-aliases.css
@@ -1,0 +1,17 @@
+.check { background-image: url(@/assets/svg/for-css/check.svg); width: 1px; }
+.footer { background-image: url(@site/static/img/showcase/gh-footer-light.svg); color: red; }
+@font-face { font-family: "!PaulMaul"; src: url(!PaulMaul.woff2) format("woff2"); font-display: swap; }
+.controls {
+  ordinary: url(image.png);
+  quoted: url("@/assets/svg/for-css/check.svg") url("@site/static/img/showcase/gh-footer-light.svg") url("!PaulMaul.woff2");
+  relative: url(//cdn.example/image.svg);
+  data: url(data:image/svg+xml;base64,AAAA);
+  fragment: url(#icon);
+  escaped: url(@/assets/a\)b.svg) url(!font\20 name.woff2) url(@/icons/\é.svg);
+  other: url(@custom/other.svg) url(!Other.woff2);
+  width: 1px;
+}
+.modifiers { background: url("image.png" format("png")); width: 1px; }
+.escaped-tail { first: url(@a\ ); second: url(!a\ ); even: url(@a\\  ); odd: url(!a\\\  ); hex: url(@a\20  ); width: 1px; }
+.unicode-tail { first: url(@a ); second: url(!a ); width: 1px; }
+.escaped-tab { background: url(@a\	); color: red; }

--- a/crates/biome_css_parser/tests/css_test_suite/ok/value/release-url-asset-aliases.css
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/value/release-url-asset-aliases.css
@@ -15,3 +15,4 @@
 .escaped-tail { first: url(@a\ ); second: url(!a\ ); even: url(@a\\  ); odd: url(!a\\\  ); hex: url(@a\20  ); width: 1px; }
 .unicode-tail { first: url(@a ); second: url(!a ); width: 1px; }
 .escaped-tab { background: url(@a\	); color: red; }
+.padding { first: url( 	@/other.svg 	); second: url( 	!Other.woff2  ); width: 1px; }

--- a/crates/biome_css_parser/tests/css_test_suite/ok/value/release-url-asset-aliases.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/value/release-url-asset-aliases.css.snap
@@ -1,0 +1,1460 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+.check { background-image: url(@/assets/svg/for-css/check.svg); width: 1px; }
+.footer { background-image: url(@site/static/img/showcase/gh-footer-light.svg); color: red; }
+@font-face { font-family: "!PaulMaul"; src: url(!PaulMaul.woff2) format("woff2"); font-display: swap; }
+.controls {
+  ordinary: url(image.png);
+  quoted: url("@/assets/svg/for-css/check.svg") url("@site/static/img/showcase/gh-footer-light.svg") url("!PaulMaul.woff2");
+  relative: url(//cdn.example/image.svg);
+  data: url(data:image/svg+xml;base64,AAAA);
+  fragment: url(#icon);
+  escaped: url(@/assets/a\)b.svg) url(!font\20 name.woff2) url(@/icons/\é.svg);
+  other: url(@custom/other.svg) url(!Other.woff2);
+  width: 1px;
+}
+.modifiers { background: url("image.png" format("png")); width: 1px; }
+.escaped-tail { first: url(@a\ ); second: url(!a\ ); even: url(@a\\  ); odd: url(!a\\\  ); hex: url(@a\20  ); width: 1px; }
+.unicode-tail { first: url(@a ); second: url(!a ); width: 1px; }
+.escaped-tab { background: url(@a\	); color: red; }
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@0..1 "." [] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@1..7 "check" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@7..9 "{" [] [Whitespace(" ")],
+                items: CssDeclarationOrRuleList [
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@9..25 "background-image" [] [],
+                                },
+                                colon_token: COLON@25..27 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssUrlFunction {
+                                        name: URL_KW@27..30 "url" [] [],
+                                        l_paren_token: L_PAREN@30..31 "(" [] [],
+                                        value: CssUrlValueRaw {
+                                            value_token: CSS_URL_VALUE_RAW_LITERAL@31..61 "@/assets/svg/for-css/check.svg" [] [],
+                                        },
+                                        modifiers: CssUrlModifierList [],
+                                        r_paren_token: R_PAREN@61..62 ")" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@62..64 ";" [] [Whitespace(" ")],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@64..69 "width" [] [],
+                                },
+                                colon_token: COLON@69..71 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssRegularDimension {
+                                        value_token: CSS_NUMBER_LITERAL@71..72 "1" [] [],
+                                        unit_token: IDENT@72..74 "px" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@74..76 ";" [] [Whitespace(" ")],
+                    },
+                ],
+                r_curly_token: R_CURLY@76..77 "}" [] [],
+            },
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@77..79 "." [Newline("\n")] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@79..86 "footer" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@86..88 "{" [] [Whitespace(" ")],
+                items: CssDeclarationOrRuleList [
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@88..104 "background-image" [] [],
+                                },
+                                colon_token: COLON@104..106 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssUrlFunction {
+                                        name: URL_KW@106..109 "url" [] [],
+                                        l_paren_token: L_PAREN@109..110 "(" [] [],
+                                        value: CssUrlValueRaw {
+                                            value_token: CSS_URL_VALUE_RAW_LITERAL@110..155 "@site/static/img/showcase/gh-footer-light.svg" [] [],
+                                        },
+                                        modifiers: CssUrlModifierList [],
+                                        r_paren_token: R_PAREN@155..156 ")" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@156..158 ";" [] [Whitespace(" ")],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@158..163 "color" [] [],
+                                },
+                                colon_token: COLON@163..165 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssIdentifier {
+                                        value_token: IDENT@165..168 "red" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@168..170 ";" [] [Whitespace(" ")],
+                    },
+                ],
+                r_curly_token: R_CURLY@170..171 "}" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@171..173 "@" [Newline("\n")] [],
+            rule: CssFontFaceAtRule {
+                declarator: CssFontFaceAtRuleDeclarator {
+                    font_face_token: FONT_FACE_KW@173..183 "font-face" [] [Whitespace(" ")],
+                },
+                block: CssDeclarationBlock {
+                    l_curly_token: L_CURLY@183..185 "{" [] [Whitespace(" ")],
+                    declarations: CssDeclarationList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@185..196 "font-family" [] [],
+                                    },
+                                    colon_token: COLON@196..198 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssString {
+                                            value_token: CSS_STRING_LITERAL@198..209 "\"!PaulMaul\"" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@209..211 ";" [] [Whitespace(" ")],
+                        },
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@211..214 "src" [] [],
+                                    },
+                                    colon_token: COLON@214..216 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssUrlFunction {
+                                            name: URL_KW@216..219 "url" [] [],
+                                            l_paren_token: L_PAREN@219..220 "(" [] [],
+                                            value: CssUrlValueRaw {
+                                                value_token: CSS_URL_VALUE_RAW_LITERAL@220..235 "!PaulMaul.woff2" [] [],
+                                            },
+                                            modifiers: CssUrlModifierList [],
+                                            r_paren_token: R_PAREN@235..237 ")" [] [Whitespace(" ")],
+                                        },
+                                        CssFunction {
+                                            name: CssIdentifier {
+                                                value_token: IDENT@237..243 "format" [] [],
+                                            },
+                                            l_paren_token: L_PAREN@243..244 "(" [] [],
+                                            items: CssParameterList [
+                                                CssListOfComponentValuesExpression {
+                                                    css_component_value_list: CssComponentValueList [
+                                                        CssString {
+                                                            value_token: CSS_STRING_LITERAL@244..251 "\"woff2\"" [] [],
+                                                        },
+                                                    ],
+                                                },
+                                            ],
+                                            r_paren_token: R_PAREN@251..252 ")" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@252..254 ";" [] [Whitespace(" ")],
+                        },
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@254..266 "font-display" [] [],
+                                    },
+                                    colon_token: COLON@266..268 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssIdentifier {
+                                            value_token: IDENT@268..272 "swap" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@272..274 ";" [] [Whitespace(" ")],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@274..275 "}" [] [],
+                },
+            },
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@275..277 "." [Newline("\n")] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@277..286 "controls" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@286..287 "{" [] [],
+                items: CssDeclarationOrRuleList [
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@287..298 "ordinary" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@298..300 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssUrlFunction {
+                                        name: URL_KW@300..303 "url" [] [],
+                                        l_paren_token: L_PAREN@303..304 "(" [] [],
+                                        value: CssUrlValueRaw {
+                                            value_token: CSS_URL_VALUE_RAW_LITERAL@304..313 "image.png" [] [],
+                                        },
+                                        modifiers: CssUrlModifierList [],
+                                        r_paren_token: R_PAREN@313..314 ")" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@314..315 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@315..324 "quoted" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@324..326 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssUrlFunction {
+                                        name: URL_KW@326..329 "url" [] [],
+                                        l_paren_token: L_PAREN@329..330 "(" [] [],
+                                        value: CssString {
+                                            value_token: CSS_STRING_LITERAL@330..362 "\"@/assets/svg/for-css/check.svg\"" [] [],
+                                        },
+                                        modifiers: CssUrlModifierList [],
+                                        r_paren_token: R_PAREN@362..364 ")" [] [Whitespace(" ")],
+                                    },
+                                    CssUrlFunction {
+                                        name: URL_KW@364..367 "url" [] [],
+                                        l_paren_token: L_PAREN@367..368 "(" [] [],
+                                        value: CssString {
+                                            value_token: CSS_STRING_LITERAL@368..415 "\"@site/static/img/showcase/gh-footer-light.svg\"" [] [],
+                                        },
+                                        modifiers: CssUrlModifierList [],
+                                        r_paren_token: R_PAREN@415..417 ")" [] [Whitespace(" ")],
+                                    },
+                                    CssUrlFunction {
+                                        name: URL_KW@417..420 "url" [] [],
+                                        l_paren_token: L_PAREN@420..421 "(" [] [],
+                                        value: CssString {
+                                            value_token: CSS_STRING_LITERAL@421..438 "\"!PaulMaul.woff2\"" [] [],
+                                        },
+                                        modifiers: CssUrlModifierList [],
+                                        r_paren_token: R_PAREN@438..439 ")" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@439..440 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@440..451 "relative" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@451..453 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssUrlFunction {
+                                        name: URL_KW@453..456 "url" [] [],
+                                        l_paren_token: L_PAREN@456..457 "(" [] [],
+                                        value: CssUrlValueRaw {
+                                            value_token: CSS_URL_VALUE_RAW_LITERAL@457..480 "//cdn.example/image.svg" [] [],
+                                        },
+                                        modifiers: CssUrlModifierList [],
+                                        r_paren_token: R_PAREN@480..481 ")" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@481..482 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@482..489 "data" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@489..491 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssUrlFunction {
+                                        name: URL_KW@491..494 "url" [] [],
+                                        l_paren_token: L_PAREN@494..495 "(" [] [],
+                                        value: CssUrlValueRaw {
+                                            value_token: CSS_URL_VALUE_RAW_LITERAL@495..525 "data:image/svg+xml;base64,AAAA" [] [],
+                                        },
+                                        modifiers: CssUrlModifierList [],
+                                        r_paren_token: R_PAREN@525..526 ")" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@526..527 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@527..538 "fragment" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@538..540 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssUrlFunction {
+                                        name: URL_KW@540..543 "url" [] [],
+                                        l_paren_token: L_PAREN@543..544 "(" [] [],
+                                        value: CssUrlValueRaw {
+                                            value_token: CSS_URL_VALUE_RAW_LITERAL@544..549 "#icon" [] [],
+                                        },
+                                        modifiers: CssUrlModifierList [],
+                                        r_paren_token: R_PAREN@549..550 ")" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@550..551 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@551..561 "escaped" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@561..563 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssUrlFunction {
+                                        name: URL_KW@563..566 "url" [] [],
+                                        l_paren_token: L_PAREN@566..567 "(" [] [],
+                                        value: CssUrlValueRaw {
+                                            value_token: CSS_URL_VALUE_RAW_LITERAL@567..584 "@/assets/a\\)b.svg" [] [],
+                                        },
+                                        modifiers: CssUrlModifierList [],
+                                        r_paren_token: R_PAREN@584..586 ")" [] [Whitespace(" ")],
+                                    },
+                                    CssUrlFunction {
+                                        name: URL_KW@586..589 "url" [] [],
+                                        l_paren_token: L_PAREN@589..590 "(" [] [],
+                                        value: CssUrlValueRaw {
+                                            value_token: CSS_URL_VALUE_RAW_LITERAL@590..609 "!font\\20 name.woff2" [] [],
+                                        },
+                                        modifiers: CssUrlModifierList [],
+                                        r_paren_token: R_PAREN@609..611 ")" [] [Whitespace(" ")],
+                                    },
+                                    CssUrlFunction {
+                                        name: URL_KW@611..614 "url" [] [],
+                                        l_paren_token: L_PAREN@614..615 "(" [] [],
+                                        value: CssUrlValueRaw {
+                                            value_token: CSS_URL_VALUE_RAW_LITERAL@615..630 "@/icons/\\é.svg" [] [],
+                                        },
+                                        modifiers: CssUrlModifierList [],
+                                        r_paren_token: R_PAREN@630..631 ")" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@631..632 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@632..640 "other" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@640..642 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssUrlFunction {
+                                        name: URL_KW@642..645 "url" [] [],
+                                        l_paren_token: L_PAREN@645..646 "(" [] [],
+                                        value: CssUrlValueRaw {
+                                            value_token: CSS_URL_VALUE_RAW_LITERAL@646..663 "@custom/other.svg" [] [],
+                                        },
+                                        modifiers: CssUrlModifierList [],
+                                        r_paren_token: R_PAREN@663..665 ")" [] [Whitespace(" ")],
+                                    },
+                                    CssUrlFunction {
+                                        name: URL_KW@665..668 "url" [] [],
+                                        l_paren_token: L_PAREN@668..669 "(" [] [],
+                                        value: CssUrlValueRaw {
+                                            value_token: CSS_URL_VALUE_RAW_LITERAL@669..681 "!Other.woff2" [] [],
+                                        },
+                                        modifiers: CssUrlModifierList [],
+                                        r_paren_token: R_PAREN@681..682 ")" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@682..683 ";" [] [],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@683..691 "width" [Newline("\n"), Whitespace("  ")] [],
+                                },
+                                colon_token: COLON@691..693 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssRegularDimension {
+                                        value_token: CSS_NUMBER_LITERAL@693..694 "1" [] [],
+                                        unit_token: IDENT@694..696 "px" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@696..697 ";" [] [],
+                    },
+                ],
+                r_curly_token: R_CURLY@697..699 "}" [Newline("\n")] [],
+            },
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@699..701 "." [Newline("\n")] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@701..711 "modifiers" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@711..713 "{" [] [Whitespace(" ")],
+                items: CssDeclarationOrRuleList [
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@713..723 "background" [] [],
+                                },
+                                colon_token: COLON@723..725 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssUrlFunction {
+                                        name: URL_KW@725..728 "url" [] [],
+                                        l_paren_token: L_PAREN@728..729 "(" [] [],
+                                        value: CssString {
+                                            value_token: CSS_STRING_LITERAL@729..741 "\"image.png\"" [] [Whitespace(" ")],
+                                        },
+                                        modifiers: CssUrlModifierList [
+                                            CssFunction {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@741..747 "format" [] [],
+                                                },
+                                                l_paren_token: L_PAREN@747..748 "(" [] [],
+                                                items: CssParameterList [
+                                                    CssListOfComponentValuesExpression {
+                                                        css_component_value_list: CssComponentValueList [
+                                                            CssString {
+                                                                value_token: CSS_STRING_LITERAL@748..753 "\"png\"" [] [],
+                                                            },
+                                                        ],
+                                                    },
+                                                ],
+                                                r_paren_token: R_PAREN@753..754 ")" [] [],
+                                            },
+                                        ],
+                                        r_paren_token: R_PAREN@754..755 ")" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@755..757 ";" [] [Whitespace(" ")],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@757..762 "width" [] [],
+                                },
+                                colon_token: COLON@762..764 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssRegularDimension {
+                                        value_token: CSS_NUMBER_LITERAL@764..765 "1" [] [],
+                                        unit_token: IDENT@765..767 "px" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@767..769 ";" [] [Whitespace(" ")],
+                    },
+                ],
+                r_curly_token: R_CURLY@769..770 "}" [] [],
+            },
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@770..772 "." [Newline("\n")] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@772..785 "escaped-tail" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@785..787 "{" [] [Whitespace(" ")],
+                items: CssDeclarationOrRuleList [
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@787..792 "first" [] [],
+                                },
+                                colon_token: COLON@792..794 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssUrlFunction {
+                                        name: URL_KW@794..797 "url" [] [],
+                                        l_paren_token: L_PAREN@797..798 "(" [] [],
+                                        value: CssUrlValueRaw {
+                                            value_token: CSS_URL_VALUE_RAW_LITERAL@798..802 "@a\\ " [] [],
+                                        },
+                                        modifiers: CssUrlModifierList [],
+                                        r_paren_token: R_PAREN@802..803 ")" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@803..805 ";" [] [Whitespace(" ")],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@805..811 "second" [] [],
+                                },
+                                colon_token: COLON@811..813 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssUrlFunction {
+                                        name: URL_KW@813..816 "url" [] [],
+                                        l_paren_token: L_PAREN@816..817 "(" [] [],
+                                        value: CssUrlValueRaw {
+                                            value_token: CSS_URL_VALUE_RAW_LITERAL@817..821 "!a\\ " [] [],
+                                        },
+                                        modifiers: CssUrlModifierList [],
+                                        r_paren_token: R_PAREN@821..822 ")" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@822..824 ";" [] [Whitespace(" ")],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@824..828 "even" [] [],
+                                },
+                                colon_token: COLON@828..830 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssUrlFunction {
+                                        name: URL_KW@830..833 "url" [] [],
+                                        l_paren_token: L_PAREN@833..834 "(" [] [],
+                                        value: CssUrlValueRaw {
+                                            value_token: CSS_URL_VALUE_RAW_LITERAL@834..840 "@a\\\\  " [] [],
+                                        },
+                                        modifiers: CssUrlModifierList [],
+                                        r_paren_token: R_PAREN@840..841 ")" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@841..843 ";" [] [Whitespace(" ")],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@843..846 "odd" [] [],
+                                },
+                                colon_token: COLON@846..848 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssUrlFunction {
+                                        name: URL_KW@848..851 "url" [] [],
+                                        l_paren_token: L_PAREN@851..852 "(" [] [],
+                                        value: CssUrlValueRaw {
+                                            value_token: CSS_URL_VALUE_RAW_LITERAL@852..859 "!a\\\\\\  " [] [],
+                                        },
+                                        modifiers: CssUrlModifierList [],
+                                        r_paren_token: R_PAREN@859..860 ")" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@860..862 ";" [] [Whitespace(" ")],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@862..865 "hex" [] [],
+                                },
+                                colon_token: COLON@865..867 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssUrlFunction {
+                                        name: URL_KW@867..870 "url" [] [],
+                                        l_paren_token: L_PAREN@870..871 "(" [] [],
+                                        value: CssUrlValueRaw {
+                                            value_token: CSS_URL_VALUE_RAW_LITERAL@871..878 "@a\\20  " [] [],
+                                        },
+                                        modifiers: CssUrlModifierList [],
+                                        r_paren_token: R_PAREN@878..879 ")" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@879..881 ";" [] [Whitespace(" ")],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@881..886 "width" [] [],
+                                },
+                                colon_token: COLON@886..888 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssRegularDimension {
+                                        value_token: CSS_NUMBER_LITERAL@888..889 "1" [] [],
+                                        unit_token: IDENT@889..891 "px" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@891..893 ";" [] [Whitespace(" ")],
+                    },
+                ],
+                r_curly_token: R_CURLY@893..894 "}" [] [],
+            },
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@894..896 "." [Newline("\n")] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@896..909 "unicode-tail" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@909..911 "{" [] [Whitespace(" ")],
+                items: CssDeclarationOrRuleList [
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@911..916 "first" [] [],
+                                },
+                                colon_token: COLON@916..918 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssUrlFunction {
+                                        name: URL_KW@918..921 "url" [] [],
+                                        l_paren_token: L_PAREN@921..922 "(" [] [],
+                                        value: CssUrlValueRaw {
+                                            value_token: CSS_URL_VALUE_RAW_LITERAL@922..926 "@a\u{a0}" [] [],
+                                        },
+                                        modifiers: CssUrlModifierList [],
+                                        r_paren_token: R_PAREN@926..927 ")" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@927..929 ";" [] [Whitespace(" ")],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@929..935 "second" [] [],
+                                },
+                                colon_token: COLON@935..937 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssUrlFunction {
+                                        name: URL_KW@937..940 "url" [] [],
+                                        l_paren_token: L_PAREN@940..941 "(" [] [],
+                                        value: CssUrlValueRaw {
+                                            value_token: CSS_URL_VALUE_RAW_LITERAL@941..946 "!a\u{2003}" [] [],
+                                        },
+                                        modifiers: CssUrlModifierList [],
+                                        r_paren_token: R_PAREN@946..947 ")" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@947..949 ";" [] [Whitespace(" ")],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@949..954 "width" [] [],
+                                },
+                                colon_token: COLON@954..956 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssRegularDimension {
+                                        value_token: CSS_NUMBER_LITERAL@956..957 "1" [] [],
+                                        unit_token: IDENT@957..959 "px" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@959..961 ";" [] [Whitespace(" ")],
+                    },
+                ],
+                r_curly_token: R_CURLY@961..962 "}" [] [],
+            },
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@962..964 "." [Newline("\n")] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@964..976 "escaped-tab" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@976..978 "{" [] [Whitespace(" ")],
+                items: CssDeclarationOrRuleList [
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@978..988 "background" [] [],
+                                },
+                                colon_token: COLON@988..990 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssUrlFunction {
+                                        name: URL_KW@990..993 "url" [] [],
+                                        l_paren_token: L_PAREN@993..994 "(" [] [],
+                                        value: CssUrlValueRaw {
+                                            value_token: CSS_URL_VALUE_RAW_LITERAL@994..998 "@a\\\t" [] [],
+                                        },
+                                        modifiers: CssUrlModifierList [],
+                                        r_paren_token: R_PAREN@998..999 ")" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@999..1001 ";" [] [Whitespace(" ")],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@1001..1006 "color" [] [],
+                                },
+                                colon_token: COLON@1006..1008 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssIdentifier {
+                                        value_token: IDENT@1008..1011 "red" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@1011..1013 ";" [] [Whitespace(" ")],
+                    },
+                ],
+                r_curly_token: R_CURLY@1013..1014 "}" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@1014..1015 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..1015
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..1014
+    0: CSS_QUALIFIED_RULE@0..77
+      0: CSS_SELECTOR_LIST@0..7
+        0: CSS_COMPOUND_SELECTOR@0..7
+          0: CSS_NESTED_SELECTOR_LIST@0..0
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@0..7
+            0: CSS_CLASS_SELECTOR@0..7
+              0: DOT@0..1 "." [] []
+              1: CSS_CUSTOM_IDENTIFIER@1..7
+                0: IDENT@1..7 "check" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@7..77
+        0: L_CURLY@7..9 "{" [] [Whitespace(" ")]
+        1: CSS_DECLARATION_OR_RULE_LIST@9..76
+          0: CSS_DECLARATION_WITH_SEMICOLON@9..64
+            0: CSS_DECLARATION@9..62
+              0: CSS_GENERIC_PROPERTY@9..62
+                0: CSS_IDENTIFIER@9..25
+                  0: IDENT@9..25 "background-image" [] []
+                1: COLON@25..27 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@27..62
+                  0: CSS_URL_FUNCTION@27..62
+                    0: URL_KW@27..30 "url" [] []
+                    1: L_PAREN@30..31 "(" [] []
+                    2: CSS_URL_VALUE_RAW@31..61
+                      0: CSS_URL_VALUE_RAW_LITERAL@31..61 "@/assets/svg/for-css/check.svg" [] []
+                    3: CSS_URL_MODIFIER_LIST@61..61
+                    4: R_PAREN@61..62 ")" [] []
+              1: (empty)
+            1: SEMICOLON@62..64 ";" [] [Whitespace(" ")]
+          1: CSS_DECLARATION_WITH_SEMICOLON@64..76
+            0: CSS_DECLARATION@64..74
+              0: CSS_GENERIC_PROPERTY@64..74
+                0: CSS_IDENTIFIER@64..69
+                  0: IDENT@64..69 "width" [] []
+                1: COLON@69..71 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@71..74
+                  0: CSS_REGULAR_DIMENSION@71..74
+                    0: CSS_NUMBER_LITERAL@71..72 "1" [] []
+                    1: IDENT@72..74 "px" [] []
+              1: (empty)
+            1: SEMICOLON@74..76 ";" [] [Whitespace(" ")]
+        2: R_CURLY@76..77 "}" [] []
+    1: CSS_QUALIFIED_RULE@77..171
+      0: CSS_SELECTOR_LIST@77..86
+        0: CSS_COMPOUND_SELECTOR@77..86
+          0: CSS_NESTED_SELECTOR_LIST@77..77
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@77..86
+            0: CSS_CLASS_SELECTOR@77..86
+              0: DOT@77..79 "." [Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@79..86
+                0: IDENT@79..86 "footer" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@86..171
+        0: L_CURLY@86..88 "{" [] [Whitespace(" ")]
+        1: CSS_DECLARATION_OR_RULE_LIST@88..170
+          0: CSS_DECLARATION_WITH_SEMICOLON@88..158
+            0: CSS_DECLARATION@88..156
+              0: CSS_GENERIC_PROPERTY@88..156
+                0: CSS_IDENTIFIER@88..104
+                  0: IDENT@88..104 "background-image" [] []
+                1: COLON@104..106 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@106..156
+                  0: CSS_URL_FUNCTION@106..156
+                    0: URL_KW@106..109 "url" [] []
+                    1: L_PAREN@109..110 "(" [] []
+                    2: CSS_URL_VALUE_RAW@110..155
+                      0: CSS_URL_VALUE_RAW_LITERAL@110..155 "@site/static/img/showcase/gh-footer-light.svg" [] []
+                    3: CSS_URL_MODIFIER_LIST@155..155
+                    4: R_PAREN@155..156 ")" [] []
+              1: (empty)
+            1: SEMICOLON@156..158 ";" [] [Whitespace(" ")]
+          1: CSS_DECLARATION_WITH_SEMICOLON@158..170
+            0: CSS_DECLARATION@158..168
+              0: CSS_GENERIC_PROPERTY@158..168
+                0: CSS_IDENTIFIER@158..163
+                  0: IDENT@158..163 "color" [] []
+                1: COLON@163..165 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@165..168
+                  0: CSS_IDENTIFIER@165..168
+                    0: IDENT@165..168 "red" [] []
+              1: (empty)
+            1: SEMICOLON@168..170 ";" [] [Whitespace(" ")]
+        2: R_CURLY@170..171 "}" [] []
+    2: CSS_AT_RULE@171..275
+      0: AT@171..173 "@" [Newline("\n")] []
+      1: CSS_FONT_FACE_AT_RULE@173..275
+        0: CSS_FONT_FACE_AT_RULE_DECLARATOR@173..183
+          0: FONT_FACE_KW@173..183 "font-face" [] [Whitespace(" ")]
+        1: CSS_DECLARATION_BLOCK@183..275
+          0: L_CURLY@183..185 "{" [] [Whitespace(" ")]
+          1: CSS_DECLARATION_LIST@185..274
+            0: CSS_DECLARATION_WITH_SEMICOLON@185..211
+              0: CSS_DECLARATION@185..209
+                0: CSS_GENERIC_PROPERTY@185..209
+                  0: CSS_IDENTIFIER@185..196
+                    0: IDENT@185..196 "font-family" [] []
+                  1: COLON@196..198 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@198..209
+                    0: CSS_STRING@198..209
+                      0: CSS_STRING_LITERAL@198..209 "\"!PaulMaul\"" [] []
+                1: (empty)
+              1: SEMICOLON@209..211 ";" [] [Whitespace(" ")]
+            1: CSS_DECLARATION_WITH_SEMICOLON@211..254
+              0: CSS_DECLARATION@211..252
+                0: CSS_GENERIC_PROPERTY@211..252
+                  0: CSS_IDENTIFIER@211..214
+                    0: IDENT@211..214 "src" [] []
+                  1: COLON@214..216 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@216..252
+                    0: CSS_URL_FUNCTION@216..237
+                      0: URL_KW@216..219 "url" [] []
+                      1: L_PAREN@219..220 "(" [] []
+                      2: CSS_URL_VALUE_RAW@220..235
+                        0: CSS_URL_VALUE_RAW_LITERAL@220..235 "!PaulMaul.woff2" [] []
+                      3: CSS_URL_MODIFIER_LIST@235..235
+                      4: R_PAREN@235..237 ")" [] [Whitespace(" ")]
+                    1: CSS_FUNCTION@237..252
+                      0: CSS_IDENTIFIER@237..243
+                        0: IDENT@237..243 "format" [] []
+                      1: L_PAREN@243..244 "(" [] []
+                      2: CSS_PARAMETER_LIST@244..251
+                        0: CSS_LIST_OF_COMPONENT_VALUES_EXPRESSION@244..251
+                          0: CSS_COMPONENT_VALUE_LIST@244..251
+                            0: CSS_STRING@244..251
+                              0: CSS_STRING_LITERAL@244..251 "\"woff2\"" [] []
+                      3: R_PAREN@251..252 ")" [] []
+                1: (empty)
+              1: SEMICOLON@252..254 ";" [] [Whitespace(" ")]
+            2: CSS_DECLARATION_WITH_SEMICOLON@254..274
+              0: CSS_DECLARATION@254..272
+                0: CSS_GENERIC_PROPERTY@254..272
+                  0: CSS_IDENTIFIER@254..266
+                    0: IDENT@254..266 "font-display" [] []
+                  1: COLON@266..268 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@268..272
+                    0: CSS_IDENTIFIER@268..272
+                      0: IDENT@268..272 "swap" [] []
+                1: (empty)
+              1: SEMICOLON@272..274 ";" [] [Whitespace(" ")]
+          2: R_CURLY@274..275 "}" [] []
+    3: CSS_QUALIFIED_RULE@275..699
+      0: CSS_SELECTOR_LIST@275..286
+        0: CSS_COMPOUND_SELECTOR@275..286
+          0: CSS_NESTED_SELECTOR_LIST@275..275
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@275..286
+            0: CSS_CLASS_SELECTOR@275..286
+              0: DOT@275..277 "." [Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@277..286
+                0: IDENT@277..286 "controls" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@286..699
+        0: L_CURLY@286..287 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@287..697
+          0: CSS_DECLARATION_WITH_SEMICOLON@287..315
+            0: CSS_DECLARATION@287..314
+              0: CSS_GENERIC_PROPERTY@287..314
+                0: CSS_IDENTIFIER@287..298
+                  0: IDENT@287..298 "ordinary" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@298..300 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@300..314
+                  0: CSS_URL_FUNCTION@300..314
+                    0: URL_KW@300..303 "url" [] []
+                    1: L_PAREN@303..304 "(" [] []
+                    2: CSS_URL_VALUE_RAW@304..313
+                      0: CSS_URL_VALUE_RAW_LITERAL@304..313 "image.png" [] []
+                    3: CSS_URL_MODIFIER_LIST@313..313
+                    4: R_PAREN@313..314 ")" [] []
+              1: (empty)
+            1: SEMICOLON@314..315 ";" [] []
+          1: CSS_DECLARATION_WITH_SEMICOLON@315..440
+            0: CSS_DECLARATION@315..439
+              0: CSS_GENERIC_PROPERTY@315..439
+                0: CSS_IDENTIFIER@315..324
+                  0: IDENT@315..324 "quoted" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@324..326 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@326..439
+                  0: CSS_URL_FUNCTION@326..364
+                    0: URL_KW@326..329 "url" [] []
+                    1: L_PAREN@329..330 "(" [] []
+                    2: CSS_STRING@330..362
+                      0: CSS_STRING_LITERAL@330..362 "\"@/assets/svg/for-css/check.svg\"" [] []
+                    3: CSS_URL_MODIFIER_LIST@362..362
+                    4: R_PAREN@362..364 ")" [] [Whitespace(" ")]
+                  1: CSS_URL_FUNCTION@364..417
+                    0: URL_KW@364..367 "url" [] []
+                    1: L_PAREN@367..368 "(" [] []
+                    2: CSS_STRING@368..415
+                      0: CSS_STRING_LITERAL@368..415 "\"@site/static/img/showcase/gh-footer-light.svg\"" [] []
+                    3: CSS_URL_MODIFIER_LIST@415..415
+                    4: R_PAREN@415..417 ")" [] [Whitespace(" ")]
+                  2: CSS_URL_FUNCTION@417..439
+                    0: URL_KW@417..420 "url" [] []
+                    1: L_PAREN@420..421 "(" [] []
+                    2: CSS_STRING@421..438
+                      0: CSS_STRING_LITERAL@421..438 "\"!PaulMaul.woff2\"" [] []
+                    3: CSS_URL_MODIFIER_LIST@438..438
+                    4: R_PAREN@438..439 ")" [] []
+              1: (empty)
+            1: SEMICOLON@439..440 ";" [] []
+          2: CSS_DECLARATION_WITH_SEMICOLON@440..482
+            0: CSS_DECLARATION@440..481
+              0: CSS_GENERIC_PROPERTY@440..481
+                0: CSS_IDENTIFIER@440..451
+                  0: IDENT@440..451 "relative" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@451..453 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@453..481
+                  0: CSS_URL_FUNCTION@453..481
+                    0: URL_KW@453..456 "url" [] []
+                    1: L_PAREN@456..457 "(" [] []
+                    2: CSS_URL_VALUE_RAW@457..480
+                      0: CSS_URL_VALUE_RAW_LITERAL@457..480 "//cdn.example/image.svg" [] []
+                    3: CSS_URL_MODIFIER_LIST@480..480
+                    4: R_PAREN@480..481 ")" [] []
+              1: (empty)
+            1: SEMICOLON@481..482 ";" [] []
+          3: CSS_DECLARATION_WITH_SEMICOLON@482..527
+            0: CSS_DECLARATION@482..526
+              0: CSS_GENERIC_PROPERTY@482..526
+                0: CSS_IDENTIFIER@482..489
+                  0: IDENT@482..489 "data" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@489..491 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@491..526
+                  0: CSS_URL_FUNCTION@491..526
+                    0: URL_KW@491..494 "url" [] []
+                    1: L_PAREN@494..495 "(" [] []
+                    2: CSS_URL_VALUE_RAW@495..525
+                      0: CSS_URL_VALUE_RAW_LITERAL@495..525 "data:image/svg+xml;base64,AAAA" [] []
+                    3: CSS_URL_MODIFIER_LIST@525..525
+                    4: R_PAREN@525..526 ")" [] []
+              1: (empty)
+            1: SEMICOLON@526..527 ";" [] []
+          4: CSS_DECLARATION_WITH_SEMICOLON@527..551
+            0: CSS_DECLARATION@527..550
+              0: CSS_GENERIC_PROPERTY@527..550
+                0: CSS_IDENTIFIER@527..538
+                  0: IDENT@527..538 "fragment" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@538..540 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@540..550
+                  0: CSS_URL_FUNCTION@540..550
+                    0: URL_KW@540..543 "url" [] []
+                    1: L_PAREN@543..544 "(" [] []
+                    2: CSS_URL_VALUE_RAW@544..549
+                      0: CSS_URL_VALUE_RAW_LITERAL@544..549 "#icon" [] []
+                    3: CSS_URL_MODIFIER_LIST@549..549
+                    4: R_PAREN@549..550 ")" [] []
+              1: (empty)
+            1: SEMICOLON@550..551 ";" [] []
+          5: CSS_DECLARATION_WITH_SEMICOLON@551..632
+            0: CSS_DECLARATION@551..631
+              0: CSS_GENERIC_PROPERTY@551..631
+                0: CSS_IDENTIFIER@551..561
+                  0: IDENT@551..561 "escaped" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@561..563 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@563..631
+                  0: CSS_URL_FUNCTION@563..586
+                    0: URL_KW@563..566 "url" [] []
+                    1: L_PAREN@566..567 "(" [] []
+                    2: CSS_URL_VALUE_RAW@567..584
+                      0: CSS_URL_VALUE_RAW_LITERAL@567..584 "@/assets/a\\)b.svg" [] []
+                    3: CSS_URL_MODIFIER_LIST@584..584
+                    4: R_PAREN@584..586 ")" [] [Whitespace(" ")]
+                  1: CSS_URL_FUNCTION@586..611
+                    0: URL_KW@586..589 "url" [] []
+                    1: L_PAREN@589..590 "(" [] []
+                    2: CSS_URL_VALUE_RAW@590..609
+                      0: CSS_URL_VALUE_RAW_LITERAL@590..609 "!font\\20 name.woff2" [] []
+                    3: CSS_URL_MODIFIER_LIST@609..609
+                    4: R_PAREN@609..611 ")" [] [Whitespace(" ")]
+                  2: CSS_URL_FUNCTION@611..631
+                    0: URL_KW@611..614 "url" [] []
+                    1: L_PAREN@614..615 "(" [] []
+                    2: CSS_URL_VALUE_RAW@615..630
+                      0: CSS_URL_VALUE_RAW_LITERAL@615..630 "@/icons/\\é.svg" [] []
+                    3: CSS_URL_MODIFIER_LIST@630..630
+                    4: R_PAREN@630..631 ")" [] []
+              1: (empty)
+            1: SEMICOLON@631..632 ";" [] []
+          6: CSS_DECLARATION_WITH_SEMICOLON@632..683
+            0: CSS_DECLARATION@632..682
+              0: CSS_GENERIC_PROPERTY@632..682
+                0: CSS_IDENTIFIER@632..640
+                  0: IDENT@632..640 "other" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@640..642 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@642..682
+                  0: CSS_URL_FUNCTION@642..665
+                    0: URL_KW@642..645 "url" [] []
+                    1: L_PAREN@645..646 "(" [] []
+                    2: CSS_URL_VALUE_RAW@646..663
+                      0: CSS_URL_VALUE_RAW_LITERAL@646..663 "@custom/other.svg" [] []
+                    3: CSS_URL_MODIFIER_LIST@663..663
+                    4: R_PAREN@663..665 ")" [] [Whitespace(" ")]
+                  1: CSS_URL_FUNCTION@665..682
+                    0: URL_KW@665..668 "url" [] []
+                    1: L_PAREN@668..669 "(" [] []
+                    2: CSS_URL_VALUE_RAW@669..681
+                      0: CSS_URL_VALUE_RAW_LITERAL@669..681 "!Other.woff2" [] []
+                    3: CSS_URL_MODIFIER_LIST@681..681
+                    4: R_PAREN@681..682 ")" [] []
+              1: (empty)
+            1: SEMICOLON@682..683 ";" [] []
+          7: CSS_DECLARATION_WITH_SEMICOLON@683..697
+            0: CSS_DECLARATION@683..696
+              0: CSS_GENERIC_PROPERTY@683..696
+                0: CSS_IDENTIFIER@683..691
+                  0: IDENT@683..691 "width" [Newline("\n"), Whitespace("  ")] []
+                1: COLON@691..693 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@693..696
+                  0: CSS_REGULAR_DIMENSION@693..696
+                    0: CSS_NUMBER_LITERAL@693..694 "1" [] []
+                    1: IDENT@694..696 "px" [] []
+              1: (empty)
+            1: SEMICOLON@696..697 ";" [] []
+        2: R_CURLY@697..699 "}" [Newline("\n")] []
+    4: CSS_QUALIFIED_RULE@699..770
+      0: CSS_SELECTOR_LIST@699..711
+        0: CSS_COMPOUND_SELECTOR@699..711
+          0: CSS_NESTED_SELECTOR_LIST@699..699
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@699..711
+            0: CSS_CLASS_SELECTOR@699..711
+              0: DOT@699..701 "." [Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@701..711
+                0: IDENT@701..711 "modifiers" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@711..770
+        0: L_CURLY@711..713 "{" [] [Whitespace(" ")]
+        1: CSS_DECLARATION_OR_RULE_LIST@713..769
+          0: CSS_DECLARATION_WITH_SEMICOLON@713..757
+            0: CSS_DECLARATION@713..755
+              0: CSS_GENERIC_PROPERTY@713..755
+                0: CSS_IDENTIFIER@713..723
+                  0: IDENT@713..723 "background" [] []
+                1: COLON@723..725 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@725..755
+                  0: CSS_URL_FUNCTION@725..755
+                    0: URL_KW@725..728 "url" [] []
+                    1: L_PAREN@728..729 "(" [] []
+                    2: CSS_STRING@729..741
+                      0: CSS_STRING_LITERAL@729..741 "\"image.png\"" [] [Whitespace(" ")]
+                    3: CSS_URL_MODIFIER_LIST@741..754
+                      0: CSS_FUNCTION@741..754
+                        0: CSS_IDENTIFIER@741..747
+                          0: IDENT@741..747 "format" [] []
+                        1: L_PAREN@747..748 "(" [] []
+                        2: CSS_PARAMETER_LIST@748..753
+                          0: CSS_LIST_OF_COMPONENT_VALUES_EXPRESSION@748..753
+                            0: CSS_COMPONENT_VALUE_LIST@748..753
+                              0: CSS_STRING@748..753
+                                0: CSS_STRING_LITERAL@748..753 "\"png\"" [] []
+                        3: R_PAREN@753..754 ")" [] []
+                    4: R_PAREN@754..755 ")" [] []
+              1: (empty)
+            1: SEMICOLON@755..757 ";" [] [Whitespace(" ")]
+          1: CSS_DECLARATION_WITH_SEMICOLON@757..769
+            0: CSS_DECLARATION@757..767
+              0: CSS_GENERIC_PROPERTY@757..767
+                0: CSS_IDENTIFIER@757..762
+                  0: IDENT@757..762 "width" [] []
+                1: COLON@762..764 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@764..767
+                  0: CSS_REGULAR_DIMENSION@764..767
+                    0: CSS_NUMBER_LITERAL@764..765 "1" [] []
+                    1: IDENT@765..767 "px" [] []
+              1: (empty)
+            1: SEMICOLON@767..769 ";" [] [Whitespace(" ")]
+        2: R_CURLY@769..770 "}" [] []
+    5: CSS_QUALIFIED_RULE@770..894
+      0: CSS_SELECTOR_LIST@770..785
+        0: CSS_COMPOUND_SELECTOR@770..785
+          0: CSS_NESTED_SELECTOR_LIST@770..770
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@770..785
+            0: CSS_CLASS_SELECTOR@770..785
+              0: DOT@770..772 "." [Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@772..785
+                0: IDENT@772..785 "escaped-tail" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@785..894
+        0: L_CURLY@785..787 "{" [] [Whitespace(" ")]
+        1: CSS_DECLARATION_OR_RULE_LIST@787..893
+          0: CSS_DECLARATION_WITH_SEMICOLON@787..805
+            0: CSS_DECLARATION@787..803
+              0: CSS_GENERIC_PROPERTY@787..803
+                0: CSS_IDENTIFIER@787..792
+                  0: IDENT@787..792 "first" [] []
+                1: COLON@792..794 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@794..803
+                  0: CSS_URL_FUNCTION@794..803
+                    0: URL_KW@794..797 "url" [] []
+                    1: L_PAREN@797..798 "(" [] []
+                    2: CSS_URL_VALUE_RAW@798..802
+                      0: CSS_URL_VALUE_RAW_LITERAL@798..802 "@a\\ " [] []
+                    3: CSS_URL_MODIFIER_LIST@802..802
+                    4: R_PAREN@802..803 ")" [] []
+              1: (empty)
+            1: SEMICOLON@803..805 ";" [] [Whitespace(" ")]
+          1: CSS_DECLARATION_WITH_SEMICOLON@805..824
+            0: CSS_DECLARATION@805..822
+              0: CSS_GENERIC_PROPERTY@805..822
+                0: CSS_IDENTIFIER@805..811
+                  0: IDENT@805..811 "second" [] []
+                1: COLON@811..813 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@813..822
+                  0: CSS_URL_FUNCTION@813..822
+                    0: URL_KW@813..816 "url" [] []
+                    1: L_PAREN@816..817 "(" [] []
+                    2: CSS_URL_VALUE_RAW@817..821
+                      0: CSS_URL_VALUE_RAW_LITERAL@817..821 "!a\\ " [] []
+                    3: CSS_URL_MODIFIER_LIST@821..821
+                    4: R_PAREN@821..822 ")" [] []
+              1: (empty)
+            1: SEMICOLON@822..824 ";" [] [Whitespace(" ")]
+          2: CSS_DECLARATION_WITH_SEMICOLON@824..843
+            0: CSS_DECLARATION@824..841
+              0: CSS_GENERIC_PROPERTY@824..841
+                0: CSS_IDENTIFIER@824..828
+                  0: IDENT@824..828 "even" [] []
+                1: COLON@828..830 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@830..841
+                  0: CSS_URL_FUNCTION@830..841
+                    0: URL_KW@830..833 "url" [] []
+                    1: L_PAREN@833..834 "(" [] []
+                    2: CSS_URL_VALUE_RAW@834..840
+                      0: CSS_URL_VALUE_RAW_LITERAL@834..840 "@a\\\\  " [] []
+                    3: CSS_URL_MODIFIER_LIST@840..840
+                    4: R_PAREN@840..841 ")" [] []
+              1: (empty)
+            1: SEMICOLON@841..843 ";" [] [Whitespace(" ")]
+          3: CSS_DECLARATION_WITH_SEMICOLON@843..862
+            0: CSS_DECLARATION@843..860
+              0: CSS_GENERIC_PROPERTY@843..860
+                0: CSS_IDENTIFIER@843..846
+                  0: IDENT@843..846 "odd" [] []
+                1: COLON@846..848 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@848..860
+                  0: CSS_URL_FUNCTION@848..860
+                    0: URL_KW@848..851 "url" [] []
+                    1: L_PAREN@851..852 "(" [] []
+                    2: CSS_URL_VALUE_RAW@852..859
+                      0: CSS_URL_VALUE_RAW_LITERAL@852..859 "!a\\\\\\  " [] []
+                    3: CSS_URL_MODIFIER_LIST@859..859
+                    4: R_PAREN@859..860 ")" [] []
+              1: (empty)
+            1: SEMICOLON@860..862 ";" [] [Whitespace(" ")]
+          4: CSS_DECLARATION_WITH_SEMICOLON@862..881
+            0: CSS_DECLARATION@862..879
+              0: CSS_GENERIC_PROPERTY@862..879
+                0: CSS_IDENTIFIER@862..865
+                  0: IDENT@862..865 "hex" [] []
+                1: COLON@865..867 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@867..879
+                  0: CSS_URL_FUNCTION@867..879
+                    0: URL_KW@867..870 "url" [] []
+                    1: L_PAREN@870..871 "(" [] []
+                    2: CSS_URL_VALUE_RAW@871..878
+                      0: CSS_URL_VALUE_RAW_LITERAL@871..878 "@a\\20  " [] []
+                    3: CSS_URL_MODIFIER_LIST@878..878
+                    4: R_PAREN@878..879 ")" [] []
+              1: (empty)
+            1: SEMICOLON@879..881 ";" [] [Whitespace(" ")]
+          5: CSS_DECLARATION_WITH_SEMICOLON@881..893
+            0: CSS_DECLARATION@881..891
+              0: CSS_GENERIC_PROPERTY@881..891
+                0: CSS_IDENTIFIER@881..886
+                  0: IDENT@881..886 "width" [] []
+                1: COLON@886..888 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@888..891
+                  0: CSS_REGULAR_DIMENSION@888..891
+                    0: CSS_NUMBER_LITERAL@888..889 "1" [] []
+                    1: IDENT@889..891 "px" [] []
+              1: (empty)
+            1: SEMICOLON@891..893 ";" [] [Whitespace(" ")]
+        2: R_CURLY@893..894 "}" [] []
+    6: CSS_QUALIFIED_RULE@894..962
+      0: CSS_SELECTOR_LIST@894..909
+        0: CSS_COMPOUND_SELECTOR@894..909
+          0: CSS_NESTED_SELECTOR_LIST@894..894
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@894..909
+            0: CSS_CLASS_SELECTOR@894..909
+              0: DOT@894..896 "." [Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@896..909
+                0: IDENT@896..909 "unicode-tail" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@909..962
+        0: L_CURLY@909..911 "{" [] [Whitespace(" ")]
+        1: CSS_DECLARATION_OR_RULE_LIST@911..961
+          0: CSS_DECLARATION_WITH_SEMICOLON@911..929
+            0: CSS_DECLARATION@911..927
+              0: CSS_GENERIC_PROPERTY@911..927
+                0: CSS_IDENTIFIER@911..916
+                  0: IDENT@911..916 "first" [] []
+                1: COLON@916..918 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@918..927
+                  0: CSS_URL_FUNCTION@918..927
+                    0: URL_KW@918..921 "url" [] []
+                    1: L_PAREN@921..922 "(" [] []
+                    2: CSS_URL_VALUE_RAW@922..926
+                      0: CSS_URL_VALUE_RAW_LITERAL@922..926 "@a\u{a0}" [] []
+                    3: CSS_URL_MODIFIER_LIST@926..926
+                    4: R_PAREN@926..927 ")" [] []
+              1: (empty)
+            1: SEMICOLON@927..929 ";" [] [Whitespace(" ")]
+          1: CSS_DECLARATION_WITH_SEMICOLON@929..949
+            0: CSS_DECLARATION@929..947
+              0: CSS_GENERIC_PROPERTY@929..947
+                0: CSS_IDENTIFIER@929..935
+                  0: IDENT@929..935 "second" [] []
+                1: COLON@935..937 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@937..947
+                  0: CSS_URL_FUNCTION@937..947
+                    0: URL_KW@937..940 "url" [] []
+                    1: L_PAREN@940..941 "(" [] []
+                    2: CSS_URL_VALUE_RAW@941..946
+                      0: CSS_URL_VALUE_RAW_LITERAL@941..946 "!a\u{2003}" [] []
+                    3: CSS_URL_MODIFIER_LIST@946..946
+                    4: R_PAREN@946..947 ")" [] []
+              1: (empty)
+            1: SEMICOLON@947..949 ";" [] [Whitespace(" ")]
+          2: CSS_DECLARATION_WITH_SEMICOLON@949..961
+            0: CSS_DECLARATION@949..959
+              0: CSS_GENERIC_PROPERTY@949..959
+                0: CSS_IDENTIFIER@949..954
+                  0: IDENT@949..954 "width" [] []
+                1: COLON@954..956 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@956..959
+                  0: CSS_REGULAR_DIMENSION@956..959
+                    0: CSS_NUMBER_LITERAL@956..957 "1" [] []
+                    1: IDENT@957..959 "px" [] []
+              1: (empty)
+            1: SEMICOLON@959..961 ";" [] [Whitespace(" ")]
+        2: R_CURLY@961..962 "}" [] []
+    7: CSS_QUALIFIED_RULE@962..1014
+      0: CSS_SELECTOR_LIST@962..976
+        0: CSS_COMPOUND_SELECTOR@962..976
+          0: CSS_NESTED_SELECTOR_LIST@962..962
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@962..976
+            0: CSS_CLASS_SELECTOR@962..976
+              0: DOT@962..964 "." [Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@964..976
+                0: IDENT@964..976 "escaped-tab" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@976..1014
+        0: L_CURLY@976..978 "{" [] [Whitespace(" ")]
+        1: CSS_DECLARATION_OR_RULE_LIST@978..1013
+          0: CSS_DECLARATION_WITH_SEMICOLON@978..1001
+            0: CSS_DECLARATION@978..999
+              0: CSS_GENERIC_PROPERTY@978..999
+                0: CSS_IDENTIFIER@978..988
+                  0: IDENT@978..988 "background" [] []
+                1: COLON@988..990 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@990..999
+                  0: CSS_URL_FUNCTION@990..999
+                    0: URL_KW@990..993 "url" [] []
+                    1: L_PAREN@993..994 "(" [] []
+                    2: CSS_URL_VALUE_RAW@994..998
+                      0: CSS_URL_VALUE_RAW_LITERAL@994..998 "@a\\\t" [] []
+                    3: CSS_URL_MODIFIER_LIST@998..998
+                    4: R_PAREN@998..999 ")" [] []
+              1: (empty)
+            1: SEMICOLON@999..1001 ";" [] [Whitespace(" ")]
+          1: CSS_DECLARATION_WITH_SEMICOLON@1001..1013
+            0: CSS_DECLARATION@1001..1011
+              0: CSS_GENERIC_PROPERTY@1001..1011
+                0: CSS_IDENTIFIER@1001..1006
+                  0: IDENT@1001..1006 "color" [] []
+                1: COLON@1006..1008 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@1008..1011
+                  0: CSS_IDENTIFIER@1008..1011
+                    0: IDENT@1008..1011 "red" [] []
+              1: (empty)
+            1: SEMICOLON@1011..1013 ";" [] [Whitespace(" ")]
+        2: R_CURLY@1013..1014 "}" [] []
+  2: EOF@1014..1015 "" [Newline("\n")] []
+
+```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/value/release-url-asset-aliases.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/value/release-url-asset-aliases.css.snap
@@ -23,6 +23,7 @@ expression: snapshot
 .escaped-tail { first: url(@a\ ); second: url(!a\ ); even: url(@a\\  ); odd: url(!a\\\  ); hex: url(@a\20  ); width: 1px; }
 .unicode-tail { first: url(@a ); second: url(!a ); width: 1px; }
 .escaped-tab { background: url(@a\	); color: red; }
+.padding { first: url( 	@/other.svg 	); second: url( 	!Other.woff2  ); width: 1px; }
 
 ```
 
@@ -874,17 +875,103 @@ CssRoot {
                 r_curly_token: R_CURLY@1013..1014 "}" [] [],
             },
         },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@1014..1016 "." [Newline("\n")] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@1016..1024 "padding" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@1024..1026 "{" [] [Whitespace(" ")],
+                items: CssDeclarationOrRuleList [
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@1026..1031 "first" [] [],
+                                },
+                                colon_token: COLON@1031..1033 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssUrlFunction {
+                                        name: URL_KW@1033..1036 "url" [] [],
+                                        l_paren_token: L_PAREN@1036..1039 "(" [] [Whitespace(" \t")],
+                                        value: CssUrlValueRaw {
+                                            value_token: CSS_URL_VALUE_RAW_LITERAL@1039..1052 "@/other.svg \t" [] [],
+                                        },
+                                        modifiers: CssUrlModifierList [],
+                                        r_paren_token: R_PAREN@1052..1053 ")" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@1053..1055 ";" [] [Whitespace(" ")],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@1055..1061 "second" [] [],
+                                },
+                                colon_token: COLON@1061..1063 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssUrlFunction {
+                                        name: URL_KW@1063..1066 "url" [] [],
+                                        l_paren_token: L_PAREN@1066..1069 "(" [] [Whitespace(" \t")],
+                                        value: CssUrlValueRaw {
+                                            value_token: CSS_URL_VALUE_RAW_LITERAL@1069..1083 "!Other.woff2  " [] [],
+                                        },
+                                        modifiers: CssUrlModifierList [],
+                                        r_paren_token: R_PAREN@1083..1084 ")" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@1084..1086 ";" [] [Whitespace(" ")],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@1086..1091 "width" [] [],
+                                },
+                                colon_token: COLON@1091..1093 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssRegularDimension {
+                                        value_token: CSS_NUMBER_LITERAL@1093..1094 "1" [] [],
+                                        unit_token: IDENT@1094..1096 "px" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@1096..1098 ";" [] [Whitespace(" ")],
+                    },
+                ],
+                r_curly_token: R_CURLY@1098..1099 "}" [] [],
+            },
+        },
     ],
-    eof_token: EOF@1014..1015 "" [Newline("\n")] [],
+    eof_token: EOF@1099..1100 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: CSS_ROOT@0..1015
+0: CSS_ROOT@0..1100
   0: (empty)
-  1: CSS_ROOT_ITEM_LIST@0..1014
+  1: CSS_ROOT_ITEM_LIST@0..1099
     0: CSS_QUALIFIED_RULE@0..77
       0: CSS_SELECTOR_LIST@0..7
         0: CSS_COMPOUND_SELECTOR@0..7
@@ -1455,6 +1542,64 @@ CssRoot {
               1: (empty)
             1: SEMICOLON@1011..1013 ";" [] [Whitespace(" ")]
         2: R_CURLY@1013..1014 "}" [] []
-  2: EOF@1014..1015 "" [Newline("\n")] []
+    8: CSS_QUALIFIED_RULE@1014..1099
+      0: CSS_SELECTOR_LIST@1014..1024
+        0: CSS_COMPOUND_SELECTOR@1014..1024
+          0: CSS_NESTED_SELECTOR_LIST@1014..1014
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@1014..1024
+            0: CSS_CLASS_SELECTOR@1014..1024
+              0: DOT@1014..1016 "." [Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@1016..1024
+                0: IDENT@1016..1024 "padding" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@1024..1099
+        0: L_CURLY@1024..1026 "{" [] [Whitespace(" ")]
+        1: CSS_DECLARATION_OR_RULE_LIST@1026..1098
+          0: CSS_DECLARATION_WITH_SEMICOLON@1026..1055
+            0: CSS_DECLARATION@1026..1053
+              0: CSS_GENERIC_PROPERTY@1026..1053
+                0: CSS_IDENTIFIER@1026..1031
+                  0: IDENT@1026..1031 "first" [] []
+                1: COLON@1031..1033 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@1033..1053
+                  0: CSS_URL_FUNCTION@1033..1053
+                    0: URL_KW@1033..1036 "url" [] []
+                    1: L_PAREN@1036..1039 "(" [] [Whitespace(" \t")]
+                    2: CSS_URL_VALUE_RAW@1039..1052
+                      0: CSS_URL_VALUE_RAW_LITERAL@1039..1052 "@/other.svg \t" [] []
+                    3: CSS_URL_MODIFIER_LIST@1052..1052
+                    4: R_PAREN@1052..1053 ")" [] []
+              1: (empty)
+            1: SEMICOLON@1053..1055 ";" [] [Whitespace(" ")]
+          1: CSS_DECLARATION_WITH_SEMICOLON@1055..1086
+            0: CSS_DECLARATION@1055..1084
+              0: CSS_GENERIC_PROPERTY@1055..1084
+                0: CSS_IDENTIFIER@1055..1061
+                  0: IDENT@1055..1061 "second" [] []
+                1: COLON@1061..1063 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@1063..1084
+                  0: CSS_URL_FUNCTION@1063..1084
+                    0: URL_KW@1063..1066 "url" [] []
+                    1: L_PAREN@1066..1069 "(" [] [Whitespace(" \t")]
+                    2: CSS_URL_VALUE_RAW@1069..1083
+                      0: CSS_URL_VALUE_RAW_LITERAL@1069..1083 "!Other.woff2  " [] []
+                    3: CSS_URL_MODIFIER_LIST@1083..1083
+                    4: R_PAREN@1083..1084 ")" [] []
+              1: (empty)
+            1: SEMICOLON@1084..1086 ";" [] [Whitespace(" ")]
+          2: CSS_DECLARATION_WITH_SEMICOLON@1086..1098
+            0: CSS_DECLARATION@1086..1096
+              0: CSS_GENERIC_PROPERTY@1086..1096
+                0: CSS_IDENTIFIER@1086..1091
+                  0: IDENT@1086..1091 "width" [] []
+                1: COLON@1091..1093 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@1093..1096
+                  0: CSS_REGULAR_DIMENSION@1093..1096
+                    0: CSS_NUMBER_LITERAL@1093..1094 "1" [] []
+                    1: IDENT@1094..1096 "px" [] []
+              1: (empty)
+            1: SEMICOLON@1096..1098 ";" [] [Whitespace(" ")]
+        2: R_CURLY@1098..1099 "}" [] []
+  2: EOF@1099..1100 "" [Newline("\n")] []
 
 ```


### PR DESCRIPTION
> Implementation were written with Codex assistance.

## Summary

Fix unquoted URLs beginning with `@` or `!` in SCSS, including `url(@/assets/icon.svg)` and `url(!PaulMaul.woff2)`.


## Test Plan

- cargo test -p biome_css_parser -p biome_css_formatter 