### PR TITLE
feat(unit_tests): support suite() as an alias of describe() in test rules (#11727)

### DIFF
--- a/.changeset/support-suite-alias.md
+++ b/.changeset/support-suite-alias.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Added support for `suite()` as an alias of `describe()` across test analysis rules and formatter. Rules now recognize `suite`, `fsuite`, `xsuite`, and `test.suite` blocks. The formatter recognises them as test declarations.

--- a/crates/biome_js_analyze/src/frameworks/unit_tests.rs
+++ b/crates/biome_js_analyze/src/frameworks/unit_tests.rs
@@ -36,8 +36,8 @@ impl LifecycleHook {
     /// `None` if the call is not a recognised hook (bare or member form).
     ///
     /// Bare form: `beforeEach(...)`, `afterAll(...)`, etc.
-    /// Member form: `test.beforeEach(...)`, `describe.afterAll(...)`, etc.,
-    /// where the object must be a known test root (`test`, `it`, `describe`).
+    /// Member form: `test.beforeEach(...)`, `describe.afterAll(...)`, `suite.beforeEach(...)`, etc.,
+    /// where the object must be a known test root (`test`, `it`, `describe`, `suite`).
     pub(crate) fn from_call_expression(call: &JsCallExpression) -> Option<Self> {
         let callee = call.callee().ok()?.omit_parentheses();
 
@@ -73,7 +73,9 @@ impl LifecycleHook {
                         }
                     })
                     .and_then(|i| i.name().and_then(|r| r.value_token()).ok())
-                    .is_some_and(|tok| matches!(tok.text_trimmed(), "test" | "it" | "describe"));
+                    .is_some_and(|tok| {
+                        matches!(tok.text_trimmed(), "test" | "it" | "describe" | "suite")
+                    });
 
                 object_is_test_root.then_some(hook)
             }
@@ -113,23 +115,27 @@ pub(crate) fn is_unit_test(call: &JsCallExpression) -> bool {
 }
 
 /// Returns `true` if the call expression is a describe block:
