### PR TITLE
fix(js/parse): avoid consuming huge iterator

### DIFF
--- a/.changeset/fair-cars-strive.md
+++ b/.changeset/fair-cars-strive.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11747](https://github.com/biomejs/biome/issues/11747): formatting and checking large parenthesized object expressions no longer exhibit quadratic slowdowns.

--- a/crates/biome_parser/src/lexer.rs
+++ b/crates/biome_parser/src/lexer.rs
@@ -743,7 +743,10 @@ where
         // Jump right to where we've left of last time rather than going through all tokens again.
         let mut remaining = n - self.lookahead.non_trivia_len();
         let current_length = self.lookahead.all_len();
-        let iter = self.lookahead_iter().skip(current_length);
+        let iter = LookaheadIterator {
+            buffered: self,
+            nth: current_length,
+        };
 
         for item in iter {
             if !item.kind().is_trivia() {


### PR DESCRIPTION
<!--
  IMPORTANT!!
  If you generated this PR with the help of any AI assistance, please disclose it in the PR.
  https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#ai-assistance-notice
-->

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #11747 

Tracked and fixed with the help of an agent. The problem was caused by `.skip`.

The fix creates a new iterator from scratch with `current_length` already set.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Will create a preview release

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
