### PR TITLE
fix(format/js): omit redundant unary operand parentheses

### DIFF
--- a/.changeset/perky-peas-notice.md
+++ b/.changeset/perky-peas-notice.md
@@ -1,0 +1,13 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed redundant parentheses around binary and logical unary operands with leading line comments.
+
+```diff
+ !(
+   // leading
+-  (a || b)
++  a || b
+ );
+```

--- a/crates/biome_js_formatter/src/js/expressions/unary_expression.rs
+++ b/crates/biome_js_formatter/src/js/expressions/unary_expression.rs
@@ -1,12 +1,27 @@
 use crate::prelude::*;
 
 use biome_formatter::{format_args, write};
+use biome_js_syntax::binary_like_expression::AnyJsBinaryLikeExpression;
 use biome_js_syntax::parentheses::NeedsParentheses;
-use biome_js_syntax::{AnyJsExpression, JsUnaryExpression};
+use biome_js_syntax::{AnyJsExpression, JsSyntaxKind, JsSyntaxNode, JsUnaryExpression};
 use biome_js_syntax::{JsUnaryExpressionFields, JsUnaryOperator};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatJsUnaryExpression;
+
+impl FormatJsUnaryExpression {
+    pub(crate) fn can_omit_argument_parentheses(argument: &JsSyntaxNode, f: &JsFormatter) -> bool {
+        AnyJsBinaryLikeExpression::can_cast(argument.kind())
+            && argument
+                .parent()
+                .is_some_and(|parent| parent.kind() == JsSyntaxKind::JS_UNARY_EXPRESSION)
+            && f.comments()
+                .leading_comments(argument)
+                .iter()
+                .any(|comment| comment.kind().is_line())
+            && !f.comments().is_suppressed(argument)
+    }
+}
 
 impl FormatNodeRule<JsUnaryExpression> for FormatJsUnaryExpression {
     fn fmt_fields(&self, node: &JsUnaryExpression, f: &mut JsFormatter) -> FormatResult<()> {

--- a/crates/biome_js_formatter/src/lib.rs
+++ b/crates/biome_js_formatter/src/lib.rs
@@ -201,6 +201,7 @@ use biome_rowan::{AstNode, SyntaxNode};
 use crate::comments::JsCommentStyle;
 use crate::context::{JsFormatContext, JsFormatOptions};
 use crate::cst::FormatJsSyntaxNode;
+use crate::js::expressions::unary_expression::FormatJsUnaryExpression;
 use crate::syntax_rewriter::transform;
 use crate::trivia::*;
 use crate::verbatim::{format_bogus_node, format_or_verbatim, format_suppressed_node};
@@ -372,7 +373,10 @@ where
 
     /// Formats the node without comments. Ignores any suppression comments.
     fn fmt_node(&self, node: &N, f: &mut JsFormatter) -> FormatResult<()> {
-        let needs_parentheses = self.needs_parentheses(node);
+        // The unary rule wraps commented arguments, including their leading comments.
+        // That wrapper also satisfies the argument's precedence requirements.
+        let needs_parentheses = self.needs_parentheses(node)
+            && !FormatJsUnaryExpression::can_omit_argument_parentheses(node.syntax(), f);
 
         let should_insert_space = needs_parentheses && f.options().delimiter_spacing().value();
 

--- a/crates/biome_js_formatter/src/utils/format_binary_like_expression.rs
+++ b/crates/biome_js_formatter/src/utils/format_binary_like_expression.rs
@@ -69,6 +69,7 @@ use biome_js_syntax::{
 };
 
 use crate::js::expressions::static_member_expression::AnyJsStaticMemberLike;
+use crate::js::expressions::unary_expression::FormatJsUnaryExpression;
 use crate::jsx::expressions::tag_expression::FormatJsxTagExpression;
 use crate::utils::format_node_without_comments::FormatAnyJsExpressionWithoutComments;
 use crate::verbatim::format_suppressed_node_skip_comments;
@@ -85,6 +86,15 @@ impl Format<JsFormatContext> for AnyJsBinaryLikeExpression {
         // Don't indent inside of conditions because conditions add their own indent and grouping.
         if is_inside_condition {
             return write!(f, [&format_once(|f| { f.join().entries(parts).finish() })]);
+        }
+
+        if FormatJsUnaryExpression::can_omit_argument_parentheses(self.syntax(), f) {
+            return write!(
+                f,
+                [group(&format_once(|f| {
+                    f.join().entries(parts).finish()
+                }))]
+            );
         }
 
         if let Some(parent) = parent.as_ref() {

--- a/crates/biome_js_formatter/tests/specs/js/module/delimiter-spacing/unary_commented_parentheses.js
+++ b/crates/biome_js_formatter/tests/specs/js/module/delimiter-spacing/unary_commented_parentheses.js
@@ -1,0 +1,5 @@
+!(// leading
+a || b);
+!!(// leading
+a || b);
+typeof (/* leading */ a || b);

--- a/crates/biome_js_formatter/tests/specs/js/module/delimiter-spacing/unary_commented_parentheses.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/delimiter-spacing/unary_commented_parentheses.js.snap
@@ -1,0 +1,44 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: js/module/delimiter-spacing/unary_commented_parentheses.js
+---
+
+# Input
+
+```js
+!(// leading
+a || b);
+!!(// leading
+a || b);
+typeof (/* leading */ a || b);
+
+```
+
+
+# Options
+
+```json
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "javascript": {
+    "formatter": {
+      "delimiterSpacing": true
+    }
+  }
+}
+```
+
+# Formatted
+
+```js
+! (
+	// leading
+	a || b
+);
+!! (
+	// leading
+	a || b
+);
+typeof (/* leading */ ( a || b ));
+
+```

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/unary_commented_parentheses.js
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/unary_commented_parentheses.js
@@ -1,0 +1,54 @@
+!(// leading
+a || b);
+
+!((
+  // leading
+  a || b
+));
+
+!(/* leading */ a && b);
+!(a || b /* trailing */);
+!(a || b // trailing
+);
+!(// leading
+a + b * c);
+!(// leading
+a ? b : c);
+!(// leading
+a = b);
+!(// leading
+a, b);
++(// leading
+a || b);
+-(// leading
+a || b);
+~(// leading
+a || b);
+typeof (// leading
+a || b);
+void (// leading
+a || b);
+delete (// leading
+a || b);
+!(// leading
+a || (b && c));
+!(// leading
+!(// nested
+a || b));
+!(// leading
+a);
+!(a || b);
+// biome-ignore format: preserve expression
+!(a   ||   b);
+
+!(
+  (
+    // blah 1
+    foo
+    // blah 2
+    || bar
+    || baz
+    // blah 3
+    || qux
+  )
+);

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/unary_commented_parentheses.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/unary_commented_parentheses.js.snap
@@ -1,0 +1,154 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: js/module/expression/unary_commented_parentheses.js
+---
+
+# Input
+
+```js
+!(// leading
+a || b);
+
+!((
+  // leading
+  a || b
+));
+
+!(/* leading */ a && b);
+!(a || b /* trailing */);
+!(a || b // trailing
+);
+!(// leading
+a + b * c);
+!(// leading
+a ? b : c);
+!(// leading
+a = b);
+!(// leading
+a, b);
++(// leading
+a || b);
+-(// leading
+a || b);
+~(// leading
+a || b);
+typeof (// leading
+a || b);
+void (// leading
+a || b);
+delete (// leading
+a || b);
+!(// leading
+a || (b && c));
+!(// leading
+!(// nested
+a || b));
+!(// leading
+a);
+!(a || b);
+// biome-ignore format: preserve expression
+!(a   ||   b);
+
+!(
+  (
+    // blah 1
+    foo
+    // blah 2
+    || bar
+    || baz
+    // blah 3
+    || qux
+  )
+);
+
+```
+
+
+# Formatted
+
+```js
+!(
+	// leading
+	a || b
+);
+
+!(
+	// leading
+	a || b
+);
+
+!(/* leading */ (a && b));
+!((a || b) /* trailing */);
+!(
+	(a || b) // trailing
+);
+!(
+	// leading
+	a + b * c
+);
+!(
+	// leading
+	(a ? b : c)
+);
+!(
+	// leading
+	(a = b)
+);
+!(
+	// leading
+	(a, b)
+);
++(
+	// leading
+	a || b
+);
+-(
+	// leading
+	a || b
+);
+~(
+	// leading
+	a || b
+);
+typeof (
+	// leading
+	a || b
+);
+void (
+	// leading
+	a || b
+);
+delete (
+	// leading
+	a || b
+);
+!(
+	// leading
+	a || (b && c)
+);
+!(
+	// leading
+	!(
+		// nested
+		a || b
+	)
+);
+!(
+	// leading
+	a
+);
+!(a || b);
+// biome-ignore format: preserve expression
+!(a   ||   b);
+
+!(
+	// blah 1
+	foo ||
+	// blah 2
+	bar ||
+	baz ||
+	// blah 3
+	qux
+);
+
+```

--- a/crates/biome_js_formatter/tests/specs/js/module/operator-linebreak/before/comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/operator-linebreak/before/comments.js.snap
@@ -109,14 +109,12 @@ a
 ```js
 !(
 	// blah 1
-	(
-		foo
-		// blah 2
-		|| bar
-		|| baz
-		// blah 3
-		|| qux
-	)
+	foo
+	// blah 2
+	|| bar
+	|| baz
+	// blah 3
+	|| qux
 );
 
 foo

--- a/crates/biome_js_formatter/tests/specs/js/module/operator-linebreak/before/unary_commented_parentheses.js
+++ b/crates/biome_js_formatter/tests/specs/js/module/operator-linebreak/before/unary_commented_parentheses.js
@@ -1,0 +1,5 @@
+!(// leading
+a || b);
+
+!((// leading
+firstLongOperand || secondLongOperand || thirdLongOperand || fourthLongOperand || fifthLongOperand));

--- a/crates/biome_js_formatter/tests/specs/js/module/operator-linebreak/before/unary_commented_parentheses.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/operator-linebreak/before/unary_commented_parentheses.js.snap
@@ -1,0 +1,49 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: js/module/operator-linebreak/before/unary_commented_parentheses.js
+---
+
+# Input
+
+```js
+!(// leading
+a || b);
+
+!((// leading
+firstLongOperand || secondLongOperand || thirdLongOperand || fourthLongOperand || fifthLongOperand));
+
+```
+
+
+# Options
+
+```json
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "javascript": {
+    "formatter": {
+        "operatorLinebreak": "before"
+    }
+    
+  }
+}
+```
+
+# Formatted
+
+```js
+!(
+	// leading
+	a || b
+);
+
+!(
+	// leading
+	firstLongOperand
+	|| secondLongOperand
+	|| thirdLongOperand
+	|| fourthLongOperand
+	|| fifthLongOperand
+);
+
+```

--- a/crates/biome_js_formatter/tests/specs/ts/unary_commented_parentheses.ts
+++ b/crates/biome_js_formatter/tests/specs/ts/unary_commented_parentheses.ts
@@ -1,0 +1,6 @@
+!(// leading
+a as boolean || b);
+!(// leading
+a satisfies boolean || b);
+!(// leading
+<boolean>a || b);

--- a/crates/biome_js_formatter/tests/specs/ts/unary_commented_parentheses.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/unary_commented_parentheses.ts.snap
@@ -1,0 +1,35 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: ts/unary_commented_parentheses.ts
+---
+
+# Input
+
+```ts
+!(// leading
+a as boolean || b);
+!(// leading
+a satisfies boolean || b);
+!(// leading
+<boolean>a || b);
+
+```
+
+
+# Formatted
+
+```ts
+!(
+	// leading
+	(a as boolean) || b
+);
+!(
+	// leading
+	(a satisfies boolean) || b
+);
+!(
+	// leading
+	<boolean>a || b
+);
+
+```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
A follow up to #11718 that fixes a separate prettier difference issue.

Admittedly, this feels a bit weird to enforce in the formatter...

implemented by astra
<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
