### PR TITLE
fix(analyzer): infer types for for-of bindings

### DIFF
--- a/.changeset/mighty-olives-sip.md
+++ b/.changeset/mighty-olives-sip.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11730](https://github.com/biomejs/biome/issues/11730): [`useExhaustiveSwitchCases`](https://biomejs.dev/linter/rules/use-exhaustive-switch-cases/) reports missing cases when iterating over a class property with `for...of`.

--- a/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/issue11730Invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/issue11730Invalid.ts
@@ -1,0 +1,15 @@
+// should generate diagnostics
+import type { Player } from "./issue11730Player.js";
+
+class GameController {
+	players: Player[];
+
+	updatePlayers() {
+		for (const player of this.players) {
+			switch (player.state) {
+				case "running":
+					break;
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/issue11730Invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/issue11730Invalid.ts.snap
@@ -1,0 +1,63 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue11730Invalid.ts
+---
+# Input
+```ts
+// should generate diagnostics
+import type { Player } from "./issue11730Player.js";
+
+class GameController {
+	players: Player[];
+
+	updatePlayers() {
+		for (const player of this.players) {
+			switch (player.state) {
+				case "running":
+					break;
+			}
+		}
+	}
+}
+
+```
+
+# Diagnostics
+```
+issue11730Invalid.ts:9:4 lint/nursery/useExhaustiveSwitchCases  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The switch statement is not exhaustive.
+  
+     7 │ 	updatePlayers() {
+     8 │ 		for (const player of this.players) {
+   > 9 │ 			switch (player.state) {
+       │ 			^^^^^^^^^^^^^^^^^^^^^^^
+  > 10 │ 				case "running":
+  > 11 │ 					break;
+  > 12 │ 			}
+       │ 			^
+    13 │ 		}
+    14 │ 	}
+  
+  i Some variants of the union type are not handled here.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i These cases are missing:
+  
+  - "jumping"
+  - "ducking"
+  
+  i Unsafe fix: Add the missing cases to the switch statement.
+  
+     9  9 │         switch (player.state) {
+    10 10 │           case "running":
+    11    │ - → → → → → break;
+       11 │ + → → → → → break;
+       12 │ + → → → → case·"jumping":·throw·new·Error("TODO:·Not·implemented·yet");
+       13 │ + → → → → case·"ducking":·throw·new·Error("TODO:·Not·implemented·yet");
+    12 14 │         }
+    13 15 │       }
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/issue11730LoopsInvalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/issue11730LoopsInvalid.ts
@@ -1,0 +1,34 @@
+// should generate diagnostics
+import type { Player } from "./issue11730Player.js";
+
+class GameController {
+	players: Player[];
+	pendingPlayers: Promise<Player>[];
+
+	updatePlayers() {
+		for (const { state } of this.players) {
+			switch (state) {
+				case "running":
+					break;
+			}
+		}
+	}
+
+	async updatePendingPlayers() {
+		for await (const player of this.pendingPlayers) {
+			switch (player.state) {
+				case "running":
+					break;
+			}
+		}
+	}
+}
+
+function updatePlayers(players: Player[]) {
+	for (const player of players) {
+		switch (player.state) {
+			case "running":
+				break;
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/issue11730LoopsInvalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/issue11730LoopsInvalid.ts.snap
@@ -1,0 +1,160 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue11730LoopsInvalid.ts
+---
+# Input
+```ts
+// should generate diagnostics
+import type { Player } from "./issue11730Player.js";
+
+class GameController {
+	players: Player[];
+	pendingPlayers: Promise<Player>[];
+
+	updatePlayers() {
+		for (const { state } of this.players) {
+			switch (state) {
+				case "running":
+					break;
+			}
+		}
+	}
+
+	async updatePendingPlayers() {
+		for await (const player of this.pendingPlayers) {
+			switch (player.state) {
+				case "running":
+					break;
+			}
+		}
+	}
+}
+
+function updatePlayers(players: Player[]) {
+	for (const player of players) {
+		switch (player.state) {
+			case "running":
+				break;
+		}
+	}
+}
+
+```
+
+# Diagnostics
+```
+issue11730LoopsInvalid.ts:10:4 lint/nursery/useExhaustiveSwitchCases  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━
+
+  i The switch statement is not exhaustive.
+  
+     8 │ 	updatePlayers() {
+     9 │ 		for (const { state } of this.players) {
+  > 10 │ 			switch (state) {
+       │ 			^^^^^^^^^^^^^^^^
+  > 11 │ 				case "running":
+  > 12 │ 					break;
+  > 13 │ 			}
+       │ 			^
+    14 │ 		}
+    15 │ 	}
+  
+  i Some variants of the union type are not handled here.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i These cases are missing:
+  
+  - "jumping"
+  - "ducking"
+  
+  i Unsafe fix: Add the missing cases to the switch statement.
+  
+    10 10 │         switch (state) {
+    11 11 │           case "running":
+    12    │ - → → → → → break;
+       12 │ + → → → → → break;
+       13 │ + → → → → case·"jumping":·throw·new·Error("TODO:·Not·implemented·yet");
+       14 │ + → → → → case·"ducking":·throw·new·Error("TODO:·Not·implemented·yet");
+    13 15 │         }
+    14 16 │       }
+  
+
+```
+
+```
+issue11730LoopsInvalid.ts:19:4 lint/nursery/useExhaustiveSwitchCases  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━
+
+  i The switch statement is not exhaustive.
+  
+    17 │ 	async updatePendingPlayers() {
+    18 │ 		for await (const player of this.pendingPlayers) {
+  > 19 │ 			switch (player.state) {
+       │ 			^^^^^^^^^^^^^^^^^^^^^^^
+  > 20 │ 				case "running":
+  > 21 │ 					break;
+  > 22 │ 			}
+       │ 			^
+    23 │ 		}
+    24 │ 	}
+  
+  i Some variants of the union type are not handled here.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i These cases are missing:
+  
+  - "jumping"
+  - "ducking"
+  
+  i Unsafe fix: Add the missing cases to the switch statement.
+  
+    19 19 │         switch (player.state) {
+    20 20 │           case "running":
+    21    │ - → → → → → break;
+       21 │ + → → → → → break;
+       22 │ + → → → → case·"jumping":·throw·new·Error("TODO:·Not·implemented·yet");
+       23 │ + → → → → case·"ducking":·throw·new·Error("TODO:·Not·implemented·yet");
+    22 24 │         }
+    23 25 │       }
+  
+
+```
+
+```
+issue11730LoopsInvalid.ts:29:3 lint/nursery/useExhaustiveSwitchCases  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━
+
+  i The switch statement is not exhaustive.
+  
+    27 │ function updatePlayers(players: Player[]) {
+    28 │ 	for (const player of players) {
+  > 29 │ 		switch (player.state) {
+       │ 		^^^^^^^^^^^^^^^^^^^^^^^
+  > 30 │ 			case "running":
+  > 31 │ 				break;
+  > 32 │ 		}
+       │ 		^
+    33 │ 	}
+    34 │ }
+  
+  i Some variants of the union type are not handled here.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+  i These cases are missing:
+  
+  - "jumping"
+  - "ducking"
+  
+  i Unsafe fix: Add the missing cases to the switch statement.
+  
+    29 29 │       switch (player.state) {
+    30 30 │         case "running":
+    31    │ - → → → → break;
+       31 │ + → → → → break;
+       32 │ + → → → case·"jumping":·throw·new·Error("TODO:·Not·implemented·yet");
+       33 │ + → → → case·"ducking":·throw·new·Error("TODO:·Not·implemented·yet");
+    32 34 │       }
+    33 35 │     }
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/issue11730Player.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/issue11730Player.ts
@@ -1,0 +1,8 @@
+type State = "running" | "jumping" | "ducking";
+
+export class Player {
+	state: State;
+	constructor(state: State) {
+		this.state = state;
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/issue11730Player.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/issue11730Player.ts.snap
@@ -1,0 +1,16 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue11730Player.ts
+---
+# Input
+```ts
+type State = "running" | "jumping" | "ducking";
+
+export class Player {
+	state: State;
+	constructor(state: State) {
+		this.state = state;
+	}
+}
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/issue11730Valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/issue11730Valid.ts
@@ -1,0 +1,40 @@
+// should not generate diagnostics
+import type { Player } from "./issue11730Player.js";
+
+class GameController {
+	players: Player[];
+
+	updatePlayers() {
+		for (const player of this.players) {
+			switch (player.state) {
+				case "running":
+				case "jumping":
+				case "ducking":
+					break;
+			}
+		}
+		for (const { state } of this.players) {
+			switch (state) {
+				case "running":
+					break;
+				default:
+					break;
+			}
+		}
+		for (const key in this.players) {
+			switch (key) {
+				case "0":
+					break;
+			}
+		}
+	}
+}
+
+function updateUnknownPlayers(players: unknown[]) {
+	for (const player of players) {
+		switch (player) {
+			case "running":
+				break;
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/issue11730Valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/issue11730Valid.ts.snap
@@ -1,0 +1,48 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue11730Valid.ts
+---
+# Input
+```ts
+// should not generate diagnostics
+import type { Player } from "./issue11730Player.js";
+
+class GameController {
+	players: Player[];
+
+	updatePlayers() {
+		for (const player of this.players) {
+			switch (player.state) {
+				case "running":
+				case "jumping":
+				case "ducking":
+					break;
+			}
+		}
+		for (const { state } of this.players) {
+			switch (state) {
+				case "running":
+					break;
+				default:
+					break;
+			}
+		}
+		for (const key in this.players) {
+			switch (key) {
+				case "0":
+					break;
+			}
+		}
+	}
+}
+
+function updateUnknownPlayers(players: unknown[]) {
+	for (const player of players) {
+		switch (player) {
+			case "running":
+				break;
+		}
+	}
+}
+
+```

--- a/crates/biome_module_graph/src/js_module_info/collector.rs
+++ b/crates/biome_module_graph/src/js_module_info/collector.rs
@@ -164,13 +164,6 @@ impl JsModuleInfoCollector {
             let ty = TypeData::from_any_js_expression(self, scope_id, &expr);
             let id = self.register_type(Cow::Owned(ty));
             self.parsed_expressions.insert(range, id);
-        } else if let Some(decl) = JsForVariableDeclaration::cast_ref(node) {
-            let scope_id = self.semantic_model.scope(node).id();
-            let type_bindings =
-                TypeData::typed_bindings_from_js_for_statement(self, scope_id, &decl)
-                    .unwrap_or_default();
-            self.variable_declarations
-                .insert(decl.syntax().clone(), type_bindings);
         } else if let Some(param) = JsFormalParameter::cast_ref(node) {
             let scope_id = self.semantic_model.scope(node).id();
             let parsed_param = FunctionParameter::from_js_formal_parameter(self, scope_id, &param);
@@ -526,7 +519,11 @@ impl JsModuleInfoCollector {
                     TypeData::from_any_js_export_default_declaration(self, scope_id, &declaration);
                 return self.reference_to_owned_data(data);
             } else if let Some(typed_bindings) = JsForVariableDeclaration::cast_ref(&ancestor)
-                .and_then(|decl| self.variable_declarations.get(decl.syntax()))
+                .and_then(|decl| {
+                    // The iterable follows the declaration in source order, so its
+                    // expressions are only cached after leaving the declaration.
+                    TypeData::typed_bindings_from_js_for_statement(self, scope_id, &decl)
+                })
             {
                 return typed_bindings
                     .iter()


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
In `for (const player of this.players)`, we were attempting to resolve the type of `const player` before `this` was resolved. This would cause `player` to get an unknown type.

fixed by astra

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #11730

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
