### PR TITLE
fix(css_parser): accept valid SCSS forward prefixes

### DIFF
--- a/crates/biome_css_formatter/tests/specs/css/at_rule/release-forward-underscore-prefix.css
+++ b/crates/biome_css_formatter/tests/specs/css/at_rule/release-forward-underscore-prefix.css
@@ -1,0 +1,4 @@
+@forward "./button" as components_*;
+@forward "./button" as components-*;
+@forward "./button" as components*;
+.native{color:red;width:1px}

--- a/crates/biome_css_formatter/tests/specs/css/at_rule/release-forward-underscore-prefix.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/at_rule/release-forward-underscore-prefix.css.snap
@@ -1,0 +1,28 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/at_rule/release-forward-underscore-prefix.css
+---
+
+# Input
+
+```css
+@forward "./button" as components_*;
+@forward "./button" as components-*;
+@forward "./button" as components*;
+.native{color:red;width:1px}
+
+```
+
+
+# Formatted
+
+```css
+@forward "./button" as components_*;
+@forward "./button" as components-*;
+@forward "./button" as components*;
+.native {
+	color: red;
+	width: 1px;
+}
+
+```

--- a/crates/biome_css_formatter/tests/specs/scss/at-rule/release-forward-underscore-prefix.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/at-rule/release-forward-underscore-prefix.scss
@@ -1,0 +1,9 @@
+@forward   './button' /* module */as /* prefix */components_* /* exports */show $components_gap,components_reset with( $components_gap:4px !default );
+@forward './button' as components-*;
+@forward  './button' as Components_* hide components_internal ;
+@forward './button' as components*;
+@forward './button' as components\5f *;
+@forward
+'./button'
+as // prefix follows
+components_*; // forwarded

--- a/crates/biome_css_formatter/tests/specs/scss/at-rule/release-forward-underscore-prefix.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/at-rule/release-forward-underscore-prefix.scss.snap
@@ -1,0 +1,39 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: scss/at-rule/release-forward-underscore-prefix.scss
+---
+
+# Input
+
+```scss
+@forward   './button' /* module */as /* prefix */components_* /* exports */show $components_gap,components_reset with( $components_gap:4px !default );
+@forward './button' as components-*;
+@forward  './button' as Components_* hide components_internal ;
+@forward './button' as components*;
+@forward './button' as components\5f *;
+@forward
+'./button'
+as // prefix follows
+components_*; // forwarded
+
+```
+
+
+# Formatted
+
+```scss
+@forward "./button" /* module */ as /* prefix */ components_* /* exports */ show $components_gap,
+components_reset with($components_gap: 4px !default);
+@forward "./button" as components-*;
+@forward "./button" as Components_* hide components_internal;
+@forward "./button" as components*;
+@forward "./button" as components\5f *;
+@forward "./button" as // prefix follows
+components_*; // forwarded
+
+```
+
+# Lines exceeding max width of 80 characters
+```
+    1: @forward "./button" /* module */ as /* prefix */ components_* /* exports */ show $components_gap,
+```

--- a/crates/biome_css_parser/src/syntax/scss/at_rule/forward_at_rule.rs
+++ b/crates/biome_css_parser/src/syntax/scss/at_rule/forward_at_rule.rs
@@ -8,6 +8,7 @@ use biome_css_syntax::CssSyntaxKind::{
     SCSS_FORWARD_AS_CLAUSE, SCSS_FORWARD_AT_RULE, SCSS_HIDE_CLAUSE, SCSS_SHOW_CLAUSE,
 };
 use biome_css_syntax::T;
+use biome_parser::diagnostic::expected_token;
 use biome_parser::prelude::ParsedSyntax::{Absent, Present};
 use biome_parser::prelude::*;
 
@@ -46,7 +47,7 @@ fn is_at_scss_forward_at_rule(p: &mut CssParser) -> bool {
     p.at(T![forward])
 }
 
-/// Parses the optional SCSS `as <prefix>-*` clause inside `@forward`.
+/// Parses the optional SCSS `as <prefix>*` clause inside `@forward`.
 ///
 /// # Example
 ///
