### PR TITLE
perf(formatter): skip unnecessary comment and context scans

### DIFF
--- a/crates/biome_css_formatter/src/css/selectors/complex_selector.rs
+++ b/crates/biome_css_formatter/src/css/selectors/complex_selector.rs
@@ -184,6 +184,15 @@ impl<'a> SelectorBoundary<'a> {
         right: &AnyCssSelector,
         comments: &'a [SourceComment<CssLanguage>],
     ) -> Self {
+        if comments.is_empty() {
+            return Self {
+                before_combinator: comments,
+                after_combinator: comments,
+                descendant_lines: None,
+                right_lines: 0,
+            };
+        }
+
         let combinator_range = combinator.text_trimmed_range();
         // Comment slices are source ordered. Keep the original side of the
         // combinator while retaining borrowed subslices for formatting.

--- a/crates/biome_css_formatter/tests/specs/css/selectors/empty-comment-boundaries.css
+++ b/crates/biome_css_formatter/tests/specs/css/selectors/empty-comment-boundaries.css
@@ -1,0 +1,7 @@
+.descendant
+
+ .child>
+ .adjacent+
+ .sibling~
+ .column||
+ .target{color:red}

--- a/crates/biome_css_formatter/tests/specs/css/selectors/empty-comment-boundaries.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/selectors/empty-comment-boundaries.css.snap
@@ -1,0 +1,27 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/selectors/empty-comment-boundaries.css
+---
+
+# Input
+
+```css
+.descendant
+
+ .child>
+ .adjacent+
+ .sibling~
+ .column||
+ .target{color:red}
+
+```
+
+
+# Formatted
+
+```css
+.descendant .child > .adjacent + .sibling ~ .column || .target {
+	color: red;
+}
+
+```

--- a/crates/biome_css_formatter/tests/specs/scss/expression/map-context-recovery.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/expression/map-context-recovery.scss
@@ -1,0 +1,2 @@
+$missingMapValue:(key:,ok:(a,b));
+.afterRecovery{color:red;}

--- a/crates/biome_css_formatter/tests/specs/scss/expression/map-context-recovery.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/expression/map-context-recovery.scss.snap
@@ -1,0 +1,23 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: scss/expression/map-context-recovery.scss
+---
+
+# Input
+
+```scss
+$missingMapValue:(key:,ok:(a,b));
+.afterRecovery{color:red;}
+
+```
+
+
+# Formatted
+
+```scss
+$missingMapValue:(key:,ok:(a,b));
+.afterRecovery {
+	color: red;
+}
+
+```

--- a/crates/biome_css_formatter/tests/specs/scss/expression/map-context.scss
+++ b/crates/biome_css_formatter/tests/specs/scss/expression/map-context.scss
@@ -4,3 +4,7 @@ $nestedValueMultiArg:(key:foo((a,b),(c,d)),);
 $doubleParenListValue:(key:((a,b)),);
 $doubleParenMapValue:(key:((a:b)),);
 $doubleParenMapValueBroken:(key:((very-very-very-very-very-very-very-very-long-map-key:very-very-very-very-very-very-very-very-long-map-value,other-key:other-other-value)),);
+$ordinaryList:(a,b);
+$emptyMapValue:(plain:(),wrapped:(()));
+$directMapKey:((a:b):value);
+$nestedMapKey:(fn((a:b)):value);

--- a/crates/biome_css_formatter/tests/specs/scss/expression/map-context.scss.snap
+++ b/crates/biome_css_formatter/tests/specs/scss/expression/map-context.scss.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
-assertion_line: 249
 info: scss/expression/map-context.scss
 ---
 
@@ -13,6 +12,10 @@ $nestedValueMultiArg:(key:foo((a,b),(c,d)),);
 $doubleParenListValue:(key:((a,b)),);
 $doubleParenMapValue:(key:((a:b)),);
 $doubleParenMapValueBroken:(key:((very-very-very-very-very-very-very-very-long-map-key:very-very-very-very-very-very-very-very-long-map-value,other-key:other-other-value)),);
+$ordinaryList:(a,b);
+$emptyMapValue:(plain:(),wrapped:(()));
+$directMapKey:((a:b):value);
+$nestedMapKey:(fn((a:b)):value);
 
 ```
 
@@ -47,6 +50,23 @@ $doubleParenMapValueBroken: (
 			other-key: other-other-value,
 		),
 	),
+);
+$ordinaryList: (a, b);
+$emptyMapValue: (
+	plain: (),
+	wrapped: (
+		(),
+	),
+);
+$directMapKey: (
+	(a: b): value,
+);
+$nestedMapKey: (
+	fn(
+		(
+			a: b,
+		)
+	): value,
 );
 
 ```

--- a/crates/biome_css_syntax/src/scss_ext/map.rs
+++ b/crates/biome_css_syntax/src/scss_ext/map.rs
@@ -172,29 +172,35 @@ fn enclosing_pair_and_role<N>(node: &N) -> Option<(ScssMapExpressionPair, ScssMa
 where
     N: AstNode<Language = CssLanguage>,
 {
-    let range = node.syntax().text_trimmed_range();
-
-    node.syntax()
+    let mut pairs = node
+        .syntax()
         .ancestors()
         .skip(1)
         .filter_map(ScssMapExpressionPair::cast)
-        .find_map(|pair| {
-            let is_key = pair
-                .key()
-                .is_ok_and(|key| key.syntax().text_trimmed_range().contains_range(range));
+        .peekable();
+    let has_enclosing_pair = pairs.peek().is_some();
+    if !has_enclosing_pair {
+        return None;
+    }
+    let range = node.syntax().text_trimmed_range();
 
-            if is_key {
-                return Some((pair, ScssMapRole::Key));
-            }
+    pairs.find_map(|pair| {
+        let is_key = pair
+            .key()
+            .is_ok_and(|key| key.syntax().text_trimmed_range().contains_range(range));
 
-            pair.value().ok().and_then(|value| {
-                value
-                    .syntax()
-                    .text_trimmed_range()
-                    .contains_range(range)
-                    .then_some((pair, ScssMapRole::Value))
-            })
+        if is_key {
+            return Some((pair, ScssMapRole::Key));
+        }
+
+        pair.value().ok().and_then(|value| {
+            value
+                .syntax()
+                .text_trimmed_range()
+                .contains_range(range)
+                .then_some((pair, ScssMapRole::Value))
         })
+    })
 }
 
 /// Classifies whether `node` is the outer expression or a nested descendant.

--- a/crates/biome_formatter/src/comments/builder.rs
+++ b/crates/biome_formatter/src/comments/builder.rs
@@ -230,7 +230,9 @@ where
 
         // Set following node to `None` because it now becomes the enclosing node.
         if let Some(following_node) = self.following_node() {
-            self.flush_comments(Some(&following_node.clone()));
+            if !self.pending_comments.is_empty() {
+                self.flush_comments(Some(&following_node.clone()));
+            }
             self.following_node_index = None;
 
             // The following node is only set after entering a node
@@ -285,6 +287,10 @@ where
     }
 
     fn flush_comments(&mut self, following: Option<&SyntaxNode<Style::Language>>) {
+        if self.pending_comments.is_empty() {
+            return;
+        }
+
         for mut comment in self.pending_comments.drain(..) {
             comment.following = following.cloned();
 


### PR DESCRIPTION
> AI assistance: Codex 
## Summary

- Skip selector-boundary scans when there are no dangling comments.
- Calculate SCSS expression ranges only when an enclosing map pair exists.
- Skip empty shared comment flushes and unnecessary syntax-node handle clones.


## Test Plan

- green ci 
