### PR TITLE
fix(useSimplifiedLogicExpression): preserve all trivia

### DIFF
--- a/.changeset/dull-meteors-wear.md
+++ b/.changeset/dull-meteors-wear.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#7984](https://github.com/biomejs/biome/issues/7984): The fix from [`useSimplifiedLogicExpression`](https://biomejs.dev/linter/rules/use-simplified-logic-expression/) now preserves line breaks in multiline conditions with line comments, preventing the right-hand side condition from being commented out.

--- a/.changeset/polite-squids-lie.md
+++ b/.changeset/polite-squids-lie.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6390](https://github.com/biomejs/biome/issues/6390): Biome now offers suppression actions for [`noDynamicNamespaceImportAccess`](https://biomejs.dev/linter/rules/no-dynamic-namespace-import-access/) in editors.

--- a/.changeset/shaky-candies-tickle.md
+++ b/.changeset/shaky-candies-tickle.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed an issue where Grit plugin code fixes weren't available as editor code actions.

--- a/crates/biome_analyze/src/analyzer_plugin.rs
+++ b/crates/biome_analyze/src/analyzer_plugin.rs
@@ -103,10 +103,6 @@ pub struct PluginVisitor<L: Language> {
     query: SyntaxKindSet<L>,
     plugin: Arc<Box<dyn AnalyzerPlugin>>,
 
-    /// When set, all nodes in this subtree are skipped until we leave it.
-    /// Used to skip subtrees that fall entirely outside the analysis range
-    /// (see the `ctx.range` check in `visit`).
-    skip_subtree: Option<SyntaxNode<L>>,
     /// Cached result of `applies_to_file` for the current file path.
     applies_to_file: FileApplicability,
 }
@@ -125,7 +121,6 @@ where
         Self {
             query,
             plugin,
-            skip_subtree: None,
             applies_to_file: FileApplicability::Unknown,
         }
     }