@@ -66,23 +67,26 @@ fn parse_scss_forward_as_clause(p: &mut CssParser) -> ParsedSyntax {
 
     p.bump(T![as]);
     let prefix = parse_regular_identifier(p).or_add_diagnostic(p, expected_identifier);
-    let invalid_prefix = prefix
-        .as_ref()
-        .filter(|prefix| !prefix.text(p).ends_with('-'));
 
-    if let Some(prefix) = invalid_prefix {
+    // Ranges detect gaps before `*`, including comments, but allow whitespace inside escapes.
+    if let Some(prefix) = prefix
+        && p.at(T![*])
+        && prefix.range(p).end() != p.cur_range().start()
+    {
         p.error(
             p.err_builder(
-                "Expected the `@forward` prefix to end with `-` before `*`.",
+                "Expected `*` immediately after the `@forward` prefix.",
                 prefix.range(p).cover(p.cur_range()),
             )
-            .with_hint("Write the clause as `as prefix-*` without spaces."),
+            .with_hint("Write the prefix and `*` together, for example `as components_*`."),
         );
     }
 
-    // Consume a stray `-` in invalid forms like `theme - *` or `as -*`.
-    p.eat(T![-]);
-
+    // Recover a stray hyphen in invalid forms such as `as theme - *`.
+    if p.at(T![-]) {
+        p.error(expected_token(T![*]));
+        p.bump(T![-]);
+    }
     p.expect(T![*]);
 
     Present(m.complete(p, SCSS_FORWARD_AS_CLAUSE))

--- a/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/forward.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/forward.scss
@@ -4,8 +4,6 @@
 
 @forward "theme" hide , $color;
 
-@forward "theme" as theme*;
-
 @forward "theme" as theme - *;
 
 @forward "theme" as theme-;

--- a/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/forward.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/forward.scss.snap
@@ -12,8 +12,6 @@ expression: snapshot
 
 @forward "theme" hide , $color;
 
-@forward "theme" as theme*;
-
 @forward "theme" as theme - *;
 
 @forward "theme" as theme-;
@@ -83,43 +81,43 @@ CssRoot {
         },
         CssAtRule {
             at_token: AT@66..69 "@" [Newline("\n"), Newline("\n")] [],
-            rule: ScssForwardAtRule {
-                forward_token: FORWARD_KW@69..77 "forward" [] [Whitespace(" ")],
-                url: CssString {
-                    value_token: CSS_STRING_LITERAL@77..85 "\"theme\"" [] [Whitespace(" ")],
-                },
-                as_clause: ScssForwardAsClause {
-                    as_token: AS_KW@85..88 "as" [] [Whitespace(" ")],
-                    prefix: CssIdentifier {
-                        value_token: IDENT@88..93 "theme" [] [],
-                    },
-                    star_token: STAR@93..94 "*" [] [],
-                },
-                visibility_clause: missing (optional),
-                with_clause: missing (optional),
-                semicolon_token: SEMICOLON@94..95 ";" [] [],
-            },
-        },
-        CssAtRule {
-            at_token: AT@95..98 "@" [Newline("\n"), Newline("\n")] [],
             rule: CssBogusAtRule {
                 items: [
-                    FORWARD_KW@98..106 "forward" [] [Whitespace(" ")],
+                    FORWARD_KW@69..77 "forward" [] [Whitespace(" ")],
                     CssString {
-                        value_token: CSS_STRING_LITERAL@106..114 "\"theme\"" [] [Whitespace(" ")],
+                        value_token: CSS_STRING_LITERAL@77..85 "\"theme\"" [] [Whitespace(" ")],
                     },
                     CssBogus {
                         items: [
-                            AS_KW@114..117 "as" [] [Whitespace(" ")],
+                            AS_KW@85..88 "as" [] [Whitespace(" ")],
                             CssIdentifier {
-                                value_token: IDENT@117..123 "theme" [] [Whitespace(" ")],
+                                value_token: IDENT@88..94 "theme" [] [Whitespace(" ")],
                             },
-                            MINUS@123..125 "-" [] [Whitespace(" ")],
-                            STAR@125..126 "*" [] [],
+                            MINUS@94..96 "-" [] [Whitespace(" ")],
+                            STAR@96..97 "*" [] [],
                         ],
                     },
-                    SEMICOLON@126..127 ";" [] [],
+                    SEMICOLON@97..98 ";" [] [],
                 ],
+            },
+        },
+        CssAtRule {
+            at_token: AT@98..101 "@" [Newline("\n"), Newline("\n")] [],
+            rule: ScssForwardAtRule {
+                forward_token: FORWARD_KW@101..109 "forward" [] [Whitespace(" ")],
+                url: CssString {
+                    value_token: CSS_STRING_LITERAL@109..117 "\"theme\"" [] [Whitespace(" ")],
+                },
+                as_clause: ScssForwardAsClause {
+                    as_token: AS_KW@117..120 "as" [] [Whitespace(" ")],
+                    prefix: CssIdentifier {
+                        value_token: IDENT@120..126 "theme-" [] [],
+                    },
+                    star_token: missing (required),
+                },
+                visibility_clause: missing (optional),
+                with_clause: missing (optional),
+                semicolon_token: SEMICOLON@126..127 ";" [] [],
             },
         },
         CssAtRule {
@@ -129,61 +127,42 @@ CssRoot {
                 url: CssString {
                     value_token: CSS_STRING_LITERAL@138..146 "\"theme\"" [] [Whitespace(" ")],
                 },
-                as_clause: ScssForwardAsClause {
-                    as_token: AS_KW@146..149 "as" [] [Whitespace(" ")],
-                    prefix: CssIdentifier {
-                        value_token: IDENT@149..155 "theme-" [] [],
-                    },
-                    star_token: missing (required),
-                },
-                visibility_clause: missing (optional),
-                with_clause: missing (optional),
-                semicolon_token: SEMICOLON@155..156 ";" [] [],
-            },
-        },
-        CssAtRule {
-            at_token: AT@156..159 "@" [Newline("\n"), Newline("\n")] [],
-            rule: ScssForwardAtRule {
-                forward_token: FORWARD_KW@159..167 "forward" [] [Whitespace(" ")],
-                url: CssString {
-                    value_token: CSS_STRING_LITERAL@167..175 "\"theme\"" [] [Whitespace(" ")],
-                },
                 as_clause: missing (optional),
                 visibility_clause: missing (optional),
                 with_clause: ScssWithClause {
-                    with_token: WITH_KW@175..180 "with" [] [Whitespace(" ")],
+                    with_token: WITH_KW@146..151 "with" [] [Whitespace(" ")],
                     configurations: ScssModuleConfigurationList {
-                        l_paren_token: L_PAREN@180..181 "(" [] [],
+                        l_paren_token: L_PAREN@151..152 "(" [] [],
                         items: ScssModuleConfigurationItemList [
                             ScssModuleConfiguration {
                                 name: ScssVariable {
-                                    dollar_token: DOLLAR@181..182 "$" [] [],
+                                    dollar_token: DOLLAR@152..153 "$" [] [],
                                     name: CssIdentifier {
-                                        value_token: IDENT@182..189 "spacing" [] [],
+                                        value_token: IDENT@153..160 "spacing" [] [],
                                     },
                                 },
-                                colon_token: COLON@189..190 ":" [] [],
+                                colon_token: COLON@160..161 ":" [] [],
                                 value: missing (required),
                                 modifier: missing (optional),
                             },
                         ],
-                        r_paren_token: R_PAREN@190..191 ")" [] [],
+                        r_paren_token: R_PAREN@161..162 ")" [] [],
                     },
                 },
-                semicolon_token: SEMICOLON@191..192 ";" [] [],
+                semicolon_token: SEMICOLON@162..163 ";" [] [],
             },
         },
     ],
-    eof_token: EOF@192..193 "" [Newline("\n")] [],
+    eof_token: EOF@163..164 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: CSS_ROOT@0..193
+0: CSS_ROOT@0..164
   0: (empty)
-  1: CSS_ROOT_ITEM_LIST@0..192
+  1: CSS_ROOT_ITEM_LIST@0..163
     0: CSS_AT_RULE@0..9
       0: AT@0..1 "@" [] []
       1: SCSS_FORWARD_AT_RULE@1..9
@@ -223,71 +202,57 @@ CssRoot {
                 0: IDENT@60..65 "color" [] []
         4: (empty)
         5: SEMICOLON@65..66 ";" [] []
-    3: CSS_AT_RULE@66..95
+    3: CSS_AT_RULE@66..98
       0: AT@66..69 "@" [Newline("\n"), Newline("\n")] []
-      1: SCSS_FORWARD_AT_RULE@69..95
+      1: CSS_BOGUS_AT_RULE@69..98
         0: FORWARD_KW@69..77 "forward" [] [Whitespace(" ")]
         1: CSS_STRING@77..85
           0: CSS_STRING_LITERAL@77..85 "\"theme\"" [] [Whitespace(" ")]
-        2: SCSS_FORWARD_AS_CLAUSE@85..94
+        2: CSS_BOGUS@85..97
           0: AS_KW@85..88 "as" [] [Whitespace(" ")]
-          1: CSS_IDENTIFIER@88..93
-            0: IDENT@88..93 "theme" [] []
-          2: STAR@93..94 "*" [] []
-        3: (empty)
-        4: (empty)
-        5: SEMICOLON@94..95 ";" [] []
-    4: CSS_AT_RULE@95..127
-      0: AT@95..98 "@" [Newline("\n"), Newline("\n")] []
-      1: CSS_BOGUS_AT_RULE@98..127
-        0: FORWARD_KW@98..106 "forward" [] [Whitespace(" ")]
-        1: CSS_STRING@106..114
-          0: CSS_STRING_LITERAL@106..114 "\"theme\"" [] [Whitespace(" ")]
-        2: CSS_BOGUS@114..126
-          0: AS_KW@114..117 "as" [] [Whitespace(" ")]
-          1: CSS_IDENTIFIER@117..123
-            0: IDENT@117..123 "theme" [] [Whitespace(" ")]
-          2: MINUS@123..125 "-" [] [Whitespace(" ")]
-          3: STAR@125..126 "*" [] []
-        3: SEMICOLON@126..127 ";" [] []
-    5: CSS_AT_RULE@127..156
-      0: AT@127..130 "@" [Newline("\n"), Newline("\n")] []
-      1: SCSS_FORWARD_AT_RULE@130..156
-        0: FORWARD_KW@130..138 "forward" [] [Whitespace(" ")]
-        1: CSS_STRING@138..146
-          0: CSS_STRING_LITERAL@138..146 "\"theme\"" [] [Whitespace(" ")]
-        2: SCSS_FORWARD_AS_CLAUSE@146..155
-          0: AS_KW@146..149 "as" [] [Whitespace(" ")]
-          1: CSS_IDENTIFIER@149..155
-            0: IDENT@149..155 "theme-" [] []
+          1: CSS_IDENTIFIER@88..94
+            0: IDENT@88..94 "theme" [] [Whitespace(" ")]
+          2: MINUS@94..96 "-" [] [Whitespace(" ")]
+          3: STAR@96..97 "*" [] []
+        3: SEMICOLON@97..98 ";" [] []
+    4: CSS_AT_RULE@98..127
+      0: AT@98..101 "@" [Newline("\n"), Newline("\n")] []
+      1: SCSS_FORWARD_AT_RULE@101..127
+        0: FORWARD_KW@101..109 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@109..117
+          0: CSS_STRING_LITERAL@109..117 "\"theme\"" [] [Whitespace(" ")]
+        2: SCSS_FORWARD_AS_CLAUSE@117..126
+          0: AS_KW@117..120 "as" [] [Whitespace(" ")]
+          1: CSS_IDENTIFIER@120..126
+            0: IDENT@120..126 "theme-" [] []
           2: (empty)
         3: (empty)
         4: (empty)
-        5: SEMICOLON@155..156 ";" [] []
-    6: CSS_AT_RULE@156..192
-      0: AT@156..159 "@" [Newline("\n"), Newline("\n")] []
-      1: SCSS_FORWARD_AT_RULE@159..192
-        0: FORWARD_KW@159..167 "forward" [] [Whitespace(" ")]
-        1: CSS_STRING@167..175
-          0: CSS_STRING_LITERAL@167..175 "\"theme\"" [] [Whitespace(" ")]
+        5: SEMICOLON@126..127 ";" [] []
+    5: CSS_AT_RULE@127..163
+      0: AT@127..130 "@" [Newline("\n"), Newline("\n")] []
+      1: SCSS_FORWARD_AT_RULE@130..163
+        0: FORWARD_KW@130..138 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@138..146
+          0: CSS_STRING_LITERAL@138..146 "\"theme\"" [] [Whitespace(" ")]
         2: (empty)
         3: (empty)
-        4: SCSS_WITH_CLAUSE@175..191
-          0: WITH_KW@175..180 "with" [] [Whitespace(" ")]
-          1: SCSS_MODULE_CONFIGURATION_LIST@180..191
-            0: L_PAREN@180..181 "(" [] []
-            1: SCSS_MODULE_CONFIGURATION_ITEM_LIST@181..190
-              0: SCSS_MODULE_CONFIGURATION@181..190
-                0: SCSS_VARIABLE@181..189
-                  0: DOLLAR@181..182 "$" [] []
-                  1: CSS_IDENTIFIER@182..189
-                    0: IDENT@182..189 "spacing" [] []
-                1: COLON@189..190 ":" [] []
+        4: SCSS_WITH_CLAUSE@146..162
+          0: WITH_KW@146..151 "with" [] [Whitespace(" ")]
+          1: SCSS_MODULE_CONFIGURATION_LIST@151..162
+            0: L_PAREN@151..152 "(" [] []
+            1: SCSS_MODULE_CONFIGURATION_ITEM_LIST@152..161
+              0: SCSS_MODULE_CONFIGURATION@152..161
+                0: SCSS_VARIABLE@152..160
+                  0: DOLLAR@152..153 "$" [] []
+                  1: CSS_IDENTIFIER@153..160
+                    0: IDENT@153..160 "spacing" [] []
+                1: COLON@160..161 ":" [] []
                 2: (empty)
                 3: (empty)
-            2: R_PAREN@190..191 ")" [] []
-        5: SEMICOLON@191..192 ";" [] []
-  2: EOF@192..193 "" [Newline("\n")] []
+            2: R_PAREN@161..162 ")" [] []
+        5: SEMICOLON@162..163 ";" [] []
+  2: EOF@163..164 "" [Newline("\n")] []
 
 ```
 
@@ -332,65 +297,52 @@ forward.scss:5:23 parse ━━━━━━━━━━━━━━━━━━�
   > 5 │ @forward "theme" hide , $color;
       │                       ^
     6 │ 
-    7 │ @forward "theme" as theme*;
+    7 │ @forward "theme" as theme - *;
   
   i Add a member like `$name` or `mixin-name` here.
   
-forward.scss:7:21 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+forward.scss:7:27 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Expected the `@forward` prefix to end with `-` before `*`.
+  × expected `*` but instead found `-`
   
     5 │ @forward "theme" hide , $color;
     6 │ 
-  > 7 │ @forward "theme" as theme*;
-      │                     ^^^^^^
+  > 7 │ @forward "theme" as theme - *;
+      │                           ^
     8 │ 
-    9 │ @forward "theme" as theme - *;
+    9 │ @forward "theme" as theme-;
   
-  i Write the clause as `as prefix-*` without spaces.
+  i Remove -
   
-forward.scss:9:21 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Expected the `@forward` prefix to end with `-` before `*`.
-  
-     7 │ @forward "theme" as theme*;
-     8 │ 
-   > 9 │ @forward "theme" as theme - *;
-       │                     ^^^^^^^
-    10 │ 
-    11 │ @forward "theme" as theme-;
-  
-  i Write the clause as `as prefix-*` without spaces.
-  
-forward.scss:11:27 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+forward.scss:9:27 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × expected `*` but instead found `;`
   
-     9 │ @forward "theme" as theme - *;
-    10 │ 
-  > 11 │ @forward "theme" as theme-;
+     7 │ @forward "theme" as theme - *;
+     8 │ 
+   > 9 │ @forward "theme" as theme-;
        │                           ^
-    12 │ 
-    13 │ @forward "theme" with ($spacing:);
+    10 │ 
+    11 │ @forward "theme" with ($spacing:);
   
   i Remove ;
   
-forward.scss:13:33 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+forward.scss:11:33 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Expected a SCSS expression but instead found ')'.
   
-    11 │ @forward "theme" as theme-;
-    12 │ 
-  > 13 │ @forward "theme" with ($spacing:);
+     9 │ @forward "theme" as theme-;
+    10 │ 
+  > 11 │ @forward "theme" with ($spacing:);
        │                                 ^
-    14 │ 
+    12 │ 
   
   i Expected a SCSS expression here.
   
-    11 │ @forward "theme" as theme-;
-    12 │ 
-  > 13 │ @forward "theme" with ($spacing:);
+     9 │ @forward "theme" as theme-;
+    10 │ 
+  > 11 │ @forward "theme" with ($spacing:);
        │                                 ^
-    14 │ 
+    12 │ 
   
 ```

--- a/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/release-forward-underscore-prefix.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/release-forward-underscore-prefix.scss
@@ -1,0 +1,18 @@
+@forward './button' as components_;
+@forward './after-underscore' as next_*;
+@forward './button' as components-;
+@forward './after-hyphen' as next_*;
+@forward './button' as *;
+@forward './after-identifier' as next_*;
+@forward './button' as components_
+@forward './after-no-semicolon' as next_*;
+@forward './button' as components_ *;
+@forward './after-space' as next_*;
+@forward './button' as components-/* gap */*;
+@forward './after-comment' as next_*;
+@forward './button' as components - *;
+@forward './after-stray-minus' as next_*;
+@forward './button' as -*;
+@forward './after-missing-identifier' as next_*;
+@forward './button' as components\5f  *;
+@forward './after-escape-gap' as next_*;

--- a/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/release-forward-underscore-prefix.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/scss/at-rule/release-forward-underscore-prefix.scss.snap
@@ -1,0 +1,774 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+@forward './button' as components_;
+@forward './after-underscore' as next_*;
+@forward './button' as components-;
+@forward './after-hyphen' as next_*;
+@forward './button' as *;
+@forward './after-identifier' as next_*;
+@forward './button' as components_
+@forward './after-no-semicolon' as next_*;
+@forward './button' as components_ *;
+@forward './after-space' as next_*;
+@forward './button' as components-/* gap */*;
+@forward './after-comment' as next_*;
+@forward './button' as components - *;
+@forward './after-stray-minus' as next_*;
+@forward './button' as -*;
+@forward './after-missing-identifier' as next_*;
+@forward './button' as components\5f  *;
+@forward './after-escape-gap' as next_*;
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssAtRule {
+            at_token: AT@0..1 "@" [] [],
+            rule: ScssForwardAtRule {
+                forward_token: FORWARD_KW@1..9 "forward" [] [Whitespace(" ")],
+                url: CssString {
+                    value_token: CSS_STRING_LITERAL@9..20 "'./button'" [] [Whitespace(" ")],
+                },
+                as_clause: ScssForwardAsClause {
+                    as_token: AS_KW@20..23 "as" [] [Whitespace(" ")],
+                    prefix: CssIdentifier {
+                        value_token: IDENT@23..34 "components_" [] [],
+                    },
+                    star_token: missing (required),
+                },
+                visibility_clause: missing (optional),
+                with_clause: missing (optional),
+                semicolon_token: SEMICOLON@34..35 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@35..37 "@" [Newline("\n")] [],
+            rule: ScssForwardAtRule {
+                forward_token: FORWARD_KW@37..45 "forward" [] [Whitespace(" ")],
+                url: CssString {
+                    value_token: CSS_STRING_LITERAL@45..66 "'./after-underscore'" [] [Whitespace(" ")],
+                },
+                as_clause: ScssForwardAsClause {
+                    as_token: AS_KW@66..69 "as" [] [Whitespace(" ")],
+                    prefix: CssIdentifier {
+                        value_token: IDENT@69..74 "next_" [] [],
+                    },
+                    star_token: STAR@74..75 "*" [] [],
+                },
+                visibility_clause: missing (optional),
+                with_clause: missing (optional),
+                semicolon_token: SEMICOLON@75..76 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@76..78 "@" [Newline("\n")] [],
+            rule: ScssForwardAtRule {
+                forward_token: FORWARD_KW@78..86 "forward" [] [Whitespace(" ")],
+                url: CssString {
+                    value_token: CSS_STRING_LITERAL@86..97 "'./button'" [] [Whitespace(" ")],
+                },
+                as_clause: ScssForwardAsClause {
+                    as_token: AS_KW@97..100 "as" [] [Whitespace(" ")],
+                    prefix: CssIdentifier {
+                        value_token: IDENT@100..111 "components-" [] [],
+                    },
+                    star_token: missing (required),
+                },
+                visibility_clause: missing (optional),
+                with_clause: missing (optional),
+                semicolon_token: SEMICOLON@111..112 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@112..114 "@" [Newline("\n")] [],
+            rule: ScssForwardAtRule {
+                forward_token: FORWARD_KW@114..122 "forward" [] [Whitespace(" ")],
+                url: CssString {
+                    value_token: CSS_STRING_LITERAL@122..139 "'./after-hyphen'" [] [Whitespace(" ")],
+                },
+                as_clause: ScssForwardAsClause {
+                    as_token: AS_KW@139..142 "as" [] [Whitespace(" ")],
+                    prefix: CssIdentifier {
+                        value_token: IDENT@142..147 "next_" [] [],
+                    },
+                    star_token: STAR@147..148 "*" [] [],
+                },
+                visibility_clause: missing (optional),
+                with_clause: missing (optional),
+                semicolon_token: SEMICOLON@148..149 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@149..151 "@" [Newline("\n")] [],
+            rule: ScssForwardAtRule {
+                forward_token: FORWARD_KW@151..159 "forward" [] [Whitespace(" ")],
+                url: CssString {
+                    value_token: CSS_STRING_LITERAL@159..170 "'./button'" [] [Whitespace(" ")],
+                },
+                as_clause: ScssForwardAsClause {
+                    as_token: AS_KW@170..173 "as" [] [Whitespace(" ")],
+                    prefix: missing (required),
+                    star_token: STAR@173..174 "*" [] [],
+                },
+                visibility_clause: missing (optional),
+                with_clause: missing (optional),
+                semicolon_token: SEMICOLON@174..175 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@175..177 "@" [Newline("\n")] [],
+            rule: ScssForwardAtRule {
+                forward_token: FORWARD_KW@177..185 "forward" [] [Whitespace(" ")],
+                url: CssString {
+                    value_token: CSS_STRING_LITERAL@185..206 "'./after-identifier'" [] [Whitespace(" ")],
+                },
+                as_clause: ScssForwardAsClause {
+                    as_token: AS_KW@206..209 "as" [] [Whitespace(" ")],
+                    prefix: CssIdentifier {
+                        value_token: IDENT@209..214 "next_" [] [],
+                    },
+                    star_token: STAR@214..215 "*" [] [],
+                },
+                visibility_clause: missing (optional),
+                with_clause: missing (optional),
+                semicolon_token: SEMICOLON@215..216 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@216..218 "@" [Newline("\n")] [],
+            rule: ScssForwardAtRule {
+                forward_token: FORWARD_KW@218..226 "forward" [] [Whitespace(" ")],
+                url: CssString {
+                    value_token: CSS_STRING_LITERAL@226..237 "'./button'" [] [Whitespace(" ")],
+                },
+                as_clause: ScssForwardAsClause {
+                    as_token: AS_KW@237..240 "as" [] [Whitespace(" ")],
+                    prefix: CssIdentifier {
+                        value_token: IDENT@240..251 "components_" [] [],
+                    },
+                    star_token: missing (required),
+                },
+                visibility_clause: missing (optional),
+                with_clause: missing (optional),
+                semicolon_token: missing (optional),
+            },
+        },
+        CssAtRule {
+            at_token: AT@251..253 "@" [Newline("\n")] [],
+            rule: ScssForwardAtRule {
+                forward_token: FORWARD_KW@253..261 "forward" [] [Whitespace(" ")],
+                url: CssString {
+                    value_token: CSS_STRING_LITERAL@261..284 "'./after-no-semicolon'" [] [Whitespace(" ")],
+                },
+                as_clause: ScssForwardAsClause {
+                    as_token: AS_KW@284..287 "as" [] [Whitespace(" ")],
+                    prefix: CssIdentifier {
+                        value_token: IDENT@287..292 "next_" [] [],
+                    },
+                    star_token: STAR@292..293 "*" [] [],
+                },
+                visibility_clause: missing (optional),
+                with_clause: missing (optional),
+                semicolon_token: SEMICOLON@293..294 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@294..296 "@" [Newline("\n")] [],
+            rule: ScssForwardAtRule {
+                forward_token: FORWARD_KW@296..304 "forward" [] [Whitespace(" ")],
+                url: CssString {
+                    value_token: CSS_STRING_LITERAL@304..315 "'./button'" [] [Whitespace(" ")],
+                },
+                as_clause: ScssForwardAsClause {
+                    as_token: AS_KW@315..318 "as" [] [Whitespace(" ")],
+                    prefix: CssIdentifier {
+                        value_token: IDENT@318..330 "components_" [] [Whitespace(" ")],
+                    },
+                    star_token: STAR@330..331 "*" [] [],
+                },
+                visibility_clause: missing (optional),
+                with_clause: missing (optional),
+                semicolon_token: SEMICOLON@331..332 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@332..334 "@" [Newline("\n")] [],
+            rule: ScssForwardAtRule {
+                forward_token: FORWARD_KW@334..342 "forward" [] [Whitespace(" ")],
+                url: CssString {
+                    value_token: CSS_STRING_LITERAL@342..358 "'./after-space'" [] [Whitespace(" ")],
+                },
+                as_clause: ScssForwardAsClause {
+                    as_token: AS_KW@358..361 "as" [] [Whitespace(" ")],
+                    prefix: CssIdentifier {
+                        value_token: IDENT@361..366 "next_" [] [],
+                    },
+                    star_token: STAR@366..367 "*" [] [],
+                },
+                visibility_clause: missing (optional),
+                with_clause: missing (optional),
+                semicolon_token: SEMICOLON@367..368 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@368..370 "@" [Newline("\n")] [],
+            rule: ScssForwardAtRule {
+                forward_token: FORWARD_KW@370..378 "forward" [] [Whitespace(" ")],
+                url: CssString {
+                    value_token: CSS_STRING_LITERAL@378..389 "'./button'" [] [Whitespace(" ")],
+                },
+                as_clause: ScssForwardAsClause {
+                    as_token: AS_KW@389..392 "as" [] [Whitespace(" ")],
+                    prefix: CssIdentifier {
+                        value_token: IDENT@392..412 "components-" [] [Comments("/* gap */")],
+                    },
+                    star_token: STAR@412..413 "*" [] [],
+                },
+                visibility_clause: missing (optional),
+                with_clause: missing (optional),
+                semicolon_token: SEMICOLON@413..414 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@414..416 "@" [Newline("\n")] [],
+            rule: ScssForwardAtRule {
+                forward_token: FORWARD_KW@416..424 "forward" [] [Whitespace(" ")],
+                url: CssString {
+                    value_token: CSS_STRING_LITERAL@424..442 "'./after-comment'" [] [Whitespace(" ")],
+                },
+                as_clause: ScssForwardAsClause {
+                    as_token: AS_KW@442..445 "as" [] [Whitespace(" ")],
+                    prefix: CssIdentifier {
+                        value_token: IDENT@445..450 "next_" [] [],
+                    },
+                    star_token: STAR@450..451 "*" [] [],
+                },
+                visibility_clause: missing (optional),
+                with_clause: missing (optional),
+                semicolon_token: SEMICOLON@451..452 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@452..454 "@" [Newline("\n")] [],
+            rule: CssBogusAtRule {
+                items: [
+                    FORWARD_KW@454..462 "forward" [] [Whitespace(" ")],
+                    CssString {
+                        value_token: CSS_STRING_LITERAL@462..473 "'./button'" [] [Whitespace(" ")],
+                    },
+                    CssBogus {
+                        items: [
+                            AS_KW@473..476 "as" [] [Whitespace(" ")],
+                            CssIdentifier {
+                                value_token: IDENT@476..487 "components" [] [Whitespace(" ")],
+                            },
+                            MINUS@487..489 "-" [] [Whitespace(" ")],
+                            STAR@489..490 "*" [] [],
+                        ],
+                    },
+                    SEMICOLON@490..491 ";" [] [],
+                ],
+            },
+        },
+        CssAtRule {
+            at_token: AT@491..493 "@" [Newline("\n")] [],
+            rule: ScssForwardAtRule {
+                forward_token: FORWARD_KW@493..501 "forward" [] [Whitespace(" ")],
+                url: CssString {
+                    value_token: CSS_STRING_LITERAL@501..523 "'./after-stray-minus'" [] [Whitespace(" ")],
+                },
+                as_clause: ScssForwardAsClause {
+                    as_token: AS_KW@523..526 "as" [] [Whitespace(" ")],
+                    prefix: CssIdentifier {
+                        value_token: IDENT@526..531 "next_" [] [],
+                    },
+                    star_token: STAR@531..532 "*" [] [],
+                },
+                visibility_clause: missing (optional),
+                with_clause: missing (optional),
+                semicolon_token: SEMICOLON@532..533 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@533..535 "@" [Newline("\n")] [],
+            rule: CssBogusAtRule {
+                items: [
+                    FORWARD_KW@535..543 "forward" [] [Whitespace(" ")],
+                    CssString {
+                        value_token: CSS_STRING_LITERAL@543..554 "'./button'" [] [Whitespace(" ")],
+                    },
+                    CssBogus {
+                        items: [
+                            AS_KW@554..557 "as" [] [Whitespace(" ")],
+                            MINUS@557..558 "-" [] [],
+                            STAR@558..559 "*" [] [],
+                        ],
+                    },
+                    SEMICOLON@559..560 ";" [] [],
+                ],
+            },
+        },
+        CssAtRule {
+            at_token: AT@560..562 "@" [Newline("\n")] [],
+            rule: ScssForwardAtRule {
+                forward_token: FORWARD_KW@562..570 "forward" [] [Whitespace(" ")],
+                url: CssString {
+                    value_token: CSS_STRING_LITERAL@570..599 "'./after-missing-identifier'" [] [Whitespace(" ")],
+                },
+                as_clause: ScssForwardAsClause {
+                    as_token: AS_KW@599..602 "as" [] [Whitespace(" ")],
+                    prefix: CssIdentifier {
+                        value_token: IDENT@602..607 "next_" [] [],
+                    },
+                    star_token: STAR@607..608 "*" [] [],
+                },
+                visibility_clause: missing (optional),
+                with_clause: missing (optional),
+                semicolon_token: SEMICOLON@608..609 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@609..611 "@" [Newline("\n")] [],
+            rule: ScssForwardAtRule {
+                forward_token: FORWARD_KW@611..619 "forward" [] [Whitespace(" ")],
+                url: CssString {
+                    value_token: CSS_STRING_LITERAL@619..630 "'./button'" [] [Whitespace(" ")],
+                },
+                as_clause: ScssForwardAsClause {
+                    as_token: AS_KW@630..633 "as" [] [Whitespace(" ")],
+                    prefix: CssIdentifier {
+                        value_token: IDENT@633..648 "components\\5f " [] [Whitespace(" ")],
+                    },
+                    star_token: STAR@648..649 "*" [] [],
+                },
+                visibility_clause: missing (optional),
+                with_clause: missing (optional),
+                semicolon_token: SEMICOLON@649..650 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@650..652 "@" [Newline("\n")] [],
+            rule: ScssForwardAtRule {
+                forward_token: FORWARD_KW@652..660 "forward" [] [Whitespace(" ")],
+                url: CssString {
+                    value_token: CSS_STRING_LITERAL@660..681 "'./after-escape-gap'" [] [Whitespace(" ")],
+                },
+                as_clause: ScssForwardAsClause {
+                    as_token: AS_KW@681..684 "as" [] [Whitespace(" ")],
+                    prefix: CssIdentifier {
+                        value_token: IDENT@684..689 "next_" [] [],
+                    },
+                    star_token: STAR@689..690 "*" [] [],
+                },
+                visibility_clause: missing (optional),
+                with_clause: missing (optional),
+                semicolon_token: SEMICOLON@690..691 ";" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@691..692 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..692
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..691
+    0: CSS_AT_RULE@0..35
+      0: AT@0..1 "@" [] []
+      1: SCSS_FORWARD_AT_RULE@1..35
+        0: FORWARD_KW@1..9 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@9..20
+          0: CSS_STRING_LITERAL@9..20 "'./button'" [] [Whitespace(" ")]
+        2: SCSS_FORWARD_AS_CLAUSE@20..34
+          0: AS_KW@20..23 "as" [] [Whitespace(" ")]
+          1: CSS_IDENTIFIER@23..34
+            0: IDENT@23..34 "components_" [] []
+          2: (empty)
+        3: (empty)
+        4: (empty)
+        5: SEMICOLON@34..35 ";" [] []
+    1: CSS_AT_RULE@35..76
+      0: AT@35..37 "@" [Newline("\n")] []
+      1: SCSS_FORWARD_AT_RULE@37..76
+        0: FORWARD_KW@37..45 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@45..66
+          0: CSS_STRING_LITERAL@45..66 "'./after-underscore'" [] [Whitespace(" ")]
+        2: SCSS_FORWARD_AS_CLAUSE@66..75
+          0: AS_KW@66..69 "as" [] [Whitespace(" ")]
+          1: CSS_IDENTIFIER@69..74
+            0: IDENT@69..74 "next_" [] []
+          2: STAR@74..75 "*" [] []
+        3: (empty)
+        4: (empty)
+        5: SEMICOLON@75..76 ";" [] []
+    2: CSS_AT_RULE@76..112
+      0: AT@76..78 "@" [Newline("\n")] []
+      1: SCSS_FORWARD_AT_RULE@78..112
+        0: FORWARD_KW@78..86 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@86..97
+          0: CSS_STRING_LITERAL@86..97 "'./button'" [] [Whitespace(" ")]
+        2: SCSS_FORWARD_AS_CLAUSE@97..111
+          0: AS_KW@97..100 "as" [] [Whitespace(" ")]
+          1: CSS_IDENTIFIER@100..111
+            0: IDENT@100..111 "components-" [] []
+          2: (empty)
+        3: (empty)
+        4: (empty)
+        5: SEMICOLON@111..112 ";" [] []
+    3: CSS_AT_RULE@112..149
+      0: AT@112..114 "@" [Newline("\n")] []
+      1: SCSS_FORWARD_AT_RULE@114..149
+        0: FORWARD_KW@114..122 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@122..139
+          0: CSS_STRING_LITERAL@122..139 "'./after-hyphen'" [] [Whitespace(" ")]
+        2: SCSS_FORWARD_AS_CLAUSE@139..148
+          0: AS_KW@139..142 "as" [] [Whitespace(" ")]
+          1: CSS_IDENTIFIER@142..147
+            0: IDENT@142..147 "next_" [] []
+          2: STAR@147..148 "*" [] []
+        3: (empty)
+        4: (empty)
+        5: SEMICOLON@148..149 ";" [] []
+    4: CSS_AT_RULE@149..175
+      0: AT@149..151 "@" [Newline("\n")] []
+      1: SCSS_FORWARD_AT_RULE@151..175
+        0: FORWARD_KW@151..159 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@159..170
+          0: CSS_STRING_LITERAL@159..170 "'./button'" [] [Whitespace(" ")]
+        2: SCSS_FORWARD_AS_CLAUSE@170..174
+          0: AS_KW@170..173 "as" [] [Whitespace(" ")]
+          1: (empty)
+          2: STAR@173..174 "*" [] []
+        3: (empty)
+        4: (empty)
+        5: SEMICOLON@174..175 ";" [] []
+    5: CSS_AT_RULE@175..216
+      0: AT@175..177 "@" [Newline("\n")] []
+      1: SCSS_FORWARD_AT_RULE@177..216
+        0: FORWARD_KW@177..185 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@185..206
+          0: CSS_STRING_LITERAL@185..206 "'./after-identifier'" [] [Whitespace(" ")]
+        2: SCSS_FORWARD_AS_CLAUSE@206..215
+          0: AS_KW@206..209 "as" [] [Whitespace(" ")]
+          1: CSS_IDENTIFIER@209..214
+            0: IDENT@209..214 "next_" [] []
+          2: STAR@214..215 "*" [] []
+        3: (empty)
+        4: (empty)
+        5: SEMICOLON@215..216 ";" [] []
+    6: CSS_AT_RULE@216..251
+      0: AT@216..218 "@" [Newline("\n")] []
+      1: SCSS_FORWARD_AT_RULE@218..251
+        0: FORWARD_KW@218..226 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@226..237
+          0: CSS_STRING_LITERAL@226..237 "'./button'" [] [Whitespace(" ")]
+        2: SCSS_FORWARD_AS_CLAUSE@237..251
+          0: AS_KW@237..240 "as" [] [Whitespace(" ")]
+          1: CSS_IDENTIFIER@240..251
+            0: IDENT@240..251 "components_" [] []
+          2: (empty)
+        3: (empty)
+        4: (empty)
+        5: (empty)
+    7: CSS_AT_RULE@251..294
+      0: AT@251..253 "@" [Newline("\n")] []
+      1: SCSS_FORWARD_AT_RULE@253..294
+        0: FORWARD_KW@253..261 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@261..284
+          0: CSS_STRING_LITERAL@261..284 "'./after-no-semicolon'" [] [Whitespace(" ")]
+        2: SCSS_FORWARD_AS_CLAUSE@284..293
+          0: AS_KW@284..287 "as" [] [Whitespace(" ")]
+          1: CSS_IDENTIFIER@287..292
+            0: IDENT@287..292 "next_" [] []
+          2: STAR@292..293 "*" [] []
+        3: (empty)
+        4: (empty)
+        5: SEMICOLON@293..294 ";" [] []
+    8: CSS_AT_RULE@294..332
+      0: AT@294..296 "@" [Newline("\n")] []
+      1: SCSS_FORWARD_AT_RULE@296..332
+        0: FORWARD_KW@296..304 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@304..315
+          0: CSS_STRING_LITERAL@304..315 "'./button'" [] [Whitespace(" ")]
+        2: SCSS_FORWARD_AS_CLAUSE@315..331
+          0: AS_KW@315..318 "as" [] [Whitespace(" ")]
+          1: CSS_IDENTIFIER@318..330
+            0: IDENT@318..330 "components_" [] [Whitespace(" ")]
+          2: STAR@330..331 "*" [] []
+        3: (empty)
+        4: (empty)
+        5: SEMICOLON@331..332 ";" [] []
+    9: CSS_AT_RULE@332..368
+      0: AT@332..334 "@" [Newline("\n")] []
+      1: SCSS_FORWARD_AT_RULE@334..368
+        0: FORWARD_KW@334..342 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@342..358
+          0: CSS_STRING_LITERAL@342..358 "'./after-space'" [] [Whitespace(" ")]
+        2: SCSS_FORWARD_AS_CLAUSE@358..367
+          0: AS_KW@358..361 "as" [] [Whitespace(" ")]
+          1: CSS_IDENTIFIER@361..366
+            0: IDENT@361..366 "next_" [] []
+          2: STAR@366..367 "*" [] []
+        3: (empty)
+        4: (empty)
+        5: SEMICOLON@367..368 ";" [] []
+    10: CSS_AT_RULE@368..414
+      0: AT@368..370 "@" [Newline("\n")] []
+      1: SCSS_FORWARD_AT_RULE@370..414
+        0: FORWARD_KW@370..378 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@378..389
+          0: CSS_STRING_LITERAL@378..389 "'./button'" [] [Whitespace(" ")]
+        2: SCSS_FORWARD_AS_CLAUSE@389..413
+          0: AS_KW@389..392 "as" [] [Whitespace(" ")]
+          1: CSS_IDENTIFIER@392..412
+            0: IDENT@392..412 "components-" [] [Comments("/* gap */")]
+          2: STAR@412..413 "*" [] []
+        3: (empty)
+        4: (empty)
+        5: SEMICOLON@413..414 ";" [] []
+    11: CSS_AT_RULE@414..452
+      0: AT@414..416 "@" [Newline("\n")] []
+      1: SCSS_FORWARD_AT_RULE@416..452
+        0: FORWARD_KW@416..424 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@424..442
+          0: CSS_STRING_LITERAL@424..442 "'./after-comment'" [] [Whitespace(" ")]
+        2: SCSS_FORWARD_AS_CLAUSE@442..451
+          0: AS_KW@442..445 "as" [] [Whitespace(" ")]
+          1: CSS_IDENTIFIER@445..450
+            0: IDENT@445..450 "next_" [] []
+          2: STAR@450..451 "*" [] []
+        3: (empty)
+        4: (empty)
+        5: SEMICOLON@451..452 ";" [] []
+    12: CSS_AT_RULE@452..491
+      0: AT@452..454 "@" [Newline("\n")] []
+      1: CSS_BOGUS_AT_RULE@454..491
+        0: FORWARD_KW@454..462 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@462..473
+          0: CSS_STRING_LITERAL@462..473 "'./button'" [] [Whitespace(" ")]
+        2: CSS_BOGUS@473..490
+          0: AS_KW@473..476 "as" [] [Whitespace(" ")]
+          1: CSS_IDENTIFIER@476..487
+            0: IDENT@476..487 "components" [] [Whitespace(" ")]
+          2: MINUS@487..489 "-" [] [Whitespace(" ")]
+          3: STAR@489..490 "*" [] []
+        3: SEMICOLON@490..491 ";" [] []
+    13: CSS_AT_RULE@491..533
+      0: AT@491..493 "@" [Newline("\n")] []
+      1: SCSS_FORWARD_AT_RULE@493..533
+        0: FORWARD_KW@493..501 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@501..523
+          0: CSS_STRING_LITERAL@501..523 "'./after-stray-minus'" [] [Whitespace(" ")]
+        2: SCSS_FORWARD_AS_CLAUSE@523..532
+          0: AS_KW@523..526 "as" [] [Whitespace(" ")]
+          1: CSS_IDENTIFIER@526..531
+            0: IDENT@526..531 "next_" [] []
+          2: STAR@531..532 "*" [] []
+        3: (empty)
+        4: (empty)
+        5: SEMICOLON@532..533 ";" [] []
+    14: CSS_AT_RULE@533..560
+      0: AT@533..535 "@" [Newline("\n")] []
+      1: CSS_BOGUS_AT_RULE@535..560
+        0: FORWARD_KW@535..543 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@543..554
+          0: CSS_STRING_LITERAL@543..554 "'./button'" [] [Whitespace(" ")]
+        2: CSS_BOGUS@554..559
+          0: AS_KW@554..557 "as" [] [Whitespace(" ")]
+          1: MINUS@557..558 "-" [] []
+          2: STAR@558..559 "*" [] []
+        3: SEMICOLON@559..560 ";" [] []
+    15: CSS_AT_RULE@560..609
+      0: AT@560..562 "@" [Newline("\n")] []
+      1: SCSS_FORWARD_AT_RULE@562..609
+        0: FORWARD_KW@562..570 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@570..599
+          0: CSS_STRING_LITERAL@570..599 "'./after-missing-identifier'" [] [Whitespace(" ")]
+        2: SCSS_FORWARD_AS_CLAUSE@599..608
+          0: AS_KW@599..602 "as" [] [Whitespace(" ")]
+          1: CSS_IDENTIFIER@602..607
+            0: IDENT@602..607 "next_" [] []
+          2: STAR@607..608 "*" [] []
+        3: (empty)
+        4: (empty)
+        5: SEMICOLON@608..609 ";" [] []
+    16: CSS_AT_RULE@609..650
+      0: AT@609..611 "@" [Newline("\n")] []
+      1: SCSS_FORWARD_AT_RULE@611..650
+        0: FORWARD_KW@611..619 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@619..630
+          0: CSS_STRING_LITERAL@619..630 "'./button'" [] [Whitespace(" ")]
+        2: SCSS_FORWARD_AS_CLAUSE@630..649
+          0: AS_KW@630..633 "as" [] [Whitespace(" ")]
+          1: CSS_IDENTIFIER@633..648
+            0: IDENT@633..648 "components\\5f " [] [Whitespace(" ")]
+          2: STAR@648..649 "*" [] []
+        3: (empty)
+        4: (empty)
+        5: SEMICOLON@649..650 ";" [] []
+    17: CSS_AT_RULE@650..691
+      0: AT@650..652 "@" [Newline("\n")] []
+      1: SCSS_FORWARD_AT_RULE@652..691
+        0: FORWARD_KW@652..660 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@660..681
+          0: CSS_STRING_LITERAL@660..681 "'./after-escape-gap'" [] [Whitespace(" ")]
+        2: SCSS_FORWARD_AS_CLAUSE@681..690
+          0: AS_KW@681..684 "as" [] [Whitespace(" ")]
+          1: CSS_IDENTIFIER@684..689
+            0: IDENT@684..689 "next_" [] []
+          2: STAR@689..690 "*" [] []
+        3: (empty)
+        4: (empty)
+        5: SEMICOLON@690..691 ";" [] []
+  2: EOF@691..692 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+release-forward-underscore-prefix.scss:1:35 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `*` but instead found `;`
+  
+  > 1 │ @forward './button' as components_;
+      │                                   ^
+    2 │ @forward './after-underscore' as next_*;
+    3 │ @forward './button' as components-;
+  
+  i Remove ;
+  
+release-forward-underscore-prefix.scss:3:35 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `*` but instead found `;`
+  
+    1 │ @forward './button' as components_;
+    2 │ @forward './after-underscore' as next_*;
+  > 3 │ @forward './button' as components-;
+      │                                   ^
+    4 │ @forward './after-hyphen' as next_*;
+    5 │ @forward './button' as *;
+  
+  i Remove ;
+  
+release-forward-underscore-prefix.scss:5:24 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected an identifier but instead found '*'.
+  
+    3 │ @forward './button' as components-;
+    4 │ @forward './after-hyphen' as next_*;
+  > 5 │ @forward './button' as *;
+      │                        ^
+    6 │ @forward './after-identifier' as next_*;
+    7 │ @forward './button' as components_
+  
+  i Expected an identifier here.
+  
+    3 │ @forward './button' as components-;
+    4 │ @forward './after-hyphen' as next_*;
+  > 5 │ @forward './button' as *;
+      │                        ^
+    6 │ @forward './after-identifier' as next_*;
+    7 │ @forward './button' as components_
+  
+release-forward-underscore-prefix.scss:8:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `*` but instead found `@`
+  
+     6 │ @forward './after-identifier' as next_*;
+     7 │ @forward './button' as components_
+   > 8 │ @forward './after-no-semicolon' as next_*;
+       │ ^
+     9 │ @forward './button' as components_ *;
+    10 │ @forward './after-space' as next_*;
+  
+  i Remove @
+  
+release-forward-underscore-prefix.scss:9:24 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected `*` immediately after the `@forward` prefix.
+  
+     7 │ @forward './button' as components_
+     8 │ @forward './after-no-semicolon' as next_*;
+   > 9 │ @forward './button' as components_ *;
+       │                        ^^^^^^^^^^^^^
+    10 │ @forward './after-space' as next_*;
+    11 │ @forward './button' as components-/* gap */*;
+  
+  i Write the prefix and `*` together, for example `as components_*`.
+  
+release-forward-underscore-prefix.scss:11:24 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected `*` immediately after the `@forward` prefix.
+  
+     9 │ @forward './button' as components_ *;
+    10 │ @forward './after-space' as next_*;
+  > 11 │ @forward './button' as components-/* gap */*;
+       │                        ^^^^^^^^^^^^^^^^^^^^^
+    12 │ @forward './after-comment' as next_*;
+    13 │ @forward './button' as components - *;
+  
+  i Write the prefix and `*` together, for example `as components_*`.
+  
+release-forward-underscore-prefix.scss:13:35 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `*` but instead found `-`
+  
+    11 │ @forward './button' as components-/* gap */*;
+    12 │ @forward './after-comment' as next_*;
+  > 13 │ @forward './button' as components - *;
+       │                                   ^
+    14 │ @forward './after-stray-minus' as next_*;
+    15 │ @forward './button' as -*;
+  
+  i Remove -
+  
+release-forward-underscore-prefix.scss:15:24 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected an identifier but instead found '-'.
+  
+    13 │ @forward './button' as components - *;
+    14 │ @forward './after-stray-minus' as next_*;
+  > 15 │ @forward './button' as -*;
+       │                        ^
+    16 │ @forward './after-missing-identifier' as next_*;
+    17 │ @forward './button' as components\5f  *;
+  
+  i Expected an identifier here.
+  
+    13 │ @forward './button' as components - *;
+    14 │ @forward './after-stray-minus' as next_*;
+  > 15 │ @forward './button' as -*;
+       │                        ^
+    16 │ @forward './after-missing-identifier' as next_*;
+    17 │ @forward './button' as components\5f  *;
+  
+release-forward-underscore-prefix.scss:17:24 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected `*` immediately after the `@forward` prefix.
+  
+    15 │ @forward './button' as -*;
+    16 │ @forward './after-missing-identifier' as next_*;
+  > 17 │ @forward './button' as components\5f  *;
+       │                        ^^^^^^^^^^^^^^^^
+    18 │ @forward './after-escape-gap' as next_*;
+    19 │ 
+  
+  i Write the prefix and `*` together, for example `as components_*`.
+  
+```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/release-forward-underscore-prefix.css
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/release-forward-underscore-prefix.css
@@ -1,0 +1,4 @@
+@forward "./button" as components_*;
+@forward "./button" as components-*;
+@forward "./button" as components*;
+.native { color: red; width: 1px; }

--- a/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/release-forward-underscore-prefix.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/at_rule/release-forward-underscore-prefix.css.snap
@@ -1,0 +1,214 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+@forward "./button" as components_*;
+@forward "./button" as components-*;
+@forward "./button" as components*;
+.native { color: red; width: 1px; }
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssAtRule {
+            at_token: AT@0..1 "@" [] [],
+            rule: CssUnknownValueAtRule {
+                name: CssIdentifier {
+                    value_token: IDENT@1..9 "forward" [] [Whitespace(" ")],
+                },
+                components: CssUnknownAtRuleComponentList {
+                    items: [
+                        CSS_STRING_LITERAL@9..20 "\"./button\"" [] [Whitespace(" ")],
+                        AS_KW@20..23 "as" [] [Whitespace(" ")],
+                        IDENT@23..34 "components_" [] [],
+                        STAR@34..35 "*" [] [],
+                    ],
+                },
+                semicolon_token: SEMICOLON@35..36 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@36..38 "@" [Newline("\n")] [],
+            rule: CssUnknownValueAtRule {
+                name: CssIdentifier {
+                    value_token: IDENT@38..46 "forward" [] [Whitespace(" ")],
+                },
+                components: CssUnknownAtRuleComponentList {
+                    items: [
+                        CSS_STRING_LITERAL@46..57 "\"./button\"" [] [Whitespace(" ")],
+                        AS_KW@57..60 "as" [] [Whitespace(" ")],
+                        IDENT@60..71 "components-" [] [],
+                        STAR@71..72 "*" [] [],
+                    ],
+                },
+                semicolon_token: SEMICOLON@72..73 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@73..75 "@" [Newline("\n")] [],
+            rule: CssUnknownValueAtRule {
+                name: CssIdentifier {
+                    value_token: IDENT@75..83 "forward" [] [Whitespace(" ")],
+                },
+                components: CssUnknownAtRuleComponentList {
+                    items: [
+                        CSS_STRING_LITERAL@83..94 "\"./button\"" [] [Whitespace(" ")],
+                        AS_KW@94..97 "as" [] [Whitespace(" ")],
+                        IDENT@97..107 "components" [] [],
+                        STAR@107..108 "*" [] [],
+                    ],
+                },
+                semicolon_token: SEMICOLON@108..109 ";" [] [],
+            },
+        },
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@109..111 "." [Newline("\n")] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@111..118 "native" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@118..120 "{" [] [Whitespace(" ")],
+                items: CssDeclarationOrRuleList [
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@120..125 "color" [] [],
+                                },
+                                colon_token: COLON@125..127 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssIdentifier {
+                                        value_token: IDENT@127..130 "red" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@130..132 ";" [] [Whitespace(" ")],
+                    },
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssGenericProperty {
+                                name: CssIdentifier {
+                                    value_token: IDENT@132..137 "width" [] [],
+                                },
+                                colon_token: COLON@137..139 ":" [] [Whitespace(" ")],
+                                value: CssGenericComponentValueList [
+                                    CssRegularDimension {
+                                        value_token: CSS_NUMBER_LITERAL@139..140 "1" [] [],
+                                        unit_token: IDENT@140..142 "px" [] [],
+                                    },
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@142..144 ";" [] [Whitespace(" ")],
+                    },
+                ],
+                r_curly_token: R_CURLY@144..145 "}" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@145..146 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..146
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..145
+    0: CSS_AT_RULE@0..36
+      0: AT@0..1 "@" [] []
+      1: CSS_UNKNOWN_VALUE_AT_RULE@1..36
+        0: CSS_IDENTIFIER@1..9
+          0: IDENT@1..9 "forward" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@9..35
+          0: CSS_STRING_LITERAL@9..20 "\"./button\"" [] [Whitespace(" ")]
+          1: AS_KW@20..23 "as" [] [Whitespace(" ")]
+          2: IDENT@23..34 "components_" [] []
+          3: STAR@34..35 "*" [] []
+        2: SEMICOLON@35..36 ";" [] []
+    1: CSS_AT_RULE@36..73
+      0: AT@36..38 "@" [Newline("\n")] []
+      1: CSS_UNKNOWN_VALUE_AT_RULE@38..73
+        0: CSS_IDENTIFIER@38..46
+          0: IDENT@38..46 "forward" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@46..72
+          0: CSS_STRING_LITERAL@46..57 "\"./button\"" [] [Whitespace(" ")]
+          1: AS_KW@57..60 "as" [] [Whitespace(" ")]
+          2: IDENT@60..71 "components-" [] []
+          3: STAR@71..72 "*" [] []
+        2: SEMICOLON@72..73 ";" [] []
+    2: CSS_AT_RULE@73..109
+      0: AT@73..75 "@" [Newline("\n")] []
+      1: CSS_UNKNOWN_VALUE_AT_RULE@75..109
+        0: CSS_IDENTIFIER@75..83
+          0: IDENT@75..83 "forward" [] [Whitespace(" ")]
+        1: CSS_UNKNOWN_AT_RULE_COMPONENT_LIST@83..108
+          0: CSS_STRING_LITERAL@83..94 "\"./button\"" [] [Whitespace(" ")]
+          1: AS_KW@94..97 "as" [] [Whitespace(" ")]
+          2: IDENT@97..107 "components" [] []
+          3: STAR@107..108 "*" [] []
+        2: SEMICOLON@108..109 ";" [] []
+    3: CSS_QUALIFIED_RULE@109..145
+      0: CSS_SELECTOR_LIST@109..118
+        0: CSS_COMPOUND_SELECTOR@109..118
+          0: CSS_NESTED_SELECTOR_LIST@109..109
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@109..118
+            0: CSS_CLASS_SELECTOR@109..118
+              0: DOT@109..111 "." [Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@111..118
+                0: IDENT@111..118 "native" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@118..145
+        0: L_CURLY@118..120 "{" [] [Whitespace(" ")]
+        1: CSS_DECLARATION_OR_RULE_LIST@120..144
+          0: CSS_DECLARATION_WITH_SEMICOLON@120..132
+            0: CSS_DECLARATION@120..130
+              0: CSS_GENERIC_PROPERTY@120..130
+                0: CSS_IDENTIFIER@120..125
+                  0: IDENT@120..125 "color" [] []
+                1: COLON@125..127 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@127..130
+                  0: CSS_IDENTIFIER@127..130
+                    0: IDENT@127..130 "red" [] []
+              1: (empty)
+            1: SEMICOLON@130..132 ";" [] [Whitespace(" ")]
+          1: CSS_DECLARATION_WITH_SEMICOLON@132..144
+            0: CSS_DECLARATION@132..142
+              0: CSS_GENERIC_PROPERTY@132..142
+                0: CSS_IDENTIFIER@132..137
+                  0: IDENT@132..137 "width" [] []
+                1: COLON@137..139 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@139..142
+                  0: CSS_REGULAR_DIMENSION@139..142
+                    0: CSS_NUMBER_LITERAL@139..140 "1" [] []
+                    1: IDENT@140..142 "px" [] []
+              1: (empty)
+            1: SEMICOLON@142..144 ";" [] [Whitespace(" ")]
+        2: R_CURLY@144..145 "}" [] []
+  2: EOF@145..146 "" [Newline("\n")] []
+
+```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/forward.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/forward.scss
@@ -6,6 +6,8 @@
 
 @forward "theme" as theme-*;
 
+@forward "theme" as theme*;
+
 @forward "theme" with ($spacing: 4px !default);
 
 @forward "theme" as theme-* show $color, button with ($spacing: 4px);

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/forward.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/forward.scss.snap
@@ -14,6 +14,8 @@ expression: snapshot
 
 @forward "theme" as theme-*;
 
+@forward "theme" as theme*;
+
 @forward "theme" with ($spacing: 4px !default);
 
 @forward "theme" as theme-* show $color, button with ($spacing: 4px);
@@ -120,111 +122,130 @@ CssRoot {
                 url: CssString {
                     value_token: CSS_STRING_LITERAL@146..154 "\"theme\"" [] [Whitespace(" ")],
                 },
+                as_clause: ScssForwardAsClause {
+                    as_token: AS_KW@154..157 "as" [] [Whitespace(" ")],
+                    prefix: CssIdentifier {
+                        value_token: IDENT@157..162 "theme" [] [],
+                    },
+                    star_token: STAR@162..163 "*" [] [],
+                },
+                visibility_clause: missing (optional),
+                with_clause: missing (optional),
+                semicolon_token: SEMICOLON@163..164 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@164..167 "@" [Newline("\n"), Newline("\n")] [],
+            rule: ScssForwardAtRule {
+                forward_token: FORWARD_KW@167..175 "forward" [] [Whitespace(" ")],
+                url: CssString {
+                    value_token: CSS_STRING_LITERAL@175..183 "\"theme\"" [] [Whitespace(" ")],
+                },
                 as_clause: missing (optional),
                 visibility_clause: missing (optional),
                 with_clause: ScssWithClause {
-                    with_token: WITH_KW@154..159 "with" [] [Whitespace(" ")],
+                    with_token: WITH_KW@183..188 "with" [] [Whitespace(" ")],
                     configurations: ScssModuleConfigurationList {
-                        l_paren_token: L_PAREN@159..160 "(" [] [],
+                        l_paren_token: L_PAREN@188..189 "(" [] [],
                         items: ScssModuleConfigurationItemList [
                             ScssModuleConfiguration {
                                 name: ScssVariable {
-                                    dollar_token: DOLLAR@160..161 "$" [] [],
+                                    dollar_token: DOLLAR@189..190 "$" [] [],
                                     name: CssIdentifier {
-                                        value_token: IDENT@161..168 "spacing" [] [],
+                                        value_token: IDENT@190..197 "spacing" [] [],
                                     },
                                 },
-                                colon_token: COLON@168..170 ":" [] [Whitespace(" ")],
+                                colon_token: COLON@197..199 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
                                         CssRegularDimension {
-                                            value_token: CSS_NUMBER_LITERAL@170..171 "4" [] [],
-                                            unit_token: IDENT@171..174 "px" [] [Whitespace(" ")],
+                                            value_token: CSS_NUMBER_LITERAL@199..200 "4" [] [],
+                                            unit_token: IDENT@200..203 "px" [] [Whitespace(" ")],
                                         },
                                     ],
                                 },
                                 modifier: ScssVariableModifier {
-                                    excl_token: BANG@174..175 "!" [] [],
-                                    value: DEFAULT_KW@175..182 "default" [] [],
+                                    excl_token: BANG@203..204 "!" [] [],
+                                    value: DEFAULT_KW@204..211 "default" [] [],
                                 },
                             },
                         ],
-                        r_paren_token: R_PAREN@182..183 ")" [] [],
+                        r_paren_token: R_PAREN@211..212 ")" [] [],
                     },
                 },
-                semicolon_token: SEMICOLON@183..184 ";" [] [],
+                semicolon_token: SEMICOLON@212..213 ";" [] [],
             },
         },
         CssAtRule {
-            at_token: AT@184..187 "@" [Newline("\n"), Newline("\n")] [],
+            at_token: AT@213..216 "@" [Newline("\n"), Newline("\n")] [],
             rule: ScssForwardAtRule {
-                forward_token: FORWARD_KW@187..195 "forward" [] [Whitespace(" ")],
+                forward_token: FORWARD_KW@216..224 "forward" [] [Whitespace(" ")],
                 url: CssString {
-                    value_token: CSS_STRING_LITERAL@195..203 "\"theme\"" [] [Whitespace(" ")],
+                    value_token: CSS_STRING_LITERAL@224..232 "\"theme\"" [] [Whitespace(" ")],
                 },
                 as_clause: ScssForwardAsClause {
-                    as_token: AS_KW@203..206 "as" [] [Whitespace(" ")],
+                    as_token: AS_KW@232..235 "as" [] [Whitespace(" ")],
                     prefix: CssIdentifier {
-                        value_token: IDENT@206..212 "theme-" [] [],
+                        value_token: IDENT@235..241 "theme-" [] [],
                     },
-                    star_token: STAR@212..214 "*" [] [Whitespace(" ")],
+                    star_token: STAR@241..243 "*" [] [Whitespace(" ")],
                 },
                 visibility_clause: ScssShowClause {
-                    show_token: SHOW_KW@214..219 "show" [] [Whitespace(" ")],
+                    show_token: SHOW_KW@243..248 "show" [] [Whitespace(" ")],
                     members: ScssModuleMemberList [
                         ScssVariable {
-                            dollar_token: DOLLAR@219..220 "$" [] [],
+                            dollar_token: DOLLAR@248..249 "$" [] [],
                             name: CssIdentifier {
-                                value_token: IDENT@220..225 "color" [] [],
+                                value_token: IDENT@249..254 "color" [] [],
                             },
                         },
-                        COMMA@225..227 "," [] [Whitespace(" ")],
+                        COMMA@254..256 "," [] [Whitespace(" ")],
                         CssIdentifier {
-                            value_token: IDENT@227..234 "button" [] [Whitespace(" ")],
+                            value_token: IDENT@256..263 "button" [] [Whitespace(" ")],
                         },
                     ],
                 },
                 with_clause: ScssWithClause {
-                    with_token: WITH_KW@234..239 "with" [] [Whitespace(" ")],
+                    with_token: WITH_KW@263..268 "with" [] [Whitespace(" ")],
                     configurations: ScssModuleConfigurationList {
-                        l_paren_token: L_PAREN@239..240 "(" [] [],
+                        l_paren_token: L_PAREN@268..269 "(" [] [],
                         items: ScssModuleConfigurationItemList [
                             ScssModuleConfiguration {
                                 name: ScssVariable {
-                                    dollar_token: DOLLAR@240..241 "$" [] [],
+                                    dollar_token: DOLLAR@269..270 "$" [] [],
                                     name: CssIdentifier {
-                                        value_token: IDENT@241..248 "spacing" [] [],
+                                        value_token: IDENT@270..277 "spacing" [] [],
                                     },
                                 },
-                                colon_token: COLON@248..250 ":" [] [Whitespace(" ")],
+                                colon_token: COLON@277..279 ":" [] [Whitespace(" ")],
                                 value: ScssExpression {
                                     items: ScssExpressionItemList [
                                         CssRegularDimension {
-                                            value_token: CSS_NUMBER_LITERAL@250..251 "4" [] [],
-                                            unit_token: IDENT@251..253 "px" [] [],
+                                            value_token: CSS_NUMBER_LITERAL@279..280 "4" [] [],
+                                            unit_token: IDENT@280..282 "px" [] [],
                                         },
                                     ],
                                 },
                                 modifier: missing (optional),
                             },
                         ],
-                        r_paren_token: R_PAREN@253..254 ")" [] [],
+                        r_paren_token: R_PAREN@282..283 ")" [] [],
                     },
                 },
-                semicolon_token: SEMICOLON@254..255 ";" [] [],
+                semicolon_token: SEMICOLON@283..284 ";" [] [],
             },
         },
     ],
-    eof_token: EOF@255..256 "" [Newline("\n")] [],
+    eof_token: EOF@284..285 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: CSS_ROOT@0..256
+0: CSS_ROOT@0..285
   0: (empty)
-  1: CSS_ROOT_ITEM_LIST@0..255
+  1: CSS_ROOT_ITEM_LIST@0..284
     0: CSS_AT_RULE@0..17
       0: AT@0..1 "@" [] []
       1: SCSS_FORWARD_AT_RULE@1..17
@@ -287,75 +308,89 @@ CssRoot {
         3: (empty)
         4: (empty)
         5: SEMICOLON@134..135 ";" [] []
-    4: CSS_AT_RULE@135..184
+    4: CSS_AT_RULE@135..164
       0: AT@135..138 "@" [Newline("\n"), Newline("\n")] []
-      1: SCSS_FORWARD_AT_RULE@138..184
+      1: SCSS_FORWARD_AT_RULE@138..164
         0: FORWARD_KW@138..146 "forward" [] [Whitespace(" ")]
         1: CSS_STRING@146..154
           0: CSS_STRING_LITERAL@146..154 "\"theme\"" [] [Whitespace(" ")]
+        2: SCSS_FORWARD_AS_CLAUSE@154..163
+          0: AS_KW@154..157 "as" [] [Whitespace(" ")]
+          1: CSS_IDENTIFIER@157..162
+            0: IDENT@157..162 "theme" [] []
+          2: STAR@162..163 "*" [] []
+        3: (empty)
+        4: (empty)
+        5: SEMICOLON@163..164 ";" [] []
+    5: CSS_AT_RULE@164..213
+      0: AT@164..167 "@" [Newline("\n"), Newline("\n")] []
+      1: SCSS_FORWARD_AT_RULE@167..213
+        0: FORWARD_KW@167..175 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@175..183
+          0: CSS_STRING_LITERAL@175..183 "\"theme\"" [] [Whitespace(" ")]
         2: (empty)
         3: (empty)
-        4: SCSS_WITH_CLAUSE@154..183
-          0: WITH_KW@154..159 "with" [] [Whitespace(" ")]
-          1: SCSS_MODULE_CONFIGURATION_LIST@159..183
-            0: L_PAREN@159..160 "(" [] []
-            1: SCSS_MODULE_CONFIGURATION_ITEM_LIST@160..182
-              0: SCSS_MODULE_CONFIGURATION@160..182
-                0: SCSS_VARIABLE@160..168
-                  0: DOLLAR@160..161 "$" [] []
-                  1: CSS_IDENTIFIER@161..168
-                    0: IDENT@161..168 "spacing" [] []
-                1: COLON@168..170 ":" [] [Whitespace(" ")]
-                2: SCSS_EXPRESSION@170..174
-                  0: SCSS_EXPRESSION_ITEM_LIST@170..174
-                    0: CSS_REGULAR_DIMENSION@170..174
-                      0: CSS_NUMBER_LITERAL@170..171 "4" [] []
-                      1: IDENT@171..174 "px" [] [Whitespace(" ")]
-                3: SCSS_VARIABLE_MODIFIER@174..182
-                  0: BANG@174..175 "!" [] []
-                  1: DEFAULT_KW@175..182 "default" [] []
-            2: R_PAREN@182..183 ")" [] []
-        5: SEMICOLON@183..184 ";" [] []
-    5: CSS_AT_RULE@184..255
-      0: AT@184..187 "@" [Newline("\n"), Newline("\n")] []
-      1: SCSS_FORWARD_AT_RULE@187..255
-        0: FORWARD_KW@187..195 "forward" [] [Whitespace(" ")]
-        1: CSS_STRING@195..203
-          0: CSS_STRING_LITERAL@195..203 "\"theme\"" [] [Whitespace(" ")]
-        2: SCSS_FORWARD_AS_CLAUSE@203..214
-          0: AS_KW@203..206 "as" [] [Whitespace(" ")]
-          1: CSS_IDENTIFIER@206..212
-            0: IDENT@206..212 "theme-" [] []
-          2: STAR@212..214 "*" [] [Whitespace(" ")]
-        3: SCSS_SHOW_CLAUSE@214..234
-          0: SHOW_KW@214..219 "show" [] [Whitespace(" ")]
-          1: SCSS_MODULE_MEMBER_LIST@219..234
-            0: SCSS_VARIABLE@219..225
-              0: DOLLAR@219..220 "$" [] []
-              1: CSS_IDENTIFIER@220..225
-                0: IDENT@220..225 "color" [] []
-            1: COMMA@225..227 "," [] [Whitespace(" ")]
-            2: CSS_IDENTIFIER@227..234
-              0: IDENT@227..234 "button" [] [Whitespace(" ")]
-        4: SCSS_WITH_CLAUSE@234..254
-          0: WITH_KW@234..239 "with" [] [Whitespace(" ")]
-          1: SCSS_MODULE_CONFIGURATION_LIST@239..254
-            0: L_PAREN@239..240 "(" [] []
-            1: SCSS_MODULE_CONFIGURATION_ITEM_LIST@240..253
-              0: SCSS_MODULE_CONFIGURATION@240..253
-                0: SCSS_VARIABLE@240..248
-                  0: DOLLAR@240..241 "$" [] []
-                  1: CSS_IDENTIFIER@241..248
-                    0: IDENT@241..248 "spacing" [] []
-                1: COLON@248..250 ":" [] [Whitespace(" ")]
-                2: SCSS_EXPRESSION@250..253
-                  0: SCSS_EXPRESSION_ITEM_LIST@250..253
-                    0: CSS_REGULAR_DIMENSION@250..253
-                      0: CSS_NUMBER_LITERAL@250..251 "4" [] []
-                      1: IDENT@251..253 "px" [] []
+        4: SCSS_WITH_CLAUSE@183..212
+          0: WITH_KW@183..188 "with" [] [Whitespace(" ")]
+          1: SCSS_MODULE_CONFIGURATION_LIST@188..212
+            0: L_PAREN@188..189 "(" [] []
+            1: SCSS_MODULE_CONFIGURATION_ITEM_LIST@189..211
+              0: SCSS_MODULE_CONFIGURATION@189..211
+                0: SCSS_VARIABLE@189..197
+                  0: DOLLAR@189..190 "$" [] []
+                  1: CSS_IDENTIFIER@190..197
+                    0: IDENT@190..197 "spacing" [] []
+                1: COLON@197..199 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@199..203
+                  0: SCSS_EXPRESSION_ITEM_LIST@199..203
+                    0: CSS_REGULAR_DIMENSION@199..203
+                      0: CSS_NUMBER_LITERAL@199..200 "4" [] []
+                      1: IDENT@200..203 "px" [] [Whitespace(" ")]
+                3: SCSS_VARIABLE_MODIFIER@203..211
+                  0: BANG@203..204 "!" [] []
+                  1: DEFAULT_KW@204..211 "default" [] []
+            2: R_PAREN@211..212 ")" [] []
+        5: SEMICOLON@212..213 ";" [] []
+    6: CSS_AT_RULE@213..284
+      0: AT@213..216 "@" [Newline("\n"), Newline("\n")] []
+      1: SCSS_FORWARD_AT_RULE@216..284
+        0: FORWARD_KW@216..224 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@224..232
+          0: CSS_STRING_LITERAL@224..232 "\"theme\"" [] [Whitespace(" ")]
+        2: SCSS_FORWARD_AS_CLAUSE@232..243
+          0: AS_KW@232..235 "as" [] [Whitespace(" ")]
+          1: CSS_IDENTIFIER@235..241
+            0: IDENT@235..241 "theme-" [] []
+          2: STAR@241..243 "*" [] [Whitespace(" ")]
+        3: SCSS_SHOW_CLAUSE@243..263
+          0: SHOW_KW@243..248 "show" [] [Whitespace(" ")]
+          1: SCSS_MODULE_MEMBER_LIST@248..263
+            0: SCSS_VARIABLE@248..254
+              0: DOLLAR@248..249 "$" [] []
+              1: CSS_IDENTIFIER@249..254
+                0: IDENT@249..254 "color" [] []
+            1: COMMA@254..256 "," [] [Whitespace(" ")]
+            2: CSS_IDENTIFIER@256..263
+              0: IDENT@256..263 "button" [] [Whitespace(" ")]
+        4: SCSS_WITH_CLAUSE@263..283
+          0: WITH_KW@263..268 "with" [] [Whitespace(" ")]
+          1: SCSS_MODULE_CONFIGURATION_LIST@268..283
+            0: L_PAREN@268..269 "(" [] []
+            1: SCSS_MODULE_CONFIGURATION_ITEM_LIST@269..282
+              0: SCSS_MODULE_CONFIGURATION@269..282
+                0: SCSS_VARIABLE@269..277
+                  0: DOLLAR@269..270 "$" [] []
+                  1: CSS_IDENTIFIER@270..277
+                    0: IDENT@270..277 "spacing" [] []
+                1: COLON@277..279 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@279..282
+                  0: SCSS_EXPRESSION_ITEM_LIST@279..282
+                    0: CSS_REGULAR_DIMENSION@279..282
+                      0: CSS_NUMBER_LITERAL@279..280 "4" [] []
+                      1: IDENT@280..282 "px" [] []
                 3: (empty)
-            2: R_PAREN@253..254 ")" [] []
-        5: SEMICOLON@254..255 ";" [] []
-  2: EOF@255..256 "" [Newline("\n")] []
+            2: R_PAREN@282..283 ")" [] []
+        5: SEMICOLON@283..284 ";" [] []
+  2: EOF@284..285 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/release-forward-underscore-prefix.scss
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/release-forward-underscore-prefix.scss
@@ -1,0 +1,11 @@
+@forward './button' as components_*;
+@forward './button' as components-*;
+@forward './button' as components_* show $components_gap, components_reset;
+@forward './button' as components_* hide components_internal;
+@forward './button' as components_* with ($gap: 4px);
+@forward './button' as components_* show $components_gap, components_reset with ($components_gap: 4px !default);
+@forward './button' as Components_*;
+@forward './button' as components*;
+@forward './button' as components1*;
+@forward './button' as show*;
+@forward './button' as components\5f *;

--- a/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/release-forward-underscore-prefix.scss.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/scss/at-rule/release-forward-underscore-prefix.scss.snap
@@ -1,0 +1,554 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+
+## Input
+
+```css
+@forward './button' as components_*;
+@forward './button' as components-*;
+@forward './button' as components_* show $components_gap, components_reset;
+@forward './button' as components_* hide components_internal;
+@forward './button' as components_* with ($gap: 4px);
+@forward './button' as components_* show $components_gap, components_reset with ($components_gap: 4px !default);
+@forward './button' as Components_*;
+@forward './button' as components*;
+@forward './button' as components1*;
+@forward './button' as show*;
+@forward './button' as components\5f *;
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    items: CssRootItemList [
+        CssAtRule {
+            at_token: AT@0..1 "@" [] [],
+            rule: ScssForwardAtRule {
+                forward_token: FORWARD_KW@1..9 "forward" [] [Whitespace(" ")],
+                url: CssString {
+                    value_token: CSS_STRING_LITERAL@9..20 "'./button'" [] [Whitespace(" ")],
+                },
+                as_clause: ScssForwardAsClause {
+                    as_token: AS_KW@20..23 "as" [] [Whitespace(" ")],
+                    prefix: CssIdentifier {
+                        value_token: IDENT@23..34 "components_" [] [],
+                    },
+                    star_token: STAR@34..35 "*" [] [],
+                },
+                visibility_clause: missing (optional),
+                with_clause: missing (optional),
+                semicolon_token: SEMICOLON@35..36 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@36..38 "@" [Newline("\n")] [],
+            rule: ScssForwardAtRule {
+                forward_token: FORWARD_KW@38..46 "forward" [] [Whitespace(" ")],
+                url: CssString {
+                    value_token: CSS_STRING_LITERAL@46..57 "'./button'" [] [Whitespace(" ")],
+                },
+                as_clause: ScssForwardAsClause {
+                    as_token: AS_KW@57..60 "as" [] [Whitespace(" ")],
+                    prefix: CssIdentifier {
+                        value_token: IDENT@60..71 "components-" [] [],
+                    },
+                    star_token: STAR@71..72 "*" [] [],
+                },
+                visibility_clause: missing (optional),
+                with_clause: missing (optional),
+                semicolon_token: SEMICOLON@72..73 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@73..75 "@" [Newline("\n")] [],
+            rule: ScssForwardAtRule {
+                forward_token: FORWARD_KW@75..83 "forward" [] [Whitespace(" ")],
+                url: CssString {
+                    value_token: CSS_STRING_LITERAL@83..94 "'./button'" [] [Whitespace(" ")],
+                },
+                as_clause: ScssForwardAsClause {
+                    as_token: AS_KW@94..97 "as" [] [Whitespace(" ")],
+                    prefix: CssIdentifier {
+                        value_token: IDENT@97..108 "components_" [] [],
+                    },
+                    star_token: STAR@108..110 "*" [] [Whitespace(" ")],
+                },
+                visibility_clause: ScssShowClause {
+                    show_token: SHOW_KW@110..115 "show" [] [Whitespace(" ")],
+                    members: ScssModuleMemberList [
+                        ScssVariable {
+                            dollar_token: DOLLAR@115..116 "$" [] [],
+                            name: CssIdentifier {
+                                value_token: IDENT@116..130 "components_gap" [] [],
+                            },
+                        },
+                        COMMA@130..132 "," [] [Whitespace(" ")],
+                        CssIdentifier {
+                            value_token: IDENT@132..148 "components_reset" [] [],
+                        },
+                    ],
+                },
+                with_clause: missing (optional),
+                semicolon_token: SEMICOLON@148..149 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@149..151 "@" [Newline("\n")] [],
+            rule: ScssForwardAtRule {
+                forward_token: FORWARD_KW@151..159 "forward" [] [Whitespace(" ")],
+                url: CssString {
+                    value_token: CSS_STRING_LITERAL@159..170 "'./button'" [] [Whitespace(" ")],
+                },
+                as_clause: ScssForwardAsClause {
+                    as_token: AS_KW@170..173 "as" [] [Whitespace(" ")],
+                    prefix: CssIdentifier {
+                        value_token: IDENT@173..184 "components_" [] [],
+                    },
+                    star_token: STAR@184..186 "*" [] [Whitespace(" ")],
+                },
+                visibility_clause: ScssHideClause {
+                    hide_token: HIDE_KW@186..191 "hide" [] [Whitespace(" ")],
+                    members: ScssModuleMemberList [
+                        CssIdentifier {
+                            value_token: IDENT@191..210 "components_internal" [] [],
+                        },
+                    ],
+                },
+                with_clause: missing (optional),
+                semicolon_token: SEMICOLON@210..211 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@211..213 "@" [Newline("\n")] [],
+            rule: ScssForwardAtRule {
+                forward_token: FORWARD_KW@213..221 "forward" [] [Whitespace(" ")],
+                url: CssString {
+                    value_token: CSS_STRING_LITERAL@221..232 "'./button'" [] [Whitespace(" ")],
+                },
+                as_clause: ScssForwardAsClause {
+                    as_token: AS_KW@232..235 "as" [] [Whitespace(" ")],
+                    prefix: CssIdentifier {
+                        value_token: IDENT@235..246 "components_" [] [],
+                    },
+                    star_token: STAR@246..248 "*" [] [Whitespace(" ")],
+                },
+                visibility_clause: missing (optional),
+                with_clause: ScssWithClause {
+                    with_token: WITH_KW@248..253 "with" [] [Whitespace(" ")],
+                    configurations: ScssModuleConfigurationList {
+                        l_paren_token: L_PAREN@253..254 "(" [] [],
+                        items: ScssModuleConfigurationItemList [
+                            ScssModuleConfiguration {
+                                name: ScssVariable {
+                                    dollar_token: DOLLAR@254..255 "$" [] [],
+                                    name: CssIdentifier {
+                                        value_token: IDENT@255..258 "gap" [] [],
+                                    },
+                                },
+                                colon_token: COLON@258..260 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssRegularDimension {
+                                            value_token: CSS_NUMBER_LITERAL@260..261 "4" [] [],
+                                            unit_token: IDENT@261..263 "px" [] [],
+                                        },
+                                    ],
+                                },
+                                modifier: missing (optional),
+                            },
+                        ],
+                        r_paren_token: R_PAREN@263..264 ")" [] [],
+                    },
+                },
+                semicolon_token: SEMICOLON@264..265 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@265..267 "@" [Newline("\n")] [],
+            rule: ScssForwardAtRule {
+                forward_token: FORWARD_KW@267..275 "forward" [] [Whitespace(" ")],
+                url: CssString {
+                    value_token: CSS_STRING_LITERAL@275..286 "'./button'" [] [Whitespace(" ")],
+                },
+                as_clause: ScssForwardAsClause {
+                    as_token: AS_KW@286..289 "as" [] [Whitespace(" ")],
+                    prefix: CssIdentifier {
+                        value_token: IDENT@289..300 "components_" [] [],
+                    },
+                    star_token: STAR@300..302 "*" [] [Whitespace(" ")],
+                },
+                visibility_clause: ScssShowClause {
+                    show_token: SHOW_KW@302..307 "show" [] [Whitespace(" ")],
+                    members: ScssModuleMemberList [
+                        ScssVariable {
+                            dollar_token: DOLLAR@307..308 "$" [] [],
+                            name: CssIdentifier {
+                                value_token: IDENT@308..322 "components_gap" [] [],
+                            },
+                        },
+                        COMMA@322..324 "," [] [Whitespace(" ")],
+                        CssIdentifier {
+                            value_token: IDENT@324..341 "components_reset" [] [Whitespace(" ")],
+                        },
+                    ],
+                },
+                with_clause: ScssWithClause {
+                    with_token: WITH_KW@341..346 "with" [] [Whitespace(" ")],
+                    configurations: ScssModuleConfigurationList {
+                        l_paren_token: L_PAREN@346..347 "(" [] [],
+                        items: ScssModuleConfigurationItemList [
+                            ScssModuleConfiguration {
+                                name: ScssVariable {
+                                    dollar_token: DOLLAR@347..348 "$" [] [],
+                                    name: CssIdentifier {
+                                        value_token: IDENT@348..362 "components_gap" [] [],
+                                    },
+                                },
+                                colon_token: COLON@362..364 ":" [] [Whitespace(" ")],
+                                value: ScssExpression {
+                                    items: ScssExpressionItemList [
+                                        CssRegularDimension {
+                                            value_token: CSS_NUMBER_LITERAL@364..365 "4" [] [],
+                                            unit_token: IDENT@365..368 "px" [] [Whitespace(" ")],
+                                        },
+                                    ],
+                                },
+                                modifier: ScssVariableModifier {
+                                    excl_token: BANG@368..369 "!" [] [],
+                                    value: DEFAULT_KW@369..376 "default" [] [],
+                                },
+                            },
+                        ],
+                        r_paren_token: R_PAREN@376..377 ")" [] [],
+                    },
+                },
+                semicolon_token: SEMICOLON@377..378 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@378..380 "@" [Newline("\n")] [],
+            rule: ScssForwardAtRule {
+                forward_token: FORWARD_KW@380..388 "forward" [] [Whitespace(" ")],
+                url: CssString {
+                    value_token: CSS_STRING_LITERAL@388..399 "'./button'" [] [Whitespace(" ")],
+                },
+                as_clause: ScssForwardAsClause {
+                    as_token: AS_KW@399..402 "as" [] [Whitespace(" ")],
+                    prefix: CssIdentifier {
+                        value_token: IDENT@402..413 "Components_" [] [],
+                    },
+                    star_token: STAR@413..414 "*" [] [],
+                },
+                visibility_clause: missing (optional),
+                with_clause: missing (optional),
+                semicolon_token: SEMICOLON@414..415 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@415..417 "@" [Newline("\n")] [],
+            rule: ScssForwardAtRule {
+                forward_token: FORWARD_KW@417..425 "forward" [] [Whitespace(" ")],
+                url: CssString {
+                    value_token: CSS_STRING_LITERAL@425..436 "'./button'" [] [Whitespace(" ")],
+                },
+                as_clause: ScssForwardAsClause {
+                    as_token: AS_KW@436..439 "as" [] [Whitespace(" ")],
+                    prefix: CssIdentifier {
+                        value_token: IDENT@439..449 "components" [] [],
+                    },
+                    star_token: STAR@449..450 "*" [] [],
+                },
+                visibility_clause: missing (optional),
+                with_clause: missing (optional),
+                semicolon_token: SEMICOLON@450..451 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@451..453 "@" [Newline("\n")] [],
+            rule: ScssForwardAtRule {
+                forward_token: FORWARD_KW@453..461 "forward" [] [Whitespace(" ")],
+                url: CssString {
+                    value_token: CSS_STRING_LITERAL@461..472 "'./button'" [] [Whitespace(" ")],
+                },
+                as_clause: ScssForwardAsClause {
+                    as_token: AS_KW@472..475 "as" [] [Whitespace(" ")],
+                    prefix: CssIdentifier {
+                        value_token: IDENT@475..486 "components1" [] [],
+                    },
+                    star_token: STAR@486..487 "*" [] [],
+                },
+                visibility_clause: missing (optional),
+                with_clause: missing (optional),
+                semicolon_token: SEMICOLON@487..488 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@488..490 "@" [Newline("\n")] [],
+            rule: ScssForwardAtRule {
+                forward_token: FORWARD_KW@490..498 "forward" [] [Whitespace(" ")],
+                url: CssString {
+                    value_token: CSS_STRING_LITERAL@498..509 "'./button'" [] [Whitespace(" ")],
+                },
+                as_clause: ScssForwardAsClause {
+                    as_token: AS_KW@509..512 "as" [] [Whitespace(" ")],
+                    prefix: CssIdentifier {
+                        value_token: IDENT@512..516 "show" [] [],
+                    },
+                    star_token: STAR@516..517 "*" [] [],
+                },
+                visibility_clause: missing (optional),
+                with_clause: missing (optional),
+                semicolon_token: SEMICOLON@517..518 ";" [] [],
+            },
+        },
+        CssAtRule {
+            at_token: AT@518..520 "@" [Newline("\n")] [],
+            rule: ScssForwardAtRule {
+                forward_token: FORWARD_KW@520..528 "forward" [] [Whitespace(" ")],
+                url: CssString {
+                    value_token: CSS_STRING_LITERAL@528..539 "'./button'" [] [Whitespace(" ")],
+                },
+                as_clause: ScssForwardAsClause {
+                    as_token: AS_KW@539..542 "as" [] [Whitespace(" ")],
+                    prefix: CssIdentifier {
+                        value_token: IDENT@542..556 "components\\5f " [] [],
+                    },
+                    star_token: STAR@556..557 "*" [] [],
+                },
+                visibility_clause: missing (optional),
+                with_clause: missing (optional),
+                semicolon_token: SEMICOLON@557..558 ";" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@558..559 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..559
+  0: (empty)
+  1: CSS_ROOT_ITEM_LIST@0..558
+    0: CSS_AT_RULE@0..36
+      0: AT@0..1 "@" [] []
+      1: SCSS_FORWARD_AT_RULE@1..36
+        0: FORWARD_KW@1..9 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@9..20
+          0: CSS_STRING_LITERAL@9..20 "'./button'" [] [Whitespace(" ")]
+        2: SCSS_FORWARD_AS_CLAUSE@20..35
+          0: AS_KW@20..23 "as" [] [Whitespace(" ")]
+          1: CSS_IDENTIFIER@23..34
+            0: IDENT@23..34 "components_" [] []
+          2: STAR@34..35 "*" [] []
+        3: (empty)
+        4: (empty)
+        5: SEMICOLON@35..36 ";" [] []
+    1: CSS_AT_RULE@36..73
+      0: AT@36..38 "@" [Newline("\n")] []
+      1: SCSS_FORWARD_AT_RULE@38..73
+        0: FORWARD_KW@38..46 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@46..57
+          0: CSS_STRING_LITERAL@46..57 "'./button'" [] [Whitespace(" ")]
+        2: SCSS_FORWARD_AS_CLAUSE@57..72
+          0: AS_KW@57..60 "as" [] [Whitespace(" ")]
+          1: CSS_IDENTIFIER@60..71
+            0: IDENT@60..71 "components-" [] []
+          2: STAR@71..72 "*" [] []
+        3: (empty)
+        4: (empty)
+        5: SEMICOLON@72..73 ";" [] []
+    2: CSS_AT_RULE@73..149
+      0: AT@73..75 "@" [Newline("\n")] []
+      1: SCSS_FORWARD_AT_RULE@75..149
+        0: FORWARD_KW@75..83 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@83..94
+          0: CSS_STRING_LITERAL@83..94 "'./button'" [] [Whitespace(" ")]
+        2: SCSS_FORWARD_AS_CLAUSE@94..110
+          0: AS_KW@94..97 "as" [] [Whitespace(" ")]
+          1: CSS_IDENTIFIER@97..108
+            0: IDENT@97..108 "components_" [] []
+          2: STAR@108..110 "*" [] [Whitespace(" ")]
+        3: SCSS_SHOW_CLAUSE@110..148
+          0: SHOW_KW@110..115 "show" [] [Whitespace(" ")]
+          1: SCSS_MODULE_MEMBER_LIST@115..148
+            0: SCSS_VARIABLE@115..130
+              0: DOLLAR@115..116 "$" [] []
+              1: CSS_IDENTIFIER@116..130
+                0: IDENT@116..130 "components_gap" [] []
+            1: COMMA@130..132 "," [] [Whitespace(" ")]
+            2: CSS_IDENTIFIER@132..148
+              0: IDENT@132..148 "components_reset" [] []
+        4: (empty)
+        5: SEMICOLON@148..149 ";" [] []
+    3: CSS_AT_RULE@149..211
+      0: AT@149..151 "@" [Newline("\n")] []
+      1: SCSS_FORWARD_AT_RULE@151..211
+        0: FORWARD_KW@151..159 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@159..170
+          0: CSS_STRING_LITERAL@159..170 "'./button'" [] [Whitespace(" ")]
+        2: SCSS_FORWARD_AS_CLAUSE@170..186
+          0: AS_KW@170..173 "as" [] [Whitespace(" ")]
+          1: CSS_IDENTIFIER@173..184
+            0: IDENT@173..184 "components_" [] []
+          2: STAR@184..186 "*" [] [Whitespace(" ")]
+        3: SCSS_HIDE_CLAUSE@186..210
+          0: HIDE_KW@186..191 "hide" [] [Whitespace(" ")]
+          1: SCSS_MODULE_MEMBER_LIST@191..210
+            0: CSS_IDENTIFIER@191..210
+              0: IDENT@191..210 "components_internal" [] []
+        4: (empty)
+        5: SEMICOLON@210..211 ";" [] []
+    4: CSS_AT_RULE@211..265
+      0: AT@211..213 "@" [Newline("\n")] []
+      1: SCSS_FORWARD_AT_RULE@213..265
+        0: FORWARD_KW@213..221 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@221..232
+          0: CSS_STRING_LITERAL@221..232 "'./button'" [] [Whitespace(" ")]
+        2: SCSS_FORWARD_AS_CLAUSE@232..248
+          0: AS_KW@232..235 "as" [] [Whitespace(" ")]
+          1: CSS_IDENTIFIER@235..246
+            0: IDENT@235..246 "components_" [] []
+          2: STAR@246..248 "*" [] [Whitespace(" ")]
+        3: (empty)
+        4: SCSS_WITH_CLAUSE@248..264
+          0: WITH_KW@248..253 "with" [] [Whitespace(" ")]
+          1: SCSS_MODULE_CONFIGURATION_LIST@253..264
+            0: L_PAREN@253..254 "(" [] []
+            1: SCSS_MODULE_CONFIGURATION_ITEM_LIST@254..263
+              0: SCSS_MODULE_CONFIGURATION@254..263
+                0: SCSS_VARIABLE@254..258
+                  0: DOLLAR@254..255 "$" [] []
+                  1: CSS_IDENTIFIER@255..258
+                    0: IDENT@255..258 "gap" [] []
+                1: COLON@258..260 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@260..263
+                  0: SCSS_EXPRESSION_ITEM_LIST@260..263
+                    0: CSS_REGULAR_DIMENSION@260..263
+                      0: CSS_NUMBER_LITERAL@260..261 "4" [] []
+                      1: IDENT@261..263 "px" [] []
+                3: (empty)
+            2: R_PAREN@263..264 ")" [] []
+        5: SEMICOLON@264..265 ";" [] []
+    5: CSS_AT_RULE@265..378
+      0: AT@265..267 "@" [Newline("\n")] []
+      1: SCSS_FORWARD_AT_RULE@267..378
+        0: FORWARD_KW@267..275 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@275..286
+          0: CSS_STRING_LITERAL@275..286 "'./button'" [] [Whitespace(" ")]
+        2: SCSS_FORWARD_AS_CLAUSE@286..302
+          0: AS_KW@286..289 "as" [] [Whitespace(" ")]
+          1: CSS_IDENTIFIER@289..300
+            0: IDENT@289..300 "components_" [] []
+          2: STAR@300..302 "*" [] [Whitespace(" ")]
+        3: SCSS_SHOW_CLAUSE@302..341
+          0: SHOW_KW@302..307 "show" [] [Whitespace(" ")]
+          1: SCSS_MODULE_MEMBER_LIST@307..341
+            0: SCSS_VARIABLE@307..322
+              0: DOLLAR@307..308 "$" [] []
+              1: CSS_IDENTIFIER@308..322
+                0: IDENT@308..322 "components_gap" [] []
+            1: COMMA@322..324 "," [] [Whitespace(" ")]
+            2: CSS_IDENTIFIER@324..341
+              0: IDENT@324..341 "components_reset" [] [Whitespace(" ")]
+        4: SCSS_WITH_CLAUSE@341..377
+          0: WITH_KW@341..346 "with" [] [Whitespace(" ")]
+          1: SCSS_MODULE_CONFIGURATION_LIST@346..377
+            0: L_PAREN@346..347 "(" [] []
+            1: SCSS_MODULE_CONFIGURATION_ITEM_LIST@347..376
+              0: SCSS_MODULE_CONFIGURATION@347..376
+                0: SCSS_VARIABLE@347..362
+                  0: DOLLAR@347..348 "$" [] []
+                  1: CSS_IDENTIFIER@348..362
+                    0: IDENT@348..362 "components_gap" [] []
+                1: COLON@362..364 ":" [] [Whitespace(" ")]
+                2: SCSS_EXPRESSION@364..368
+                  0: SCSS_EXPRESSION_ITEM_LIST@364..368
+                    0: CSS_REGULAR_DIMENSION@364..368
+                      0: CSS_NUMBER_LITERAL@364..365 "4" [] []
+                      1: IDENT@365..368 "px" [] [Whitespace(" ")]
+                3: SCSS_VARIABLE_MODIFIER@368..376
+                  0: BANG@368..369 "!" [] []
+                  1: DEFAULT_KW@369..376 "default" [] []
+            2: R_PAREN@376..377 ")" [] []
+        5: SEMICOLON@377..378 ";" [] []
+    6: CSS_AT_RULE@378..415
+      0: AT@378..380 "@" [Newline("\n")] []
+      1: SCSS_FORWARD_AT_RULE@380..415
+        0: FORWARD_KW@380..388 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@388..399
+          0: CSS_STRING_LITERAL@388..399 "'./button'" [] [Whitespace(" ")]
+        2: SCSS_FORWARD_AS_CLAUSE@399..414
+          0: AS_KW@399..402 "as" [] [Whitespace(" ")]
+          1: CSS_IDENTIFIER@402..413
+            0: IDENT@402..413 "Components_" [] []
+          2: STAR@413..414 "*" [] []
+        3: (empty)
+        4: (empty)
+        5: SEMICOLON@414..415 ";" [] []
+    7: CSS_AT_RULE@415..451
+      0: AT@415..417 "@" [Newline("\n")] []
+      1: SCSS_FORWARD_AT_RULE@417..451
+        0: FORWARD_KW@417..425 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@425..436
+          0: CSS_STRING_LITERAL@425..436 "'./button'" [] [Whitespace(" ")]
+        2: SCSS_FORWARD_AS_CLAUSE@436..450
+          0: AS_KW@436..439 "as" [] [Whitespace(" ")]
+          1: CSS_IDENTIFIER@439..449
+            0: IDENT@439..449 "components" [] []
+          2: STAR@449..450 "*" [] []
+        3: (empty)
+        4: (empty)
+        5: SEMICOLON@450..451 ";" [] []
+    8: CSS_AT_RULE@451..488
+      0: AT@451..453 "@" [Newline("\n")] []
+      1: SCSS_FORWARD_AT_RULE@453..488
+        0: FORWARD_KW@453..461 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@461..472
+          0: CSS_STRING_LITERAL@461..472 "'./button'" [] [Whitespace(" ")]
+        2: SCSS_FORWARD_AS_CLAUSE@472..487
+          0: AS_KW@472..475 "as" [] [Whitespace(" ")]
+          1: CSS_IDENTIFIER@475..486
+            0: IDENT@475..486 "components1" [] []
+          2: STAR@486..487 "*" [] []
+        3: (empty)
+        4: (empty)
+        5: SEMICOLON@487..488 ";" [] []
+    9: CSS_AT_RULE@488..518
+      0: AT@488..490 "@" [Newline("\n")] []
+      1: SCSS_FORWARD_AT_RULE@490..518
+        0: FORWARD_KW@490..498 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@498..509
+          0: CSS_STRING_LITERAL@498..509 "'./button'" [] [Whitespace(" ")]
+        2: SCSS_FORWARD_AS_CLAUSE@509..517
+          0: AS_KW@509..512 "as" [] [Whitespace(" ")]
+          1: CSS_IDENTIFIER@512..516
+            0: IDENT@512..516 "show" [] []
+          2: STAR@516..517 "*" [] []
+        3: (empty)
+        4: (empty)
+        5: SEMICOLON@517..518 ";" [] []
+    10: CSS_AT_RULE@518..558
+      0: AT@518..520 "@" [Newline("\n")] []
+      1: SCSS_FORWARD_AT_RULE@520..558
+        0: FORWARD_KW@520..528 "forward" [] [Whitespace(" ")]
+        1: CSS_STRING@528..539
+          0: CSS_STRING_LITERAL@528..539 "'./button'" [] [Whitespace(" ")]
+        2: SCSS_FORWARD_AS_CLAUSE@539..557
+          0: AS_KW@539..542 "as" [] [Whitespace(" ")]
+          1: CSS_IDENTIFIER@542..556
+            0: IDENT@542..556 "components\\5f " [] []
+          2: STAR@556..557 "*" [] []
+        3: (empty)
+        4: (empty)
+        5: SEMICOLON@557..558 ";" [] []
+  2: EOF@558..559 "" [Newline("\n")] []
+
+```


### PR DESCRIPTION
> Implementation used Codex assistance.

## Summary

Accept valid SCSS `@forward` prefixes such as `components_*` and `components*`.

```scss
// Underscore prefix
@forward "./button" as components_*;

// Prefix without a separator
@forward "./button" as components*;

// With a visibility clause
@forward "./button" as components_* show $components_gap, components_reset;
```

## Test Plan

- cargo test -p biome_css_parser -p biome_css_formatter
