### PR TITLE
fix(format/js): keep comments above binary operators with operatorLinebreak before

### DIFF
--- a/.changeset/warm-sites-relax.md
+++ b/.changeset/warm-sites-relax.md
@@ -1,0 +1,13 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#8573](https://github.com/biomejs/biome/issues/8573): own-line comments before binary operators stay above the operator when `javascript.formatter.operatorLinebreak` is `"before"`.
+
+```diff
+ foo
+-  || // comment
+-  bar;
++  // comment
++  || bar;
+```

--- a/crates/biome_js_formatter/src/jsx/expressions/tag_expression.rs
+++ b/crates/biome_js_formatter/src/jsx/expressions/tag_expression.rs
@@ -10,7 +10,17 @@ use biome_js_syntax::{
 use biome_rowan::AstNode;
 
 #[derive(Debug, Clone, Default)]
-pub struct FormatJsxTagExpression;
+pub struct FormatJsxTagExpression {
+    skip_comments: bool,
+}
+
+impl FormatJsxTagExpression {
+    pub(crate) fn without_comments() -> Self {
+        Self {
+            skip_comments: true,
+        }
+    }
+}
 
 impl FormatNodeRule<JsxTagExpression> for FormatJsxTagExpression {
     fn fmt_fields(&self, node: &JsxTagExpression, f: &mut JsFormatter) -> FormatResult<()> {
@@ -21,9 +31,9 @@ impl FormatNodeRule<JsxTagExpression> for FormatJsxTagExpression {
                 write![
                     f,
                     [
-                        format_leading_comments(node.syntax()),
+                        (!self.skip_comments).then_some(format_leading_comments(node.syntax())),
                         node.tag().format(),
-                        format_trailing_comments(node.syntax())
+                        (!self.skip_comments).then_some(format_trailing_comments(node.syntax()))
                     ]
                 ]
             }
@@ -39,9 +49,10 @@ impl FormatNodeRule<JsxTagExpression> for FormatJsxTagExpression {
                     write!(
                         f,
                         [soft_block_indent(&format_args![
-                            format_leading_comments(node.syntax()),
+                            (!self.skip_comments).then_some(format_leading_comments(node.syntax())),
                             node.tag().format(),
-                            format_trailing_comments(node.syntax())
+                            (!self.skip_comments)
+                                .then_some(format_trailing_comments(node.syntax()))
                         ])]
                     )?;
 

--- a/crates/biome_js_formatter/src/utils/format_binary_like_expression.rs
+++ b/crates/biome_js_formatter/src/utils/format_binary_like_expression.rs
@@ -54,17 +54,25 @@
 //! and right side of each Right side.
 
 use crate::prelude::*;
-use biome_formatter::{Buffer, CstFormatContext, format_args, write};
+use biome_formatter::trivia::{
+    format_leading_comments_from_slice, format_trailing_comments_from_slice,
+};
+use biome_formatter::{Buffer, CstFormatContext, FormatContext, format_args, write};
 use biome_js_syntax::binary_like_expression::{
     AnyJsBinaryLikeExpression, AnyJsBinaryLikeLeftExpression,
 };
 
 use crate::{JsFormatOptions, context::OperatorLinebreak};
-use biome_js_syntax::{AnyJsExpression, JsSyntaxKind, JsSyntaxNode, JsUnaryExpression};
+use biome_js_syntax::{
+    AnyJsExpression, JsArrayExpression, JsArrowFunctionExpression, JsClassExpression, JsLanguage,
+    JsObjectExpression, JsSyntaxKind, JsSyntaxNode, JsUnaryExpression,
+};
 
 use crate::js::expressions::static_member_expression::AnyJsStaticMemberLike;
-use biome_rowan::{AstNode, SyntaxResult};
-use std::fmt::Debug;
+use crate::jsx::expressions::tag_expression::FormatJsxTagExpression;
+use crate::utils::format_node_without_comments::FormatAnyJsExpressionWithoutComments;
+use crate::verbatim::format_suppressed_node_skip_comments;
+use biome_rowan::{AstNode, SyntaxKindSet, SyntaxResult};
 use std::iter::FusedIterator;
 
 impl Format<JsFormatContext> for AnyJsBinaryLikeExpression {
@@ -273,31 +281,10 @@ impl Format<JsFormatContext> for BinaryLeftOrRightSide {
                     .mark_suppression_checked(binary_like_expression.syntax());
 
                 let right = binary_like_expression.right()?;
-                let operator_token = binary_like_expression.operator_token()?;
 
-                let operator_and_right_expression = format_with(|f| {
-                    let should_inline = binary_like_expression.should_inline_logical_expression();
-                    let options: &JsFormatOptions = f.options();
-                    let op_linebreak = options.operator_linebreak();
-
-                    if should_inline {
-                        write!(f, [space(), operator_token.format(), space()])?;
-                    } else if let OperatorLinebreak::Before = op_linebreak {
-                        write!(
-                            f,
-                            [soft_line_break_or_space(), operator_token.format(), space()]
-                        )?;
-                    } else {
-                        write!(
-                            f,
-                            [space(), operator_token.format(), soft_line_break_or_space()]
-                        )?;
-                    }
-
-                    write!(f, [right.format()])?;
-
-                    Ok(())
-                });
+                let operator_and_right_expression = FormatBinaryLikeOperatorAndRight {
+                    expression: binary_like_expression,
+                };
 
                 let syntax = binary_like_expression.syntax();
                 let parent = syntax.parent();
@@ -358,6 +345,93 @@ impl Format<JsFormatContext> for BinaryLeftOrRightSide {
                 Ok(())
             }
         }
+    }
+}
+
+struct FormatBinaryLikeOperatorAndRight<'a> {
+    expression: &'a AnyJsBinaryLikeExpression,
+}
+
+const EXPRESSIONS_WITH_INTERNAL_DANGLING_COMMENTS: SyntaxKindSet<JsLanguage> =
+    JsArrayExpression::KIND_SET
+        .union(JsObjectExpression::KIND_SET)
+        .union(JsArrowFunctionExpression::KIND_SET)
+        .union(JsClassExpression::KIND_SET);
+
+impl Format<JsFormatContext> for FormatBinaryLikeOperatorAndRight<'_> {
+    fn fmt(&self, f: &mut JsFormatter) -> FormatResult<()> {
+        let right = self.expression.right()?;
+        let operator_token = self.expression.operator_token()?;
+        let should_inline = self.expression.should_inline_logical_expression();
+        let options: &JsFormatOptions = f.options();
+        let op_linebreak = options.operator_linebreak();
+
+        if op_linebreak == OperatorLinebreak::Before
+            && f.comments().has_leading_own_line_comment(right.syntax())
+        {
+            let comments = f.comments().clone();
+            let is_suppressed = comments.is_suppressed(right.syntax())
+                || comments.is_global_suppressed(right.syntax());
+            let mut leading_comments = comments.leading_comments(right.syntax());
+            let mut trailing_comments = comments.trailing_comments(right.syntax());
+            if is_suppressed {
+                let source_range = f.context().source_map().map_or_else(
+                    || right.syntax().text_trimmed_range(),
+                    |source_map| source_map.trimmed_source_range(right.syntax()),
+                );
+                let outside_leading = leading_comments.partition_point(|comment| {
+                    comment.piece().text_range().end() <= source_range.start()
+                });
+                leading_comments = &leading_comments[..outside_leading];
+                let inside_trailing = trailing_comments.partition_point(|comment| {
+                    comment.piece().text_range().end() <= source_range.end()
+                });
+                trailing_comments = &trailing_comments[inside_trailing..];
+            }
+            write!(
+                f,
+                [
+                    soft_line_break_or_space(),
+                    format_leading_comments_from_slice(leading_comments),
+                    operator_token.format(),
+                    space(),
+                ]
+            )?;
+            if is_suppressed {
+                write!(f, [format_suppressed_node_skip_comments(right.syntax())])?;
+            } else {
+                if let AnyJsExpression::JsxTagExpression(node) = &right {
+                    FormatJsxTagExpression::without_comments().fmt_node(node, f)?;
+                } else {
+                    FormatAnyJsExpressionWithoutComments.fmt(&right, f)?;
+                }
+                if !EXPRESSIONS_WITH_INTERNAL_DANGLING_COMMENTS.matches(right.syntax().kind()) {
+                    write!(
+                        f,
+                        [format_dangling_comments(right.syntax()).with_soft_block_indent()]
+                    )?;
+                }
+            }
+            return write!(f, [format_trailing_comments_from_slice(trailing_comments)]);
+        }
+
+        if should_inline {
+            write!(f, [space(), operator_token.format(), space()])?;
+        } else if let OperatorLinebreak::Before = op_linebreak {
+            write!(
+                f,
+                [soft_line_break_or_space(), operator_token.format(), space()]
+            )?;
+        } else {
+            write!(
+                f,
+                [space(), operator_token.format(), soft_line_break_or_space()]
+            )?;
+        }
+
+        write!(f, [right.format()])?;
+
+        Ok(())
     }
 }
 

--- a/crates/biome_js_formatter/src/utils/format_node_without_comments.rs
+++ b/crates/biome_js_formatter/src/utils/format_node_without_comments.rs
@@ -137,7 +137,9 @@ impl FormatRule<AnyJsExpression> for FormatAnyJsExpressionWithoutComments {
             AnyJsExpression::JsThisExpression(node) => FormatJsThisExpression.fmt_node(node, f),
             AnyJsExpression::JsUnaryExpression(node) => FormatJsUnaryExpression.fmt_node(node, f),
             AnyJsExpression::JsYieldExpression(node) => FormatJsYieldExpression.fmt_node(node, f),
-            AnyJsExpression::JsxTagExpression(node) => FormatJsxTagExpression.fmt_node(node, f),
+            AnyJsExpression::JsxTagExpression(node) => {
+                FormatJsxTagExpression::default().fmt_node(node, f)
+            }
             AnyJsExpression::TsAsExpression(node) => FormatTsAsExpression.fmt_node(node, f),
             AnyJsExpression::TsInstantiationExpression(node) => {
                 FormatTsInstantiationExpression.fmt_node(node, f)

--- a/crates/biome_js_formatter/tests/specs/js/module/operator-linebreak/before/comments.js
+++ b/crates/biome_js_formatter/tests/specs/js/module/operator-linebreak/before/comments.js
@@ -1,0 +1,80 @@
+!(
+  (
+    // blah 1
+    foo
+    // blah 2
+    || bar
+    || baz
+    // blah 3
+    || qux
+  )
+);
+
+foo
+// logical
+&& bar;
+
+foo
+// arithmetic
++ bar
+// multiplication
+* baz;
+
+foo
+// membership
+in bar;
+
+foo
+// instance
+instanceof Bar;
+
+foo
+// fallback
+?? bar;
+
+foo // trailing
+|| bar;
+
+foo
+/* own line block */
+|| bar;
+
+foo || /* inline block */ bar;
+
+foo
+// object
+|| { /* inner */ };
+
+foo
+// array
++ [ /* inner */ ];
+
+foo
+// class
+|| class { /* inner */ };
+
+foo
+// biome-ignore format: preserve operand spacing
+|| call(  a,b );
+
+foo
+// first
+// second
+|| bar; // last
+
+foo
+// biome-ignore format: preserve parenthesized operand
+|| (
+  // inside parentheses
+  call(  a,b )
+);
+
+foo
+// biome-ignore format: preserve parentheses
+|| ((((((((((call(  a,b ))))))))))) // keep
+|| baz;
+
+((((foo))));
+a
+// biome-ignore format: preserve operand
+|| bar /*x*/ || baz;

--- a/crates/biome_js_formatter/tests/specs/js/module/operator-linebreak/before/comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/operator-linebreak/before/comments.js.snap
@@ -1,0 +1,198 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: js/module/operator-linebreak/before/comments.js
+---
+
+# Input
+
+```js
+!(
+  (
+    // blah 1
+    foo
+    // blah 2
+    || bar
+    || baz
+    // blah 3
+    || qux
+  )
+);
+
+foo
+// logical
+&& bar;
+
+foo
+// arithmetic
++ bar
+// multiplication
+* baz;
+
+foo
+// membership
+in bar;
+
+foo
+// instance
+instanceof Bar;
+
+foo
+// fallback
+?? bar;
+
+foo // trailing
+|| bar;
+
+foo
+/* own line block */
+|| bar;
+
+foo || /* inline block */ bar;
+
+foo
+// object
+|| { /* inner */ };
+
+foo
+// array
++ [ /* inner */ ];
+
+foo
+// class
+|| class { /* inner */ };
+
+foo
+// biome-ignore format: preserve operand spacing
+|| call(  a,b );
+
+foo
+// first
+// second
+|| bar; // last
+
+foo
+// biome-ignore format: preserve parenthesized operand
+|| (
+  // inside parentheses
+  call(  a,b )
+);
+
+foo
+// biome-ignore format: preserve parentheses
+|| ((((((((((call(  a,b ))))))))))) // keep
+|| baz;
+
+((((foo))));
+a
+// biome-ignore format: preserve operand
+|| bar /*x*/ || baz;
+
+```
+
+
+# Options
+
+```json
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "javascript": {
+    "formatter": {
+        "operatorLinebreak": "before"
+    }
+    
+  }
+}
+```
+
+# Formatted
+
+```js
+!(
+	// blah 1
+	(
+		foo
+		// blah 2
+		|| bar
+		|| baz
+		// blah 3
+		|| qux
+	)
+);
+
+foo
+	// logical
+	&& bar;
+
+foo
+	// arithmetic
+	+ bar
+		// multiplication
+		* baz;
+
+foo
+	// membership
+	in bar;
+
+foo
+	// instance
+	instanceof Bar;
+
+foo
+	// fallback
+	?? bar;
+
+foo // trailing
+	|| bar;
+
+foo
+	/* own line block */
+	|| bar;
+
+foo || /* inline block */ bar;
+
+foo
+	// object
+	|| {
+		/* inner */
+	};
+
+foo
+	// array
+	+ [
+		/* inner */
+	];
+
+foo
+	// class
+	|| class {
+		/* inner */
+	};
+
+foo
+	// biome-ignore format: preserve operand spacing
+	|| call(  a,b );
+
+foo
+	// first
+	// second
+	|| bar; // last
+
+foo
+	// biome-ignore format: preserve parenthesized operand
+	|| (
+  // inside parentheses
+  call(  a,b )
+);
+
+foo
+	// biome-ignore format: preserve parentheses
+	|| ((((((((((call(  a,b ))))))))))) // keep
+	|| baz;
+
+foo;
+a
+	// biome-ignore format: preserve operand
+	|| bar /*x*/
+	|| baz;
+
+```

--- a/crates/biome_js_formatter/tests/specs/jsx/operator_linebreak/comments.jsx
+++ b/crates/biome_js_formatter/tests/specs/jsx/operator_linebreak/comments.jsx
@@ -1,0 +1,9 @@
+foo
+// comment
+&& <Bar />;
+
+foo
+// comment
++ (
+  <Bar /> // trailing
+);

--- a/crates/biome_js_formatter/tests/specs/jsx/operator_linebreak/comments.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/operator_linebreak/comments.jsx.snap
@@ -1,0 +1,45 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: jsx/operator_linebreak/comments.jsx
+---
+
+# Input
+
+```jsx
+foo
+// comment
+&& <Bar />;
+
+foo
+// comment
++ (
+  <Bar /> // trailing
+);
+
+```
+
+
+# Options
+
+```json
+{
+  "javascript": {
+    "formatter": {
+      "operatorLinebreak": "before"
+    }
+  }
+}
+```
+
+# Formatted
+
+```jsx
+foo
+// comment
+&& <Bar />;
+
+foo
+// comment
++ <Bar />; // trailing
+
+```

--- a/crates/biome_js_formatter/tests/specs/jsx/operator_linebreak/options.json
+++ b/crates/biome_js_formatter/tests/specs/jsx/operator_linebreak/options.json
@@ -1,0 +1,7 @@
+{
+  "javascript": {
+    "formatter": {
+      "operatorLinebreak": "before"
+    }
+  }
+}


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
keeps comments above binary operators when `operatorLinebreak` is `"before"`. they were getting moved after the operator.

implemented by astra

fixes #8573

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots, checked with prettier-compare

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
