### PR TITLE
perf(css_formatter): skip include scans without closing comments

### DIFF
--- a/crates/biome_css_formatter/src/utils/scss_closing_comments.rs
+++ b/crates/biome_css_formatter/src/utils/scss_closing_comments.rs
@@ -16,7 +16,7 @@ pub(crate) enum ClosingCommentSpacing {
 
 /// Returns `true` when an include argument node owns comments before `)`.
 pub(crate) fn owns_include_closing_comments(node: &CssSyntaxNode, f: &CssFormatter) -> bool {
-    is_in_scss_include_arguments(node) && f.comments().has_dangling_comments(node)
+    f.comments().has_dangling_comments(node) && is_in_scss_include_arguments(node)
 }
 
 /// Returns `true` when an include-owned map prints comments before `)`.

--- a/crates/biome_css_formatter/tests/specs/scss/at-rule/closing-comment-ownership.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/at-rule/closing-comment-ownership.scss
@@ -1,0 +1,13 @@
+.ownership{
+value:fn(1px,2px);
+after-ordinary:1;
+value:fn(1px,2px,/* ordinary close */);
+after-ordinary-comment:2;
+@include mix(1px,2px);
+after-include:3;
+@include mix(1px,2px,/* include close */);
+after-include-comment:4;
+@include mix($args... // spread close
+);
+after-spread:5;
+}

--- a/crates/biome_css_formatter/tests/specs/scss/at-rule/closing-comment-ownership.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/at-rule/closing-comment-ownership.scss.snap
@@ -1,0 +1,44 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: scss/at-rule/closing-comment-ownership.scss
+---
+
+# Input
+
+```scss
+.ownership{
+value:fn(1px,2px);
+after-ordinary:1;
+value:fn(1px,2px,/* ordinary close */);
+after-ordinary-comment:2;
+@include mix(1px,2px);
+after-include:3;
+@include mix(1px,2px,/* include close */);
+after-include-comment:4;
+@include mix($args... // spread close
+);
+after-spread:5;
+}
+
+```
+
+
+# Formatted
+
+```scss
+.ownership {
+	value: fn(1px, 2px);
+	after-ordinary: 1;
+	value: fn(1px, 2px /* ordinary close */);
+	after-ordinary-comment: 2;
+	@include mix(1px, 2px);
+	after-include: 3;
+	@include mix(1px, 2px /* include close */);
+	after-include-comment: 4;
+	@include mix(
+		$args... // spread close
+	);
+	after-spread: 5;
+}
+
+```


### PR DESCRIPTION
> AI assistance: Codex 

## Summary

Check for dangling comments before searching for enclosing `@include` arguments. 

## Test Plan

- green ci