@@ -142,29 +137,9 @@ where
         event: &WalkEvent<SyntaxNode<Self::Language>>,
         ctx: VisitorContext<Self::Language>,
     ) {
-        let node = match event {
-            WalkEvent::Enter(node) => node,
-            WalkEvent::Leave(node) => {
-                if let Some(skip_subtree) = &self.skip_subtree
-                    && skip_subtree == node
-                {
-                    self.skip_subtree = None;
-                }
-
-                return;
-            }
+        let WalkEvent::Enter(node) = event else {
+            return;
         };
-
-        if self.skip_subtree.is_some() {
-            return;
-        }
-
-        if let Some(range) = ctx.range
-            && node.text_range_with_trivia().ordering(range).is_ne()
-        {
-            self.skip_subtree = Some(node.clone());
-            return;
-        }
 
         // TODO: Integrate to [`VisitorContext::match_query`]?
         let kind = node.kind();
@@ -230,11 +205,6 @@ pub struct BatchPluginVisitor<L: Language> {
     /// Union of all plugin queries.
     any_query: SyntaxKindSet<L>,
 
-    /// When set, all nodes in this subtree are skipped until we leave it.
-    /// Used to skip subtrees that fall entirely outside the analysis range
-    /// (see the `ctx.range` check in `visit`).
-    skip_subtree: Option<SyntaxNode<L>>,
-
     /// Cached per-plugin results of `applies_to_file`. Populated lazily on
     /// first `WalkEvent::Enter` — the file path is constant for the entire walk.
     applicable: Option<Vec<bool>>,
@@ -264,7 +234,6 @@ where
         Self {
             plugins,
             any_query,
-            skip_subtree: None,
             applicable: None,
         }
     }
@@ -281,29 +250,9 @@ where
         event: &WalkEvent<SyntaxNode<Self::Language>>,
         ctx: VisitorContext<Self::Language>,
     ) {
-        let node = match event {
-            WalkEvent::Enter(node) => node,
-            WalkEvent::Leave(node) => {
-                if let Some(skip_subtree) = &self.skip_subtree
-                    && skip_subtree == node
-                {
-                    self.skip_subtree = None;
-                }
-
-                return;
-            }
+        let WalkEvent::Enter(node) = event else {
+            return;
         };
-
-        if self.skip_subtree.is_some() {
-            return;
-        }
-
-        if let Some(range) = ctx.range
-            && node.text_range_with_trivia().ordering(range).is_ne()
-        {
-            self.skip_subtree = Some(node.clone());
-            return;
-        }
 
         let kind = node.kind();
 

--- a/crates/biome_analyze/src/syntax.rs
+++ b/crates/biome_analyze/src/syntax.rs
@@ -1,4 +1,5 @@
 use biome_rowan::{AstNode, Language, SyntaxNode, WalkEvent};
+use std::marker::PhantomData;
 
 use crate::{
     AddVisitor, Phases, QueryKey, QueryMatch, Queryable, ServiceBag, Visitor, VisitorContext,
@@ -44,17 +45,11 @@ impl<L: Language + 'static> QueryMatch for SyntaxNode<L> {
 /// The [SyntaxVisitor] is the simplest form of visitor implemented for the
 /// analyzer, it simply broadcast each [WalkEvent::Enter] as a query match
 /// event for the [SyntaxNode] being entered
-pub struct SyntaxVisitor<L: Language> {
-    /// If a subtree is currently being skipped by the visitor, for instance
-    /// because it has a suppression comment, this stores the root [SyntaxNode]
-    /// of that subtree. The visitor will then ignore all events until it
-    /// receives a [WalkEvent::Leave] for the `skip_subtree` node
-    skip_subtree: Option<SyntaxNode<L>>,
-}
+pub struct SyntaxVisitor<L: Language>(PhantomData<L>);
 
 impl<L: Language> Default for SyntaxVisitor<L> {
     fn default() -> Self {
-        Self { skip_subtree: None }
+        Self(PhantomData)
     }
 }
 
@@ -62,29 +57,9 @@ impl<L: Language + 'static> Visitor for SyntaxVisitor<L> {
     type Language = L;
 
     fn visit(&mut self, event: &WalkEvent<SyntaxNode<Self::Language>>, mut ctx: VisitorContext<L>) {
-        let node = match event {
-            WalkEvent::Enter(node) => node,
-            WalkEvent::Leave(node) => {
-                if let Some(skip_subtree) = &self.skip_subtree
-                    && skip_subtree == node
-                {
-                    self.skip_subtree = None;
-                }
-
-                return;
-            }
+        let WalkEvent::Enter(node) = event else {
+            return;
         };
-
-        if self.skip_subtree.is_some() {
-            return;
-        }
-
-        if let Some(range) = ctx.range
-            && node.text_range_with_trivia().ordering(range).is_ne()
-        {
-            self.skip_subtree = Some(node.clone());
-            return;
-        }
 
         ctx.match_query(node.clone());
     }
@@ -93,7 +68,7 @@ impl<L: Language + 'static> Visitor for SyntaxVisitor<L> {
 #[cfg(test)]
 mod tests {
     use biome_rowan::{
-        AstNode, BatchMutation, SyntaxNode, SyntaxToken,
+        AstNode, BatchMutation, SyntaxNode, SyntaxToken, TextRange, TextSize,
         raw_language::{RawLanguage, RawLanguageKind, RawLanguageRoot, RawSyntaxTreeBuilder},
     };
     use std::convert::Infallible;
@@ -121,9 +96,10 @@ mod tests {
         }
     }
 
-    /// Checks the syntax visitor emits a [QueryMatch] for each node in the syntax tree
+    /// Checks the syntax visitor emits a [QueryMatch] for each node in the syntax tree,
+    /// including query nodes outside the requested signal range.
     #[test]
-    fn syntax_visitor() {
+    fn syntax_visitor_emits_queries_outside_the_signal_range() {
         let root = {
             let mut builder = RawSyntaxTreeBuilder::new();
 
@@ -212,7 +188,7 @@ mod tests {
 
         let ctx: AnalyzerContext<RawLanguage> = AnalyzerContext {
             root,
-            range: None,
+            range: Some(TextRange::new(TextSize::from(1), TextSize::from(2))),
             services: ServiceBag::default(),
             options: &AnalyzerOptions::default(),
         };

--- a/crates/biome_js_analyze/src/lint/complexity/use_simplified_logic_expression.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_simplified_logic_expression.rs
@@ -225,6 +225,14 @@ fn simplify_de_morgan(node: &JsLogicalExpression) -> Option<JsUnaryExpression> {
     let operator_token = node.operator_token().ok()?;
     match (left, right) {
         (AnyJsExpression::JsUnaryExpression(left), AnyJsExpression::JsUnaryExpression(right)) => {
+            let right_operator_token = right.operator_token().ok()?;
+            let mut right_operator_trivia: Vec<_> =
+                right_operator_token.leading_trivia().pieces().collect();
+            right_operator_trivia.extend(right_operator_token.trailing_trivia().pieces());
+            let right_argument = right
+                .argument()
+                .ok()?
+                .prepend_trivia_pieces(right_operator_trivia)?;
             let mut next_logic_expression = match operator_token.kind() {
                 T![||] => node
                     .clone()
@@ -235,7 +243,7 @@ fn simplify_de_morgan(node: &JsLogicalExpression) -> Option<JsUnaryExpression> {
                 _ => return None,
             }?;
             next_logic_expression = next_logic_expression.with_left(left.argument().ok()?);
-            next_logic_expression = next_logic_expression.with_right(right.argument().ok()?);
+            next_logic_expression = next_logic_expression.with_right(right_argument);
             Some(make::js_unary_expression(
                 make::token(T![!]),
                 AnyJsExpression::JsParenthesizedExpression(make::parenthesized(

--- a/crates/biome_js_analyze/tests/specs/complexity/useSimplifiedLogicExpression/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/complexity/useSimplifiedLogicExpression/invalid.js
@@ -6,3 +6,10 @@ const r3 = null ?? nonNullExp;
 const boolExpr1 = true;
 const boolExpr2 = false;
 const r4 = /*1*/ !boolExpr1 /*2*/  || /*3*/ !boolExpr2 /*4*/ 
+
+if (
+    !showThinking && // while it's thinking there is hope to get suggestions
+    !comments?.length
+) {
+    console.log();
+}

--- a/crates/biome_js_analyze/tests/specs/complexity/useSimplifiedLogicExpression/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useSimplifiedLogicExpression/invalid.js.snap
@@ -13,6 +13,13 @@ const boolExpr1 = true;
 const boolExpr2 = false;
 const r4 = /*1*/ !boolExpr1 /*2*/  || /*3*/ !boolExpr2 /*4*/ 
 
+if (
+    !showThinking && // while it's thinking there is hope to get suggestions
+    !comments?.length
+) {
+    console.log();
+}
+
 ```
 
 # Diagnostics
@@ -76,19 +83,48 @@ invalid.js:8:18 lint/complexity/useSimplifiedLogicExpression  FIXABLE  ━━━
 
   i Logical expression contains unnecessary complexity.
   
-    6 │ const boolExpr1 = true;
-    7 │ const boolExpr2 = false;
-  > 8 │ const r4 = /*1*/ !boolExpr1 /*2*/  || /*3*/ !boolExpr2 /*4*/·
-      │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    9 │ 
+     6 │ const boolExpr1 = true;
+     7 │ const boolExpr2 = false;
+   > 8 │ const r4 = /*1*/ !boolExpr1 /*2*/  || /*3*/ !boolExpr2 /*4*/·
+       │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     9 │ 
+    10 │ if (
   
   i Safe fix: Reduce the complexity of the logical expression.
   
-    6 6 │   const boolExpr1 = true;
-    7 7 │   const boolExpr2 = false;
-    8   │ - const·r4·=·/*1*/·!boolExpr1·/*2*/··||·/*3*/·!boolExpr2·/*4*/·
-      8 │ + const·r4·=·/*1*/·!(boolExpr1·/*2*/··&&·/*3*/·boolExpr2·/*4*/·)·/*4*/·
-    9 9 │   
+     6  6 │   const boolExpr1 = true;
+     7  7 │   const boolExpr2 = false;
+     8    │ - const·r4·=·/*1*/·!boolExpr1·/*2*/··||·/*3*/·!boolExpr2·/*4*/·
+        8 │ + const·r4·=·/*1*/·!(boolExpr1·/*2*/··&&·/*3*/·boolExpr2·/*4*/·)·/*4*/·
+     9  9 │   
+    10 10 │   if (
+  
+
+```
+
+```
+invalid.js:11:5 lint/complexity/useSimplifiedLogicExpression  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Logical expression contains unnecessary complexity.
+  
+    10 │ if (
+  > 11 │     !showThinking && // while it's thinking there is hope to get suggestions
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 12 │     !comments?.length
+       │     ^^^^^^^^^^^^^^^^^
+    13 │ ) {
+    14 │     console.log();
+  
+  i Safe fix: Reduce the complexity of the logical expression.
+  
+     9  9 │   
+    10 10 │   if (
+    11    │ - ····!showThinking·&&·//·while·it's·thinking·there·is·hope·to·get·suggestions
+    12    │ - ····!comments?.length
+       11 │ + ····!(showThinking·||·//·while·it's·thinking·there·is·hope·to·get·suggestions
+       12 │ + ····comments?.length)
+    13 13 │   ) {
+    14 14 │       console.log();
   
 
 ```

--- a/crates/biome_lsp/Cargo.toml
+++ b/crates/biome_lsp/Cargo.toml
@@ -46,8 +46,9 @@ url                  = { workspace = true }
 uuid                 = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["io-util", "macros", "rt", "rt-multi-thread"] }
-tower = { workspace = true, features = ["timeout"] }
+biome_service = { path = "../biome_service", features = ["js_plugin"] }
+tokio         = { workspace = true, features = ["io-util", "macros", "rt", "rt-multi-thread"] }
+tower         = { workspace = true, features = ["timeout"] }
 
 [lints]
 workspace = true

--- a/crates/biome_lsp/src/server.tests.rs
+++ b/crates/biome_lsp/src/server.tests.rs
@@ -1085,6 +1085,106 @@ async fn pull_quick_fixes() -> Result<()> {
 }
 
 #[tokio::test]
+async fn pull_suppressions_when_query_and_signal_ranges_are_disjoint() -> Result<()> {
+    let factory = ServerFactory::default();
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+
+    server
+        .open_document("import * as foo from \"foo\";\nconst key = \"bar\";\nfoo[key];")
+        .await?;
+
+    let diagnostic = Diagnostic {
+        range: Range {
+            start: Position {
+                line: 2,
+                character: 0,
+            },
+            end: Position {
+                line: 2,
+                character: 8,
+            },
+        },
+        severity: Some(DiagnosticSeverity::WARNING),
+        code: Some(NumberOrString::String(String::from(
+            "lint/performance/noDynamicNamespaceImportAccess",
+        ))),
+        source: Some(String::from("biome")),
+        message: String::from("Avoid accessing namespace imports dynamically."),
+        ..Default::default()
+    };
+
+    let res: CodeActionResponse = server
+        .request(
+            "textDocument/codeAction",
+            "pull_code_actions",
+            CodeActionParams {
+                text_document: TextDocumentIdentifier {
+                    uri: uri!("document.js"),
+                },
+                range: Range {
+                    start: Position {
+                        line: 2,
+                        character: 4,
+                    },
+                    end: Position {
+                        line: 2,
+                        character: 4,
+                    },
+                },
+                context: CodeActionContext {
+                    diagnostics: vec![diagnostic.clone()],
+                    only: Some(vec![CodeActionKind::QUICKFIX]),
+                    ..Default::default()
+                },
+                work_done_progress_params: WorkDoneProgressParams {
+                    work_done_token: None,
+                },
+                partial_result_params: PartialResultParams {
+                    partial_result_token: None,
+                },
+            },
+        )
+        .await?
+        .context("codeAction returned None")?;
+
+    let action_kinds: Vec<_> = res
+        .iter()
+        .map(|action| match action {
+            CodeActionOrCommand::CodeAction(action) => {
+                assert_eq!(
+                    action.diagnostics.as_deref(),
+                    Some(std::slice::from_ref(&diagnostic))
+                );
+                assert!(action.edit.is_some());
+                action.kind.clone().unwrap()
+            }
+            CodeActionOrCommand::Command(_) => panic!("expected code action"),
+        })
+        .collect();
+    assert_eq!(
+        action_kinds,
+        [
+            CodeActionKind::new("quickfix.suppressRule.inline.biome"),
+            CodeActionKind::new("quickfix.suppressRule.topLevel.biome"),
+        ]
+    );
+
+    server.close_document().await?;
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn pull_quick_fixes_with_resolve() -> Result<()> {
     let factory = ServerFactory::default();
     let (service, client) = factory.create().into_inner();
@@ -1675,6 +1775,198 @@ async fn plugin_rewrite_pull_diagnostics() -> Result<()> {
     } else {
         panic!("Expected PublishDiagnostics, got {notification:?}");
     }
+
+    server.close_document().await?;
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn pull_plugin_code_action_at_diagnostic_start() -> Result<()> {
+    let fs = MemoryFileSystem::default();
+    let config = r#"{
+        "plugins": ["useConsoleInfo.grit"],
+        "linter": {
+            "rules": { "recommended": false }
+        }
+    }"#;
+    let plugin = br#"language js
+
+`console.log($msg)` as $call where {
+    register_diagnostic(
+        span = $call,
+        message = "Use console.info instead of console.log.",
+        severity = "warn"
+    ),
+    $call => `console.info($msg)`
+}"#;
+
+    fs.insert(to_utf8_file_path_buf(uri!("biome.json")), config);
+    fs.insert(to_utf8_file_path_buf(uri!("useConsoleInfo.grit")), plugin);
+
+    let factory = ServerFactory::new_with_fs(Arc::new(fs));
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, mut receiver) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+    server.load_configuration().await?;
+    server
+        .open_named_document("console.log(\"hello\");", uri!("document.js"), "javascript")
+        .await?;
+
+    let notification = wait_for_notification(&mut receiver, |n| n.is_publish_diagnostics()).await;
+    let Some(ServerNotification::PublishDiagnostics(params)) = notification else {
+        panic!("expected plugin diagnostics");
+    };
+    let [diagnostic] = params.diagnostics.as_slice() else {
+        panic!("expected one plugin diagnostic: {params:?}");
+    };
+
+    let res: CodeActionResponse = server
+        .request(
+            "textDocument/codeAction",
+            "pull_code_actions",
+            CodeActionParams {
+                text_document: TextDocumentIdentifier {
+                    uri: uri!("document.js"),
+                },
+                range: Range {
+                    start: Position {
+                        line: 0,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 0,
+                        character: 0,
+                    },
+                },
+                context: CodeActionContext {
+                    diagnostics: vec![diagnostic.clone()],
+                    only: Some(vec![CodeActionKind::QUICKFIX]),
+                    ..Default::default()
+                },
+                work_done_progress_params: WorkDoneProgressParams {
+                    work_done_token: None,
+                },
+                partial_result_params: PartialResultParams {
+                    partial_result_token: None,
+                },
+            },
+        )
+        .await?
+        .context("codeAction returned None")?;
+
+    let [CodeActionOrCommand::CodeAction(action)] = res.as_slice() else {
+        panic!("expected one plugin code action: {res:?}");
+    };
+    assert_eq!(
+        action.kind,
+        Some(CodeActionKind::new("quickfix.biome.plugin"))
+    );
+    assert_eq!(action.title, "Rewrite suggested by plugin `useConsoleInfo`");
+    assert!(action.edit.is_some());
+
+    server.close_document().await?;
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn pull_js_plugin_code_action_when_query_and_diagnostic_ranges_are_disjoint() -> Result<()> {
+    let fs = MemoryFileSystem::default();
+    let config = r#"{
+        "plugins": ["renameReference.js"],
+        "linter": {
+            "rules": { "recommended": false }
+        }
+    }"#;
+    let plugin = br#"import { createMutation, defineRule, factory, registerDiagnostic, semantic } from "@biomejs/runtime/plugin";
+
+export const renameReference = defineRule({
+    query: semantic("JS_REFERENCE_IDENTIFIER"),
+    run(node, { model }) {
+        const binding = model.binding(node);
+        if (!binding) return;
+
+        const mutation = createMutation(binding.syntax());
+        mutation.replaceToken(node.token("valueToken"), factory.token("IDENT", "renamed"));
+        registerDiagnostic(binding.syntax(), "warning", "Rename the reference.", {
+            mutation,
+            message: "Rename reference",
+            kind: "safe",
+        });
+    },
+});"#;
+
+    fs.insert(to_utf8_file_path_buf(uri!("biome.json")), config);
+    fs.insert(to_utf8_file_path_buf(uri!("renameReference.js")), plugin);
+
+    let factory = ServerFactory::new_with_fs(Arc::new(fs));
+    let (service, client) = factory.create().into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, mut receiver) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+    server.load_configuration().await?;
+    server
+        .open_named_document("let value = 1;\nvalue;", uri!("document.js"), "javascript")
+        .await?;
+
+    let notification = wait_for_notification(&mut receiver, |n| n.is_publish_diagnostics()).await;
+    let Some(ServerNotification::PublishDiagnostics(params)) = notification else {
+        panic!("expected plugin diagnostics");
+    };
+    let [diagnostic] = params.diagnostics.as_slice() else {
+        panic!("expected one plugin diagnostic: {params:?}");
+    };
+
+    let res: CodeActionResponse = server
+        .request(
+            "textDocument/codeAction",
+            "pull_code_actions",
+            CodeActionParams {
+                text_document: TextDocumentIdentifier {
+                    uri: uri!("document.js"),
+                },
+                range: diagnostic.range,
+                context: CodeActionContext {
+                    diagnostics: vec![diagnostic.clone()],
+                    only: Some(vec![CodeActionKind::QUICKFIX]),
+                    ..Default::default()
+                },
+                work_done_progress_params: WorkDoneProgressParams {
+                    work_done_token: None,
+                },
+                partial_result_params: PartialResultParams {
+                    partial_result_token: None,
+                },
+            },
+        )
+        .await?
+        .context("codeAction returned None")?;
+
+    let [CodeActionOrCommand::CodeAction(action)] = res.as_slice() else {
+        panic!("expected one JavaScript plugin code action: {res:?}");
+    };
+    assert_eq!(
+        action.kind,
+        Some(CodeActionKind::new("quickfix.biome.plugin"))
+    );
+    assert_eq!(action.title, "Rename reference");
+    assert!(action.edit.is_some());
 
     server.close_document().await?;
     server.shutdown().await?;

--- a/crates/biome_plugin_loader/src/semantic.tests.rs
+++ b/crates/biome_plugin_loader/src/semantic.tests.rs
@@ -1,12 +1,12 @@
 use super::tests::{load_test_plugin_from_source, render_diagnostics, services, snap_diagnostics};
 use super::*;
 use biome_analyze::{AnalysisFilter, AnalyzerOptions, ControlFlow, Never};
-use biome_diagnostics::PrintDescription;
+use biome_diagnostics::{Diagnostic, PrintDescription};
 use biome_js_analyze::JsAnalyzerServices;
 use biome_js_parser::{JsParserOptions, parse};
 use biome_js_semantic::{SemanticModel, SemanticModelOptions, semantic_model};
 use biome_js_syntax::JsSyntaxKind;
-use biome_rowan::AstNode;
+use biome_rowan::{AstNode, TextRange, TextSize};
 use serde_json::{Value, json};
 
 fn native_summary(model: &SemanticModel) -> Value {
@@ -299,6 +299,59 @@ fn semantic_rules_use_the_supplied_model_and_syntax_rules_keep_their_context() {
         plugin_source,
         &[("/file.js", "let value = 1; value;")],
         rendered,
+    );
+}
+
+#[test]
+fn analysis_range_filters_plugin_diagnostics_not_queries() {
+    let plugin_source = r#"import { defineRule, semantic, registerDiagnostic } from "@biomejs/runtime/plugin";
+        export const reportDeclaration = defineRule({
+            query: semantic("JS_REFERENCE_IDENTIFIER"),
+            run(node, { model }) {
+                const binding = model.binding(node);
+                registerDiagnostic(binding.syntax(), "information", "declaration");
+                registerDiagnostic(node, "information", "reference");
+            },
+        });"#;
+    let plugin = load_test_plugin_from_source("/plugin.js", plugin_source, None);
+    let source_type = JsFileSource::js_module();
+    let parsed = parse(
+        "let value = 1;\nvalue;",
+        source_type,
+        JsParserOptions::default(),
+    );
+    let model = semantic_model(&parsed.tree(), SemanticModelOptions::from(&source_type));
+    let plugins: Vec<Arc<Box<dyn AnalyzerPlugin>>> = vec![Arc::new(Box::new(plugin))];
+    let declaration_range = TextRange::new(TextSize::from(4), TextSize::from(9));
+    let mut emitted = Vec::new();
+
+    let (_, diagnostics) = biome_js_analyze::analyze(
+        &parsed.tree(),
+        AnalysisFilter {
+            enabled_rules: Some(&[]),
+            range: Some(declaration_range),
+            ..AnalysisFilter::default()
+        },
+        &AnalyzerOptions::default(),
+        &plugins,
+        JsAnalyzerServices::default()
+            .with_source_type(source_type)
+            .with_semantic_model(&model),
+        |signal| {
+            if let Some(diagnostic) = signal.diagnostic() {
+                emitted.push((
+                    PrintDescription(&diagnostic).to_string(),
+                    diagnostic.location().span,
+                ));
+            }
+            ControlFlow::<Never>::Continue(())
+        },
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+    assert_eq!(
+        emitted,
+        [(String::from("declaration"), Some(declaration_range))]
     );
 }
 

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -3651,6 +3651,21 @@ impl Workspace for WorkspaceServerWithDb<'_> {
             self.settings_handle_with_query(&settings, EditorFeatures::default(), query_context);
         let (parsed_source, parsed_snippets) = self.get_parsed_snippets_and_parse_source(&path)?;
 
+        let plugins = cfg_select! {
+            feature = "plugins" => {
+                if categories.contains(biome_analyze::RuleCategory::Lint) {
+                    self.get_analyzer_plugins_for_project(
+                        settings.as_ref().source_path().unwrap_or_default().as_path(),
+                        &settings.as_ref().get_plugins_for_path(&path),
+                    )
+                    .map_err(WorkspaceError::plugin_errors)?
+                } else {
+                    Vec::new()
+                }
+            },
+            _ => biome_analyze::AnalyzerPluginVec::new()
+        };
+
         let mut result = code_actions(CodeActionsParams {
             parsed_source: parsed_source.into(),
             range,
@@ -3663,7 +3678,7 @@ impl Workspace for WorkspaceServerWithDb<'_> {
             skip: &skip,
             suppression_reason: None,
             enabled_rules: &enabled_rules,
-            plugins: Vec::new(),
+            plugins: plugins.clone(),
             categories,
             working_directory: Some(working_directory.as_path()),
             compute_actions,
@@ -3699,7 +3714,7 @@ impl Workspace for WorkspaceServerWithDb<'_> {
                 skip: &skip,
                 suppression_reason: None,
                 enabled_rules: &enabled_rules,
-                plugins: Vec::new(),
+                plugins: plugins.clone(),
                 categories,
                 working_directory: Some(working_directory.as_path()),
                 compute_actions,


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

> Fixed with a coding agent

Closes #7783
Closes #6390

This PR fixes:
- a bug in a lint rule where its code fix didn't preserve all trivia, causing invalid code
- a bug where, when requesting code actions in a certain range, the signals emitted by a rule didn't appear in the editors
- a bug where code fixes for plugins weren't executed in the editor

Regarding the second bug, here is an ELI18 of the problem, AI-generated

<details>

The bug came from treating three different ranges as if they were the same.

## The Three Ranges

Given:

```js
import * as Icons from "./icons";
// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Query range

const Icon = Icons[name];
//           ^^^^^^^^^^^ Signal range and LSP cursor range
```

1. **Query range:** the syntax node that causes the rule to run.
2. **Signal range:** where the resulting diagnostic/action is located.
3. **Requested range:** the cursor or selection sent by the editor.

For `noDynamicNamespaceImportAccess`, the query is the import declaration:

`crates/biome_js_analyze/src/lint/performance/no_dynamic_namespace_import_access.rs:70-74`

The rule then follows semantic references and creates signals at later computed accesses:

`crates/biome_js_analyze/src/lint/performance/no_dynamic_namespace_import_access.rs:98-123`

These ranges are disjoint: they do not overlap.

## What `skip_subtree` Did

The old `SyntaxVisitor` received the editor’s requested range. When it encountered a syntax node that did not overlap that range, it skipped the entire subtree.

Conceptually:

```rust
if query_node.does_not_overlap(editor_range) {
    skip_everything_inside(query_node);
}
```

When the cursor was on `Icons[name]`:

1. The visitor reached the earlier import statement.
2. The import did not overlap the cursor range.
3. The visitor skipped the import subtree.
4. `JsImportNamespaceClause` was never sent to `QueryMatcher`.
5. `NoDynamicNamespaceImportAccess::run` never executed.
6. The signal for `Icons[name]` was never created.
7. Without a signal, suppression actions could not be generated.

Visiting `Icons[name]` later did not help because the rule was registered for `JsImportNamespaceClause`, not `JsComputedMemberExpression`.

## Why This Was Incorrect

Skipping descendants was structurally valid: descendants cannot exist outside their parent node’s source range.

The invalid assumption was:

```text
A query outside the requested range cannot produce a signal inside it.
```

Biome rules do not guarantee that. A query can use semantic information to report another location anywhere in the file.

The analyzer already has the correct filter after rule execution:

```rust
if range_match(requested_range, signal_range) {
    emit_signal();
}
```

`crates/biome_analyze/src/lib.rs:528-536`

The correct flow is therefore:

```text
Run query
    ↓
Create signal with its actual range
    ↓
Compare signal range with editor range
    ↓
Emit or discard signal
```

The broken flow was:

```text
Compare query range with editor range
    ↓
Possibly skip query
    ↓
Never discover an otherwise matching signal
```

## Plugin Equivalent

A JavaScript plugin can query a later reference but report its declaration:

```js
let value = 1; // diagnostic range
value;         // plugin query range
```

If the editor requests actions on the declaration, the old plugin visitor skips the later reference before evaluating the plugin. The declaration diagnostic and its action are never produced.

The plugin visitors now follow the same model as native rules:

```text
Evaluate all matching query nodes
    ↓
Queue diagnostics using their reported ranges
    ↓
Let the analyzer’s final range filter select the relevant signals
```

`skip_subtree` was not generally defective. Using it before knowing the eventual signal range was the defect.

</details>
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added tests. I also added a test for JS plugins in preparation to the release

<!-- What demonstrates that your implementation is correct? -->

## Docs

N/A

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
