### PR TITLE
refactor(js_analyze): extract shared DOM AST utilities

### DIFF
--- a/crates/biome_js_analyze/src/ast_utils.rs
+++ b/crates/biome_js_analyze/src/ast_utils.rs
@@ -10,6 +10,8 @@ use biome_js_syntax::{
 };
 use biome_rowan::{AstNode, AstSeparatedList, SyntaxKindSet, TriviaPiece};
 
+pub(crate) mod dom;
+
 /// Add any leading and trailing trivia from given source node to the token.
 ///
 /// Adds whitespace trivia if needed for safe replacement of source node.

--- a/crates/biome_js_analyze/src/ast_utils/dom.rs
+++ b/crates/biome_js_analyze/src/ast_utils/dom.rs
@@ -1,0 +1,316 @@
+//! Shared AST utilities for DOM lint rules.
+
+use biome_js_syntax::{
+    AnyJsExpression, AnyJsLiteralExpression, JsArrayExpression, JsArrowFunctionExpression,
+    JsCallExpression, JsClassExpression, JsFunctionExpression, JsLanguage, JsObjectExpression,
+    JsStaticMemberExpression, JsTemplateExpression, static_value::StaticValue,
+};
+use biome_rowan::{AstNode, SyntaxKindSet};
+
+const DEFINITELY_NOT_DOM_NODE_KINDS: SyntaxKindSet<JsLanguage> = AnyJsLiteralExpression::KIND_SET
+    .union(JsArrayExpression::KIND_SET)
+    .union(JsArrowFunctionExpression::KIND_SET)
+    .union(JsClassExpression::KIND_SET)
+    .union(JsFunctionExpression::KIND_SET)
+    .union(JsObjectExpression::KIND_SET)
+    .union(JsTemplateExpression::KIND_SET);
+
+/// Legacy DOM query methods.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum LegacyDomQueryMethod {
+    /// `getElementById()`.
+    ElementById,
+    /// `getElementsByClassName()`.
+    ElementsByClassName,
+    /// `getElementsByTagName()`.
+    ElementsByTagName,
+    /// `getElementsByName()`.
+    ElementsByName,
+}
+
+impl LegacyDomQueryMethod {
+    /// Maps the legacy DOM query method name to the corresponding enum variant.
+    fn from_name(name: &str) -> Option<Self> {
+        Some(match name {
+            "getElementById" => Self::ElementById,
+            "getElementsByClassName" => Self::ElementsByClassName,
+            "getElementsByTagName" => Self::ElementsByTagName,
+            "getElementsByName" => Self::ElementsByName,
+            _ => return None,
+        })
+    }
+
+    /// Returns the preferred `querySelector*` replacement for this legacy method.
+    pub(crate) fn preferred_name(self) -> &'static str {
+        match self {
+            Self::ElementById => "querySelector",
+            Self::ElementsByClassName | Self::ElementsByTagName | Self::ElementsByName => {
+                "querySelectorAll"
+            }
+        }
+    }
+}
+
+/// A DOM lookup candidate with a static member and one non-spread argument.
+/// Receiver types and argument values are not validated.
+pub(crate) struct DomQueryCall {
+    pub(crate) member: JsStaticMemberExpression,
+    pub(crate) argument: AnyJsExpression,
+}
+
+/// Matches `getElementById`, `getElementsByClassName`, `getElementsByTagName`,
+/// or `getElementsByName` calls with one non-spread argument.
+/// Computed access and optional chains are excluded.
+pub(crate) fn legacy_dom_query_call(
+    call: &JsCallExpression,
+) -> Option<(LegacyDomQueryMethod, DomQueryCall)> {
+    if call.is_optional_chain() {
+        return None;
+    }
+    let query = dom_query_call(call)?;
+    if query.member.is_optional_chain() {
+        return None;
+    }
+    let name = query
+        .member
+        .member()
+        .ok()?
+        .as_js_name()?
+        .value_token()
+        .ok()?;
+    let method = LegacyDomQueryMethod::from_name(name.text_trimmed())?;
+    Some((method, query))
+}
+
+/// Matches `.querySelector()` calls with one non-spread argument.
+/// Computed access, optional calls, and optional member access are excluded.
+/// Callers must check for optional chains in the receiver and surrounding syntax.
+pub(crate) fn query_selector_call(call: &JsCallExpression) -> Option<DomQueryCall> {
+    let query = dom_query_call(call)?;
+    let name = query
+        .member
+        .member()
+        .ok()?
+        .as_js_name()?
+        .value_token()
+        .ok()?;
+    (name.text_trimmed() == "querySelector").then_some(query)
+}
+
+fn dom_query_call(call: &JsCallExpression) -> Option<DomQueryCall> {
+    if call.is_optional() {
+        return None;
+    }
+    let callee = call.callee().ok()?.omit_parentheses();
+    let member = callee.as_js_static_member_expression()?.clone();
+    if member.is_optional() {
+        return None;
+    }
+    Some(DomQueryCall {
+        member,
+        argument: first_and_only_argument(call)?,
+    })
+}
+
+/// Returns the only argument passed to `call`.
+///
+/// Useful for selecting DOM lookup calls with a single ID, class name, tag name,
+/// name, or CSS selector argument before rewriting or combining queries.
+///
+/// Returns `None` if the call does not have exactly one non-spread argument or
+/// its arguments cannot be read.
+fn first_and_only_argument(call: &JsCallExpression) -> Option<AnyJsExpression> {
+    let mut args = call.arguments().ok()?.args().into_iter();
+    let argument = args.next()?.ok()?.as_any_js_expression()?.clone();
+
+    if args.next().is_none() {
+        Some(argument)
+    } else {
+        None
+    }
+}
+
+/// Returns `true` for expressions excluded from DOM receiver checks to avoid
+/// obvious false positives:
+///
+/// - literals like `"text"`, `null`, and `1`
+/// - array and object literals like `[]` and `{}`
+/// - function and class expressions
+/// - template literals like `` `text` ``
+/// - the identifier `undefined`
+///
+/// Everything else is treated as potentially DOM-like, including identifiers,
+/// member expressions, and other unknown expressions.
+pub(crate) fn is_definitely_not_dom_node(expr: &AnyJsExpression) -> bool {
+    let expr = expr.clone().omit_parentheses();
+
+    DEFINITELY_NOT_DOM_NODE_KINDS.matches(expr.syntax().kind())
+        || expr
+            .as_static_value()
+            .is_some_and(|value| matches!(value, StaticValue::Undefined(_)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        LegacyDomQueryMethod, is_definitely_not_dom_node, legacy_dom_query_call,
+        query_selector_call,
+    };
+    use biome_js_parser::{JsParserOptions, parse};
+    use biome_js_syntax::{AnyJsExpression, JsExpressionStatement};
+    use biome_languages::JsFileSource;
+    use biome_rowan::AstNode;
+
+    fn expression(source: &str) -> AnyJsExpression {
+        let parsed = parse(
+            &format!("({source})"),
+            JsFileSource::js_module(),
+            JsParserOptions::default(),
+        );
+        assert!(!parsed.has_errors(), "{source}");
+        parsed
+            .syntax()
+            .descendants()
+            .find_map(JsExpressionStatement::cast)
+            .expect("expression statement")
+            .expression()
+            .expect("expression")
+            .omit_parentheses()
+    }
+
+    #[test]
+    fn excludes_non_dom_receivers() {
+        for source in [
+            "null",
+            "true",
+            "false",
+            "0",
+            "1n",
+            "'text'",
+            "/regex/",
+            "[]",
+            "({})",
+            "(() => {})",
+            "(function () {})",
+            "(class {})",
+            "`text`",
+            "`${value}`",
+            "tag`text`",
+            "undefined",
+            "(((null)))",
+        ] {
+            assert!(is_definitely_not_dom_node(&expression(source)), "{source}");
+        }
+    }
+
+    #[test]
+    fn allows_potential_dom_receivers() {
+        for source in [
+            "document",
+            "element",
+            "window.document",
+            "getElement()",
+            "new Node()",
+            "this",
+            "(element)",
+            "condition ? first : second",
+            "first || second",
+        ] {
+            assert!(!is_definitely_not_dom_node(&expression(source)), "{source}");
+        }
+    }
+
+    #[test]
+    fn matches_dom_query_methods() {
+        for (name, method) in [
+            ("getElementById", Some(LegacyDomQueryMethod::ElementById)),
+            (
+                "getElementsByClassName",
+                Some(LegacyDomQueryMethod::ElementsByClassName),
+            ),
+            (
+                "getElementsByTagName",
+                Some(LegacyDomQueryMethod::ElementsByTagName),
+            ),
+            (
+                "getElementsByName",
+                Some(LegacyDomQueryMethod::ElementsByName),
+            ),
+            ("querySelector", None),
+        ] {
+            for (arguments, expected) in [
+                ("()", None),
+                ("('a')", Some("'a'")),
+                ("(('a'))", Some("('a')")),
+                ("('a',)", Some("'a'")),
+                ("(selector)", Some("selector")),
+                ("('a', 'b')", None),
+                ("(...selectors)", None),
+                ("('a', ...selectors)", None),
+            ] {
+                for callee in [format!("node.{name}"), format!("(node.{name})")] {
+                    let source = format!("{callee}{arguments}");
+                    let expression = expression(&source);
+                    let call = expression.as_js_call_expression().expect("call expression");
+                    let legacy = legacy_dom_query_call(call);
+                    let selector = query_selector_call(call);
+                    let query = if let Some(method) = method {
+                        assert!(selector.is_none(), "{source}");
+                        assert_eq!(
+                            legacy.as_ref().map(|(kind, _)| *kind),
+                            expected.map(|_| method),
+                            "{source}"
+                        );
+                        legacy.map(|(_, query)| query)
+                    } else {
+                        assert!(legacy.is_none(), "{source}");
+                        selector
+                    };
+                    let argument =
+                        query.map(|query| query.argument.syntax().text_trimmed().to_string());
+                    assert_eq!(argument.as_deref(), expected, "{source}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn rejects_unsupported_dom_query_calls() {
+        for name in [
+            "getElementById",
+            "getElementsByClassName",
+            "getElementsByTagName",
+            "getElementsByName",
+            "querySelector",
+        ] {
+            for source in [
+                format!("{name}('a')"),
+                format!("node['{name}']('a')"),
+                format!("node?.{name}('a')"),
+                format!("node.{name}?.('a')"),
+                "node.querySelectorAll('a')".to_string(),
+                "node.unrelated('a')".to_string(),
+            ] {
+                let expression = expression(&source);
+                let call = expression.as_js_call_expression().expect("call expression");
+                assert!(legacy_dom_query_call(call).is_none(), "{source}");
+                assert!(query_selector_call(call).is_none(), "{source}");
+            }
+        }
+    }
+
+    #[test]
+    fn preserves_receiver_optional_chain_checks() {
+        for source in [
+            "node?.child.getElementById('a')",
+            "(node?.child.getElementById)('a')",
+        ] {
+            let expression = expression(source);
+            let call = expression.as_js_call_expression().expect("call expression");
+            assert!(legacy_dom_query_call(call).is_none(), "{source}");
+        }
+        let expression = expression("node?.child.querySelector('a')");
+        let call = expression.as_js_call_expression().expect("call expression");
+        assert!(query_selector_call(call).is_some());
+    }
+}

--- a/crates/biome_js_analyze/src/lint/nursery/use_better_dom_traversing.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_better_dom_traversing.rs
@@ -1,4 +1,7 @@
-use crate::JsRuleAction;
+use crate::{
+    JsRuleAction,
+    ast_utils::dom::{is_definitely_not_dom_node, query_selector_call},
+};
 use biome_analyze::{
     Ast, FixKind, Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule,
     options::PreferredQuote,
@@ -7,7 +10,7 @@ use biome_console::markup;
 use biome_js_factory::make::{self, js_string_literal_expression, js_string_literal_single_quotes};
 use biome_js_syntax::{
     AnyJsExpression, AnyJsLiteralExpression, JsCallExpression, JsComputedMemberExpression,
-    JsStaticMemberExpression, JsSyntaxNode, static_value::StaticValue,
+    JsStaticMemberExpression, JsSyntaxNode,
 };
 use biome_rowan::{AstNode, BatchMutationExt, Direction, declare_node_union};
 use biome_rule_options::use_better_dom_traversing::UseBetterDomTraversingOptions;
@@ -240,10 +243,9 @@ impl Rule for UseBetterDomTraversing {
                 } else {
                     format!(":scope {}", selectors.join(" "))
                 };
-                let argument = first_and_only_argument(node)?;
-                let callee = node.callee().ok()?.omit_parentheses();
-                let member = callee.as_js_static_member_expression()?;
-                let inner_object = member.object().ok()?;
+                let query = query_selector_call(node)?;
+                let argument = query.argument;
+                let inner_object = query.member.object().ok()?;
                 mutation.replace_node(
                     argument,
                     make_string_literal_expression(&merged_selector, ctx.preferred_quote()),
@@ -314,7 +316,7 @@ fn parent_element_chain_state(
 }
 
 fn merge_query_selector_state(node: &JsCallExpression) -> Option<UseBetterDomTraversingState> {
-    if !is_query_selector_call(node)
+    if query_selector_call(node).is_none()
         || is_followed_by_static_query_selector(node)
         || is_inside_optional_chain(node.syntax())
     {
@@ -473,17 +475,6 @@ fn is_props_children(collection: &JsStaticMemberExpression) -> bool {
     static_member_named(&object, "props").is_some()
 }
 
-fn is_query_selector_call(call: &JsCallExpression) -> bool {
-    if call.is_optional() {
-        return false;
-    }
-    let Ok(callee) = call.callee() else {
-        return false;
-    };
-    static_member_named(&callee, "querySelector").is_some()
-        && first_and_only_argument(call).is_some()
-}
-
 fn is_followed_by_static_query_selector(call: &JsCallExpression) -> bool {
     let Some(parent) = call.syntax().parent() else {
         return false;
@@ -495,13 +486,6 @@ fn is_followed_by_static_query_selector(call: &JsCallExpression) -> bool {
         .object()
         .ok()
         .is_none_or(|object| object.syntax() != call.syntax())
-        || member.is_optional()
-        || member
-            .member()
-            .ok()
-            .and_then(|name| name.as_js_name().cloned())
-            .and_then(|name| name.value_token().ok())
-            .is_none_or(|token| token.text_trimmed() != "querySelector")
     {
         return false;
     }
@@ -511,16 +495,15 @@ fn is_followed_by_static_query_selector(call: &JsCallExpression) -> bool {
     let Some(outer) = JsCallExpression::cast(grand) else {
         return false;
     };
-    if outer.is_optional()
-        || outer
-            .callee()
-            .ok()
-            .is_none_or(|callee| callee.syntax() != member.syntax())
+    if outer
+        .callee()
+        .ok()
+        .is_none_or(|callee| callee.syntax() != member.syntax())
     {
         return false;
     }
-    first_and_only_argument(&outer)
-        .and_then(|argument| static_selector(&argument))
+    query_selector_call(&outer)
+        .and_then(|query| static_selector(&query.argument))
         .is_some()
 }
 
@@ -535,17 +518,14 @@ fn query_selector_chain(
         let AnyJsExpression::JsCallExpression(current) = current_expr.clone() else {
             break;
         };
-        if !is_query_selector_call(&current) {
+        let Some(query) = query_selector_call(&current) else {
             break;
-        }
-        let argument = first_and_only_argument(&current)?;
-        let Some(selector) = static_selector(&argument) else {
+        };
+        let Some(selector) = static_selector(&query.argument) else {
             break;
         };
         selectors.push(selector);
-        let callee = current.callee().ok()?;
-        let member = static_member_named(&callee, "querySelector")?;
-        raw_root = member.object().ok()?;
+        raw_root = query.member.object().ok()?;
         current_expr = raw_root.clone().omit_parentheses();
     }
 
@@ -609,16 +589,6 @@ fn is_inside_optional_chain(node: &JsSyntaxNode) -> bool {
     false
 }
 
-fn first_and_only_argument(call: &JsCallExpression) -> Option<AnyJsExpression> {
-    let mut args = call.arguments().ok()?.args().into_iter();
-    let argument = args.next()?.ok()?.as_any_js_expression()?.clone();
-    if args.next().is_none() {
-        Some(argument)
-    } else {
-        None
-    }
-}
-
 fn static_selector(expr: &AnyJsExpression) -> Option<String> {
     let expr = expr.clone().omit_parentheses();
     if let AnyJsExpression::JsTemplateExpression(template) = &expr
@@ -664,26 +634,6 @@ fn has_comments_inside(node: &JsSyntaxNode) -> bool {
     };
     first.has_trailing_comments()
         || tokens.any(|token| token.has_leading_comments() || token.has_trailing_comments())
-}
-
-/// Returns `true` when the receiver cannot be a DOM node.
-///
-/// Copied from the approach in `useDomQuerySelector`: only exclude syntax that
-/// is guaranteed not to be a node, such as literals, arrays, objects, and functions.
-fn is_definitely_not_dom_node(expr: &AnyJsExpression) -> bool {
-    let expr = expr.clone().omit_parentheses();
-    matches!(
-        expr,
-        AnyJsExpression::AnyJsLiteralExpression(_)
-            | AnyJsExpression::JsArrayExpression(_)
-            | AnyJsExpression::JsArrowFunctionExpression(_)
-            | AnyJsExpression::JsClassExpression(_)
-            | AnyJsExpression::JsFunctionExpression(_)
-            | AnyJsExpression::JsObjectExpression(_)
-            | AnyJsExpression::JsTemplateExpression(_)
-    ) || expr
-        .as_static_value()
-        .is_some_and(|value| matches!(value, StaticValue::Undefined(_)))
 }
 
 fn make_string_literal_expression(value: &str, preferred_quote: PreferredQuote) -> AnyJsExpression {

--- a/crates/biome_js_analyze/src/lint/nursery/use_dom_query_selector.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_dom_query_selector.rs
@@ -1,4 +1,10 @@
-use crate::{JsRuleAction, services::semantic::Semantic};
+use crate::{
+    JsRuleAction,
+    ast_utils::dom::{
+        LegacyDomQueryMethod as QueryMethod, is_definitely_not_dom_node, legacy_dom_query_call,
+    },
+    services::semantic::Semantic,
+};
 use biome_analyze::{
     FixKind, Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule,
     options::PreferredQuote,
@@ -10,9 +16,9 @@ use biome_js_factory::make::{
 };
 use biome_js_syntax::{
     AnyJsExpression, AnyJsMemberExpression, AnyJsTemplateElement, JsCallExpression,
-    JsTemplateExpression, T, global_identifier, static_value::StaticValue,
+    JsTemplateExpression, T, global_identifier,
 };
-use biome_rowan::{AstNode, AstNodeList, BatchMutationExt, TextRange};
+use biome_rowan::{AstNodeList, BatchMutationExt, TextRange};
 use biome_rule_options::use_dom_query_selector::UseDomQuerySelectorOptions;
 
 declare_lint_rule! {
@@ -105,22 +111,10 @@ impl Rule for UseDomQuerySelector {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let call = ctx.query();
 
-        if call.is_optional() || call.is_optional_chain() {
-            return None;
-        }
-
-        let callee = call.callee().ok()?.omit_parentheses();
-        let member = AnyJsMemberExpression::cast(callee.into_syntax())?;
-        if member.is_optional_chain()
-            || matches!(member, AnyJsMemberExpression::JsComputedMemberExpression(_))
-        {
-            return None;
-        }
-
-        let method_name = member.member_name()?;
-        let method = QueryMethod::from_name(method_name.text())?;
-
-        let argument = first_and_only_argument(call)?;
+        let (method, query) = legacy_dom_query_call(call)?;
+        let member = query.member;
+        let method_name = member.member().ok()?.as_js_name()?.value_token().ok()?;
+        let argument = query.argument;
         let object = member.object().ok()?.omit_parentheses();
         if is_ignored(&object, ctx.options()) || is_definitely_not_dom_node(&object) {
             return None;
@@ -128,7 +122,7 @@ impl Rule for UseDomQuerySelector {
 
         Some(RuleState {
             method,
-            range: method_name.range(),
+            range: method_name.text_trimmed_range(),
             fixable: can_fix_argument(&argument, method),
         })
     }
@@ -158,9 +152,9 @@ impl Rule for UseDomQuerySelector {
         }
 
         let call = ctx.query();
-        let callee = call.callee().ok()?.omit_parentheses();
-        let member = AnyJsMemberExpression::cast(callee.into_syntax())?;
-        let argument = first_and_only_argument(call)?;
+        let (_, query) = legacy_dom_query_call(call)?;
+        let member = AnyJsMemberExpression::from(query.member);
+        let argument = query.argument;
 
         let mut mutation = ctx.root().begin();
         replace_method_name(
@@ -192,91 +186,6 @@ impl Rule for UseDomQuerySelector {
             mutation,
         ))
     }
-}
-
-/// Legacy DOM query methods recognized by this rule.
-#[derive(Clone, Copy, Debug)]
-enum QueryMethod {
-    /// `getElementById()`.
-    ElementById,
-    /// `getElementsByClassName()`.
-    ElementsByClassName,
-    /// `getElementsByTagName()`.
-    ElementsByTagName,
-    /// `getElementsByName()`.
-    ElementsByName,
-}
-
-impl QueryMethod {
-    /// Maps the legacy DOM query method name to the corresponding enum variant.
-    fn from_name(name: &str) -> Option<Self> {
-        Some(match name {
-            "getElementById" => Self::ElementById,
-            "getElementsByClassName" => Self::ElementsByClassName,
-            "getElementsByTagName" => Self::ElementsByTagName,
-            "getElementsByName" => Self::ElementsByName,
-            _ => return None,
-        })
-    }
-
-    /// Returns the preferred `querySelector*` replacement for this legacy method.
-    fn preferred_name(self) -> &'static str {
-        match self {
-            Self::ElementById => "querySelector",
-            Self::ElementsByClassName | Self::ElementsByTagName | Self::ElementsByName => {
-                "querySelectorAll"
-            }
-        }
-    }
-}
-
-/// Returns the only argument passed to `call`.
-///
-/// Calls with zero arguments or more than one argument are ignored because this
-/// rule only rewrites the single-selector form.
-///
-/// The source rule ignores spread arguments, so they are also ignored here.
-fn first_and_only_argument(call: &JsCallExpression) -> Option<AnyJsExpression> {
-    let mut args = call.arguments().ok()?.args().into_iter();
-    let argument = args.next()?.ok()?.as_any_js_expression()?.clone();
-
-    if args.next().is_none() {
-        Some(argument)
-    } else {
-        None
-    }
-}
-
-/// Returns `true` when the object of a legacy DOM query call is syntactically
-/// incapable of being a DOM node. It's a mechanism to avoid obvious false positives.
-///
-/// This rule is supposed to report nearly any call shape like `value.getElementById(...)`
-/// and only excludes receivers whose syntax guarantees they are not DOM nodes,
-/// such as:
-///
-/// - literals like `"text"`, `null`, and `1`
-/// - array and object literals like `[]` and `{}`
-/// - function and class expressions
-/// - template literals like `` `text` ``
-/// - the global `undefined` value
-///
-/// Everything else is treated as potentially DOM-like, including identifiers,
-/// member expressions, and other unknown expressions.
-fn is_definitely_not_dom_node(expr: &AnyJsExpression) -> bool {
-    let expr = expr.clone().omit_parentheses();
-
-    matches!(
-        expr,
-        AnyJsExpression::AnyJsLiteralExpression(_)
-            | AnyJsExpression::JsArrayExpression(_)
-            | AnyJsExpression::JsArrowFunctionExpression(_)
-            | AnyJsExpression::JsClassExpression(_)
-            | AnyJsExpression::JsFunctionExpression(_)
-            | AnyJsExpression::JsObjectExpression(_)
-            | AnyJsExpression::JsTemplateExpression(_)
-    ) || expr
-        .as_static_value()
-        .is_some_and(|value| matches!(value, StaticValue::Undefined(_)))
 }
 
 fn is_ignored(expr: &AnyJsExpression, options: &UseDomQuerySelectorOptions) -> bool {


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Pulls some shared functionality related to DOM apis in to a shared module. eslint-plugin-unicorn has a bunch of rules for DOM apis, so I'm sure this will see a lot of use and get expanded.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
no snapshot changes

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
