### PR TITLE
fix(useImportExtensions): support JSX imports with declarations

### DIFF
--- a/.changeset/fix-jsx-import-declarations.md
+++ b/.changeset/fix-jsx-import-declarations.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#8893](https://github.com/biomejs/biome/issues/8893): [`useImportExtensions`](https://biomejs.dev/linter/rules/use-import-extensions/) no longer suggests adding `.ts` to `.jsx` imports when a colocated `.d.ts` file provides type declarations.

--- a/crates/biome_js_analyze/src/lint/correctness/use_import_extensions.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_import_extensions.rs
@@ -253,8 +253,9 @@ fn get_extensionless_import(
     let mut existing_extension = path.extension();
 
     match (resolved_path_sub_extension, existing_extension) {
-        (Some("d"), Some("js")) if resolved_extension.is_some_and(|ext| ext == "ts") => {
-            return None; // We resolved a `.d.ts` file, but imported the `.js` file: OK.
+        (Some("d"), Some("js" | "jsx")) if resolved_extension.is_some_and(|ext| ext == "ts") => {
+            // Declaration files provide types without changing the runtime import extension.
+            return None;
         }
         (Some(_), _) if path.file_name()?.starts_with(resolved_path.file_name()?) => {
             return None; // For cases like `./foo.css` -> `./foo.css.ts`

--- a/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/sub/generated/index.jsx
+++ b/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/sub/generated/index.jsx
@@ -1,0 +1,1 @@
+/* should not generate diagnostics */

--- a/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/sub/generated/index.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/sub/generated/index.jsx.snap
@@ -1,0 +1,9 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: index.jsx
+---
+# Input
+```jsx
+/* should not generate diagnostics */
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/valid.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/valid.js
@@ -28,3 +28,7 @@ import './sub/baz.css';
 import './sub/baz.css.com';
 
 import "./sub/generated/index.js";
+import "./sub/generated/index.jsx";
+import("./sub/generated/index.jsx");
+require("./sub/generated/index.jsx");
+export * from "./sub/generated/index.jsx";

--- a/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/valid.js.snap
@@ -34,5 +34,9 @@ import './sub/baz.css';
 import './sub/baz.css.com';
 
 import "./sub/generated/index.js";
+import "./sub/generated/index.jsx";
+import("./sub/generated/index.jsx");
+require("./sub/generated/index.jsx");
+export * from "./sub/generated/index.jsx";
 
 ```


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Some projects require test files to import `test` or `it`. This extends the code fix to update the imports so that when those functions are imported, the tests will still run. 

fixed by astra
<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #8893

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
snapshots

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
