### PR TITLE
fix(types): resolve generic method signatures in their own scope

### DIFF
--- a/.changeset/nine-yaks-smash.md
+++ b/.changeset/nine-yaks-smash.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11692](https://github.com/biomejs/biome/issues/11692): [`noFloatingPromises`](https://biomejs.dev/linter/rules/no-floating-promises/) now detects unhandled promises returned through generic method signatures, including Playwright fixtures.

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/genericMethodScope.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/genericMethodScope.ts
@@ -1,0 +1,19 @@
+// should generate diagnostics
+
+declare const factory: { create<T>(): T };
+factory.create<Promise<void>>();
+
+interface Test<Args> {
+	(body: (args: Args) => void): void;
+	extend<T>(): Test<Args & T>;
+}
+
+declare const base: Test<{}>;
+const test = base.extend<{
+	fixture: () => Promise<void>;
+	service: { run(): Promise<void> };
+}>();
+test(({ fixture, service }) => {
+	fixture();
+	service.run();
+});

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/genericMethodScope.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/genericMethodScope.ts.snap
@@ -1,0 +1,84 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: genericMethodScope.ts
+---
+# Input
+```ts
+// should generate diagnostics
+
+declare const factory: { create<T>(): T };
+factory.create<Promise<void>>();
+
+interface Test<Args> {
+	(body: (args: Args) => void): void;
+	extend<T>(): Test<Args & T>;
+}
+
+declare const base: Test<{}>;
+const test = base.extend<{
+	fixture: () => Promise<void>;
+	service: { run(): Promise<void> };
+}>();
+test(({ fixture, service }) => {
+	fixture();
+	service.run();
+});
+
+```
+
+# Diagnostics
+```
+genericMethodScope.ts:4:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    3 │ declare const factory: { create<T>(): T };
+  > 4 │ factory.create<Promise<void>>();
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │ 
+    6 │ interface Test<Args> {
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+genericMethodScope.ts:17:2 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    15 │ }>();
+    16 │ test(({ fixture, service }) => {
+  > 17 │ 	fixture();
+       │ 	^^^^^^^^^^
+    18 │ 	service.run();
+    19 │ });
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```
+
+```
+genericMethodScope.ts:18:2 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    16 │ test(({ fixture, service }) => {
+    17 │ 	fixture();
+  > 18 │ 	service.run();
+       │ 	^^^^^^^^^^^^^^
+    19 │ });
+    20 │ 
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i This rule belongs to the nursery group, which means it is not yet stable and may change in the future. Visit https://biomejs.dev/linter/#nursery for more information.
+  
+
+```

--- a/crates/biome_js_type_info/src/local_inference.rs
+++ b/crates/biome_js_type_info/src/local_inference.rs
@@ -2471,13 +2471,22 @@ impl TypeMember {
                 })
             }
             AnyTsTypeMember::TsMethodSignatureTypeMember(member) => {
+                let type_parameters = member.type_parameters();
+                // Reusing the enclosing scope lets nongeneric signatures share raw types.
+                let scope_id = if type_parameters.is_some() {
+                    collector
+                        .scope_for_node(member.syntax())
+                        .unwrap_or(scope_id)
+                } else {
+                    scope_id
+                };
                 member.name().ok().and_then(|name| name.name()).map(|name| {
                     let function = Function {
                         is_async: false,
                         type_parameters: generic_params_from_ts_type_params(
                             collector,
                             scope_id,
-                            member.type_parameters(),
+                            type_parameters,
                         ),
                         name: Some(name.clone().into()),
                         parameters: function_params_from_js_params(

--- a/crates/biome_js_type_info/src/type_store.rs
+++ b/crates/biome_js_type_info/src/type_store.rs
@@ -7,7 +7,7 @@ use hashbrown::{HashTable, hash_table::Entry};
 use rustc_hash::FxHasher;
 
 use biome_js_semantic::ScopeId;
-use biome_js_syntax::AnyJsExpression;
+use biome_js_syntax::{AnyJsExpression, JsSyntaxNode};
 
 use crate::{
     RawTypeId, TypeData, TypeId, TypeReference, Union, globals::GLOBAL_UNDEFINED_ID,
@@ -102,6 +102,11 @@ fn hash_data(data: &TypeData) -> u64 {
 
 /// Interface used while collecting a module's stable raw type table.
 pub trait RawTypeCollector {
+    /// Returns the node's lexical scope, or `None` for collectors without a semantic model.
+    fn scope_for_node(&self, _node: &JsSyntaxNode) -> Option<ScopeId> {
+        None
+    }
+
     fn find_type(&self, type_data: &TypeData) -> Option<TypeId>;
     fn get_by_id(&self, id: TypeId) -> &TypeData;
     fn register_type(&mut self, type_data: Cow<TypeData>) -> TypeId;

--- a/crates/biome_module_graph/src/js_module_info/collector.rs
+++ b/crates/biome_module_graph/src/js_module_info/collector.rs
@@ -856,6 +856,10 @@ impl JsModuleInfoCollector {
 }
 
 impl RawTypeCollector for JsModuleInfoCollector {
+    fn scope_for_node(&self, node: &JsSyntaxNode) -> Option<ScopeId> {
+        Some(self.semantic_model.scope(node).id())
+    }
+
     fn find_type(&self, type_data: &TypeData) -> Option<TypeId> {
         self.types.find(type_data)
     }

--- a/crates/biome_module_graph/tests/spec_tests/callback_parameters.test.rs
+++ b/crates/biome_module_graph/tests/spec_tests/callback_parameters.test.rs
@@ -404,3 +404,109 @@ fn test_callback_parameter_query_does_not_infer_module_types() {
     assert_function_query_was_run(&db, infer_binding_type, input, &events);
     assert_function_query_was_not_run(&db, infer_module_types, module, &events);
 }
+
+#[test]
+fn test_callback_parameter_from_imported_generic_method() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/fixtures.ts".into(),
+        r#"
+        export interface Test<Args> {
+            (body: (args: Args) => void): void;
+            extend<T>(): Test<Args & T>;
+        }
+        export declare const base: Test<{}>;
+        "#,
+    );
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+        import { base } from "./fixtures";
+        const test = base.extend<{ service: { go(): Promise<void> } }>();
+        test(({ service }) => {});
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts", "/src/fixtures.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let service = normalized_binding_ty(&db, module, "service");
+    assert_service_returns_promise(&db, module, service);
+}
+
+#[test]
+fn test_method_type_parameter_shadows_enclosing_type_parameter() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+        interface Factory<T> {
+            create<T = string>(): T;
+            outer(): T;
+        }
+        declare const factory: Factory<number>;
+        const explicit = factory.create<boolean>();
+        const defaulted = factory.create();
+        const outer = factory.outer();
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+
+    assert!(is_inferred_boolean(
+        &db,
+        normalized_binding_ty(&db, module, "explicit")
+    ));
+    assert!(is_inferred_string(
+        &db,
+        normalized_binding_ty(&db, module, "defaulted")
+    ));
+    assert!(is_inferred_number(
+        &db,
+        normalized_binding_ty(&db, module, "outer")
+    ));
+}
+
+#[test]
+fn test_non_generic_method_signatures_share_return_types() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"
+        interface Factory<T> {
+            first(): T | null;
+            second(): T | null;
+        }
+        "#,
+    );
+
+    let db = build_js_test_module_db(&fs, &["/src/index.ts"], true);
+    let module = db
+        .module_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let ModuleInfoKind::Js(info) = module.kind(&db) else {
+        panic!("module must contain JavaScript information");
+    };
+    let return_type = |name: &str| {
+        info.raw_types
+            .iter()
+            .find_map(|ty| match ty {
+                biome_js_type_info::RawTypeData::Function(function)
+                    if function
+                        .name
+                        .as_ref()
+                        .is_some_and(|value| value.text() == name) =>
+                {
+                    Some(&function.return_type)
+                }
+                _ => None,
+            })
+            .expect("method signature must be collected")
+    };
+
+    assert_eq!(return_type("first"), return_type("second"));
+}


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Given:
```ts
declare const x: { f<T>(): T };
x.f<Promise<void>>();
```

Biome was trying to resolve T in the `declare const` outside of the scope where `T` is valid. So it would never see it declared on the function.

implemented by astra
<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #11692
<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