-/// - Bare call: `describe(...)`, `fdescribe(...)`, `xdescribe(...)`
-/// - Member call: `test.describe(...)`, `it.describe(...)`, `describe.each(...)`
-///   where the object is a known test root (`test`, `it`, or `describe`).
+/// - Bare call: `describe(...)`, `fdescribe(...)`, `xdescribe(...)`, `suite(...)`, `fsuite(...)`, `xsuite(...)`
+/// - Member call: `test.describe(...)`, `it.describe(...)`, `test.suite(...)`, `describe.each(...)`, `suite.each(...)`
+///   where the object is a known test root (`test`, `it`, `describe`, or `suite`), or a modifier chain (`suite.only(...)`, `suite.skip(...)`, etc.).
 ///
 /// Only `JsStaticMemberExpression` callees are considered — computed member
 /// expressions like `obj["describe"]()` are not matched.
 fn is_describe_callee(callee: &AnyJsExpression) -> bool {
     match callee {
-        // describe(...) / fdescribe(...) / xdescribe(...)
-        AnyJsExpression::JsIdentifierExpression(ident) => ident
-            .name()
-            .and_then(|r| r.value_token())
-            .is_ok_and(|tok| matches!(tok.text_trimmed(), "describe" | "fdescribe" | "xdescribe")),
+        // describe(...) / fdescribe(...) / xdescribe(...) / suite(...) / fsuite(...) / xsuite(...)
+        AnyJsExpression::JsIdentifierExpression(ident) => {
+            ident.name().and_then(|r| r.value_token()).is_ok_and(|tok| {
+                matches!(
+                    tok.text_trimmed(),
+                    "describe" | "fdescribe" | "xdescribe" | "suite" | "fsuite" | "xsuite"
+                )
+            })
+        }
 
-        // test.describe(...) / it.describe(...) / describe.each(...) etc.
+        // test.describe(...) / it.describe(...) / test.suite(...) / describe.skip(...) / suite.only(...) etc.
         AnyJsExpression::JsStaticMemberExpression(member) => {
-            let member_is_describe = member
+            let member_name = member
                 .member()
                 .ok()
                 .and_then(|m| {
@@ -139,27 +145,31 @@ fn is_describe_callee(callee: &AnyJsExpression) -> bool {
                         None
                     }
                 })
-                .and_then(|n| n.value_token().ok())
-                .is_some_and(|tok| tok.text_trimmed() == "describe");
+                .and_then(|n| n.value_token().ok());
 
-            if !member_is_describe {
+            let Some(member_name) = member_name else {
                 return false;
+            };
+
+            let Ok(object) = member.object() else {
+                return false;
+            };
+            let object = object.omit_parentheses();
+
+            if matches!(member_name.text_trimmed(), "describe" | "suite") {
+                if let AnyJsExpression::JsIdentifierExpression(i) = object {
+                    return i.name().and_then(|r| r.value_token()).is_ok_and(|tok| {
+                        matches!(tok.text_trimmed(), "test" | "it" | "describe" | "suite")
+                    });
+                }
+            } else if matches!(
+                member_name.text_trimmed(),
+                "only" | "skip" | "fixme" | "concurrent" | "sequential"
+            ) {
+                return is_describe_callee(&object);
             }
 
-            // The left-hand object must be a known test root identifier.
-            member
-                .object()
-                .ok()
-                .map(|o| o.omit_parentheses())
-                .and_then(|o| {
-                    if let AnyJsExpression::JsIdentifierExpression(i) = o {
-                        Some(i)
-                    } else {
-                        None
-                    }
-                })
-                .and_then(|i| i.name().and_then(|r| r.value_token()).ok())
-                .is_some_and(|tok| matches!(tok.text_trimmed(), "test" | "it" | "describe"))
+            false
         }
 
         _ => false,
@@ -637,8 +647,36 @@ mod tests {
             Some(TestBlockKind::Describe)
         );
         assert_eq!(
+            TestBlockKind::from_call_expression(&first_call("suite('test', () => {})")),
+            Some(TestBlockKind::Describe)
+        );
+        assert_eq!(
+            TestBlockKind::from_call_expression(&first_call("fsuite('test', () => {})")),
+            Some(TestBlockKind::Describe)
+        );
+        assert_eq!(
+            TestBlockKind::from_call_expression(&first_call("xsuite('test', () => {})")),
+            Some(TestBlockKind::Describe)
+        );
+        assert_eq!(
+            TestBlockKind::from_call_expression(&first_call("test.suite('test', () => {})")),
+            Some(TestBlockKind::Describe)
+        );
+        assert_eq!(
             TestBlockKind::from_call_expression(&first_call(
                 "describe.each([1, 2])('test', () => {})"
+            )),
+            Some(TestBlockKind::Describe)
+        );
+        assert_eq!(
+            TestBlockKind::from_call_expression(&first_call(
+                "suite.each([1, 2])('test', () => {})"
+            )),
+            Some(TestBlockKind::Describe)
+        );
+        assert_eq!(
+            TestBlockKind::from_call_expression(&first_call(
+                "suite.skip.each([1, 2])('test', () => {})"
             )),
             Some(TestBlockKind::Describe)
         );
@@ -649,6 +687,14 @@ mod tests {
         assert_eq!(
             TestBlockKind::from_call_expression(&first_call("test.each([1, 2])('test', () => {})")),
             Some(TestBlockKind::Test)
+        );
+    }
+
+    #[test]
+    fn suite_before_each_member() {
+        assert_eq!(
+            LifecycleHook::from_call_expression(&first_call("suite.beforeEach(() => {})")),
+            Some(LifecycleHook::BeforeEach)
         );
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_focused_tests.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_focused_tests.rs
@@ -62,7 +62,7 @@ const ONLY_KEYWORD: &str = "only";
 const FDESCRIBE_KEYWORD: &str = "fdescribe";
 /// Focused test keyword as used in e.g. Jasmine or Angular
 const FIT_KEYWORD: &str = "fit";
-const CALLEE_NAMES: [&str; 3] = ["describe", "it", "test"];
+const CALLEE_NAMES: [&str; 4] = ["describe", "it", "test", "suite"];
 
 impl Rule for NoFocusedTests {
     type Query = Ast<JsCallExpression>;
@@ -185,9 +185,12 @@ fn match_function_name_pattern(callee: &AnyJsExpression) -> Option<FunctionNameA
         .get_callee_member_name()
         .filter(|function_name| {
             let name = function_name.text_trimmed();
-            // Detect f-prefixed functions like fdescribe, fit
+            // Detect f-prefixed functions like fdescribe, fit, ftest, fsuite
             name.starts_with('f')
-                && (name == FDESCRIBE_KEYWORD || name == FIT_KEYWORD || name == "ftest")
+                && (name == FDESCRIBE_KEYWORD
+                    || name == FIT_KEYWORD
+                    || name == "ftest"
+                    || name == "fsuite")
         })
         .map(|function_name| FunctionNameAndRange {
             name: function_name.token_text_trimmed(),
@@ -307,6 +310,11 @@ fn fix_function_name_pattern(
         "ftest" => {
             // Replace ftest with test
             mutation.replace_token(function_name, make::ident("test"));
+            Some(())
+        }
+        "fsuite" => {
+            // Replace fsuite with suite
+            mutation.replace_token(function_name, make::ident("suite"));
             Some(())
         }
         _ => None,

--- a/crates/biome_js_analyze/src/lint/suspicious/no_skipped_tests.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_skipped_tests.rs
@@ -66,7 +66,7 @@ declare_lint_rule! {
     }
 }
 
-const FUNCTION_NAMES: [&str; 5] = ["skip", "fixme", "xdescribe", "xit", "xtest"];
+const FUNCTION_NAMES: [&str; 6] = ["skip", "fixme", "xdescribe", "xit", "xtest", "xsuite"];
 
 impl Rule for NoSkippedTests {
     type Query = Ast<JsCallExpression>;
@@ -148,6 +148,10 @@ impl Rule for NoSkippedTests {
                     replaced_function = make::ident("test");
                     mutation.replace_token(function_name, replaced_function);
                 }
+                "xsuite" => {
+                    replaced_function = make::ident("suite");
+                    mutation.replace_token(function_name, replaced_function);
+                }
                 _ => {}
             }
         } else {
@@ -187,25 +191,25 @@ fn detect_bare_skip_call(
 
     // Determine if this is a skip/fixme pattern
     let (annotation, name_range) = match names.as_slice() {
-        // test.skip() / it.skip() / describe.skip() / test.fixme() / it.fixme() / describe.fixme()
+        // test.skip() / it.skip() / describe.skip() / suite.skip() / test.fixme() / it.fixme() / describe.fixme() / suite.fixme()
         [(_, _root), (range, name)]
-            if matches!(_root.text(), "test" | "it" | "describe")
+            if matches!(_root.text(), "test" | "it" | "describe" | "suite")
                 && (name.text() == "skip" || name.text() == "fixme") =>
         {
             (annotation_for(name.text()), *range)
         }
-        // test.describe.skip() / test.describe.fixme() / test.step.skip() / test.step.fixme()
+        // test.describe.skip() / test.describe.fixme() / test.suite.skip() / test.suite.fixme() / test.step.skip() / test.step.fixme()
         [(_, root), (_, middle), (range, name)]
             if root.text() == "test"
-                && (middle.text() == "describe" || middle.text() == "step")
+                && (middle.text() == "describe" || middle.text() == "suite" || middle.text() == "step")
                 && (name.text() == "skip" || name.text() == "fixme") =>
         {
             (annotation_for(name.text()), *range)
         }
-        // test.describe.parallel.skip() / test.describe.serial.skip() / etc.
+        // test.describe.parallel.skip() / test.describe.serial.skip() / test.suite.parallel.skip() / etc.
         [(_, root), (_, desc), (_, mode), (range, name)]
             if root.text() == "test"
-                && desc.text() == "describe"
+                && (desc.text() == "describe" || desc.text() == "suite")
                 && (mode.text() == "parallel" || mode.text() == "serial")
                 && (name.text() == "skip" || name.text() == "fixme") =>
         {
@@ -264,8 +268,8 @@ fn detect_bare_skip_call(
             // Standard static member: handled by Path 1
             return None;
         }
-        if root_name == "describe" {
-            // describe.skip("name", fn) handled by Path 1 (unless bracket notation)
+        if root_name == "describe" || root_name == "suite" {
+            // describe.skip("name", fn) / suite.skip("name", fn) handled by Path 1 (unless bracket notation)
             if arg_count >= 1 && has_string_first_arg(call_expr) && !is_computed {
                 return None;
             }

--- a/crates/biome_js_analyze/tests/specs/nursery/noIdenticalTestTitle/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noIdenticalTestTitle/invalid.js
@@ -25,3 +25,15 @@ describe('template titles', () => {
 // Duplicate describe titles using no-substitution templates
 describe(`suite alpha`, () => {});
 describe(`suite alpha`, () => {});
+
+// Duplicate test titles inside a suite
+suite('my suite', () => {
+  it('should do bar', () => {});
+  it('should do bar', () => {});
+});
+
+// Duplicate suite titles inside a suite
+suite('outer suite', () => {
+  suite('nested', () => {});
+  suite('nested', () => {});
+});

--- a/crates/biome_js_analyze/tests/specs/nursery/noIdenticalTestTitle/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noIdenticalTestTitle/invalid.js.snap
@@ -32,6 +32,18 @@ describe('template titles', () => {
 describe(`suite alpha`, () => {});
 describe(`suite alpha`, () => {});
 
+// Duplicate test titles inside a suite
+suite('my suite', () => {
+  it('should do bar', () => {});
+  it('should do bar', () => {});
+});
+
+// Duplicate suite titles inside a suite
+suite('outer suite', () => {
+  suite('nested', () => {});
+  suite('nested', () => {});
+});
+
 ```
 
 # Diagnostics
@@ -129,6 +141,49 @@ invalid.js:27:1 lint/nursery/noIdenticalTestTitle ━━━━━━━━━━
   > 27 │ describe(`suite alpha`, () => {});
        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     28 │ 
+    29 │ // Duplicate test titles inside a suite
+  
+  i A describe with this title already exists in the same scope.
+  
+  i Rename the describe to give it a unique, descriptive title.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.js:32:3 lint/nursery/noIdenticalTestTitle ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Duplicate test title found.
+  
+    30 │ suite('my suite', () => {
+    31 │   it('should do bar', () => {});
+  > 32 │   it('should do bar', () => {});
+       │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    33 │ });
+    34 │ 
+  
+  i A test with this title already exists in the same scope.
+  
+  i Rename the test to give it a unique, descriptive title.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.js:38:3 lint/nursery/noIdenticalTestTitle ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Duplicate describe title found.
+  
+    36 │ suite('outer suite', () => {
+    37 │   suite('nested', () => {});
+  > 38 │   suite('nested', () => {});
+       │   ^^^^^^^^^^^^^^^^^^^^^^^^^
+    39 │ });
+    40 │ 
   
   i A describe with this title already exists in the same scope.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/useTestHooksOnTop/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/useTestHooksOnTop/invalid.js
@@ -51,3 +51,9 @@ describe('mixed top level owner', () => {
     afterAll(() => {});
   });
 });
+
+// Hook after test in suite
+suite('my suite', () => {
+  it('does something', () => {});
+  beforeEach(() => {});
+});

--- a/crates/biome_js_analyze/tests/specs/nursery/useTestHooksOnTop/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useTestHooksOnTop/invalid.js.snap
@@ -58,6 +58,12 @@ describe('mixed top level owner', () => {
   });
 });
 
+// Hook after test in suite
+suite('my suite', () => {
+  it('does something', () => {});
+  beforeEach(() => {});
+});
+
 ```
 
 # Diagnostics
@@ -360,6 +366,34 @@ invalid.js:51:5 lint/nursery/useTestHooksOnTop ━━━━━━━━━━━
        │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     51 │     afterAll(() => {});
     52 │   });
+  
+  i Move the hook above all test cases in the same block for better readability.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.js:58:3 lint/nursery/useTestHooksOnTop ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Lifecycle hook beforeEach appears after a test case.
+  
+    56 │ suite('my suite', () => {
+    57 │   it('does something', () => {});
+  > 58 │   beforeEach(() => {});
+       │   ^^^^^^^^^^^^^^^^^^^^
+    59 │ });
+    60 │ 
+  
+  i Placing the hook after this test case makes it harder to spot the setup and teardown for these tests at a glance.
+  
+    55 │ // Hook after test in suite
+    56 │ suite('my suite', () => {
+  > 57 │   it('does something', () => {});
+       │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    58 │   beforeEach(() => {});
+    59 │ });
   
   i Move the hook above all test cases in the same block for better readability.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/useValidTestTitle/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/useValidTestTitle/invalid.js
@@ -34,3 +34,8 @@ describe(MyComponent, () => {});
 test.each([[1, 2]])('', () => {});
 test.each([[1, 2]])(' leading space', () => {});
 describe.each([[1, 2]])(123, () => {});
+
+// suite calls with invalid titles
+suite('', () => {});
+suite(' leading space', () => {});
+suite.each([[1, 2]])('', () => {});

--- a/crates/biome_js_analyze/tests/specs/nursery/useValidTestTitle/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useValidTestTitle/invalid.js.snap
@@ -41,6 +41,11 @@ test.each([[1, 2]])('', () => {});
 test.each([[1, 2]])(' leading space', () => {});
 describe.each([[1, 2]])(123, () => {});
 
+// suite calls with invalid titles
+suite('', () => {});
+suite(' leading space', () => {});
+suite.each([[1, 2]])('', () => {});
+
 ```
 
 # Diagnostics
@@ -483,10 +488,76 @@ invalid.js:36:25 lint/nursery/useValidTestTitle ━━━━━━━━━━�
   > 36 │ describe.each([[1, 2]])(123, () => {});
        │                         ^^^
     37 │ 
+    38 │ // suite calls with invalid titles
   
   i Test titles must be strings to ensure test runners and reporters can properly display them.
   
   i Provide a string literal or template literal as the title.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.js:39:7 lint/nursery/useValidTestTitle ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The describe title is empty.
+  
+    38 │ // suite calls with invalid titles
+  > 39 │ suite('', () => {});
+       │       ^^
+    40 │ suite(' leading space', () => {});
+    41 │ suite.each([[1, 2]])('', () => {});
+  
+  i A title is required to identify the describe in test reports.
+  
+  i Provide a descriptive title for this describe.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+invalid.js:40:7 lint/nursery/useValidTestTitle  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The describe title has leading or trailing whitespace.
+  
+    38 │ // suite calls with invalid titles
+    39 │ suite('', () => {});
+  > 40 │ suite(' leading space', () => {});
+       │       ^^^^^^^^^^^^^^^^
+    41 │ suite.each([[1, 2]])('', () => {});
+    42 │ 
+  
+  i Accidental whitespace can cause inconsistent test output and formatting issues in reports.
+  
+  i Remove the accidental whitespace at the start of the title.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i Safe fix: Trim leading and trailing whitespace from the title.
+  
+    40 │ suite('·leading·space',·()·=>·{});
+       │        -                          
+
+```
+
+```
+invalid.js:41:22 lint/nursery/useValidTestTitle ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The describe title is empty.
+  
+    39 │ suite('', () => {});
+    40 │ suite(' leading space', () => {});
+  > 41 │ suite.each([[1, 2]])('', () => {});
+       │                      ^^
+    42 │ 
+  
+  i A title is required to identify the describe in test reports.
+  
+  i Provide a descriptive title for this describe.
   
   i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/useValidTestTitle/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/useValidTestTitle/valid.js
@@ -31,6 +31,10 @@ describe(`suite for ${moduleName}`, () => {});
 // .each calls
 test.each([[1, 2]])('adds %i and %i', () => {});
 describe.each([[1, 2]])('suite %i', () => {});
+suite.each([[1, 2]])('suite %i', () => {});
+
+// Valid suite calls
+suite('valid suite title', () => {});
 
 // Spread argument (dynamic, cannot check statically)
 it(...args);

--- a/crates/biome_js_analyze/tests/specs/nursery/useValidTestTitle/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useValidTestTitle/valid.js.snap
@@ -37,6 +37,10 @@ describe(`suite for ${moduleName}`, () => {});
 // .each calls
 test.each([[1, 2]])('adds %i and %i', () => {});
 describe.each([[1, 2]])('suite %i', () => {});
+suite.each([[1, 2]])('suite %i', () => {});
+
+// Valid suite calls
+suite('valid suite title', () => {});
 
 // Spread argument (dynamic, cannot check statically)
 it(...args);

--- a/crates/biome_js_analyze/tests/specs/suspicious/noFocusedTests/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noFocusedTests/invalid.js
@@ -28,3 +28,9 @@ test.only(name = name || "bar", () => {});
 describe.only.each([["a"], ["b"]])("%s", (a) => {});
 it.only.each([["a"], ["b"]])("%s", (a) => {});
 test.only.each([["a"], ["b"]])("%s", (a) => {});
+
+fsuite("foo", () => {});
+suite.only("bar", () => {});
+suite["only"]("bar", function () {});
+suite.only.each([["a"], ["b"]])("%s", (a) => {});
+

--- a/crates/biome_js_analyze/tests/specs/suspicious/noFocusedTests/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noFocusedTests/invalid.js.snap
@@ -35,6 +35,12 @@ describe.only.each([["a"], ["b"]])("%s", (a) => {});
 it.only.each([["a"], ["b"]])("%s", (a) => {});
 test.only.each([["a"], ["b"]])("%s", (a) => {});
 
+fsuite("foo", () => {});
+suite.only("bar", () => {});
+suite["only"]("bar", function () {});
+suite.only.each([["a"], ["b"]])("%s", (a) => {});
+
+
 ```
 
 # Diagnostics
@@ -554,6 +560,7 @@ invalid.js:30:6 lint/suspicious/noFocusedTests  FIXABLE  ━━━━━━━�
   > 30 │ test.only.each([["a"], ["b"]])("%s", (a) => {});
        │      ^^^^
     31 │ 
+    32 │ fsuite("foo", () => {});
   
   i The 'only' method is often used for debugging or during implementation.
   
@@ -563,5 +570,100 @@ invalid.js:30:6 lint/suspicious/noFocusedTests  FIXABLE  ━━━━━━━�
   
     30 │ test.only.each([["a"],·["b"]])("%s",·(a)·=>·{});
        │     -----                                       
+
+```
+
+```
+invalid.js:32:1 lint/suspicious/noFocusedTests  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't focus the test.
+  
+    30 │ test.only.each([["a"], ["b"]])("%s", (a) => {});
+    31 │ 
+  > 32 │ fsuite("foo", () => {});
+       │ ^^^^^^
+    33 │ suite.only("bar", () => {});
+    34 │ suite["only"]("bar", function () {});
+  
+  i The 'fsuite' method is often used for debugging or during implementation.
+  
+  i Consider removing 'f' prefix from 'fsuite' to ensure all tests are executed.
+  
+  i Unsafe fix: Remove focus from test.
+  
+    30 30 │   test.only.each([["a"], ["b"]])("%s", (a) => {});
+    31 31 │   
+    32    │ - fsuite("foo",·()·=>·{});
+       32 │ + suite("foo",·()·=>·{});
+    33 33 │   suite.only("bar", () => {});
+    34 34 │   suite["only"]("bar", function () {});
+  
+
+```
+
+```
+invalid.js:33:7 lint/suspicious/noFocusedTests  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't focus the test.
+  
+    32 │ fsuite("foo", () => {});
+  > 33 │ suite.only("bar", () => {});
+       │       ^^^^
+    34 │ suite["only"]("bar", function () {});
+    35 │ suite.only.each([["a"], ["b"]])("%s", (a) => {});
+  
+  i The 'only' method is often used for debugging or during implementation.
+  
+  i Consider removing 'only' to ensure all tests are executed.
+  
+  i Unsafe fix: Remove focus from test.
+  
+    33 │ suite.only("bar",·()·=>·{});
+       │      -----                  
+
+```
+
+```
+invalid.js:34:1 lint/suspicious/noFocusedTests  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't focus the test.
+  
+    32 │ fsuite("foo", () => {});
+    33 │ suite.only("bar", () => {});
+  > 34 │ suite["only"]("bar", function () {});
+       │ ^^^^^^^^^^^^^
+    35 │ suite.only.each([["a"], ["b"]])("%s", (a) => {});
+    36 │ 
+  
+  i The 'only' method is often used for debugging or during implementation.
+  
+  i Consider removing 'only' to ensure all tests are executed.
+  
+  i Unsafe fix: Remove focus from test.
+  
+    34 │ suite["only"]("bar",·function·()·{});
+       │      --------                        
+
+```
+
+```
+invalid.js:35:7 lint/suspicious/noFocusedTests  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't focus the test.
+  
+    33 │ suite.only("bar", () => {});
+    34 │ suite["only"]("bar", function () {});
+  > 35 │ suite.only.each([["a"], ["b"]])("%s", (a) => {});
+       │       ^^^^
+    36 │ 
+  
+  i The 'only' method is often used for debugging or during implementation.
+  
+  i Consider removing 'only' to ensure all tests are executed.
+  
+  i Unsafe fix: Remove focus from test.
+  
+    35 │ suite.only.each([["a"],·["b"]])("%s",·(a)·=>·{});
+       │      -----                                       
 
 ```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noSkippedTests/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noSkippedTests/invalid.js
@@ -31,3 +31,10 @@ test["skip"]("bracket notation", async () => {});
 test("bare skip", async () => {
     test.skip();
 });
+
+xsuite('foo', () => {});
+suite.skip("test", () => {});
+suite.fixme("fixme suite", () => {});
+suite["skip"]("bracket notation", async () => {});
+test.suite.skip("skipped suite", () => {});
+

--- a/crates/biome_js_analyze/tests/specs/suspicious/noSkippedTests/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noSkippedTests/invalid.js.snap
@@ -38,6 +38,13 @@ test("bare skip", async () => {
     test.skip();
 });
 
+xsuite('foo', () => {});
+suite.skip("test", () => {});
+suite.fixme("fixme suite", () => {});
+suite["skip"]("bracket notation", async () => {});
+test.suite.skip("skipped suite", () => {});
+
+
 ```
 
 # Diagnostics
@@ -555,6 +562,139 @@ invalid.js:32:10 lint/suspicious/noSkippedTests  FIXABLE  ━━━━━━━�
        32 │ + ····test();
     33 33 │   });
     34 34 │   
+  
+
+```
+
+```
+invalid.js:35:1 lint/suspicious/noSkippedTests  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't disable tests.
+  
+    33 │ });
+    34 │ 
+  > 35 │ xsuite('foo', () => {});
+       │ ^^^^^^
+    36 │ suite.skip("test", () => {});
+    37 │ suite.fixme("fixme suite", () => {});
+  
+  i Disabling tests is useful when debugging or creating placeholder while working.
+  
+  i If this is intentional, and you want to commit a disabled test, add a suppression comment.
+  
+  i Unsafe fix: Enable the test.
+  
+    33 33 │   });
+    34 34 │   
+    35    │ - xsuite('foo',·()·=>·{});
+       35 │ + suite('foo',·()·=>·{});
+    36 36 │   suite.skip("test", () => {});
+    37 37 │   suite.fixme("fixme suite", () => {});
+  
+
+```
+
+```
+invalid.js:36:7 lint/suspicious/noSkippedTests  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't disable tests.
+  
+    35 │ xsuite('foo', () => {});
+  > 36 │ suite.skip("test", () => {});
+       │       ^^^^
+    37 │ suite.fixme("fixme suite", () => {});
+    38 │ suite["skip"]("bracket notation", async () => {});
+  
+  i Disabling tests is useful when debugging or creating placeholder while working.
+  
+  i If this is intentional, and you want to commit a disabled test, add a suppression comment.
+  
+  i Unsafe fix: Enable the test.
+  
+    34 34 │   
+    35 35 │   xsuite('foo', () => {});
+    36    │ - suite.skip("test",·()·=>·{});
+       36 │ + suite("test",·()·=>·{});
+    37 37 │   suite.fixme("fixme suite", () => {});
+    38 38 │   suite["skip"]("bracket notation", async () => {});
+  
+
+```
+
+```
+invalid.js:37:7 lint/suspicious/noSkippedTests  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't disable tests.
+  
+    35 │ xsuite('foo', () => {});
+    36 │ suite.skip("test", () => {});
+  > 37 │ suite.fixme("fixme suite", () => {});
+       │       ^^^^^
+    38 │ suite["skip"]("bracket notation", async () => {});
+    39 │ test.suite.skip("skipped suite", () => {});
+  
+  i Disabling tests is useful when debugging or creating placeholder while working.
+  
+  i If this is intentional, and you want to commit a disabled test, add a suppression comment.
+  
+  i Unsafe fix: Enable the test.
+  
+    35 35 │   xsuite('foo', () => {});
+    36 36 │   suite.skip("test", () => {});
+    37    │ - suite.fixme("fixme·suite",·()·=>·{});
+       37 │ + suite("fixme·suite",·()·=>·{});
+    38 38 │   suite["skip"]("bracket notation", async () => {});
+    39 39 │   test.suite.skip("skipped suite", () => {});
+  
+
+```
+
+```
+invalid.js:38:7 lint/suspicious/noSkippedTests  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't disable tests.
+  
+    36 │ suite.skip("test", () => {});
+    37 │ suite.fixme("fixme suite", () => {});
+  > 38 │ suite["skip"]("bracket notation", async () => {});
+       │       ^^^^^^
+    39 │ test.suite.skip("skipped suite", () => {});
+    40 │ 
+  
+  i Disabling tests is useful when debugging or creating placeholder while working.
+  
+  i If this is intentional, and you want to commit a disabled test, add a suppression comment.
+  
+  i Unsafe fix: Enable the test.
+  
+    38 │ suite["skip"]("bracket·notation",·async·()·=>·{});
+       │      --------                                     
+
+```
+
+```
+invalid.js:39:12 lint/suspicious/noSkippedTests  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't disable tests.
+  
+    37 │ suite.fixme("fixme suite", () => {});
+    38 │ suite["skip"]("bracket notation", async () => {});
+  > 39 │ test.suite.skip("skipped suite", () => {});
+       │            ^^^^
+    40 │ 
+  
+  i Disabling tests is useful when debugging or creating placeholder while working.
+  
+  i If this is intentional, and you want to commit a disabled test, add a suppression comment.
+  
+  i Unsafe fix: Enable the test.
+  
+    37 37 │   suite.fixme("fixme suite", () => {});
+    38 38 │   suite["skip"]("bracket notation", async () => {});
+    39    │ - test.suite.skip("skipped·suite",·()·=>·{});
+       39 │ + test.suite("skipped·suite",·()·=>·{});
+    40 40 │   
+    41 41 │   
   
 
 ```

--- a/crates/biome_js_formatter/tests/specs/js/module/declarations/test_declaration.js
+++ b/crates/biome_js_formatter/tests/specs/js/module/declarations/test_declaration.js
@@ -38,3 +38,23 @@ test.concurrent.each(arr)(
   "works as expected", () => {
   expect();
 });
+
+suite("test", () => {
+  it(``, async () => {
+  });
+});
+
+suite(`${foo + bar}`, 
+  () => {}
+);
+
+suite("with retry option", { retry: 2 }, () => {
+  it("does something", () => {});
+});
+
+fsuite("focused suite", () => {});
+
+xsuite("skipped suite", () => {});
+
+test.suite("test suite", () => {});
+

--- a/crates/biome_js_formatter/tests/specs/js/module/declarations/test_declaration.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/declarations/test_declaration.js.snap
@@ -47,6 +47,26 @@ test.concurrent.each(arr)(
   expect();
 });
 
+suite("test", () => {
+  it(``, async () => {
+  });
+});
+
+suite(`${foo + bar}`, 
+  () => {}
+);
+
+suite("with retry option", { retry: 2 }, () => {
+  it("does something", () => {});
+});
+
+fsuite("focused suite", () => {});
+
+xsuite("skipped suite", () => {});
+
+test.suite("test suite", () => {});
+
+
 ```
 
 
@@ -88,5 +108,21 @@ it("with timeout option", { timeout: 5000 }, () => {
 test.concurrent.each(arr)("works as expected", () => {
 	expect();
 });
+
+suite("test", () => {
+	it(``, async () => {});
+});
+
+suite(`${foo + bar}`, () => {});
+
+suite("with retry option", { retry: 2 }, () => {
+	it("does something", () => {});
+});
+
+fsuite("focused suite", () => {});
+
+xsuite("skipped suite", () => {});
+
+test.suite("test suite", () => {});
 
 ```

--- a/crates/biome_js_syntax/src/expr_ext.rs
+++ b/crates/biome_js_syntax/src/expr_ext.rs
@@ -935,19 +935,27 @@ impl AnyJsExpression {
     /// - `test.(only|skip|fixme|todo|fails|failing|concurrent|sequential).(only|skip|fixme|todo|fails|failing|concurrent|sequential)`
     /// - `describe.(only|skip|fixme|todo|shuffle|concurrent|sequential)`
     /// - `describe.(only|skip|fixme|todo|shuffle|concurrent|sequential).(only|skip|fixme|todo|shuffle|concurrent|sequential)`
+    /// - `suite.(only|skip|fixme|todo|shuffle|concurrent|sequential)`
+    /// - `suite.(only|skip|fixme|todo|shuffle|concurrent|sequential).(only|skip|fixme|todo|shuffle|concurrent|sequential)`
     /// - `test.step`
     /// - `test.step.(skip|fixme)`
     /// - `test.describe`
     /// - `test.describe.(only|skip|fixme)`
     /// - `test.describe.(parallel|serial)`
     /// - `test.describe.(parallel|serial).(only|skip|fixme)`
+    /// - `test.suite`
+    /// - `test.suite.(only|skip|fixme)`
+    /// - `test.suite.(parallel|serial)`
+    /// - `test.suite.(parallel|serial).(only|skip|fixme)`
     /// - `skip`
     /// - `xit`
     /// - `xdescribe`
     /// - `xtest`
+    /// - `xsuite`
     /// - `fit`
     /// - `fdescribe`
     /// - `ftest`
+    /// - `fsuite`
     /// - `Deno.test`
     ///
     /// Elements within parentheses `()` can be any of the listed options separated by `|`.
@@ -974,7 +982,7 @@ impl AnyJsExpression {
         let fifth = members.next().map(TokenText::text);
 
         match first {
-            Some("describe") => match second {
+            Some("describe" | "suite") => match second {
                 None => true,
                 Some(
                     "concurrent" | "sequential" | "only" | "skip" | "fixme" | "todo" | "shuffle",
@@ -1017,7 +1025,7 @@ impl AnyJsExpression {
                             | "failing",
                     )
                 ),
-                Some("describe") => match third {
+                Some("describe" | "suite") => match third {
                     None => true,
                     Some("only" | "skip" | "fixme") => fourth.is_none(),
                     Some("parallel" | "serial") => match fourth {
@@ -1033,7 +1041,10 @@ impl AnyJsExpression {
                 Some("test") => third.is_none(),
                 _ => false,
             },
-            Some("skip" | "xit" | "xdescribe" | "xtest" | "fit" | "fdescribe" | "ftest") => true,
+            Some(
+                "skip" | "xit" | "xdescribe" | "xtest" | "fit" | "fdescribe" | "ftest" | "fsuite"
+                | "xsuite",
+            ) => true,
             _ => false,
         }
     }
@@ -1052,9 +1063,11 @@ impl AnyJsExpression {
     ///
     /// - `test.each`
     /// - `describe.each`
+    /// - `suite.each`
     /// - `it.each`
     /// - `test.only.each`
     /// - `describe.skip.each`
+    /// - `suite.skip.each`
     /// - `it.concurrent.each`
     /// - `test.prop`
     ///
@@ -1086,12 +1099,12 @@ impl AnyJsExpression {
     }
 
     /// Checks whether the current function call is:
-    /// - `describe`
+    /// - `describe` or `suite`
     pub fn contains_describe_call(&self) -> bool {
         let mut members = CalleeNamesIterator::new(self.clone());
 
         if let Some(member) = members.next() {
-            return member.text() == "describe";
+            return matches!(member.text(), "describe" | "suite");
         }
         false
     }
@@ -1125,8 +1138,8 @@ impl AnyJsExpression {
     /// Checks whether the current expression contains a focused test pattern.
     ///
     /// This method detects any of the following focused test patterns:
-    /// - `describe.only`, `it.only`, `test.only`
-    /// - `fdescribe`, `fit`, `ftest`
+    /// - `describe.only`, `it.only`, `test.only`, `suite.only`
+    /// - `fdescribe`, `fit`, `ftest`, `fsuite`
     /// - `test.concurrent.only`
     /// - `it.concurrent.only`
     ///
@@ -1149,16 +1162,16 @@ impl AnyJsExpression {
         // Jasmine / Angular focused test patterns (f prepended)
         if let Some(token) = &first {
             let name = token.text();
-            if matches!(name, "fdescribe" | "fit" | "ftest") && second.is_none() {
+            if matches!(name, "fdescribe" | "fit" | "ftest" | "fsuite") && second.is_none() {
                 return Ok(true);
             }
         }
 
         // Handle cases with .only
         if let (Some(first_token), Some(second_token)) = (&first, &second) {
-            // Check for direct .only pattern: test.only, it.only, describe.only
+            // Check for direct .only pattern: test.only, it.only, describe.only, suite.only
             if first_token.text() == "only"
-                && matches!(second_token.text(), "test" | "it" | "describe")
+                && matches!(second_token.text(), "test" | "it" | "describe" | "suite")
             {
                 return Ok(true);
             }
@@ -1181,6 +1194,7 @@ impl AnyJsExpression {
     /// This method detects patterns like:
     /// - `test.only.each`
     /// - `describe.only.each`
+    /// - `suite.only.each`
     /// - `it.only.each`
     ///
     /// ## Examples
@@ -1216,12 +1230,15 @@ impl AnyJsExpression {
                 "test"
                     | "it"
                     | "describe"
+                    | "suite"
                     | "xtest"
                     | "xit"
                     | "xdescribe"
+                    | "xsuite"
                     | "ftest"
                     | "fit"
                     | "fdescribe"
+                    | "fsuite"
             ) {
                 return Ok(true);
             }


### PR DESCRIPTION
<!--
IMPORTANT!!
If you generated this PR with the help of any AI assistance, please disclose it in the PR.
https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

> This PR was developed with the assistance of an AI coding assistant.

## Summary

Closes #11727.

This PR adds support for `suite()` as an alias of `describe()` across test analysis rules and syntax helpers.

Testing frameworks such as Vitest and Mocha provide `suite()` alongside `describe()`. This change ensures that:
- `suite`, `fsuite`, `xsuite`, and `test.suite` are recognized as test suite blocks (`TestBlockKind::Describe`).
- Suite-level lifecycle hooks (`suite.beforeEach`, etc.) are recognized.
- Test modifier patterns (`suite.only`, `suite.skip`, `suite.each`) are handled consistently.
- Existing unit-test rules (`noIdenticalTestTitle`, `useTestHooksOnTop`, `useValidTestTitle`) automatically apply to `suite` blocks without duplicate rule logic.

## Test Plan

- Added unit tests in `crates/biome_js_analyze/src/frameworks/unit_tests.rs` for `suite`, `fsuite`, `xsuite`, `test.suite`, `suite.each`, `suite.skip.each`, and `suite.beforeEach`.
- Added test cases and generated snapshot assertions for:
  - `noIdenticalTestTitle`
  - `useTestHooksOnTop`
  - `useValidTestTitle`
- Verified that all unit tests pass (`cargo test -p biome_js_syntax -p biome_js_analyze`).
- Verified linter checks (`cargo clippy -p biome_js_syntax -p biome_js_analyze --all-targets -- --deny warnings`).

## Docs

Internal unit-test framework utility enhancement; rule documentation remains unchanged.