### PR TITLE
docs: clarify the usage of 'use strict' in ESM and CommonJS files

### DIFF
--- a/crates/biome_js_analyze/src/lint/suspicious/no_redundant_use_strict.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_redundant_use_strict.rs
@@ -23,7 +23,7 @@ declare_lint_rule! {
  /// ```
  ///
  /// If the type is undefined, ESM module is assumed.
- /// CommonJS files (`.cjs`, or files inside a project with `"type": "commonjs"`) are in non-strict mode. 
+ /// CommonJS files (`.cjs`, or `.js` files inside a project with `"type": "commonjs"`) are in non-strict mode. 
  /// For them, the directive `"use strict"` is accepted and advised.
  ///
  /// ## Examples

--- a/crates/biome_js_analyze/src/lint/suspicious/no_redundant_use_strict.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_redundant_use_strict.rs
@@ -13,8 +13,8 @@ use biome_rowan::{AstNode, AstNodeList, BatchMutationExt, declare_node_union};
 declare_lint_rule! {
  /// Prevents from having redundant `"use strict"`.
  ///
- /// The directive `"use strict"` **isn't** needed in `.mjs` files, or in `.js` files inside projects where the `package.json` defines library as module:
- ///
+ /// The directive `"use strict"` <a href="https://262.ecma-international.org/6.0/#sec-strict-mode-code">**isn't** needed</a> in an ESM module.
+ /// This includes `.mjs` files, or `.js` files inside projects where the `package.json` defines the library as a module:
  ///
  /// ```json,ignore
  /// {
@@ -22,7 +22,9 @@ declare_lint_rule! {
  /// }
  /// ```
  ///
- /// Instead, `.cjs` files are considered "scripts" and the directive `"use strict"` is accepted and advised.
+ /// If the type is undefined, ESM module is assumed.
+ /// CommonJS files (`.cjs`, or files inside a project with `"type": "commonjs"`) are in non-strict mode. 
+ /// For them, the directive `"use strict"` is accepted and advised.
  ///
  /// ## Examples
  ///


### PR DESCRIPTION
## Summary

The default assumption of strict mode _without_ declaring `"type": "module"` in `package.json` came as a surprise to me.   Frankly, I consider that assumption a bug... but the project's direction is clear:
* https://github.com/biomejs/biome/issues/10314#issuecomment-4415812206
* https://github.com/biomejs/biome/issues/3524#issuecomment-2256032368

This PR updates the docs to align with the default functionality - files are assumed to be ESM by default when unspecified in `package.json`

## Test Plan

N/A

## Docs

See summary

## AI Disclosure

Nope, 100% human here.
