### PR TITLE
fix(format/svelte): format JavaScript in attribute value expressions

### DIFF
--- a/.changeset/smooth-plums-lead.md
+++ b/.changeset/smooth-plums-lead.md
@@ -1,0 +1,16 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11304](https://github.com/biomejs/biome/issues/11304): Svelte attribute values such as `onclick={...}` are now formatted as JavaScript instead of keeping their original layout.
+
+```diff
+-<form onsubmit={(event)=>{event.preventDefault();submitForm();  trackSubmission();}}></form>
++<form
++	onsubmit={(event) => {
++		event.preventDefault();
++		submitForm();
++		trackSubmission();
++	}}
++></form>
+```

--- a/crates/biome_formatter/src/lib.rs
+++ b/crates/biome_formatter/src/lib.rs
@@ -1074,6 +1074,42 @@ pub struct SourceMarker {
     pub dest: TextSize,
 }
 
+/// The document a caller produces for an embedded node, together with the
+/// layout the embed protocol applies to it.
+///
+/// The layout is a property of the host construct, not of the embedded
+/// content: the same guest language is formatted as a block where it occupies
+/// a whole host node and inline where it is spliced into one position of a
+/// host line.
+#[derive(Debug, Clone)]
+pub enum EmbeddedDocument {
+    /// The embedded content occupies a whole block of the host document.
+    ///
+    /// The embed protocol closes a block embed with a hard line so the host
+    /// token that follows it starts on a new line and the enclosing groups
+    /// break.
+    Block(Document),
+
+    /// The embedded content is spliced into a single position of the host
+    /// document, such as a template expression inside an attribute value.
+    ///
+    /// The embed protocol inserts no line break of its own, so the enclosing
+    /// layout stays free to keep the embed on one line. The embed only forces
+    /// the enclosing groups to break when the embedded document itself
+    /// contains a hard line.
+    Inline(Document),
+}
+
+/// The layout of the most recently visited `StartEmbedded` tag.
+///
+/// `EndEmbedded` carries no payload of its own, so the layout is recovered from
+/// the start tag it closes.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum EmbeddedLayout {
+    Block,
+    Inline,
+}
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Formatted<Context> {
     document: Document,
@@ -1090,35 +1126,45 @@ impl<Context> Formatted<Context> {
         &self.context
     }
 
-    /// Visits each embedded element and replaces it with elements contained inside the [Document]
-    /// emitted by `fn_format_embedded`
+    /// Visits each embedded element and replaces it with elements contained inside the
+    /// [EmbeddedDocument] emitted by `fn_format_embedded`
     pub fn format_embedded<F>(&mut self, mut fn_format_embedded: F)
     where
-        F: FnMut(TextRange) -> Option<Document>,
+        F: FnMut(TextRange) -> Option<EmbeddedDocument>,
     {
-        let mut last_start_resolved = false;
+        let mut last_start = None;
         self.document.transform(move |element| match element {
             FormatElement::Tag(Tag::StartEmbedded(range)) => match fn_format_embedded(*range) {
-                Some(document) => {
-                    last_start_resolved = true;
+                Some(EmbeddedDocument::Block(document)) => {
+                    last_start = Some(EmbeddedLayout::Block);
+                    Some(FormatElement::Interned(Interned::new(
+                        document.into_elements(),
+                    )))
+                }
+                Some(EmbeddedDocument::Inline(document)) => {
+                    last_start = Some(EmbeddedLayout::Inline);
                     Some(FormatElement::Interned(Interned::new(
                         document.into_elements(),
                     )))
                 }
                 None => {
                     // Keep the StartEmbedded tag so it stays paired with EndEmbedded.
-                    last_start_resolved = false;
+                    last_start = None;
                     None
                 }
             },
-            FormatElement::Tag(Tag::EndEmbedded) => {
-                if last_start_resolved {
-                    Some(FormatElement::Line(LineMode::Hard))
-                } else {
-                    // Keep EndEmbedded paired with the unresolved StartEmbedded.
-                    None
+            FormatElement::Tag(Tag::EndEmbedded) => match last_start {
+                Some(EmbeddedLayout::Block) => Some(FormatElement::Line(LineMode::Hard)),
+                // An inline embed is spliced into its host position, so its end
+                // tag contributes no output of its own. The caller decides what
+                // follows the embed and where any pending line suffix has to be
+                // flushed before it.
+                Some(EmbeddedLayout::Inline) => {
+                    Some(FormatElement::Interned(Interned::new(Vec::new())))
                 }
-            }
+                // Keep EndEmbedded paired with the unresolved StartEmbedded.
+                None => None,
+            },
             _ => None,
         });
     }

--- a/crates/biome_formatter/src/prelude.rs
+++ b/crates/biome_formatter/src/prelude.rs
@@ -14,7 +14,7 @@ pub use crate::format_element::tag::{LabelId, Tag, TagKind};
 pub use crate::token::number::{NumberFormatOptions, format_trimmed_number};
 
 pub use crate::{
-    Buffer as _, BufferExtensions, Format, Format as _, FormatResult, FormatRule,
+    Buffer as _, BufferExtensions, EmbeddedDocument, Format, Format as _, FormatResult, FormatRule,
     FormatTextCaseExt as _, FormatWithRule as _, SimpleFormatContext, best_fitting, dbg_write,
     format, format_args, write,
 };

--- a/crates/biome_html_formatter/src/html/auxiliary/attribute_single_text_expression.rs
+++ b/crates/biome_html_formatter/src/html/auxiliary/attribute_single_text_expression.rs
@@ -1,8 +1,10 @@
 use crate::prelude::*;
-use biome_formatter::{FormatRuleWithOptions, write};
+use biome_formatter::{CstFormatContext, FormatContext, FormatRuleWithOptions, write};
 use biome_html_syntax::{
-    HtmlAttributeSingleTextExpression, HtmlAttributeSingleTextExpressionFields,
+    HtmlAttributeInitializerClause, HtmlAttributeSingleTextExpression,
+    HtmlAttributeSingleTextExpressionFields,
 };
+use biome_rowan::{AstNode, TextRange};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatHtmlAttributeSingleTextExpression {
@@ -10,6 +12,42 @@ pub(crate) struct FormatHtmlAttributeSingleTextExpression {
 }
 
 impl FormatNodeRule<HtmlAttributeSingleTextExpression> for FormatHtmlAttributeSingleTextExpression {
+    /// Returns the range of the JavaScript payload of a Svelte attribute value.
+    ///
+    /// Only the value form (`name={expression}`) is delegated. The other
+    /// positions that hold this node - an attribute-position expression such as
+    /// `<a {expression}>`, and an expression inside a quoted template value -
+    /// are printed from their source text, and the `compact` form removes the
+    /// braces instead of keeping the payload.
+    fn embedded_node_range(
+        &self,
+        node: &HtmlAttributeSingleTextExpression,
+        f: &mut HtmlFormatter,
+    ) -> Option<TextRange> {
+        if self.compact
+            || !f.context().options().file_source().is_svelte()
+            || !f.context().should_delegate_fmt_embedded_nodes()
+            || !node
+                .syntax()
+                .parent()
+                .is_some_and(|parent| HtmlAttributeInitializerClause::can_cast(parent.kind()))
+        {
+            return None;
+        }
+
+        let expression = node.expression().ok()?;
+        if f.context().comments().is_suppressed(expression.syntax()) {
+            return None;
+        }
+
+        let token = expression.html_literal_token().ok()?;
+        f.state_mut().track_token(&token);
+        // An attribute value is parsed as a directive payload, so the service
+        // always resolves this range as an inline embed. A block embed would
+        // close with a hard line and split the attribute list.
+        Some(token.text_range())
+    }
+
     fn fmt_fields(
         &self,
         node: &HtmlAttributeSingleTextExpression,

--- a/crates/biome_html_formatter/tests/specs/html/component-frameworks/svelte-component-casing.svelte.snap
+++ b/crates/biome_html_formatter/tests/specs/html/component-frameworks/svelte-component-casing.svelte.snap
@@ -33,7 +33,7 @@ import Select from "./Select.svelte";
 
 <Button label="test button" />
 <TextInput placeholder="enter text" />
-<Select options={['a', 'b']} />
+<Select options={["a", "b"]} />
 <button>native button</button>
 <input type="text">
 <select>

--- a/crates/biome_html_formatter/tests/specs/html/svelte/directive_member_expression.svelte.snap
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/directive_member_expression.svelte.snap
@@ -19,7 +19,7 @@ info: svelte/directive_member_expression.svelte
 
 ```svelte
 <button use:obj.action>action</button>
-<button use:obj.action={{leet: 1337}}>with params</button>
+<button use:obj.action={{ leet: 1337 }}>with params</button>
 <div in:renderer.in|global out:renderer.out|global></div>
 <div transition:lib.fade|local={{ duration: 200 }}>fading</div>
 <div in:a.b.c|global>deep</div>

--- a/crates/biome_html_formatter/tests/specs/html/svelte/directive_multiple.svelte.snap
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/directive_multiple.svelte.snap
@@ -17,10 +17,10 @@ info: svelte/directive_multiple.svelte
 ```svelte
 <input
 	bind:value={name}
-	use:tooltip={{text: 'Enter your name'}}
+	use:tooltip={{ text: "Enter your name" }}
 	class:invalid={!isValid}
 >
-<div in:fade out:fly={{y: 200}} class:active style:opacity={opacity}>
+<div in:fade out:fly={{ y: 200 }} class:active style:opacity={opacity}>
 	Multiple directives
 </div>
 

--- a/crates/biome_html_formatter/tests/specs/html/svelte/directive_transition_modifiers.svelte.snap
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/directive_transition_modifiers.svelte.snap
@@ -18,6 +18,6 @@ info: svelte/directive_transition_modifiers.svelte
 ```svelte
 <div transition:fade>Content</div>
 <p transition:slide|global>Global transition</p>
-<span transition:fly={{y: 200, duration: 500}}>Complex</span>
+<span transition:fly={{ y: 200, duration: 500 }}>Complex</span>
 
 ```

--- a/crates/biome_html_formatter/tests/specs/html/svelte/directive_use_basic.svelte.snap
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/directive_use_basic.svelte.snap
@@ -16,6 +16,6 @@ info: svelte/directive_use_basic.svelte
 
 ```svelte
 <div use:clickOutside>Click outside handler</div>
-<button use:longpress={{duration: 500}}>Long press me</button>
+<button use:longpress={{ duration: 500 }}>Long press me</button>
 
 ```

--- a/crates/biome_html_formatter/tests/specs/html/svelte/double_curly.svelte.snap
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/double_curly.svelte.snap
@@ -28,6 +28,6 @@ info: svelte/double_curly.svelte
 
 <p>{{ a: true }}</p>
 <p>{JSON.stringify(  { foo: "bar" }  )}</p>
-<div class={{  active: isActive }}></div>
+<div class={{ active: isActive }}></div>
 
 ```

--- a/crates/biome_html_formatter/tests/specs/html/svelte/issue_11304.svelte
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/issue_11304.svelte
@@ -1,0 +1,11 @@
+<form onsubmit={(event)=>{event.preventDefault();submitForm();  trackSubmission();}}></form>
+
+<input bind:value={name}>
+<div class={{active: isActive}}></div>
+<button on:click={(visible = !visible)}>toggle</button>
+<Select options={['a', 'b']} />
+
+<button on:click={handler // the comment stays inside the expression
+}>commented</button>
+
+<button on:click={a +}>unformattable</button>

--- a/crates/biome_html_formatter/tests/specs/html/svelte/issue_11304.svelte.snap
+++ b/crates/biome_html_formatter/tests/specs/html/svelte/issue_11304.svelte.snap
@@ -1,0 +1,49 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: svelte/issue_11304.svelte
+---
+
+# Input
+
+```svelte
+<form onsubmit={(event)=>{event.preventDefault();submitForm();  trackSubmission();}}></form>
+
+<input bind:value={name}>
+<div class={{active: isActive}}></div>
+<button on:click={(visible = !visible)}>toggle</button>
+<Select options={['a', 'b']} />
+
+<button on:click={handler // the comment stays inside the expression
+}>commented</button>
+
+<button on:click={a +}>unformattable</button>
+
+```
+
+
+# Formatted
+
+```svelte
+<form
+	onsubmit={(event) => {
+		event.preventDefault();
+		submitForm();
+		trackSubmission();
+	}}
+></form>
+
+<input bind:value={name}>
+<div class={{ active: isActive }}></div>
+<button on:click={(visible = !visible)}>toggle</button>
+<Select options={["a", "b"]} />
+
+<button
+	on:click={handler // the comment stays inside the expression
+	}
+>
+	commented
+</button>
+
+<button on:click={a +}>unformattable</button>
+
+```

--- a/crates/biome_service/src/file_handlers/html.rs
+++ b/crates/biome_service/src/file_handlers/html.rs
@@ -52,10 +52,10 @@ use biome_formatter::FormatElement;
 #[cfg(feature = "html_embeds")]
 use biome_formatter::format_element::{Interned, LineMode};
 #[cfg(feature = "html_embeds")]
-use biome_formatter::prelude::{Document, Tag};
+use biome_formatter::prelude::{Document, EmbeddedDocument, Tag, TextWidth};
 use biome_formatter::{
-    AttributePosition, BracketSameLine, IndentStyle, IndentWidth, LineEnding, LineWidth, Printed,
-    TrailingNewline,
+    AttributePosition, BracketSameLine, IndentStyle, IndentWidth, LINE_TERMINATORS, LineEnding,
+    LineWidth, Printed, TrailingNewline, normalize_newlines,
 };
 use biome_fs::BiomePath;
 use biome_html_analyze::{HtmlAnalyzerServices, HtmlSuppression, analyze};
@@ -80,6 +80,8 @@ use biome_js_syntax::{AnyJsRoot, JsLanguage, JsSyntaxToken, JsTemplateChunkEleme
 #[cfg(feature = "html_embeds")]
 use biome_json_syntax::JsonLanguage;
 use biome_languages::HtmlFileSource;
+#[cfg(feature = "html_embeds")]
+use biome_languages::javascript::{JsEmbeddingKind, SvelteEmbeddingKind};
 #[cfg(feature = "html_embeds")]
 use biome_parser::AnyParse;
 #[cfg(feature = "html_embeds")]
@@ -800,6 +802,7 @@ fn format_embedded(
 
     let tree = parse.syntax(&workspace_db);
     let indent_script_and_style = options.indent_script_and_style().value();
+    let indent_width = options.indent_width();
     let mut formatted = format_node(options, &tree, true)?;
     formatted.format_embedded(move |range| {
         let mut iter = embedded_nodes.iter();
@@ -838,21 +841,63 @@ fn format_embedded(
                     .parsed_origin()
                     .parse(&workspace_db)
                     .embedded_syntax::<JsLanguage>();
-                let formatted =
-                    biome_js_formatter::format_node_with_offset(js_options, &node).ok()?;
+                let formatted = biome_js_formatter::format_node_with_offset(js_options, &node).ok();
 
-                let document = formatted.into_document();
                 if file_source.is_svelte_declaration() {
-                    Some(Document::new(vec![
+                    Some(EmbeddedDocument::Block(Document::new(vec![
                         FormatElement::Token { text: "{" },
-                        FormatElement::Interned(Interned::new(document.into_elements())),
+                        FormatElement::Interned(Interned::new(
+                            formatted?.into_document().into_elements(),
+                        )),
                         FormatElement::Token { text: "}" },
-                    ]))
+                    ])))
+                } else if matches!(
+                    file_source.as_embedding_kind(),
+                    JsEmbeddingKind::Svelte {
+                        embedding_kind: SvelteEmbeddingKind::Expression,
+                        ..
+                    }
+                ) {
+                    // An expression inside an attribute shares its line with the
+                    // attribute list, so it must not close with a block break.
+                    let payload = match formatted {
+                        Some(formatted) => FormatElement::Interned(Interned::new(
+                            formatted.into_document().into_elements(),
+                        )),
+                        // The host node is printed as nothing but this embed, so
+                        // an unresolved payload would remove the expression from
+                        // the document. Keeping the parsed text leaves a payload
+                        // the JavaScript formatter rejects, such as `{a +}`, in
+                        // place until the syntax error is fixed.
+                        None => {
+                            let source = node.inner().text_trimmed().to_string();
+                            // The printer expands only `\n` into the configured
+                            // line ending, so every other line terminator has to
+                            // become `\n` before the text is handed over.
+                            let text = normalize_newlines(&source, LINE_TERMINATORS);
+                            let text_width = TextWidth::from_text(&text, indent_width);
+                            FormatElement::Text {
+                                text: text.into_owned().into(),
+                                text_width,
+                            }
+                        }
+                    };
+                    Some(EmbeddedDocument::Inline(Document::new(vec![
+                        FormatElement::Token { text: "{" },
+                        payload,
+                        // A payload that ends in a line comment, such as
+                        // `{handler // note}`, leaves a line suffix pending. The
+                        // closing brace has to be separated from it, or the
+                        // brace is printed inside the comment and the source no
+                        // longer parses back to the same expression.
+                        FormatElement::LineSuffixBoundary,
+                        FormatElement::Token { text: "}" },
+                    ])))
                 } else {
-                    Some(wrap_document(
-                        document,
+                    Some(EmbeddedDocument::Block(wrap_document(
+                        formatted?.into_document(),
                         !file_source.as_embedding_kind().is_astro_frontmatter(),
-                    ))
+                    )))
                 }
             }
             DocumentFileSource::Json(_) => {
@@ -864,7 +909,10 @@ fn format_embedded(
                     .embedded_syntax::<JsonLanguage>();
                 let formatted =
                     biome_json_formatter::format_node_with_offset(json_options, &node).ok()?;
-                Some(wrap_document(formatted.into_document(), true))
+                Some(EmbeddedDocument::Block(wrap_document(
+                    formatted.into_document(),
+                    true,
+                )))
             }
             DocumentFileSource::Css(_) => {
                 let css_options = css::resolve_format_options(
@@ -879,7 +927,10 @@ fn format_embedded(
                     .embedded_syntax::<CssLanguage>();
                 let formatted =
                     biome_css_formatter::format_node_with_offset(css_options, &node).ok()?;
-                Some(wrap_document(formatted.into_document(), true))
+                Some(EmbeddedDocument::Block(wrap_document(
+                    formatted.into_document(),
+                    true,
+                )))
             }
             _ => None,
         }

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -48,7 +48,7 @@ use biome_db::AnyParsedSource;
 #[cfg(feature = "js_embeds")]
 use biome_formatter::FormatElement;
 #[cfg(feature = "js_embeds")]
-use biome_formatter::prelude::{Document, Interned, LineMode, Tag};
+use biome_formatter::prelude::{Document, EmbeddedDocument, Interned, LineMode, Tag};
 use biome_formatter::{
     AttributePosition, BracketSameLine, BracketSpacing, DelimiterSpacing, Expand, FormatError,
     IndentStyle, IndentWidth, LineEnding, LineWidth, Printed, QuoteStyle, TrailingNewline,
@@ -1754,7 +1754,9 @@ fn format_embedded(
                         .embedded_syntax::<CssLanguage>();
                     let formatted =
                         biome_css_formatter::format_node_with_offset(css_options, &node).ok()?;
-                    Some(wrap_document(formatted.into_document()))
+                    Some(EmbeddedDocument::Block(wrap_document(
+                        formatted.into_document(),
+                    )))
                 }
                 #[cfg(feature = "lang_graphql")]
                 DocumentFileSource::Graphql(_) => {
@@ -1771,7 +1773,9 @@ fn format_embedded(
                     let formatted =
                         biome_graphql_formatter::format_node_with_offset(graphql_options, &node)
                             .ok()?;
-                    Some(wrap_document(formatted.into_document()))
+                    Some(EmbeddedDocument::Block(wrap_document(
+                        formatted.into_document(),
+                    )))
                 }
                 _ => None,
             }


### PR DESCRIPTION
## Summary

This fixes #11304, where JavaScript inside Svelte attribute value expressions such as `onsubmit={...}` was left unformatted.

The existing embedded-formatting path was designed for block-level embedded content and terminates the embedded document with a hard line. Reusing that behavior for an inline attribute expression would force the surrounding attribute list to break across lines.

This change adds an inline form of embedded formatting so the JavaScript payload can be delegated to the JavaScript formatter without introducing a host-level line break. If the embedded JavaScript cannot be formatted, the original source text is preserved instead of being dropped.

The change is intentionally limited to Svelte attribute value expressions and does not expand formatting to shorthand attributes, quoted interpolation, or Astro expressions.

Fixes #11304

## Test Plan

Verified the regression with a dedicated Svelte fixture and regenerated the affected snapshots with `cargo-insta`.

Relevant checks passed:

- `just f`
- `just l`
- `cargo test -p biome_html_formatter --test spec_tests`
- `cargo test -p biome_html_formatter`
- `cargo test -p biome_formatter`
- `cargo test -p biome_js_formatter`
- `cargo test -p biome_service --all-features`
- `cargo test -p biome_cli -- svelte`
- `git diff --check`

The formatter regression suite passes without unrelated snapshot changes, and the new fixture verifies that the JavaScript inside the attribute expression is formatted while the surrounding Svelte attribute layout remains stable.

## Docs

No documentation change is required. This fixes existing Svelte formatter behavior and does not add a new option, rule, or user-facing configuration surface.

## AI assistance

AI tools were used extensively during this contribution.

Claude Code was used for local code investigation, implementation, snapshot generation and review, changeset preparation, test and lint execution, and local Git preparation. A separate Claude Code subagent was used for an independent code review using the repository's `biome-code-review` workflow.

Codex was used during an earlier investigation stage of the contribution. ChatGPT was used for GitHub-state checks, contribution planning, task scoping, and review of agent reports.

I reviewed the resulting implementation, diff, test evidence, and final contribution scope, and I am responsible for the submitted changes and this pull request communication.