### PR TITLE
fix(format/js): add newline before closing angle bracket after commented type arguments

### DIFF
--- a/.changeset/sharp-taxes-lie.md
+++ b/.changeset/sharp-taxes-lie.md
@@ -1,0 +1,14 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11722](https://github.com/biomejs/biome/issues/11722): the JavaScript formatter inserts a newline before the closing angle bracket when a leading comment forces type arguments onto multiple lines.
+
+```diff
+ type Foo = Record<
+   // comment
+   string,
+-  number>;
++  number
++>;
+```

--- a/crates/biome_js_formatter/src/ts/expressions/type_arguments.rs
+++ b/crates/biome_js_formatter/src/ts/expressions/type_arguments.rs
@@ -92,10 +92,7 @@ impl FormatNodeRule<TsTypeArguments> for FormatTsTypeArguments {
                 f,
                 [group(&format_args![
                     l_angle_token.format(),
-                    indent(&format_args![
-                        hard_line_break(),
-                        ts_type_argument_list.format()
-                    ]),
+                    block_indent(&ts_type_argument_list.format()),
                     r_angle_token.format()
                 ])]
             )

--- a/crates/biome_js_formatter/tests/specs/ts/type/issue_5091.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/issue_5091.ts.snap
@@ -30,7 +30,8 @@ declare const Namespace: {
 		// a comment
 		{
 			children: unknown;
-		}>;
+		}
+	>;
 };
 
 ```

--- a/crates/biome_js_formatter/tests/specs/ts/type/type_argument_comments.ts
+++ b/crates/biome_js_formatter/tests/specs/ts/type/type_argument_comments.ts
@@ -1,0 +1,37 @@
+type Foo = Record<
+  // comment
+  string,
+  number
+>
+
+type Single = Array<
+  // comment
+  string
+>
+
+type Block = Record<
+  /* comment */
+  string,
+  number
+>
+
+type Between = Record<string,
+  // comment
+  number
+>
+
+type Trailing = Record<string, number // comment
+>
+
+type Inline = Record</* comment */ string, number>
+
+type Object = Array<
+  // comment
+  { value: string }
+>
+
+type Nested = Promise<Record<
+  // comment
+  string,
+  number
+>>

--- a/crates/biome_js_formatter/tests/specs/ts/type/type_argument_comments.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/type_argument_comments.ts.snap
@@ -1,0 +1,97 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+assertion_line: 249
+info: ts/type/type_argument_comments.ts
+---
+
+# Input
+
+```ts
+type Foo = Record<
+  // comment
+  string,
+  number
+>
+
+type Single = Array<
+  // comment
+  string
+>
+
+type Block = Record<
+  /* comment */
+  string,
+  number
+>
+
+type Between = Record<string,
+  // comment
+  number
+>
+
+type Trailing = Record<string, number // comment
+>
+
+type Inline = Record</* comment */ string, number>
+
+type Object = Array<
+  // comment
+  { value: string }
+>
+
+type Nested = Promise<Record<
+  // comment
+  string,
+  number
+>>
+
+```
+
+
+# Formatted
+
+```ts
+type Foo = Record<
+	// comment
+	string,
+	number
+>;
+
+type Single = Array<
+	// comment
+	string
+>;
+
+type Block = Record<
+	/* comment */
+	string,
+	number
+>;
+
+type Between = Record<
+	string,
+	// comment
+	number
+>;
+
+type Trailing = Record<
+	string,
+	number // comment
+>;
+
+type Inline = Record</* comment */ string, number>;
+
+type Object = Array<
+	// comment
+	{ value: string }
+>;
+
+type Nested = Promise<
+	Record<
+		// comment
+		string,
+		number
+	>
+>;
+
+```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #11722

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
