### PR TITLE
fix(html): write fixes back to attribute-expression embeds

### DIFF
--- a/.changeset/fix-attribute-expression-fix-write-back.md
+++ b/.changeset/fix-attribute-expression-fix-write-back.md
@@ -4,7 +4,7 @@
 
 Fixed [#10247](https://github.com/biomejs/biome/issues/10247): `biome check --write`/`biome lint --write` now correctly writes fixes for code inside an HTML attribute expression (for example a Svelte `onclick={...}` handler, or a mustache expression like `{count}`), instead of silently reporting the diagnostic as fixable and applying nothing.
 
-For example, running the [`useBlockStatements`](https://biomejs.dev/linter/rules/use-block-statements/) fix on this Svelte component used to leave the file unchanged:
+For example, running `biome lint --write --unsafe` for [`useBlockStatements`](https://biomejs.dev/linter/rules/use-block-statements/) (an unsafe fix) on this Svelte component used to leave the file unchanged:
 
 ```svelte
 <button onclick={() => { if (open) close(); }}>Close</button>

--- a/.changeset/fix-attribute-expression-fix-write-back.md
+++ b/.changeset/fix-attribute-expression-fix-write-back.md
@@ -1,0 +1,11 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#10247](https://github.com/biomejs/biome/issues/10247): `biome check --write`/`biome lint --write` now correctly writes fixes for code inside an HTML attribute expression (for example a Svelte `onclick={...}` handler, or a mustache expression like `{count}`), instead of silently reporting the diagnostic as fixable and applying nothing.
+
+For example, running the [`useBlockStatements`](https://biomejs.dev/linter/rules/use-block-statements/) fix on this Svelte component used to leave the file unchanged:
+
+```svelte
+<button onclick={() => { if (open) close(); }}>Close</button>
+```

--- a/crates/biome_cli/tests/cases/handle_svelte_files.rs
+++ b/crates/biome_cli/tests/cases/handle_svelte_files.rs
@@ -674,3 +674,91 @@ fn format_svelte_ts_generics_files_write() {
         result,
     ));
 }
+
+// Regression test for https://github.com/biomejs/biome/issues/10247
+#[test]
+fn full_support_writes_attribute_expression_fix() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    fs.insert(
+        "biome.json".into(),
+        r#"{
+            "html": { "experimentalFullSupportEnabled": true },
+            "linter": {
+                "rules": { "recommended": false, "style": { "useBlockStatements": "warn" } }
+            }
+        }"#
+        .as_bytes(),
+    );
+
+    let svelte_file_path = Utf8Path::new("file.svelte");
+    fs.insert(
+        svelte_file_path.into(),
+        r#"<script lang="ts">
+	let open = true;
+
+	function close() {
+		open = false;
+	}
+</script>
+
+<button
+	type="button"
+	onclick={() => {
+		if (open) close();
+	}}
+>
+	Close
+</button>
+"#
+        .as_bytes(),
+    );
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(
+            [
+                "lint",
+                "--write",
+                "--unsafe",
+                "--only=style/useBlockStatements",
+                svelte_file_path.as_str(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_file_contents(
+        &fs,
+        svelte_file_path,
+        r#"<script lang="ts">
+	let open = true;
+
+	function close() {
+		open = false;
+	}
+</script>
+
+<button
+	type="button"
+	onclick={() => {
+		if (open) { close(); }
+	}}
+>
+	Close
+</button>
+"#,
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "full_support_writes_attribute_expression_fix",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/full_support_writes_attribute_expression_fix.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/full_support_writes_attribute_expression_fix.snap
@@ -1,0 +1,42 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "html": { "experimentalFullSupportEnabled": true },
+  "linter": {
+    "rules": { "recommended": false, "style": { "useBlockStatements": "warn" } }
+  }
+}
+```
+
+## `file.svelte`
+
+```svelte
+<script lang="ts">
+	let open = true;
+
+	function close() {
+		open = false;
+	}
+</script>
+
+<button
+	type="button"
+	onclick={() => {
+		if (open) { close(); }
+	}}
+>
+	Close
+</button>
+
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file in <TIME>. Fixed 1 file.
+```

--- a/crates/biome_html_syntax/src/element_ext.rs
+++ b/crates/biome_html_syntax/src/element_ext.rs
@@ -6,8 +6,8 @@ use crate::{
     AnyAstroDirective, AnyHtmlAttribute, AnyHtmlContent, AnyHtmlElement, AnyHtmlTagName,
     AnyHtmlTextExpression, AnySvelteBlock, AnyVueDirective, AstroEmbeddedContent,
     HtmlAttributeList, HtmlElement, HtmlEmbeddedContent, HtmlOpeningElement,
-    HtmlProcessingInstruction, HtmlSelfClosingElement, HtmlSyntaxToken, HtmlTagName, ScriptType,
-    inner_string_text,
+    HtmlProcessingInstruction, HtmlSelfClosingElement, HtmlSyntaxToken, HtmlTagName,
+    HtmlTextExpression, ScriptType, inner_string_text,
 };
 use biome_aria::Attribute;
 use biome_parser::{TokenSet, token_set};
@@ -670,7 +670,7 @@ impl biome_aria::Element for AnyHtmlTagElement {
 }
 
 declare_node_union! {
-    pub AnyEmbeddedContent = HtmlEmbeddedContent | AstroEmbeddedContent
+    pub AnyEmbeddedContent = HtmlEmbeddedContent | AstroEmbeddedContent | HtmlTextExpression
 }
 
 impl AnyEmbeddedContent {
@@ -678,6 +678,12 @@ impl AnyEmbeddedContent {
         match self {
             Self::HtmlEmbeddedContent(node) => node.value_token().ok(),
             Self::AstroEmbeddedContent(node) => node.content_token(),
+            // The `{...}` in an attribute expression (`onclick={...}`), a
+            // Svelte/Vue directive value, or a text/mustache expression
+            // (`{count}`) all carry their raw snippet text as this token.
+            // See `parse_embedded_nodes.rs`, which records `element_range`
+            // as this node's own range for each of those candidate kinds.
+            Self::HtmlTextExpression(node) => node.html_literal_token().ok(),
         }
     }
 }


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

## Summary

Fixes #10247.

`update_snippets` (the function that splices a fixed embedded snippet's new code back into the host HTML/Svelte/Vue/Astro document) finds the node to patch by casting tree descendants to `AnyEmbeddedContent`, which only covered `HtmlEmbeddedContent` (`<script>`/`<style>`) and `AstroEmbeddedContent` (frontmatter). It didn't cover `HtmlTextExpression` — the node that holds the raw JS text for a `{...}` attribute expression (e.g. Svelte's `onclick={...}`), a Svelte/Vue directive value, or a mustache/text expression (e.g. `{count}`).

The fix for a rule violation inside one of those was still computed correctly against the standalone embedded-document analysis (hence the `FIXABLE` diagnostic), but the write-back loop never found a matching element, so `mutation.replace_token` was never called for it — the fix was silently dropped and `biome check --write` printed "No fixes applied".

```svelte
<button onclick={() => { if (open) close(); }}>Close</button>
```

`biome lint --write --unsafe` for `useBlockStatements` reports this as fixable but, before this change, left the file untouched. The same code as a plain `.ts` file was fixed correctly, which is what pointed at the embedded-content write-back path specifically.

Added `HtmlTextExpression` to the `AnyEmbeddedContent` union (`crates/biome_html_syntax/src/element_ext.rs`) so its token gets found and replaced the same way `HtmlEmbeddedContent`/`AstroEmbeddedContent` already are. `parse_embedded_nodes.rs` already records `element_range` as this exact node's own range for attribute expressions, directives, and text expressions, so no other change is needed for the write-back loop to pick them up.

## Test Plan

- Added `full_support_writes_attribute_expression_fix` to `biome_cli`'s `handle_svelte_files` tests, reproducing the issue's exact repro end-to-end (`lint --write --unsafe` on a `.svelte` file with `html.experimentalFullSupportEnabled`, asserting the file content after the run)
- `cargo test -p biome_cli`: 922 passed, 0 failed (full suite)
- `cargo test -p biome_html_syntax`: 12 passed, 0 failed
- Added a changeset

## Docs

Not applicable — this is a bug fix to internal write-back plumbing, no new rule/action/option.

---

This PR was written primarily by Claude Code (investigation, fix, and tests).
